### PR TITLE
docs: demo GIF, rule catalogs, and README cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,85 +7,46 @@
 [![Build](https://github.com/calvin-mcdowell/batesian/actions/workflows/ci.yml/badge.svg)](https://github.com/calvin-mcdowell/batesian/actions)
 [![DCO](https://img.shields.io/badge/contributor%20agreement-DCO-blue.svg)](https://developercertificate.org)
 
-Batesian is a red-team CLI that sends crafted adversarial payloads against A2A and MCP protocol implementations to surface vulnerabilities that observation-only tools never reach: SSRF via push-notification callbacks, OAuth scope escalation through dynamic client registration, JWS algorithm confusion, cross-session context injection, and more.
+Batesian is a red-team CLI that sends crafted adversarial payloads against A2A and MCP protocol
+implementations to surface vulnerabilities that observation-only tools never reach: SSRF via
+push-notification callbacks, OAuth scope escalation, JWS algorithm confusion, cross-session
+context injection, and more.
 
 ![Batesian demo](docs/demo.gif)
 
-> **Authorized use only.** Only run Batesian against systems you own or have explicit written permission to test. Unauthorized use is illegal and unethical.
+> **Authorized use only.** Only run Batesian against systems you own or have explicit written
+> permission to test. Unauthorized use is illegal and unethical.
 
 ---
 
 ## Why Batesian exists
 
-Most agent security tooling today takes an observational posture: connect to a running server, read what it exposes, check spec compliance, and pattern-match for known strings. That approach is genuinely useful and catches a real class of problems.
+Most agent security tooling takes an observational posture: connect to a running server, read what
+it exposes, check spec compliance, and pattern-match for known strings. That approach is genuinely
+useful and catches a real class of problems.
 
-It leaves another class completely untested. Some vulnerabilities only surface when the system processes a crafted attack payload -- an abused OAuth registration flow, a push-notification callback pointed at an attacker-controlled host, a JWS signature stripped down to `"alg":"none"`. Passive inspection cannot reach these because they require the server to act, not just exist.
+It leaves another class completely untested. Some vulnerabilities only surface when the system
+processes a crafted attack payload -- an abused OAuth registration flow, a push-notification
+callback pointed at an attacker-controlled host, a JWS signature stripped down to `"alg":"none"`.
+Passive inspection cannot reach these because they require the server to act, not just exist.
 
-Batesian is built for that second class. It does not replace observational scanning. It covers the ground that observational scanning structurally cannot.
+Batesian is built for that second class. It does not replace observational scanning. It covers the
+ground that observational scanning structurally cannot.
+
+See [docs/comparison.md](docs/comparison.md) for a full breakdown against other tools in the space.
 
 ---
 
 ## What Batesian tests
 
-### A2A (Agent-to-Agent)
+Batesian ships **18 A2A rules** and **16 MCP rules**, covering SSRF, OAuth abuse, JWS algorithm
+confusion, prompt injection, protocol downgrade, TLS enforcement, and more.
 
-| Rule ID | Attack | What it confirms |
-|---|---|---|
-| `a2a-push-ssrf-001` | Push Notification SSRF | Server makes outbound HTTP request to an attacker-controlled callback URL |
-| `a2a-extcard-unauth-001` | Extended Agent Card Disclosure | Privileged capabilities leak from `GET /extendedAgentCard` without authentication |
-| `a2a-jws-algconf-001` | JWS Algorithm Confusion | Server accepts JWS with `"alg":"none"` or RS256-to-HS256 downgrade |
-| `a2a-session-smuggle-001` | Agent Session Smuggling | Covert instructions injected into a session by a malicious peer agent |
-| `a2a-task-idor-001` | Task IDOR | Unauthenticated session retrieves task history belonging to another session |
-| `a2a-context-orphan-001` | Cross-Session Context Injection | New session reads or injects into a context owned by a different session |
-| `a2a-json-rpc-fuzz-001` | JSON-RPC Mutation Fuzzing | Malformed payloads produce stack traces or unhandled panics |
-| `a2a-peer-impersonation-001` | Peer Agent Impersonation | Forged JWT claiming a trusted peer identity accepted without origin verification |
-| `a2a-delegation-escalation-001` | Delegation Escalation | Privileged metadata injected in `configuration` blocks accepted without validation |
-| `a2a-wellknown-hostinject-001` | Agent Card Host Header Injection | Attacker-controlled domain reflected in Agent Card via `Host` / `X-Forwarded-Host` |
-| `a2a-artifact-tamper-001` | Task Artifact Tampering | Completed task re-submitted with different content; server accepts without immutability check |
-| `a2a-skill-poison-001` | Skill Description Injection | Agent Card skill descriptions or examples contain prompt injection patterns |
-| `a2a-url-mismatch-001` | Agent Card URL Mismatch | Agent Card `url` field points to a different domain than the card's serving host |
-| `a2a-tls-downgrade-001` | TLS Downgrade | Agent Card and RPC endpoints respond over plain HTTP without HTTPS redirect |
-| `a2a-capability-inflation-001` | Capability Inflation | `tasks/send` with undeclared elevated permissions accepted without a validation error |
-| `a2a-security-headers-001` | Missing Security Headers | A2A endpoints return no HSTS, X-Content-Type-Options, or framing protection headers |
-| `a2a-registry-poison-001` | Agent Registry Poisoning | Registry endpoint accepts unauthenticated agent card registration or identity overwrite |
-| `a2a-circular-delegation-001` | Circular Delegation | Agent accepts `tasks/send` with a 10-hop delegation chain and no depth-limit error |
+- [A2A rule catalog](docs/rules-a2a.md) -- Agent-to-Agent protocol attacks
+- [MCP rule catalog](docs/rules-mcp.md) -- Model Context Protocol attacks
 
-### MCP (Model Context Protocol)
-
-| Rule ID | Attack | What it confirms |
-|---|---|---|
-| `mcp-oauth-dcr-001` | OAuth DCR Scope Escalation | Dynamic client registration grants excessive scopes or accepts hijacked redirect URIs |
-| `mcp-tool-poison-001` | Tool Poisoning / Rug Pull | Tool descriptions contain prompt injection patterns or change across sessions |
-| `mcp-resources-unauth-001` | Unauthenticated Resource Read | Resources endpoint returns secrets or configuration data without credentials |
-| `mcp-sampling-inject-001` | Sampling Injection | `sampling/createMessage` requests from the server embed prompt injection |
-| `mcp-token-replay-001` | Bearer Token Replay | OAuth tokens with incorrect `aud` claims accepted without audience validation |
-| `mcp-init-downgrade-001` | Protocol Version Downgrade | Server disables security controls when negotiating protocol version `2024-11-05` |
-| `mcp-cors-wildcard-001` | CORS Wildcard with Credentials | Server returns `Access-Control-Allow-Origin: *` alongside `Access-Control-Allow-Credentials: true` |
-| `mcp-prompt-unauth-001` | Prompt Templates Without Auth | `prompts/list` and `prompts/get` respond without credentials |
-| `mcp-context-flood-001` | Context Window Flooding | Server accepts 1MB and 5MB tool call arguments with no payload size limit |
-| `mcp-tool-namespace-001` | Tool Namespace Collision | Tool descriptions differ between two independent sessions (rug pull precondition) |
-| `mcp-sse-hijack-001` | Unauthenticated SSE Stream | SSE stream endpoints accept connections without authentication |
-| `mcp-init-instructions-inject-001` | Server Instructions Injection | `serverInfo.instructions` returned at initialize time contains prompt injection patterns |
-| `mcp-ratelimit-absent-001` | Missing Rate Limiting | Server accepts 25-request burst with no HTTP 429 or throttle response |
-| `mcp-homoglyph-tool-001` | Tool Name Homoglyph | Server accepts `tools/call` with Unicode homoglyph tool names without identity normalization |
-| `mcp-injection-params-001` | Tool Parameter Injection | SQL errors, command output, or script tags reflected from unsanitized tool call arguments |
-| `mcp-security-headers-001` | Missing Security Headers | MCP endpoints return no HSTS, X-Content-Type-Options, or framing protection headers |
-
-## What makes Batesian different
-
-|  | Batesian | Snyk agent-scan | cisco/a2a-scanner | cisco/mcp-scanner |
-|---|:---:|:---:|:---:|:---:|
-| **Approach** | Active red-team | Passive supply-chain scan | Passive static + light endpoint | Passive YARA / LLM / behavioral |
-| Active adversarial probing | ✓ | ✗ | ✗ | ✗ |
-| OOB / blind SSRF detection | ✓ | ✗ | ✗ | ✗ |
-| Cryptographic attack testing | ✓ | ✗ | ✗ | ✗ |
-| OAuth flow attack testing | ✓ | ✗ | ✗ | ✗ |
-| CORS misconfiguration testing | ✓ | ✗ | ✗ | ✗ |
-| Protocol version downgrade attacks | ✓ | ✗ | ✗ | ✗ |
-| Single compiled binary, no runtime dependencies | ✓ | ✗ | ✗ | ✗ |
-| No cloud account or API key required | ✓ | ✗ (Snyk token) | optional | optional |
-| Air-gap / offline compatible | ✓ | ✗ | ✗ | ✗ |
-| YAML rule packs (no Go required to add rules) | ✓ | ✗ | ✗ | ✗ |
+Each finding is classified as `confirmed` (exploit succeeded) or `indicator` (behavioral signal
+warranting manual review). All rules ship with CWE references and remediation guidance.
 
 ---
 
@@ -118,39 +79,15 @@ batesian scan --target https://mcp.example.com \
 batesian init
 ```
 
+---
+
 ## Rule packs
 
-Batesian attack rules are YAML files. Anyone can write new attack patterns without touching Go. Rules load at runtime; no recompilation needed.
+Attack rules are YAML files. Anyone can write new attack patterns without touching Go. Rules load
+at runtime -- no recompilation needed. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full
+authoring guide including the rule schema, validation checklist, and testing requirements.
 
-Each rule pairs a metadata block with an `attack.type` that maps to a registered Go executor. The executor reads target-specific parameters from the YAML and decides how to probe the server. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full authoring guide.
-
-```yaml
-# Minimal rule skeleton -- see CONTRIBUTING.md for the full schema.
-id: a2a-example-001
-info:
-  name: Example A2A Rule
-  author: your-handle
-  severity: high          # critical | high | medium | low | info
-  description: |
-    One-paragraph description of the vulnerability and why it matters.
-  references:
-    - https://a2aprotocol.ai/docs/specification
-  tags:
-    - a2a
-    - authentication
-
-attack:
-  protocol: a2a           # a2a | mcp
-  type: a2a-example       # must match a registered executor in engine.go
-
-assert:
-  - condition: example_condition
-    description: "Human-readable finding description"
-    severity: high
-
-remediation: |
-  Detailed fix guidance for developers.
-```
+---
 
 ## Python SDK
 
@@ -168,15 +105,23 @@ assert results.critical_count == 0
 
 See [`sdk/python/`](sdk/python/) for installation, full API reference, and CI integration examples.
 
+---
+
 ## Status
 
-The rule engine and all 34 bundled rules are production-ready. New rules and protocol coverage are in active development. Star or watch to follow progress.
+The rule engine and all 34 bundled rules are production-ready. New rules and protocol coverage are
+in active development. Star or watch to follow progress.
+
+---
 
 ## Contributing
 
 Contributions welcome, especially new attack rules. No engine knowledge required to write a rule.
 
-See [CONTRIBUTING.md](CONTRIBUTING.md). All contributors sign off commits with a DCO (`git commit -s`).
+See [CONTRIBUTING.md](CONTRIBUTING.md). All contributors sign off commits with a DCO
+(`git commit -s`).
+
+---
 
 ## References
 
@@ -185,6 +130,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). All contributors sign off commits with a
 - [MCP Security Best Practices](https://modelcontextprotocol.io/docs/tutorials/security/authorization)
 - [Unit 42: Agent Session Smuggling in A2A Systems](https://unit42.paloaltonetworks.com/agent-session-smuggling-in-agent2agent-systems/)
 - [OWASP GenAI Security Project](https://genai.owasp.org)
+
+---
 
 ## License
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,28 @@
+# Batesian vs. Other Tools
+
+|  | Batesian | Snyk agent-scan | cisco/a2a-scanner | cisco/mcp-scanner |
+|---|:---:|:---:|:---:|:---:|
+| **Approach** | Active red-team | Passive supply-chain scan | Passive static + light endpoint | Passive YARA / LLM / behavioral |
+| Active adversarial probing | ✓ | ✗ | ✗ | ✗ |
+| OOB / blind SSRF detection | ✓ | ✗ | ✗ | ✗ |
+| Cryptographic attack testing | ✓ | ✗ | ✗ | ✗ |
+| OAuth flow attack testing | ✓ | ✗ | ✗ | ✗ |
+| CORS misconfiguration testing | ✓ | ✗ | ✗ | ✗ |
+| Protocol version downgrade attacks | ✓ | ✗ | ✗ | ✗ |
+| Single compiled binary, no runtime dependencies | ✓ | ✗ | ✗ | ✗ |
+| No cloud account or API key required | ✓ | ✗ (Snyk token) | optional | optional |
+| Air-gap / offline compatible | ✓ | ✗ | ✗ | ✗ |
+| YAML rule packs (no Go required to add rules) | ✓ | ✗ | ✗ | ✗ |
+
+## Why the distinction matters
+
+Most agent security tooling takes an observational posture: connect, read what the server exposes,
+check spec compliance, and pattern-match for known strings. That catches a real class of problems.
+
+It leaves another class completely untested. Some vulnerabilities only surface when the system
+processes a crafted attack payload -- an abused OAuth registration flow, a push-notification
+callback pointed at an attacker-controlled host, a JWS signature stripped to `"alg":"none"`.
+Passive inspection cannot reach these because they require the server to act, not just exist.
+
+Batesian is built for that second class. It does not replace observational scanning. It covers the
+ground that observational scanning structurally cannot.

--- a/docs/rules-a2a.md
+++ b/docs/rules-a2a.md
@@ -1,0 +1,211 @@
+# A2A Attack Rules
+
+Batesian ships **18 rules** targeting the [Agent-to-Agent (A2A) protocol](https://google.github.io/A2A/).
+All rules are active -- they send crafted payloads and evaluate the server's response rather than
+passively observing what the endpoint exposes.
+
+| Rule ID | Attack | Severity | CWE |
+|---|---|:---:|---|
+| `a2a-push-ssrf-001` | [Push Notification SSRF](#a2a-push-ssrf-001) | High | CWE-918 |
+| `a2a-extcard-unauth-001` | [Extended Agent Card Unauthenticated Disclosure](#a2a-extcard-unauth-001) | High | CWE-862 |
+| `a2a-jws-algconf-001` | [JWS Algorithm Confusion / Signature Bypass](#a2a-jws-algconf-001) | Critical | CWE-327 |
+| `a2a-session-smuggle-001` | [Agent Role Injection / Session Smuggling](#a2a-session-smuggle-001) | High | CWE-384 |
+| `a2a-task-idor-001` | [Task IDOR via Unauthenticated tasks/get](#a2a-task-idor-001) | High | CWE-639 |
+| `a2a-context-orphan-001` | [Cross-Session Context Injection](#a2a-context-orphan-001) | High | CWE-200 |
+| `a2a-json-rpc-fuzz-001` | [JSON-RPC Mutation Fuzzing](#a2a-json-rpc-fuzz-001) | Medium | CWE-20 |
+| `a2a-peer-impersonation-001` | [Peer Agent Impersonation via Forged JWT](#a2a-peer-impersonation-001) | Critical | CWE-290 |
+| `a2a-delegation-escalation-001` | [Privilege Escalation via Delegation Metadata](#a2a-delegation-escalation-001) | High | CWE-269 |
+| `a2a-wellknown-hostinject-001` | [Agent Card Host Header Injection](#a2a-wellknown-hostinject-001) | High | CWE-601 |
+| `a2a-artifact-tamper-001` | [Task Artifact Tampering via Task ID Reuse](#a2a-artifact-tamper-001) | High | CWE-284 |
+| `a2a-skill-poison-001` | [Skill Description Injection](#a2a-skill-poison-001) | High | CWE-20 |
+| `a2a-url-mismatch-001` | [Agent Card URL Disagrees with Origin Domain](#a2a-url-mismatch-001) | Medium | CWE-345 |
+| `a2a-tls-downgrade-001` | [TLS Downgrade / Plain HTTP Acceptance](#a2a-tls-downgrade-001) | High | CWE-319 |
+| `a2a-capability-inflation-001` | [Undeclared Capability Acceptance](#a2a-capability-inflation-001) | High | CWE-284 |
+| `a2a-security-headers-001` | [Missing HTTP Security Headers](#a2a-security-headers-001) | Low | CWE-16 |
+| `a2a-registry-poison-001` | [Unauthenticated Agent Registry Poisoning](#a2a-registry-poison-001) | High | CWE-290 |
+| `a2a-circular-delegation-001` | [Circular Task Delegation](#a2a-circular-delegation-001) | Medium | CWE-674 |
+
+---
+
+## Rule Details
+
+### a2a-push-ssrf-001
+
+**Push Notification SSRF** | Severity: High | CWE-918
+
+Registers an attacker-controlled URL as a push notification callback, then submits a task. A
+vulnerable server makes an outbound HTTP request to the callback on task completion, confirming
+blind SSRF. This is a confirmed unfixed issue in the reference `a2a-python` SDK as of April 2026.
+
+---
+
+### a2a-extcard-unauth-001
+
+**Extended Agent Card Unauthenticated Disclosure** | Severity: High | CWE-862
+
+Fetches the extended agent card endpoints (`/extendedAgentCard`,
+`/agent/authenticatedExtendedCard`) without credentials. A vulnerable server returns privileged
+capability information -- OAuth scopes, internal skill metadata -- that should require
+authentication.
+
+---
+
+### a2a-jws-algconf-001
+
+**JWS Algorithm Confusion / Signature Bypass** | Severity: Critical | CWE-327
+
+Crafts JWS tokens with `"alg":"none"` and with an RS256-to-HS256 downgrade (signing an RS256
+key with HMAC-SHA256). A vulnerable server accepts unsigned or trivially forged tokens, allowing
+identity spoofing without knowledge of the private key.
+
+---
+
+### a2a-session-smuggle-001
+
+**Agent Role Injection / Session Smuggling** | Severity: High | CWE-384
+
+Sends a `tasks/send` request with `role: agent` in the message parts from an unauthenticated
+client. A vulnerable server accepts the elevated role claim, allowing covert instruction
+injection into a session under an agent identity.
+
+---
+
+### a2a-task-idor-001
+
+**Task IDOR via Unauthenticated tasks/get** | Severity: High | CWE-639
+
+Submits a task from one session, then attempts to retrieve it via `tasks/get` from a different,
+unauthenticated session using the known task ID. A vulnerable server returns the task state and
+artifacts to any caller who knows the ID.
+
+---
+
+### a2a-context-orphan-001
+
+**Cross-Session Context Injection via contextId Reuse** | Severity: High | CWE-200
+
+Creates a task with a known `contextId`, then injects a new task into the same context from a
+separate unauthenticated session. A vulnerable server processes the injected task within the
+original session's context, enabling cross-session data leakage or instruction smuggling.
+
+---
+
+### a2a-json-rpc-fuzz-001
+
+**JSON-RPC Mutation Fuzzing** | Severity: Medium | CWE-20
+
+Sends a series of malformed JSON-RPC payloads: missing `method`, wrong `id` type, extra unknown
+fields, deeply nested objects. A vulnerable server responds with 500 errors or stack traces
+rather than spec-compliant error responses.
+
+---
+
+### a2a-peer-impersonation-001
+
+**Peer Agent Impersonation via Forged JWT** | Severity: Critical | CWE-290
+
+Crafts a Bearer JWT claiming to be a trusted peer agent identity and submits it to the A2A
+endpoint without a valid signature. A vulnerable server accepts the request without verifying the
+token's signature or origin, allowing full peer identity spoofing.
+
+---
+
+### a2a-delegation-escalation-001
+
+**Privilege Escalation via Delegation Metadata Injection** | Severity: High | CWE-269
+
+Injects elevated permission metadata into the `configuration` block of a `tasks/send` request.
+A vulnerable server echoes back or acts on the injected delegation metadata without validating
+that the caller is authorized to claim those permissions.
+
+---
+
+### a2a-wellknown-hostinject-001
+
+**Agent Card Host Header Injection** | Severity: High | CWE-601
+
+Requests the agent card at `/.well-known/agent-card.json` with a crafted `Host`,
+`X-Forwarded-Host`, or `X-Original-Host` header. A vulnerable server reflects the attacker-
+controlled domain in the card's `url` field, enabling cache poisoning or open redirect via the
+agent directory.
+
+---
+
+### a2a-artifact-tamper-001
+
+**Task Artifact Tampering via Task ID Reuse** | Severity: High | CWE-284
+
+Submits a task, captures its ID after completion, then resubmits the same task ID with different
+content. A vulnerable server accepts the resubmission without enforcing immutability on completed
+task artifacts.
+
+---
+
+### a2a-skill-poison-001
+
+**Skill Description Injection** | Severity: High | CWE-20
+
+Retrieves the agent card and checks skill `description` and `examples` fields for prompt
+injection patterns -- phrases like "ignore previous instructions", system role overrides, and
+hidden Markdown directives. A vulnerable server serves agent cards that could poison downstream
+LLM agents consuming the metadata.
+
+---
+
+### a2a-url-mismatch-001
+
+**Agent Card URL Disagrees with Origin Domain** | Severity: Medium | CWE-345
+
+Compares the `url` field in the agent card against the domain the card was served from. A
+mismatch is an indicator of a misconfigured or spoofed deployment -- the card may have been
+copied or proxied without updating its identity fields.
+
+---
+
+### a2a-tls-downgrade-001
+
+**TLS Downgrade / Plain HTTP Acceptance** | Severity: High | CWE-319
+
+Sends the agent card fetch and JSON-RPC request over plain `http://`. A vulnerable server
+responds successfully over cleartext rather than redirecting to HTTPS, exposing all traffic to
+interception.
+
+---
+
+### a2a-capability-inflation-001
+
+**Undeclared Capability Acceptance** | Severity: High | CWE-284
+
+Sends a `tasks/send` request claiming elevated permissions that were never declared in the agent
+card's capability set. A vulnerable server processes the request without rejecting the
+undeclared capability claim.
+
+---
+
+### a2a-security-headers-001
+
+**Missing HTTP Security Headers** | Severity: Low | CWE-16
+
+Checks A2A endpoints for the presence of `Strict-Transport-Security`, `X-Content-Type-Options`,
+`X-Frame-Options`, `Content-Security-Policy`, `Referrer-Policy`, and `Permissions-Policy`. Absent
+headers are reported as indicators.
+
+---
+
+### a2a-registry-poison-001
+
+**Unauthenticated Agent Registry Poisoning** | Severity: High | CWE-290
+
+Sends an unauthenticated POST to common agent registry endpoints attempting to register or
+overwrite an agent card entry. A vulnerable registry accepts the registration without
+authentication, allowing an attacker to inject malicious agent identities.
+
+---
+
+### a2a-circular-delegation-001
+
+**Circular Task Delegation** | Severity: Medium | CWE-674
+
+Submits a `tasks/send` request that includes a 10-hop delegation chain in its metadata. A
+vulnerable server processes the request without enforcing a delegation depth limit, opening the
+door to unbounded recursive delegation loops.

--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -1,0 +1,190 @@
+# MCP Attack Rules
+
+Batesian ships **16 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
+All rules are active -- they send crafted payloads and evaluate the server's response rather than
+passively observing what the endpoint exposes.
+
+| Rule ID | Attack | Severity | CWE |
+|---|---|:---:|---|
+| `mcp-oauth-dcr-001` | [OAuth DCR Scope Escalation](#mcp-oauth-dcr-001) | High | CWE-284 |
+| `mcp-tool-poison-001` | [Tool Description Poisoning / Rug Pull](#mcp-tool-poison-001) | High | CWE-494 |
+| `mcp-resources-unauth-001` | [Unauthenticated Resource Read](#mcp-resources-unauth-001) | Critical | CWE-862 |
+| `mcp-sampling-inject-001` | [Sampling Capability Injection Surface](#mcp-sampling-inject-001) | High | CWE-20 |
+| `mcp-token-replay-001` | [OAuth Token Audience Validation Bypass](#mcp-token-replay-001) | High | CWE-294 |
+| `mcp-init-downgrade-001` | [Protocol Version Downgrade Auth Bypass](#mcp-init-downgrade-001) | High | CWE-757 |
+| `mcp-cors-wildcard-001` | [CORS Wildcard Origin with Credentials](#mcp-cors-wildcard-001) | High | CWE-942 |
+| `mcp-prompt-unauth-001` | [Prompt Templates Without Authentication](#mcp-prompt-unauth-001) | Medium | CWE-862 |
+| `mcp-context-flood-001` | [Context Window Flooding](#mcp-context-flood-001) | Medium | CWE-400 |
+| `mcp-tool-namespace-001` | [Tool Name Collision Across Sessions](#mcp-tool-namespace-001) | High | CWE-20 |
+| `mcp-sse-hijack-001` | [Unauthenticated SSE Stream](#mcp-sse-hijack-001) | High | CWE-862 |
+| `mcp-init-instructions-inject-001` | [Server Instructions Prompt Injection](#mcp-init-instructions-inject-001) | High | CWE-20 |
+| `mcp-ratelimit-absent-001` | [Missing Rate Limiting](#mcp-ratelimit-absent-001) | Medium | CWE-770 |
+| `mcp-homoglyph-tool-001` | [Tool Name Unicode Homoglyph Attack](#mcp-homoglyph-tool-001) | Medium | CWE-20 |
+| `mcp-injection-params-001` | [Tool Parameter Injection (SQL / Command / XSS)](#mcp-injection-params-001) | High | CWE-77 |
+| `mcp-security-headers-001` | [Missing HTTP Security Headers](#mcp-security-headers-001) | Low | CWE-16 |
+
+---
+
+## Rule Details
+
+### mcp-oauth-dcr-001
+
+**OAuth DCR Scope Escalation** | Severity: High | CWE-284
+
+Sends a dynamic client registration request to the OAuth server's DCR endpoint with an inflated
+scope set and a hijacked redirect URI. A vulnerable server grants the requested scopes without
+validating them against an allowlist, or accepts redirect URIs pointing to attacker-controlled
+domains.
+
+---
+
+### mcp-tool-poison-001
+
+**Tool Description Poisoning / Rug Pull Detection** | Severity: High | CWE-494
+
+Fetches the tool list and checks each tool `description` and `inputSchema` for prompt injection
+patterns (role overrides, ignore-previous-instructions payloads, hidden Markdown directives).
+Also calls `tools/list` twice across independent sessions and flags any description change as a
+rug pull indicator.
+
+---
+
+### mcp-resources-unauth-001
+
+**Unauthenticated Resource Read** | Severity: Critical | CWE-862
+
+Sends `resources/list` and `resources/read` without any credentials. A vulnerable server returns
+resource contents -- which may include secrets, configuration, or internal data -- without
+requiring authentication.
+
+---
+
+### mcp-sampling-inject-001
+
+**Sampling Capability Injection Surface** | Severity: High | CWE-20
+
+Inspects the server's `sampling` capability declaration and sends a crafted
+`sampling/createMessage` request embedding prompt injection payloads in the message content. A
+vulnerable server forwards the injected content to the downstream LLM without sanitization.
+
+---
+
+### mcp-token-replay-001
+
+**OAuth Token Audience Validation Bypass** | Severity: High | CWE-294
+
+Crafts a Bearer JWT with a mismatched `aud` claim (targeting a different service), a future
+`nbf`, and an expired `exp`, then submits it to the MCP endpoint. A vulnerable server accepts
+the token without validating audience, time bounds, or signature.
+
+---
+
+### mcp-init-downgrade-001
+
+**Protocol Version Downgrade Auth Bypass** | Severity: High | CWE-757
+
+Initializes the MCP session negotiating the older protocol version `2024-11-05` instead of the
+current spec version. A vulnerable server disables security controls (authentication requirements,
+scope enforcement) when operating in compatibility mode.
+
+---
+
+### mcp-cors-wildcard-001
+
+**CORS Wildcard Origin with Credentials** | Severity: High | CWE-942
+
+Sends a preflight request with `Origin: https://attacker.example.com` and checks whether the
+server returns both `Access-Control-Allow-Origin: *` and
+`Access-Control-Allow-Credentials: true`. This combination allows cross-origin requests with
+credentials from any domain, enabling CSRF against authenticated MCP endpoints.
+
+---
+
+### mcp-prompt-unauth-001
+
+**Prompt Templates Without Authentication** | Severity: Medium | CWE-862
+
+Sends `prompts/list` and `prompts/get` without credentials. A vulnerable server returns prompt
+template definitions -- which may contain sensitive system instructions or internal context --
+without requiring authentication.
+
+---
+
+### mcp-context-flood-001
+
+**Context Window Flooding** | Severity: Medium | CWE-400
+
+Sends `tools/call` requests with 1 MB and 5 MB argument payloads. A vulnerable server accepts
+the oversized payloads without a 413 or similar rejection, leaving it open to context window
+exhaustion attacks against downstream LLMs.
+
+---
+
+### mcp-tool-namespace-001
+
+**Tool Name Collision Across Sessions** | Severity: High | CWE-20
+
+Opens two independent MCP sessions and compares the tool lists returned by each. Any tool that
+appears in one session but not the other -- or with a different description -- is flagged as a
+namespace collision indicator and a rug pull precondition.
+
+---
+
+### mcp-sse-hijack-001
+
+**Unauthenticated SSE Stream** | Severity: High | CWE-862
+
+Connects to the MCP SSE endpoint (`/sse`, `/events`, `/stream`) without authentication. A
+vulnerable server establishes the SSE stream without requiring credentials, allowing an attacker
+to receive real-time server-push messages intended for authenticated clients.
+
+---
+
+### mcp-init-instructions-inject-001
+
+**Server Instructions Prompt Injection** | Severity: High | CWE-20
+
+Initializes an MCP session and inspects the `serverInfo.instructions` field returned by the
+server. A vulnerable server embeds prompt injection payloads in the instructions block, which
+are consumed by client-side LLMs during session setup.
+
+---
+
+### mcp-ratelimit-absent-001
+
+**Missing Rate Limiting** | Severity: Medium | CWE-770
+
+Sends 25 rapid `initialize` requests and checks whether any response carries HTTP 429 or a
+`Retry-After` header. A server with no rate limiting accepts the burst without throttling,
+leaving it open to resource exhaustion and credential-stuffing attacks.
+
+---
+
+### mcp-homoglyph-tool-001
+
+**Tool Name Unicode Homoglyph Attack** | Severity: Medium | CWE-20
+
+Sends a `tools/call` request substituting Unicode homoglyphs for characters in a legitimate
+tool name (e.g., Cyrillic "a" for Latin "a"). A vulnerable server routes the call to the
+matching tool without Unicode normalization, enabling tool invocation via visually identical but
+semantically distinct identifiers.
+
+---
+
+### mcp-injection-params-001
+
+**Tool Parameter Injection (SQL / Command / XSS)** | Severity: High | CWE-77
+
+Calls each advertised tool with SQL injection, shell command injection, and script tag payloads
+in string parameters. A vulnerable server reflects the injected content in its response (error
+messages, output fields), indicating the parameters are passed to a backend without sanitization.
+
+---
+
+### mcp-security-headers-001
+
+**Missing HTTP Security Headers** | Severity: Low | CWE-16
+
+Checks MCP endpoints for the presence of `Strict-Transport-Security`, `X-Content-Type-Options`,
+`X-Frame-Options`, `Content-Security-Policy`, `Referrer-Policy`, and `Permissions-Policy`. Absent
+headers are reported as indicators.


### PR DESCRIPTION
## Summary

- `docs/demo.tape`: vhs tape script for recording the demo GIF
- `docs/demo.gif`: Rendered demo GIF (generated via Docker `ghcr.io/charmbracelet/vhs`)
- `docs/rules-a2a.md`: Full A2A rule catalog with severity, CWE, and per-rule detail sections (18 rules)
- `docs/rules-mcp.md`: Full MCP rule catalog with severity, CWE, and per-rule detail sections (16 rules)
- `docs/comparison.md`: Comparison table moved out of README with supporting context
- `README.md`: Embed demo GIF, strip rule tables and comparison table, fix status section

## Why

The README was becoming a scrollable catalog. Every new rule makes it worse. The rule docs pages give each rule room to breathe (severity, CWE, what the exploit actually does) while keeping the README focused on the hook, quickstart, and links.

## Re-rendering the GIF

```bash
python testdata/a2a_vulnerable_server.py &
GOOS=linux GOARCH=amd64 go build -o bin/batesian ./cmd/batesian
docker run --rm -v "${PWD}:/vhs" ghcr.io/charmbracelet/vhs docs/demo.tape
```

## Type of change

- [x] Documentation / housekeeping
