### PR TITLE
chore: fix goreleaser config for v0.1.0 release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,7 +5,6 @@ project_name: batesian
 before:
   hooks:
     - go mod tidy
-    - go generate ./...
 
 builds:
   - id: batesian
@@ -20,7 +19,7 @@ builds:
     goarch:
       - amd64
       - arm64
-    # Exclude windows/arm64 — uncommon and adds release size without benefit.
+    # Exclude windows/arm64 -- uncommon target, adds release size without benefit.
     ignore:
       - goos: windows
         goarch: arm64
@@ -49,6 +48,7 @@ archives:
       - README.md
       - LICENSE
       - CONTRIBUTING.md
+      - CHANGELOG.md
 
 checksum:
   name_template: checksums.txt
@@ -92,16 +92,30 @@ release:
     ## Batesian {{.Version}}
 
     Adversarial red-team CLI for AI agent protocols (A2A and MCP).
+    34 bundled attack rules. Single binary. No runtime dependencies.
 
     ### Install
 
+    **Go:**
     ```bash
-    # Go
     go install github.com/calvin-mcdowell/batesian/cmd/batesian@{{.Tag}}
-
-    # Binary -- download from assets below, then:
-    chmod +x batesian && sudo mv batesian /usr/local/bin/
     ```
 
+    **Binary (Linux / macOS):**
+    ```bash
+    # Download the archive for your platform from the assets below, then:
+    tar -xzf batesian_*.tar.gz
+    chmod +x batesian
+    sudo mv batesian /usr/local/bin/
+    ```
+
+    **Binary (Windows):**
+    Download the `.zip` from assets below, extract, and place `batesian.exe` in a directory on your `PATH`.
+
   footer: |
+    ---
+    {{ if .PreviousTag -}}
     **Full changelog**: https://github.com/calvin-mcdowell/batesian/compare/{{.PreviousTag}}...{{.Tag}}
+    {{- else -}}
+    **Full changelog**: https://github.com/calvin-mcdowell/batesian/commits/{{.Tag}}
+    {{- end }}


### PR DESCRIPTION
## Summary

Fix `.goreleaser.yaml` ahead of the v0.1.0 release. Validated locally with `goreleaser release --snapshot --clean`.

## Changes

- Remove `go generate ./...` hook (no directives exist; adds failure risk for no benefit)
- Add `CHANGELOG.md` to archive file list (was missing from tarballs/zips)
- Fix release footer: `{{.PreviousTag}}` is empty for a first release -- now conditionally falls back to a commits URL instead of producing an invalid compare URL
- Expand release header install instructions with separate Linux/macOS and Windows steps

## Dry-run output (snapshot)

All 5 platform artifacts built and verified:

```
batesian_0.0.1-next_darwin_arm64.tar.gz   ✓
batesian_0.0.1-next_darwin_x86_64.tar.gz  ✓
batesian_0.0.1-next_linux_arm64.tar.gz    ✓
batesian_0.0.1-next_linux_x86_64.tar.gz   ✓
batesian_0.0.1-next_windows_x86_64.zip    ✓
checksums.txt                              ✓
```

Each archive contains: `batesian` (or `batesian.exe`), `README.md`, `LICENSE`, `CONTRIBUTING.md`, `CHANGELOG.md`.

Version injection confirmed: `batesian version 0.0.1-next (commit 89a68ac, built 2026-04-29T07:27:18Z)`

## After this merges

```bash
git checkout main && git pull
git tag -a v0.1.0 -m "v0.1.0"
git push origin v0.1.0
```

CI picks up the tag, runs build/lint/vuln, then goreleaser fires and publishes the release.

## Type of change

- [x] Tooling / release infrastructure
