### PR TITLE
docs: note probe does not support SARIF output

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ batesian scan --target https://mcp.example.com \
 batesian init
 ```
 
+Use `scan` for SARIF (for example GitHub Code Scanning uploads). The `probe` command does not support `--output sarif`; it is for quick reconnaissance with table or JSON output only.
+
 ---
 
 ## Rule packs


### PR DESCRIPTION
Clarifies in README that SARIF is only for `scan`, not `probe` (matches CLI behavior).

Rationale: probe is reconnaissance; SARIF ingestion is aligned with full scan findings.
