### PR TITLE
docs: complete testdata rule coverage map; link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ Contributions welcome, especially new attack rules. No engine knowledge required
 See [CONTRIBUTING.md](CONTRIBUTING.md). Contributions are accepted under the same
 [Apache License 2.0](LICENSE) as the rest of the project.
 
+For vulnerable Python test servers, ports, and how rules map to each server, see
+[`testdata/README.md`](testdata/README.md).
+
 ---
 
 ## References

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -32,6 +32,17 @@ pip install starlette uvicorn httpx mcp
 | `mcp_flood_namespace_sse_server.py` | 7781 | `mcp-context-flood-001`, `mcp-tool-namespace-001`, `mcp-sse-hijack-001` |
 | `mcp_injection_server.py` | 7783 | `mcp-init-instructions-inject-001`, `mcp-injection-params-001`, `mcp-ratelimit-absent-001`, `mcp-homoglyph-tool-001` |
 
+**Coverage.** All **18** bundled A2A rules (`a2a-*-001`) appear in the table
+above. Of the **16** bundled MCP rules (`mcp-*-001`), **13** are exercised by
+the Python servers listed here. The other **3** have no standalone Python
+server yet; they are validated only with `net/http/httptest` in Go unit tests:
+
+| Rule ID | Go tests |
+|---------|----------|
+| `mcp-security-headers-001` | `internal/attack/mcp/security_headers_test.go` |
+| `mcp-token-replay-001` | `internal/attack/mcp/token_replay_test.go` |
+| `mcp-sampling-inject-001` | `internal/attack/mcp/sampling_inject_test.go` |
+
 `mockserver.go` is a Go helper used by unit tests via `net/http/httptest`. It is
 not a standalone server.
 


### PR DESCRIPTION
Review item #7 + README discoverability.

## `testdata/README.md`

- States that all **18** A2A rules appear in the server registry table.
- States that **13 / 16** MCP rules are covered by the listed Python servers.
- Adds a small table for the **3** MCP rules that have **no** standalone Python server yet, with pointers to the Go `httptest` test files where they are validated (`mcp-security-headers-001`, `mcp-token-replay-001`, `mcp-sampling-inject-001`).

## Root `README.md`

- One-line link under **Contributing** to `testdata/README.md` so contributors find the map without bloating the main README.

No code changes.
