### PR TITLE
fix: add tag trigger to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [main, dev]
+    tags: ['v*']
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary

The release job was never firing because the CI workflow only triggered on branch pushes, not tag pushes. The `if: startsWith(github.ref, 'refs/tags/v')` condition on the release job was correct but unreachable.

## Change

Add `tags: ['v*']` to the `on: push:` trigger so CI runs when a version tag is pushed.

## After merging

Re-push the v0.1.0 tag to trigger the release:

```bash
git tag -d v0.1.0
git push origin :refs/tags/v0.1.0
git tag -a v0.1.0 -m "v0.1.0"
git push origin v0.1.0
```

## Type of change

- [x] Bug fix (CI/CD)
