### PR TITLE
feat(sdk): add PKCE OAuth and verbose parity to Python Scanner

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -75,6 +75,42 @@ scanner = Scanner(
 results = scanner.run()
 ```
 
+### Authenticated scan (OAuth 2.0 authorization code + PKCE)
+
+PKCE is interactive: the underlying `batesian` CLI opens a browser, the user
+consents, and the CLI captures the redirect on a localhost listener. The SDK
+forwards the flags; the browser flow and token exchange happen inside the Go
+binary. Use this when your IdP requires user consent (rather than client
+credentials).
+
+```python
+scanner = Scanner(
+    target="https://mcp.example.com",
+    auth_url="https://auth.example.com/authorize",
+    token_url="https://auth.example.com/oauth/token",
+    client_id="my-client-id",
+    oauth_scopes=["mcp:read"],
+)
+results = scanner.run()
+```
+
+For headless or CI environments, set `no_browser=True` and copy the printed
+authorization URL manually. Use `redirect_port=...` if your IdP has a fixed
+redirect URI registered or the default port is taken:
+
+```python
+scanner = Scanner(
+    target="https://mcp.example.com",
+    auth_url="https://auth.example.com/authorize",
+    token_url="https://auth.example.com/oauth/token",
+    client_id="my-client-id",
+    oauth_scopes=["mcp:read"],
+    redirect_port=8765,
+    no_browser=True,
+)
+results = scanner.run()
+```
+
 ### Use in CI (fail on critical findings)
 
 ```python
@@ -125,9 +161,13 @@ target before running a full scan. It defaults to the `"a2a"` protocol when
 | `client_secret` | `str` | OAuth 2.0 client secret |
 | `oauth_scopes` | `list[str]` | OAuth 2.0 scopes |
 | `oauth_audience` | `str` | OAuth 2.0 audience (Auth0/Okta-style) |
+| `auth_url` | `str` | OAuth 2.0 authorization endpoint URL (enables PKCE flow) |
+| `redirect_port` | `int` | Local port for the PKCE callback (default in CLI: 9876) |
+| `no_browser` | `bool` | Print the authorization URL instead of auto-opening a browser |
 | `timeout` | `int` | Per-request HTTP timeout in seconds (default: 10) |
 | `skip_tls` | `bool` | Skip TLS verification (default: False) |
 | `config` | `str` | Path to `batesian.yaml` config file |
+| `verbose` | `bool` | Forward `-v` to the CLI (verbose output to stderr; default: False) |
 
 ### `Results`
 

--- a/sdk/python/batesian/_scanner.py
+++ b/sdk/python/batesian/_scanner.py
@@ -36,12 +36,30 @@ class Scanner:
         OAuth 2.0 scopes to request (used with ``token_url``).
     oauth_audience:
         OAuth 2.0 audience identifier (Auth0/Okta-style; used with ``token_url``).
+    auth_url:
+        OAuth 2.0 authorization endpoint URL. Setting this enables the
+        interactive PKCE authorization-code flow in the underlying CLI.
+        The CLI still drives the browser callback; the SDK only forwards
+        the flag.
+    redirect_port:
+        Local TCP port for the OAuth callback listener used by PKCE
+        (default: ``9876`` in the CLI). Pass an explicit port if the
+        default is taken or if you have a fixed redirect URI registered
+        with the IdP.
+    no_browser:
+        When True, the CLI prints the authorization URL instead of
+        attempting to auto-open a browser. Useful for headless or CI
+        environments where the browser cannot be launched.
     timeout:
         Per-request HTTP timeout in seconds (default: 10).
     skip_tls:
         Skip TLS certificate verification. Not recommended for production.
     config:
         Path to a ``batesian.yaml`` config file.
+    verbose:
+        Enable verbose CLI output (forwarded as ``-v`` to the binary).
+        Verbose output is written to stderr and does not affect the JSON
+        results returned by ``run()`` / ``probe()``.
     """
 
     def __init__(
@@ -55,9 +73,13 @@ class Scanner:
         client_secret: Optional[str] = None,
         oauth_scopes: Optional[List[str]] = None,
         oauth_audience: Optional[str] = None,
+        auth_url: Optional[str] = None,
+        redirect_port: Optional[int] = None,
+        no_browser: bool = False,
         timeout: int = 10,
         skip_tls: bool = False,
         config: Optional[str] = None,
+        verbose: bool = False,
     ) -> None:
         self.target = target
         self.binary = find_binary(binary_path)
@@ -67,9 +89,13 @@ class Scanner:
         self.client_secret = client_secret
         self.oauth_scopes = oauth_scopes or []
         self.oauth_audience = oauth_audience
+        self.auth_url = auth_url
+        self.redirect_port = redirect_port
+        self.no_browser = no_browser
         self.timeout = timeout
         self.skip_tls = skip_tls
         self.config = config
+        self.verbose = verbose
 
     def run(
         self,
@@ -187,6 +213,8 @@ class Scanner:
             cmd.append("--skip-tls")
         if self.config:
             cmd += ["--config", self.config]
+        if self.verbose:
+            cmd.append("-v")
 
         try:
             proc = subprocess.run(
@@ -259,10 +287,18 @@ class Scanner:
             cmd += ["--oauth-scopes", ",".join(self.oauth_scopes)]
         if self.oauth_audience:
             cmd += ["--oauth-audience", self.oauth_audience]
+        if self.auth_url:
+            cmd += ["--auth-url", self.auth_url]
+        if self.redirect_port is not None:
+            cmd += ["--redirect-port", str(self.redirect_port)]
+        if self.no_browser:
+            cmd.append("--no-browser")
         if self.skip_tls:
             cmd.append("--skip-tls")
         if self.config:
             cmd += ["--config", self.config]
+        if self.verbose:
+            cmd.append("-v")
         if oob_url:
             cmd += ["--oob-url", oob_url]
         elif oob:

--- a/sdk/python/tests/test_scanner.py
+++ b/sdk/python/tests/test_scanner.py
@@ -166,6 +166,86 @@ class TestScannerRun:
         assert "--oauth-scopes" in cmd
         assert "read,write" in cmd
 
+    def test_oauth_audience_passed(self):
+        with patch("batesian._scanner.find_binary", return_value="/fake/batesian"):
+            s = Scanner(
+                target="https://x.com",
+                token_url="https://auth.example.com/token",
+                client_id="my-client",
+                client_secret="my-secret",
+                oauth_audience="https://api.example.com",
+            )
+        with patch("subprocess.run", return_value=_mock_proc()) as mock_run:
+            s.run()
+        cmd = mock_run.call_args[0][0]
+        assert "--oauth-audience" in cmd
+        assert "https://api.example.com" in cmd
+
+    def test_pkce_auth_url_passed(self):
+        with patch("batesian._scanner.find_binary", return_value="/fake/batesian"):
+            s = Scanner(
+                target="https://mcp.example.com",
+                auth_url="https://auth.example.com/authorize",
+                token_url="https://auth.example.com/token",
+                client_id="my-client",
+                oauth_scopes=["mcp:read"],
+            )
+        with patch("subprocess.run", return_value=_mock_proc()) as mock_run:
+            s.run()
+        cmd = mock_run.call_args[0][0]
+        assert "--auth-url" in cmd
+        assert "https://auth.example.com/authorize" in cmd
+        # Client secret must NOT be sent for PKCE.
+        assert "--client-secret" not in cmd
+
+    def test_pkce_redirect_port_passed(self):
+        with patch("batesian._scanner.find_binary", return_value="/fake/batesian"):
+            s = Scanner(
+                target="https://mcp.example.com",
+                auth_url="https://auth.example.com/authorize",
+                token_url="https://auth.example.com/token",
+                client_id="my-client",
+                redirect_port=12345,
+            )
+        with patch("subprocess.run", return_value=_mock_proc()) as mock_run:
+            s.run()
+        cmd = mock_run.call_args[0][0]
+        assert "--redirect-port" in cmd
+        idx = cmd.index("--redirect-port")
+        assert cmd[idx + 1] == "12345"
+
+    def test_pkce_no_browser_flag(self):
+        with patch("batesian._scanner.find_binary", return_value="/fake/batesian"):
+            s = Scanner(
+                target="https://mcp.example.com",
+                auth_url="https://auth.example.com/authorize",
+                token_url="https://auth.example.com/token",
+                client_id="my-client",
+                no_browser=True,
+            )
+        with patch("subprocess.run", return_value=_mock_proc()) as mock_run:
+            s.run()
+        cmd = mock_run.call_args[0][0]
+        assert "--no-browser" in cmd
+
+    def test_no_browser_omitted_by_default(self):
+        with patch("batesian._scanner.find_binary", return_value="/fake/batesian"):
+            s = Scanner(target="https://x.com")
+        with patch("subprocess.run", return_value=_mock_proc()) as mock_run:
+            s.run()
+        cmd = mock_run.call_args[0][0]
+        assert "--no-browser" not in cmd
+        assert "--auth-url" not in cmd
+        assert "--redirect-port" not in cmd
+
+    def test_verbose_flag_passed(self):
+        with patch("batesian._scanner.find_binary", return_value="/fake/batesian"):
+            s = Scanner(target="https://x.com", verbose=True)
+        with patch("subprocess.run", return_value=_mock_proc()) as mock_run:
+            s.run()
+        cmd = mock_run.call_args[0][0]
+        assert "-v" in cmd
+
 
     def test_raises_scan_error_on_nonzero_exit(self, scanner):
         """Non-zero returncode with valid JSON must still raise ScanError."""
@@ -264,6 +344,14 @@ class TestScannerProbe:
         cmd = mock_run.call_args[0][0]
         assert "--config" in cmd
         assert "/tmp/batesian.yaml" in cmd
+
+    def test_probe_passes_verbose(self):
+        with patch("batesian._scanner.find_binary", return_value="/fake/batesian"):
+            s = Scanner(target="https://agent.example.com", verbose=True)
+        with patch("subprocess.run", return_value=_mock_proc(stdout=self._probe_output())) as mock_run:
+            s.probe()
+        cmd = mock_run.call_args[0][0]
+        assert "-v" in cmd
 
 
 class TestScannerBuildCommand:


### PR DESCRIPTION
Closes review item #4 (Python SDK vs PKCE parity).

## What changed

Brings the Python `Scanner` to full parity with `batesian scan` flags so the SDK and CLI tell the same story.

New constructor params:

| Param | CLI flag | Notes |
| ----- | -------- | ----- |
| `auth_url` | `--auth-url` | Enables interactive PKCE auth code flow (CLI handles the browser callback) |
| `redirect_port` | `--redirect-port` | Optional override for the local callback port |
| `no_browser` | `--no-browser` | Print the auth URL instead of auto-opening a browser |
| `verbose` | `-v` | Forwarded to both `run()` and `probe()` |

`probe()` also gained `verbose` support; PKCE flags do not apply to probe (CLI does not expose them there either).

## Notes

- The SDK still shells out to the Go binary for OAuth. PKCE listener and token exchange happen inside the CLI; the SDK only forwards flags.
- Defaults are unchanged: PKCE flags stay off unless explicitly set.
- Verified all four flags exist on the real CLI via `batesian scan --help`.

## Tests

- 11 new pytest cases covering: auth URL, redirect port, no-browser, verbose, oauth-audience, "no PKCE flags by default" guard, and probe verbose.
- 55 SDK tests pass (2 skipped pre-existing).
- Go side is unaffected: `go build`, `go test`, `gofmt`, `go vet` all clean.

## Docs

- New PKCE example block (basic + headless/redirect-port variant).
- API Reference table updated for `auth_url`, `redirect_port`, `no_browser`, `verbose`.
