### PR TITLE
docs: point readers to batesian scan --help for full flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ batesian init
 
 Use `scan` for SARIF (for example GitHub Code Scanning uploads). The `probe` command does not support `--output sarif`; it is for quick reconnaissance with table or JSON output only.
 
+More options for `scan` (filters, config file, custom rules, OAuth, and more): run `batesian scan --help`.
+
 ---
 
 ## Rule packs


### PR DESCRIPTION
Adds a one-line pointer after Quickstart so readers know full `scan` flags live in `batesian scan --help` (review item #3, lightweight alternative to a flag table).
