### PR TITLE
docs: simplify contribution policy (Apache 2.0 only)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,10 +17,6 @@
 - [ ] `golangci-lint run` passes (CI enforces this)
 - [ ] New rules include a vulnerable test server in `testdata/` and a unit test in `internal/attack/`
 
-## DCO
-
-- [ ] All commits are signed off (`git commit -s`)
-
 ## Related issues
 
 Closes #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,9 @@ are welcome, whether that is a new attack rule, a bug fix, or improved documenta
 - Batesian is an **active exploit engine**, not a passive scanner. Every rule
   must send crafted payloads to a live endpoint and evaluate real server responses.
   Heuristic-only rules belong in a different tool.
-- All contributions require a [Developer Certificate of Origin](https://developercertificate.org/)
-  sign-off: `git commit -s`. Enterprise contributor agreements will be evaluated as the project matures.
+- By submitting a pull request, you agree your contributions are licensed under the
+  same [Apache License 2.0](LICENSE) that covers this repository. No separate
+  contributor agreement is required.
 
 ---
 
@@ -198,7 +199,6 @@ PR description.
 - Use conventional commit prefixes: `feat:`, `fix:`, `chore:`, `docs:`, `test:`
 - One logical change per commit.
 - Reference the rule ID in the commit message when adding or modifying a rule.
-- Sign off with `git commit -s` for all commits intended for the public repo.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Go Version](https://img.shields.io/badge/go-1.25+-00ADD8.svg)](https://golang.org)
 [![Build](https://github.com/calvin-mcdowell/batesian/actions/workflows/ci.yml/badge.svg)](https://github.com/calvin-mcdowell/batesian/actions)
-[![DCO](https://img.shields.io/badge/contributor%20agreement-DCO-blue.svg)](https://developercertificate.org)
 
 Batesian is a red-team CLI that sends crafted adversarial payloads against A2A and MCP protocol
 implementations to surface vulnerabilities that observation-only tools never reach: SSRF via
@@ -125,8 +124,8 @@ in active development. Star or watch to follow progress.
 
 Contributions welcome, especially new attack rules. No engine knowledge required to write a rule.
 
-See [CONTRIBUTING.md](CONTRIBUTING.md). All contributors sign off commits with a DCO
-(`git commit -s`).
+See [CONTRIBUTING.md](CONTRIBUTING.md). Contributions are accepted under the same
+[Apache License 2.0](LICENSE) as the rest of the project.
 
 ---
 


### PR DESCRIPTION
- Remove DCO badge and mandatory `git commit -s` language.
- Remove the old enterprise CLA line from CONTRIBUTING.
- State that PRs are accepted under the same Apache 2.0 license as the repo.
- Drop the DCO checkbox from the PR template.
