### PR TITLE
chore: rename Go module and repo URLs to calbebop

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,10 @@
 # Default owner for all files
-* @calvin-mcdowell
+* @calbebop
 
 # Attack rules and executors
-/rules/ @calvin-mcdowell
-/internal/attack/ @calvin-mcdowell
-/internal/engine/ @calvin-mcdowell
+/rules/ @calbebop
+/internal/attack/ @calbebop
+/internal/engine/ @calbebop
 
 # SDK
-/sdk/ @calvin-mcdowell
+/sdk/ @calbebop

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -105,7 +105,7 @@ changelog:
 
 release:
   github:
-    owner: calvin-mcdowell
+    owner: calbebop
     name: batesian
   draft: false
   prerelease: auto
@@ -120,7 +120,7 @@ release:
 
     **Go:**
     ```bash
-    go install github.com/calvin-mcdowell/batesian/cmd/batesian@{{.Tag}}
+    go install github.com/calbebop/batesian/cmd/batesian@{{.Tag}}
     ```
 
     **Binary (Linux / macOS):**
@@ -137,7 +137,7 @@ release:
   footer: |
     ---
     {{ if .PreviousTag -}}
-    **Full changelog**: https://github.com/calvin-mcdowell/batesian/compare/{{.PreviousTag}}...{{.Tag}}
+    **Full changelog**: https://github.com/calbebop/batesian/compare/{{.PreviousTag}}...{{.Tag}}
     {{- else -}}
-    **Full changelog**: https://github.com/calvin-mcdowell/batesian/commits/{{.Tag}}
+    **Full changelog**: https://github.com/calbebop/batesian/commits/{{.Tag}}
     {{- end }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,7 +222,7 @@ PR description.
 ## Getting Help
 
 For general questions, start a thread in the
-[Discussions](https://github.com/calvin-mcdowell/batesian/discussions) tab.
+[Discussions](https://github.com/calbebop/batesian/discussions) tab.
 For bug reports or new rule requests, open an issue using one of the existing
 templates. For security-sensitive matters, please follow the process in
 [`SECURITY.md`](SECURITY.md) rather than opening a public issue.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all build test lint vet fmt clean install run help
 
 BINARY := batesian
-PKG := github.com/calvin-mcdowell/batesian
+PKG := github.com/calbebop/batesian
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Go Version](https://img.shields.io/badge/go-1.25+-00ADD8.svg)](https://golang.org)
-[![Build](https://github.com/calvin-mcdowell/batesian/actions/workflows/ci.yml/badge.svg)](https://github.com/calvin-mcdowell/batesian/actions)
+[![Build](https://github.com/calbebop/batesian/actions/workflows/ci.yml/badge.svg)](https://github.com/calbebop/batesian/actions)
 
 Batesian is a red-team CLI that sends crafted adversarial payloads against A2A and MCP protocol
 implementations to surface vulnerabilities in OAuth flows, push-notification callbacks, JWS
@@ -52,7 +52,7 @@ warranting manual review). All rules ship with CWE references and remediation gu
 
 ```bash
 # Install (no API keys, no Python, no setup)
-go install github.com/calvin-mcdowell/batesian/cmd/batesian@latest
+go install github.com/calbebop/batesian/cmd/batesian@latest
 
 # Probe an A2A endpoint and map the attack surface
 batesian probe --target https://agent.example.com --protocol a2a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 If you discover a security vulnerability in Batesian itself, **please do not open a public GitHub issue.**
 
 Report it privately via GitHub's Security Advisory feature:
-1. Go to the [Security tab](https://github.com/calvin-mcdowell/batesian/security) of this repository
+1. Go to the [Security tab](https://github.com/calbebop/batesian/security) of this repository
 2. Click "Report a vulnerability"
 3. Fill in the details
 

--- a/cmd/batesian/main.go
+++ b/cmd/batesian/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/calvin-mcdowell/batesian/internal/cli"
+	"github.com/calbebop/batesian/internal/cli"
 )
 
 // Version variables are injected at build time by goreleaser via -ldflags.

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Batesian
-        run: go install github.com/calvin-mcdowell/batesian/cmd/batesian@latest
+        run: go install github.com/calbebop/batesian/cmd/batesian@latest
 
       - name: Run scan (SARIF output)
         run: |
@@ -134,7 +134,7 @@ batesian-scan:
   image: golang:1.25
   stage: test
   script:
-    - go install github.com/calvin-mcdowell/batesian/cmd/batesian@latest
+    - go install github.com/calbebop/batesian/cmd/batesian@latest
     - batesian scan --target $AGENT_TARGET_URL --output json > batesian-results.json
     - |
       jq -e '(.findings // []) | map(select(.severity == "critical")) | length == 0' \
@@ -152,7 +152,7 @@ batesian-scan:
 ```groovy
 stage('Agent Security Scan') {
     steps {
-        sh 'go install github.com/calvin-mcdowell/batesian/cmd/batesian@latest'
+        sh 'go install github.com/calbebop/batesian/cmd/batesian@latest'
         sh '''
             batesian scan \
               --target ${AGENT_TARGET_URL} \

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/calvin-mcdowell/batesian
+module github.com/calbebop/batesian
 
 go 1.25.9
 

--- a/internal/attack/a2a/artifact_tamper.go
+++ b/internal/attack/a2a/artifact_tamper.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // ArtifactTamperExecutor tests whether an A2A server allows a client to

--- a/internal/attack/a2a/artifact_tamper_test.go
+++ b/internal/attack/a2a/artifact_tamper_test.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	a2aattack "github.com/calvin-mcdowell/batesian/internal/attack/a2a"
+	"github.com/calbebop/batesian/internal/attack"
+	a2aattack "github.com/calbebop/batesian/internal/attack/a2a"
 )
 
 type taskStore struct {

--- a/internal/attack/a2a/capability_inflation.go
+++ b/internal/attack/a2a/capability_inflation.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // privilegeClaims are the configuration fields injected to simulate capability inflation.

--- a/internal/attack/a2a/capability_inflation_test.go
+++ b/internal/attack/a2a/capability_inflation_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	a2aattack "github.com/calvin-mcdowell/batesian/internal/attack/a2a"
+	"github.com/calbebop/batesian/internal/attack"
+	a2aattack "github.com/calbebop/batesian/internal/attack/a2a"
 )
 
 func TestCapabilityInflation_AcceptsElevatedConfig(t *testing.T) {

--- a/internal/attack/a2a/circular_delegation.go
+++ b/internal/attack/a2a/circular_delegation.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // CircularDelegationExecutor tests whether an A2A agent enforces delegation

--- a/internal/attack/a2a/circular_delegation_test.go
+++ b/internal/attack/a2a/circular_delegation_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	a2aattack "github.com/calvin-mcdowell/batesian/internal/attack/a2a"
+	"github.com/calbebop/batesian/internal/attack"
+	a2aattack "github.com/calbebop/batesian/internal/attack/a2a"
 )
 
 func a2aRPCBase(w http.ResponseWriter, req map[string]interface{}, handler func(http.ResponseWriter, map[string]interface{})) {

--- a/internal/attack/a2a/context_orphan.go
+++ b/internal/attack/a2a/context_orphan.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // ContextOrphanExecutor tests whether A2A enforces contextId ownership across

--- a/internal/attack/a2a/context_orphan_test.go
+++ b/internal/attack/a2a/context_orphan_test.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	a2aattack "github.com/calvin-mcdowell/batesian/internal/attack/a2a"
+	"github.com/calbebop/batesian/internal/attack"
+	a2aattack "github.com/calbebop/batesian/internal/attack/a2a"
 )
 
 // contextOrphanRC returns a minimal RuleContext for context orphan tests.

--- a/internal/attack/a2a/delegation_escalation.go
+++ b/internal/attack/a2a/delegation_escalation.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // DelegationEscalationExecutor tests whether an A2A worker agent accepts and

--- a/internal/attack/a2a/delegation_escalation_test.go
+++ b/internal/attack/a2a/delegation_escalation_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	a2aattack "github.com/calvin-mcdowell/batesian/internal/attack/a2a"
+	"github.com/calbebop/batesian/internal/attack"
+	a2aattack "github.com/calbebop/batesian/internal/attack/a2a"
 )
 
 func delegationEscalationRC() attack.RuleContext {

--- a/internal/attack/a2a/extcard.go
+++ b/internal/attack/a2a/extcard.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 const (

--- a/internal/attack/a2a/extcard_test.go
+++ b/internal/attack/a2a/extcard_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	"github.com/calvin-mcdowell/batesian/internal/attack/a2a"
+	"github.com/calbebop/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack/a2a"
 )
 
 // Shared helpers used by all test files in this package.

--- a/internal/attack/a2a/json_rpc_fuzz.go
+++ b/internal/attack/a2a/json_rpc_fuzz.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // stackTraceKeywords are substrings that indicate a leaked runtime stack trace

--- a/internal/attack/a2a/json_rpc_fuzz_test.go
+++ b/internal/attack/a2a/json_rpc_fuzz_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	a2aattack "github.com/calvin-mcdowell/batesian/internal/attack/a2a"
+	"github.com/calbebop/batesian/internal/attack"
+	a2aattack "github.com/calbebop/batesian/internal/attack/a2a"
 )
 
 func jsonRPCFuzzRC() attack.RuleContext {

--- a/internal/attack/a2a/jws_algconf.go
+++ b/internal/attack/a2a/jws_algconf.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // JWSAlgConfExecutor inspects A2A AgentCard JWS signatures for algorithm

--- a/internal/attack/a2a/jws_algconf_test.go
+++ b/internal/attack/a2a/jws_algconf_test.go
@@ -8,8 +8,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	"github.com/calvin-mcdowell/batesian/internal/attack/a2a"
+	"github.com/calbebop/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack/a2a"
 )
 
 // buildProtectedHeader base64url-encodes a JSON protected header for use in

--- a/internal/attack/a2a/peer_impersonation.go
+++ b/internal/attack/a2a/peer_impersonation.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // PeerImpersonationExecutor tests whether an A2A server validates the

--- a/internal/attack/a2a/peer_impersonation_test.go
+++ b/internal/attack/a2a/peer_impersonation_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	a2aattack "github.com/calvin-mcdowell/batesian/internal/attack/a2a"
+	"github.com/calbebop/batesian/internal/attack"
+	a2aattack "github.com/calbebop/batesian/internal/attack/a2a"
 )
 
 func peerImpersonationRC() attack.RuleContext {

--- a/internal/attack/a2a/push_ssrf.go
+++ b/internal/attack/a2a/push_ssrf.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	"github.com/calvin-mcdowell/batesian/internal/oob"
+	"github.com/calbebop/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/oob"
 )
 
 // PushSSRFExecutor tests whether an A2A server makes outbound HTTP requests to

--- a/internal/attack/a2a/push_ssrf_test.go
+++ b/internal/attack/a2a/push_ssrf_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack/a2a"
+	"github.com/calbebop/batesian/internal/attack/a2a"
 )
 
 // TestPushSSRFExecutor_MethodNotFound verifies that a server rejecting all A2A

--- a/internal/attack/a2a/registry_poison.go
+++ b/internal/attack/a2a/registry_poison.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // registryPaths are common paths where A2A agent registries expose registration endpoints.

--- a/internal/attack/a2a/registry_poison_test.go
+++ b/internal/attack/a2a/registry_poison_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	a2aattack "github.com/calvin-mcdowell/batesian/internal/attack/a2a"
+	"github.com/calbebop/batesian/internal/attack"
+	a2aattack "github.com/calbebop/batesian/internal/attack/a2a"
 )
 
 func TestRegistryPoison_AcceptsUnauthenticated(t *testing.T) {

--- a/internal/attack/a2a/security_headers.go
+++ b/internal/attack/a2a/security_headers.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // securityHeader describes one HTTP security header check.

--- a/internal/attack/a2a/security_headers_test.go
+++ b/internal/attack/a2a/security_headers_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	a2aattack "github.com/calvin-mcdowell/batesian/internal/attack/a2a"
+	"github.com/calbebop/batesian/internal/attack"
+	a2aattack "github.com/calbebop/batesian/internal/attack/a2a"
 )
 
 func agentCardHandler(w http.ResponseWriter, _ *http.Request) {

--- a/internal/attack/a2a/session_smuggle.go
+++ b/internal/attack/a2a/session_smuggle.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // SessionSmuggleExecutor tests A2A agent role injection and cross-context task access.

--- a/internal/attack/a2a/session_smuggle_test.go
+++ b/internal/attack/a2a/session_smuggle_test.go
@@ -8,8 +8,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	"github.com/calvin-mcdowell/batesian/internal/attack/a2a"
+	"github.com/calbebop/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack/a2a"
 )
 
 // TestSessionSmuggleExecutor_RoleInjectionAccepted verifies that when the

--- a/internal/attack/a2a/skill_poison.go
+++ b/internal/attack/a2a/skill_poison.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // skillPoisonPattern is a named regex with a heuristic score.

--- a/internal/attack/a2a/skill_poison_test.go
+++ b/internal/attack/a2a/skill_poison_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	a2aattack "github.com/calvin-mcdowell/batesian/internal/attack/a2a"
+	"github.com/calbebop/batesian/internal/attack"
+	a2aattack "github.com/calbebop/batesian/internal/attack/a2a"
 )
 
 func TestSkillPoison_DescriptionInjection(t *testing.T) {

--- a/internal/attack/a2a/task_idor.go
+++ b/internal/attack/a2a/task_idor.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // TaskIDORExecutor tests whether A2A task history is accessible by unauthenticated

--- a/internal/attack/a2a/task_idor_test.go
+++ b/internal/attack/a2a/task_idor_test.go
@@ -8,8 +8,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	"github.com/calvin-mcdowell/batesian/internal/attack/a2a"
+	"github.com/calbebop/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack/a2a"
 )
 
 // TestTaskIDORExecutor_IDORConfirmed verifies that when GetTask succeeds for a

--- a/internal/attack/a2a/tls_downgrade.go
+++ b/internal/attack/a2a/tls_downgrade.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // TLSDowngradeExecutor tests whether A2A endpoints accept plain HTTP connections

--- a/internal/attack/a2a/tls_downgrade_test.go
+++ b/internal/attack/a2a/tls_downgrade_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	a2aattack "github.com/calvin-mcdowell/batesian/internal/attack/a2a"
+	"github.com/calbebop/batesian/internal/attack"
+	a2aattack "github.com/calbebop/batesian/internal/attack/a2a"
 )
 
 func TestTLSDowngrade_AcceptsHTTP(t *testing.T) {

--- a/internal/attack/a2a/url_mismatch.go
+++ b/internal/attack/a2a/url_mismatch.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // URLMismatchExecutor checks whether the A2A Agent Card url field points to

--- a/internal/attack/a2a/url_mismatch_test.go
+++ b/internal/attack/a2a/url_mismatch_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	a2aattack "github.com/calvin-mcdowell/batesian/internal/attack/a2a"
+	"github.com/calbebop/batesian/internal/attack"
+	a2aattack "github.com/calbebop/batesian/internal/attack/a2a"
 )
 
 func TestURLMismatch_CardURLDifferentDomain(t *testing.T) {

--- a/internal/attack/a2a/wellknown_hostinject.go
+++ b/internal/attack/a2a/wellknown_hostinject.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // hostInjectCanary is the value injected into host-related headers.

--- a/internal/attack/a2a/wellknown_hostinject_test.go
+++ b/internal/attack/a2a/wellknown_hostinject_test.go
@@ -8,8 +8,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	a2aattack "github.com/calvin-mcdowell/batesian/internal/attack/a2a"
+	"github.com/calbebop/batesian/internal/attack"
+	a2aattack "github.com/calbebop/batesian/internal/attack/a2a"
 )
 
 func TestWellKnownHostInject_XForwardedHostReflected(t *testing.T) {

--- a/internal/attack/http.go
+++ b/internal/attack/http.go
@@ -155,7 +155,7 @@ func (c *HTTPClient) do(ctx context.Context, method, url string, body io.Reader,
 	if err != nil {
 		return nil, fmt.Errorf("building %s %s: %w", method, url, err)
 	}
-	req.Header.Set("User-Agent", "batesian/"+Version+" (https://github.com/calvin-mcdowell/batesian)")
+	req.Header.Set("User-Agent", "batesian/"+Version+" (https://github.com/calbebop/batesian)")
 	// MCP streamable HTTP requires text/event-stream in Accept; A2A servers ignore it.
 	req.Header.Set("Accept", "application/json, text/event-stream")
 	// Inject the bearer token unless the caller overrides Authorization explicitly.

--- a/internal/attack/http_test.go
+++ b/internal/attack/http_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 func TestNewUnauthHTTPClient_StripsToken(t *testing.T) {

--- a/internal/attack/mcp/context_flood.go
+++ b/internal/attack/mcp/context_flood.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // floodSizes defines the payload sizes to test, in bytes.

--- a/internal/attack/mcp/context_flood_test.go
+++ b/internal/attack/mcp/context_flood_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	mcpattack "github.com/calvin-mcdowell/batesian/internal/attack/mcp"
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
 )
 
 func TestContextFlood_AcceptsLargePayload(t *testing.T) {

--- a/internal/attack/mcp/cors_wildcard.go
+++ b/internal/attack/mcp/cors_wildcard.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // corsProbeOrigin is the attacker-controlled origin sent in CORS probes.

--- a/internal/attack/mcp/cors_wildcard_test.go
+++ b/internal/attack/mcp/cors_wildcard_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	mcpattack "github.com/calvin-mcdowell/batesian/internal/attack/mcp"
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
 )
 
 func TestCORSWildcard_ReflectsOriginWithCredentials(t *testing.T) {

--- a/internal/attack/mcp/homoglyph_tool.go
+++ b/internal/attack/mcp/homoglyph_tool.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // homoglyphMap maps ASCII characters to visually similar Unicode codepoints.

--- a/internal/attack/mcp/homoglyph_tool_test.go
+++ b/internal/attack/mcp/homoglyph_tool_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	mcpattack "github.com/calvin-mcdowell/batesian/internal/attack/mcp"
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
 )
 
 func homoglyphMCPBase(w http.ResponseWriter, req map[string]interface{}, toolCallHandler func(http.ResponseWriter, map[string]interface{})) {

--- a/internal/attack/mcp/init_downgrade.go
+++ b/internal/attack/mcp/init_downgrade.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // InitDowngradeExecutor probes whether an MCP server accepts the pre-auth

--- a/internal/attack/mcp/init_downgrade_test.go
+++ b/internal/attack/mcp/init_downgrade_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	mcpattack "github.com/calvin-mcdowell/batesian/internal/attack/mcp"
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
 )
 
 func TestInitDowngrade_VulnerableServer(t *testing.T) {

--- a/internal/attack/mcp/init_instructions_inject.go
+++ b/internal/attack/mcp/init_instructions_inject.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // InitInstructionsInjectExecutor reads the serverInfo.instructions field from a

--- a/internal/attack/mcp/init_instructions_inject_test.go
+++ b/internal/attack/mcp/init_instructions_inject_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	mcpattack "github.com/calvin-mcdowell/batesian/internal/attack/mcp"
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
 )
 
 func TestInitInstructionsInject_InjectionInInstructions(t *testing.T) {

--- a/internal/attack/mcp/injection_params.go
+++ b/internal/attack/mcp/injection_params.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // injectionPayload pairs a payload string with its attack class and severity.

--- a/internal/attack/mcp/injection_params_test.go
+++ b/internal/attack/mcp/injection_params_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	mcpattack "github.com/calvin-mcdowell/batesian/internal/attack/mcp"
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
 )
 
 func injectionMCPBase(_ *testing.T, toolCallHandler func(http.ResponseWriter, map[string]interface{})) *httptest.Server {

--- a/internal/attack/mcp/oauth_dcr.go
+++ b/internal/attack/mcp/oauth_dcr.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // OAuthDCRExecutor tests whether an MCP server's OAuth 2.1 dynamic client

--- a/internal/attack/mcp/oauth_dcr_test.go
+++ b/internal/attack/mcp/oauth_dcr_test.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	mcpattack "github.com/calvin-mcdowell/batesian/internal/attack/mcp"
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
 )
 
 func oauthRC() attack.RuleContext {

--- a/internal/attack/mcp/prompt_unauth.go
+++ b/internal/attack/mcp/prompt_unauth.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // PromptUnauthExecutor probes whether MCP prompt templates are accessible

--- a/internal/attack/mcp/prompt_unauth_test.go
+++ b/internal/attack/mcp/prompt_unauth_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	mcpattack "github.com/calvin-mcdowell/batesian/internal/attack/mcp"
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
 )
 
 func TestPromptUnauth_PromptsExposed(t *testing.T) {

--- a/internal/attack/mcp/ratelimit_absent.go
+++ b/internal/attack/mcp/ratelimit_absent.go
@@ -7,7 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 const (

--- a/internal/attack/mcp/ratelimit_absent_test.go
+++ b/internal/attack/mcp/ratelimit_absent_test.go
@@ -8,8 +8,8 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	mcpattack "github.com/calvin-mcdowell/batesian/internal/attack/mcp"
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
 )
 
 func mcpInitHandler(w http.ResponseWriter, _ *http.Request, req map[string]interface{}) {

--- a/internal/attack/mcp/resources_unauth.go
+++ b/internal/attack/mcp/resources_unauth.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // credentialPatterns detects secrets and credentials in resource content.

--- a/internal/attack/mcp/resources_unauth_test.go
+++ b/internal/attack/mcp/resources_unauth_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	mcpattack "github.com/calvin-mcdowell/batesian/internal/attack/mcp"
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
 )
 
 func resourcesRC() attack.RuleContext {

--- a/internal/attack/mcp/sampling_inject.go
+++ b/internal/attack/mcp/sampling_inject.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // SamplingInjectExecutor probes whether an MCP server advertises or triggers

--- a/internal/attack/mcp/sampling_inject_test.go
+++ b/internal/attack/mcp/sampling_inject_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	mcpattack "github.com/calvin-mcdowell/batesian/internal/attack/mcp"
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
 )
 
 func samplingRC() attack.RuleContext {

--- a/internal/attack/mcp/security_headers.go
+++ b/internal/attack/mcp/security_headers.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // mcpSecurityHeader describes one HTTP security header check for MCP endpoints.

--- a/internal/attack/mcp/security_headers_test.go
+++ b/internal/attack/mcp/security_headers_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	mcpattack "github.com/calvin-mcdowell/batesian/internal/attack/mcp"
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
 )
 
 func mcpInitResponse(w http.ResponseWriter, req map[string]interface{}) {

--- a/internal/attack/mcp/sse_hijack.go
+++ b/internal/attack/mcp/sse_hijack.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // ssePaths contains the paths where MCP servers commonly expose SSE streams.

--- a/internal/attack/mcp/sse_hijack_test.go
+++ b/internal/attack/mcp/sse_hijack_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	mcpattack "github.com/calvin-mcdowell/batesian/internal/attack/mcp"
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
 )
 
 func TestSSEHijack_OpenStreamWithoutAuth(t *testing.T) {

--- a/internal/attack/mcp/token_replay.go
+++ b/internal/attack/mcp/token_replay.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // TokenReplayExecutor tests whether an MCP server validates the `aud` claim on

--- a/internal/attack/mcp/token_replay_test.go
+++ b/internal/attack/mcp/token_replay_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	mcpattack "github.com/calvin-mcdowell/batesian/internal/attack/mcp"
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
 )
 
 func tokenReplayRC() attack.RuleContext {

--- a/internal/attack/mcp/tool_namespace.go
+++ b/internal/attack/mcp/tool_namespace.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // ToolNamespaceExecutor connects to an MCP server twice with independent

--- a/internal/attack/mcp/tool_namespace_test.go
+++ b/internal/attack/mcp/tool_namespace_test.go
@@ -8,8 +8,8 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	mcpattack "github.com/calvin-mcdowell/batesian/internal/attack/mcp"
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
 )
 
 func TestToolNamespace_StableTools(t *testing.T) {

--- a/internal/attack/mcp/tool_poison.go
+++ b/internal/attack/mcp/tool_poison.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 )
 
 // poisonPattern is a named regex pattern with a heuristic score and category.

--- a/internal/attack/mcp/tool_poison_test.go
+++ b/internal/attack/mcp/tool_poison_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	mcpattack "github.com/calvin-mcdowell/batesian/internal/attack/mcp"
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
 )
 
 func testRC() attack.RuleContext {

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/auth"
+	"github.com/calbebop/batesian/internal/auth"
 )
 
 func TestFetchClientCredentialsToken_Success(t *testing.T) {

--- a/internal/auth/pkce_browser_test.go
+++ b/internal/auth/pkce_browser_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/calvin-mcdowell/batesian/internal/auth"
+	"github.com/calbebop/batesian/internal/auth"
 )
 
 // performPKCEFlowForTest forwards to the test-only export that lets us pass a

--- a/internal/cli/init_config.go
+++ b/internal/cli/init_config.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/calvin-mcdowell/batesian/internal/config"
+	"github.com/calbebop/batesian/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/probe.go
+++ b/internal/cli/probe.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/calvin-mcdowell/batesian/internal/protocol/a2a"
-	"github.com/calvin-mcdowell/batesian/internal/protocol/mcp"
-	"github.com/calvin-mcdowell/batesian/internal/report"
+	"github.com/calbebop/batesian/internal/protocol/a2a"
+	"github.com/calbebop/batesian/internal/protocol/mcp"
+	"github.com/calbebop/batesian/internal/report"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"fmt"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack"
 	"github.com/spf13/cobra"
 )
 
@@ -25,7 +25,7 @@ Unlike passive scanners, Batesian actively probes: it impersonates malicious age
 abuses OAuth flows, fuzzes protocol messages, and finds vulnerabilities that read-only
 scanners never see.
 
-Documentation: https://github.com/calvin-mcdowell/batesian`,
+Documentation: https://github.com/calbebop/batesian`,
 }
 
 // Execute is the entrypoint called by main.

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -6,13 +6,13 @@ import (
 	"os"
 	"strings"
 
-	batesian "github.com/calvin-mcdowell/batesian"
-	attackpkg "github.com/calvin-mcdowell/batesian/internal/attack"
-	"github.com/calvin-mcdowell/batesian/internal/auth"
-	"github.com/calvin-mcdowell/batesian/internal/config"
-	"github.com/calvin-mcdowell/batesian/internal/engine"
-	"github.com/calvin-mcdowell/batesian/internal/report"
-	"github.com/calvin-mcdowell/batesian/internal/rules"
+	batesian "github.com/calbebop/batesian"
+	attackpkg "github.com/calbebop/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/auth"
+	"github.com/calbebop/batesian/internal/config"
+	"github.com/calbebop/batesian/internal/engine"
+	"github.com/calbebop/batesian/internal/report"
+	"github.com/calbebop/batesian/internal/rules"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/config"
+	"github.com/calbebop/batesian/internal/config"
 )
 
 func TestLoad_EmptyPath_NoFile(t *testing.T) {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -6,10 +6,10 @@ import (
 	"context"
 	"fmt"
 
-	attackpkg "github.com/calvin-mcdowell/batesian/internal/attack"
-	a2aattack "github.com/calvin-mcdowell/batesian/internal/attack/a2a"
-	mcpattack "github.com/calvin-mcdowell/batesian/internal/attack/mcp"
-	"github.com/calvin-mcdowell/batesian/internal/rules"
+	attackpkg "github.com/calbebop/batesian/internal/attack"
+	a2aattack "github.com/calbebop/batesian/internal/attack/a2a"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+	"github.com/calbebop/batesian/internal/rules"
 )
 
 // RunResult holds the findings and any error from executing a single rule.

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -3,10 +3,10 @@ package engine_test
 import (
 	"testing"
 
-	batesian "github.com/calvin-mcdowell/batesian"
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	"github.com/calvin-mcdowell/batesian/internal/engine"
-	"github.com/calvin-mcdowell/batesian/internal/rules"
+	batesian "github.com/calbebop/batesian"
+	"github.com/calbebop/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/engine"
+	"github.com/calbebop/batesian/internal/rules"
 )
 
 // TestAllBundledRulesResolve loads every YAML rule shipped with the binary and

--- a/internal/protocol/a2a/client.go
+++ b/internal/protocol/a2a/client.go
@@ -88,7 +88,7 @@ func NewClient(baseURL string, opts ...ClientOption) (*Client, error) {
 		},
 		baseURL: base,
 		headers: map[string]string{
-			"User-Agent": "batesian/dev (https://github.com/calvin-mcdowell/batesian)",
+			"User-Agent": "batesian/dev (https://github.com/calbebop/batesian)",
 			"Accept":     "application/json",
 		},
 	}

--- a/internal/protocol/mcp/client.go
+++ b/internal/protocol/mcp/client.go
@@ -359,7 +359,7 @@ func (c *Client) newRequest(ctx context.Context, ep string, body []byte) (*http.
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json, text/event-stream")
-	req.Header.Set("User-Agent", "batesian/dev (https://github.com/calvin-mcdowell/batesian)")
+	req.Header.Set("User-Agent", "batesian/dev (https://github.com/calbebop/batesian)")
 	if c.bearerToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.bearerToken)
 	}

--- a/internal/report/printer.go
+++ b/internal/report/printer.go
@@ -9,8 +9,8 @@ import (
 	"text/tabwriter"
 	"time"
 
-	attackpkg "github.com/calvin-mcdowell/batesian/internal/attack"
-	"github.com/calvin-mcdowell/batesian/internal/engine"
+	attackpkg "github.com/calbebop/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/engine"
 	"github.com/fatih/color"
 )
 
@@ -67,7 +67,7 @@ func New(w io.Writer, verbose bool) *Printer {
 func (p *Printer) Banner() {
 	fmt.Fprintln(p.w)
 	fmt.Fprintf(p.w, "  %s  adversarial red-team for AI agent protocols\n", Bold("batesian"))
-	fmt.Fprintf(p.w, "  %s\n", Dim("github.com/calvin-mcdowell/batesian"))
+	fmt.Fprintf(p.w, "  %s\n", Dim("github.com/calbebop/batesian"))
 	fmt.Fprintln(p.w)
 }
 

--- a/internal/report/printer_test.go
+++ b/internal/report/printer_test.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/calvin-mcdowell/batesian/internal/attack"
-	"github.com/calvin-mcdowell/batesian/internal/engine"
-	"github.com/calvin-mcdowell/batesian/internal/report"
-	"github.com/calvin-mcdowell/batesian/internal/rules"
+	"github.com/calbebop/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/engine"
+	"github.com/calbebop/batesian/internal/report"
+	"github.com/calbebop/batesian/internal/rules"
 )
 
 // TestPrintScanSummary_RiskIndicatorTag verifies that a finding with

--- a/internal/report/sarif.go
+++ b/internal/report/sarif.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"sort"
 
-	attackpkg "github.com/calvin-mcdowell/batesian/internal/attack"
-	"github.com/calvin-mcdowell/batesian/internal/engine"
+	attackpkg "github.com/calbebop/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/engine"
 )
 
 // SARIF v2.1.0 output for GitHub Security tab integration.
@@ -141,7 +141,7 @@ func buildSARIF(results []engine.RunResult, toolVersion string) sarifLog {
 					Driver: sarifDriver{
 						Name:           "batesian",
 						Version:        toolVersion,
-						InformationURI: "https://github.com/calvin-mcdowell/batesian",
+						InformationURI: "https://github.com/calbebop/batesian",
 						Rules:          rules,
 					},
 				},

--- a/rules/a2a/skill-poison-001.yaml
+++ b/rules/a2a/skill-poison-001.yaml
@@ -26,7 +26,7 @@ info:
   references:
     - https://google.github.io/A2A/specification/
     - https://owasp.org/www-project-top-10-for-large-language-model-applications/
-    - https://github.com/calvin-mcdowell/batesian/blob/main/rules/mcp/tool-poison-001.yaml
+    - https://github.com/calbebop/batesian/blob/main/rules/mcp/tool-poison-001.yaml
     - https://cwe.mitre.org/data/definitions/20.html
     - https://cwe.mitre.org/data/definitions/79.html
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,6 +1,6 @@
 # batesian Python SDK
 
-Python wrapper around the [Batesian](https://github.com/calvin-mcdowell/batesian) red-team CLI for AI agent protocols.
+Python wrapper around the [Batesian](https://github.com/calbebop/batesian) red-team CLI for AI agent protocols.
 
 ## Requirements
 
@@ -8,7 +8,7 @@ Python wrapper around the [Batesian](https://github.com/calvin-mcdowell/batesian
 - The `batesian` CLI binary installed and on `PATH`
 
 ```bash
-go install github.com/calvin-mcdowell/batesian/cmd/batesian@latest
+go install github.com/calbebop/batesian/cmd/batesian@latest
 ```
 
 ## Install
@@ -19,7 +19,7 @@ go install github.com/calvin-mcdowell/batesian/cmd/batesian@latest
 From Git:
 
 ```bash
-pip install "batesian @ git+https://github.com/calvin-mcdowell/batesian.git@main#subdirectory=sdk/python"
+pip install "batesian @ git+https://github.com/calbebop/batesian.git@main#subdirectory=sdk/python"
 ```
 
 Or from source (within this directory):

--- a/sdk/python/batesian/_binary.py
+++ b/sdk/python/batesian/_binary.py
@@ -50,7 +50,7 @@ def find_binary(binary_path: Optional[str] = None) -> str:
 
     raise BinaryNotFoundError(
         "batesian binary not found. Install with:\n"
-        "  go install github.com/calvin-mcdowell/batesian/cmd/batesian@latest\n"
+        "  go install github.com/calbebop/batesian/cmd/batesian@latest\n"
         "or set the BATESIAN_BIN environment variable to its path."
     )
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -30,9 +30,9 @@ dependencies = []
 dev = ["pytest>=7", "pytest-cov"]
 
 [project.urls]
-Homepage = "https://github.com/calvin-mcdowell/batesian"
-Repository = "https://github.com/calvin-mcdowell/batesian"
-Issues = "https://github.com/calvin-mcdowell/batesian/issues"
+Homepage = "https://github.com/calbebop/batesian"
+Repository = "https://github.com/calbebop/batesian"
+Issues = "https://github.com/calbebop/batesian/issues"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary

Renames the Go module and all repository references from `github.com/calvin-mcdowell/batesian` to `github.com/calbebop/batesian` after the GitHub account rename to **@calbebop**.

## What changed

- **`go.mod`** and every **import path** across the codebase
- **Documentation**: README, CONTRIBUTING, SECURITY, `docs/ci-cd.md`
- **SDK**: Python `pyproject.toml`, README, `_binary.py` install hint
- **Automation**: `.goreleaser.yaml` (`owner`), release notes URLs
- **`.github/CODEOWNERS`**: `@calbebop`
- **`Makefile`**: `PKG` variable
- **Metadata strings**: User-Agent, SARIF `InformationURI`, CLI help URL
- **`rules/a2a/skill-poison-001.yaml`** reference link

## Breaking change

Downstream Go projects must update imports:

```text
github.com/calvin-mcdowell/batesian/... → github.com/calbebop/batesian/...
```

GitHub HTTP redirects may still resolve the old module path for a time; **do not rely on that** long term.

## Post-merge (maintainer)

- Confirm **local `git remote`** uses `https://github.com/calbebop/batesian.git` (this branch was pushed with that URL).
- **pkg.go.dev** will pick up the new module path after the default branch contains this commit.

## Verification

- `go build ./...` and `go test ./...`
- `pytest sdk/python/tests`
