### PR TITLE
docs: update status section for v0.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ See [`sdk/python/`](sdk/python/) for installation, full API reference, and CI in
 
 ## Status
 
-Early development. Active construction. Star or watch this repo to follow progress.
+The rule engine and all 34 bundled rules are production-ready. New rules and protocol coverage are in active development. Star or watch to follow progress.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Update the README status section ahead of the v0.1.0 release. "Early development. Active construction." undersells a production-ready tool with 34 tested rules and a passing CI pipeline.

## Changes

- `README.md`: Replace placeholder status with an accurate description of current state

## Type of change

- [x] Documentation update