### PR TITLE
chore: launch polish (CI + README operator notes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [main, dev]
     tags: ['v*']
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   build:
@@ -75,11 +75,28 @@ jobs:
       - name: govulncheck
         run: go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
 
+  python-sdk:
+    name: Python SDK
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install SDK and test dependencies
+        run: python -m pip install -e "./sdk/python[dev]"
+
+      - name: pytest
+        run: python -m pytest sdk/python/tests -q
+
   release:
     name: Release (goreleaser)
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [build, lint, vuln]
+    needs: [build, lint, vuln, python-sdk]
     permissions:
       contents: write    # create GitHub releases and upload assets
       id-token: write    # cosign keyless signing via Sigstore OIDC

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ context injection, and more.
 
 > **Authorized use only.** Only run Batesian against systems you own or have explicit written
 > permission to test. Unauthorized use is illegal and unethical.
+>
+> **Secrets and TLS.** Prefer `BATESIAN_TOKEN` (or your secret manager) over pasting long-lived
+> credentials into shared terminals or CI logs. Use `--skip-tls` only when you must talk to a
+> target with intentionally broken TLS (for example a local lab with self-signed certificates).
 
 ---
 


### PR DESCRIPTION
## CI

- **`python-sdk` job:** installs the SDK with `pip install -e "./sdk/python[dev]"` and runs `pytest sdk/python/tests` on Ubuntu with Python **3.12**.
- **PR triggers:** `pull_request` now includes **`dev`** as well as **`main`**, so feature branches opened against `dev` get the same checks as `main`.
- **Releases:** `release` (GoReleaser) now **`needs: [build, lint, vuln, python-sdk]`** so a failing SDK test blocks a tagged release.

## README

- Adds a short second paragraph under the authorized-use callout: prefer `BATESIAN_TOKEN` / secret managers for credentials, and reserve `--skip-tls` for local labs with broken TLS.
