### PR TITLE
feat(mcp): mcp-oauth-audience-002 - audience-binding probes (closes #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ evidence and actionable remediation, not a one-time manual poke at the endpoint.
 
 ## What Batesian tests
 
-Batesian ships **18 A2A rules** and **16 MCP rules**, covering SSRF, OAuth abuse, JWS algorithm
+Batesian ships **18 A2A rules** and **17 MCP rules**, covering SSRF, OAuth abuse, JWS algorithm
 confusion, prompt injection, protocol downgrade, TLS enforcement, and more.
 
 - [A2A rule catalog](docs/rules-a2a.md) — Agent-to-Agent protocol attacks

--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -1,6 +1,6 @@
 # MCP Attack Rules
 
-Batesian ships **16 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
+Batesian ships **17 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
 All rules are active -- they send crafted payloads and evaluate the server's response rather than
 passively observing what the endpoint exposes.
 
@@ -11,6 +11,7 @@ passively observing what the endpoint exposes.
 | `mcp-resources-unauth-001` | [Unauthenticated Resource Read](#mcp-resources-unauth-001) | Critical | CWE-862 |
 | `mcp-sampling-inject-001` | [Sampling Capability Injection Surface](#mcp-sampling-inject-001) | High | CWE-20 |
 | `mcp-token-replay-001` | [OAuth Token Audience Validation Bypass](#mcp-token-replay-001) | High | CWE-294 |
+| `mcp-oauth-audience-002` | [OAuth Audience Matching Bug Probes](#mcp-oauth-audience-002) | High | CWE-863 |
 | `mcp-init-downgrade-001` | [Protocol Version Downgrade Auth Bypass](#mcp-init-downgrade-001) | High | CWE-757 |
 | `mcp-cors-wildcard-001` | [CORS Wildcard Origin with Credentials](#mcp-cors-wildcard-001) | High | CWE-942 |
 | `mcp-prompt-unauth-001` | [Prompt Templates Without Authentication](#mcp-prompt-unauth-001) | Medium | CWE-862 |
@@ -76,6 +77,26 @@ vulnerable server forwards the injected content to the downstream LLM without sa
 Crafts a Bearer JWT with a mismatched `aud` claim (targeting a different service), a future
 `nbf`, and an expired `exp`, then submits it to the MCP endpoint. A vulnerable server accepts
 the token without validating audience, time bounds, or signature.
+
+---
+
+### mcp-oauth-audience-002
+
+**OAuth Audience Matching Bug Probes** | Severity: High | CWE-863
+
+Probes whether the server's `aud` matching logic is robust to common implementation bugs
+(`Contains` / `HasPrefix` substring matching, case folding, URL canonicalization, array-shape
+branch skip) once the operator's expected audience value is known. Three forged HS256 JWT
+canaries are derived from the value supplied via `--audience-claim` (or auto-discovered via
+RFC 9728 protected resource metadata) and submitted to the first responsive MCP endpoint.
+Per-endpoint outcomes are coalesced into a single rule-level finding.
+
+**Honest scope.** Because probes are forged HS256 self-signed tokens, acceptance indicates a
+compound failure of signature validation **and** audience matching. Catching servers that
+validate signatures correctly but still mis-handle `aud` (the Parse CVE-2026-30863 /
+RFC 7523-bis class) requires a real validly-signed cross-resource token and is tracked as a
+follow-up. If `mcp-token-replay-001` is already firing on this target, fix those findings
+first; this rule's results will likely be subsumed.
 
 ---
 

--- a/internal/attack/executor.go
+++ b/internal/attack/executor.go
@@ -41,6 +41,13 @@ type Options struct {
 
 	// Verbose enables debug logging.
 	Verbose bool
+
+	// AudienceClaim is the operator-supplied expected JWT `aud` value for the
+	// target MCP resource server. Currently consumed only by mcp-oauth-audience-002,
+	// which derives canary-mismatch probes (substring/case/array-shape) from this
+	// value. When empty, that rule attempts RFC 9728 protected-resource-metadata
+	// auto-discovery and otherwise reports Inconclusive.
+	AudienceClaim string
 }
 
 // Confidence describes how certain the finding is.

--- a/internal/attack/mcp/oauth_audience.go
+++ b/internal/attack/mcp/oauth_audience.go
@@ -71,8 +71,8 @@ func (e *OAuthAudienceExecutor) Execute(ctx context.Context, target string, opts
 
 	expected := strings.TrimSpace(opts.AudienceClaim)
 	if expected == "" {
-		discovered, err := discoverExpectedAudience(ctx, client, vars.BaseURL)
-		if err != nil || discovered == "" {
+		discovered := discoverExpectedAudience(ctx, client, vars.BaseURL)
+		if discovered == "" {
 			// Precondition not met: no operator input and no discoverable
 			// resource metadata. Skip silently rather than emit a misleading
 			// finding. Operators who want this rule to run should pass
@@ -204,19 +204,16 @@ func hasUpper(s string) bool {
 //  2. GET that URL and read `resource`.
 //  3. Fall back to GET {base}/.well-known/oauth-protected-resource.
 //
-// Returns the resource URI on success, or an empty string with no error if
-// nothing usable was found (caller treats that as "skip").
-func discoverExpectedAudience(ctx context.Context, client *attack.HTTPClient, baseURL string) (string, error) {
+// Returns the resource URI on success, or an empty string if nothing
+// usable was found (caller treats that as "skip").
+func discoverExpectedAudience(ctx context.Context, client *attack.HTTPClient, baseURL string) string {
 	if metaURL := probeWWWAuthenticateResourceMetadata(ctx, client, baseURL); metaURL != "" {
 		if resource := fetchResourceFromMetadata(ctx, client, metaURL); resource != "" {
-			return resource, nil
+			return resource
 		}
 	}
 	wellKnown := baseURL + "/.well-known/oauth-protected-resource"
-	if resource := fetchResourceFromMetadata(ctx, client, wellKnown); resource != "" {
-		return resource, nil
-	}
-	return "", nil
+	return fetchResourceFromMetadata(ctx, client, wellKnown)
 }
 
 // probeWWWAuthenticateResourceMetadata sends an unauth initialize request to

--- a/internal/attack/mcp/oauth_audience.go
+++ b/internal/attack/mcp/oauth_audience.go
@@ -1,0 +1,492 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// OAuthAudienceExecutor implements rule mcp-oauth-audience-002.
+//
+// It complements mcp-token-replay-001 by probing whether the server's `aud`
+// matching logic is robust to common implementation bugs (substring match,
+// case canonicalization, array-shape branch skip) once the operator's expected
+// audience value is known. The expected value is taken from
+// opts.AudienceClaim or, when unset, RFC 9728 protected-resource-metadata.
+//
+// Because probes are forged HS256 self-signed tokens, acceptance indicates a
+// compound failure: signature validation AND audience matching both inadequate.
+// The "validly signed cross-resource token" class (Parse CVE-2026-30863) is
+// out of scope for v1 and is tracked as a follow-up issue.
+type OAuthAudienceExecutor struct {
+	rule attack.RuleContext
+}
+
+// NewOAuthAudienceExecutor creates an executor for mcp-oauth-audience.
+func NewOAuthAudienceExecutor(r attack.RuleContext) *OAuthAudienceExecutor {
+	return &OAuthAudienceExecutor{rule: r}
+}
+
+// canaryDomain is appended to the operator's expected audience to construct an
+// unmistakably wrong substring-trap value. Using `.invalid` (RFC 6761 §6.4)
+// guarantees the canary cannot resolve to a real resource.
+const canaryDomain = ".canary-batesian-mismatch.invalid"
+
+// audienceProbe describes one forged-JWT probe and its assertion semantics.
+type audienceProbe struct {
+	name        string
+	audClaim    interface{} // string or []string
+	titleSuffix string
+	descSuffix  string
+}
+
+// audVerdict is the per-probe classification used during coalescing.
+type audVerdict int
+
+const (
+	verdictRejected audVerdict = iota
+	verdictAcceptedVulnerable
+	verdictAcceptedAmbiguous
+	verdictInconclusive
+)
+
+// probeOutcome captures the per-probe result against a chosen endpoint.
+type probeOutcome struct {
+	probe    audienceProbe
+	verdict  audVerdict
+	status   int
+	bodySnip string
+	tokenHP  string // header.payload (signature redacted)
+}
+
+// Execute runs the audience-matching probes against the target.
+func (e *OAuthAudienceExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
+	vars := attack.NewVars(target, opts.OOBListenerURL)
+	client := attack.NewHTTPClient(opts, vars)
+
+	expected := strings.TrimSpace(opts.AudienceClaim)
+	if expected == "" {
+		discovered, err := discoverExpectedAudience(ctx, client, vars.BaseURL)
+		if err != nil || discovered == "" {
+			// Precondition not met: no operator input and no discoverable
+			// resource metadata. Skip silently rather than emit a misleading
+			// finding. Operators who want this rule to run should pass
+			// --audience-claim or expose RFC 9728 metadata on the target.
+			return nil, nil
+		}
+		expected = discovered
+	}
+
+	probes := buildProbes(expected)
+
+	endpoint, outcomes, err := runProbesAgainstEndpoint(ctx, client, vars.BaseURL, probes)
+	if err != nil {
+		return nil, err
+	}
+	if endpoint == "" {
+		// No candidate endpoint produced a usable response for any probe.
+		return nil, nil
+	}
+
+	finding := coalesceOutcomes(e.rule, endpoint, expected, outcomes)
+	if finding == nil {
+		return nil, nil
+	}
+	return []attack.Finding{*finding}, nil
+}
+
+// buildProbes constructs the v1 probe set from the operator's expected audience.
+//
+// The substring trap appends a clearly-different invalid-TLD canary so any
+// validator using strings.Contains/HasPrefix/HasSuffix accepts the wrapped
+// value. The case-canonicalization trap toggles case (or default-port presence
+// when the value is already lowercase). The array probe submits two canaries
+// in JSON-array form so validators that branch on the claim shape and skip
+// the array path are exposed.
+func buildProbes(expected string) []audienceProbe {
+	substringTrap := expected + canaryDomain
+
+	caseTrap := caseCanonicalizationVariant(expected)
+
+	arrayCanaries := []string{
+		"https://canary-batesian-a" + canaryDomain,
+		"https://canary-batesian-b" + canaryDomain,
+	}
+
+	return []audienceProbe{
+		{
+			name:        "aud-substring-trap",
+			audClaim:    substringTrap,
+			titleSuffix: "accepted JWT whose aud is a substring-wrapped mismatch",
+			descSuffix: "The server accepted a bearer token whose `aud` claim wraps the " +
+				"expected audience inside a clearly-different value (`" + substringTrap + "`). " +
+				"This is consistent with a validator that uses `Contains` / `HasPrefix` / " +
+				"`HasSuffix` instead of the strict StringOrURI compare required by RFC 7519 §4.1.3.",
+		},
+		{
+			name:        "aud-case-canonicalization-trap",
+			audClaim:    caseTrap,
+			titleSuffix: "accepted JWT whose aud differs only in case or default-port presence",
+			descSuffix: "The server accepted a bearer token whose `aud` claim is the expected " +
+				"audience with case folding or default-port canonicalization applied (`" + caseTrap + "`). " +
+				"RFC 7519 audience comparison must be exact and case-sensitive; canonicalization " +
+				"performed by the validator inflates the set of accepted values.",
+		},
+		{
+			name:        "aud-array-canary-only",
+			audClaim:    arrayCanaries,
+			titleSuffix: "accepted JWT whose aud is an array of mismatched canaries",
+			descSuffix: "The server accepted a bearer token whose `aud` claim is a JSON array " +
+				"containing only canaries that do not match the expected audience. This is " +
+				"consistent with a validator that inspects only string-form `aud` and treats " +
+				"array-shape claims as pre-validated.",
+		},
+	}
+}
+
+// caseCanonicalizationVariant returns a value that differs from `expected`
+// only in case or default-port presence. RFC 7519 requires strict comparison,
+// so a server that accepts the variant is mishandling the claim.
+func caseCanonicalizationVariant(expected string) string {
+	if hasUpper(expected) {
+		return strings.ToLower(expected)
+	}
+	// Already lowercase: toggle default-port presence to provoke
+	// canonicalizing URL parsers.
+	if strings.HasPrefix(expected, "https://") && !defaultPortRE.MatchString(expected) {
+		return injectDefaultPort(expected, "https", "443")
+	}
+	if strings.HasPrefix(expected, "http://") && !defaultPortRE.MatchString(expected) {
+		return injectDefaultPort(expected, "http", "80")
+	}
+	// Last resort: append uppercase suffix; still differs only by case.
+	return expected + "/X"
+}
+
+// defaultPortRE matches a host:port suffix anywhere in the URL authority.
+// We use it to detect whether a default port has already been embedded.
+var defaultPortRE = regexp.MustCompile(`://[^/]+:\d+`)
+
+// injectDefaultPort places :port immediately after the host, producing a
+// URL that canonicalizes back to `expected` per RFC 3986 §3.2.3 if a server
+// runs the value through a URL parser before comparing.
+func injectDefaultPort(expected, scheme, port string) string {
+	prefix := scheme + "://"
+	rest := strings.TrimPrefix(expected, prefix)
+	slash := strings.Index(rest, "/")
+	host := rest
+	tail := ""
+	if slash >= 0 {
+		host = rest[:slash]
+		tail = rest[slash:]
+	}
+	return prefix + host + ":" + port + tail
+}
+
+func hasUpper(s string) bool {
+	for _, r := range s {
+		if r >= 'A' && r <= 'Z' {
+			return true
+		}
+	}
+	return false
+}
+
+// discoverExpectedAudience implements the RFC 9728 fallback chain.
+//
+//  1. Probe POST {base}/mcp without auth and parse
+//     `WWW-Authenticate: ... resource_metadata="<url>"`.
+//  2. GET that URL and read `resource`.
+//  3. Fall back to GET {base}/.well-known/oauth-protected-resource.
+//
+// Returns the resource URI on success, or an empty string with no error if
+// nothing usable was found (caller treats that as "skip").
+func discoverExpectedAudience(ctx context.Context, client *attack.HTTPClient, baseURL string) (string, error) {
+	if metaURL := probeWWWAuthenticateResourceMetadata(ctx, client, baseURL); metaURL != "" {
+		if resource := fetchResourceFromMetadata(ctx, client, metaURL); resource != "" {
+			return resource, nil
+		}
+	}
+	wellKnown := baseURL + "/.well-known/oauth-protected-resource"
+	if resource := fetchResourceFromMetadata(ctx, client, wellKnown); resource != "" {
+		return resource, nil
+	}
+	return "", nil
+}
+
+// probeWWWAuthenticateResourceMetadata sends an unauth initialize request to
+// the first responsive endpoint candidate and returns the resource_metadata
+// URL advertised in the WWW-Authenticate response header, if any.
+func probeWWWAuthenticateResourceMetadata(ctx context.Context, client *attack.HTTPClient, baseURL string) string {
+	body := json.RawMessage(mcpInitBody)
+	for _, ep := range endpointCandidates(baseURL) {
+		// Use no Authorization header (override any opts.Token) so the server
+		// emits its 401 challenge with resource_metadata advertisement.
+		resp, err := client.POST(ctx, ep, map[string]string{
+			"Authorization": "",
+			"Content-Type":  "application/json",
+		}, body)
+		if err != nil {
+			continue
+		}
+		// 401 is the expected discovery response; some servers also emit the
+		// header on 403. We accept any response that carries the header.
+		if u := parseResourceMetadataURL(resp.Headers.Get("WWW-Authenticate")); u != "" {
+			return u
+		}
+	}
+	return ""
+}
+
+// resourceMetadataRE extracts the resource_metadata="..." parameter from a
+// WWW-Authenticate header per RFC 9728 §5.1.
+var resourceMetadataRE = regexp.MustCompile(`(?i)resource_metadata\s*=\s*"([^"]+)"`)
+
+func parseResourceMetadataURL(header string) string {
+	if header == "" {
+		return ""
+	}
+	m := resourceMetadataRE.FindStringSubmatch(header)
+	if len(m) != 2 {
+		return ""
+	}
+	parsed, err := url.Parse(m[1])
+	if err != nil || !parsed.IsAbs() {
+		return ""
+	}
+	return parsed.String()
+}
+
+// fetchResourceFromMetadata GETs the metadata document and returns the
+// `resource` field if present and absolute.
+func fetchResourceFromMetadata(ctx context.Context, client *attack.HTTPClient, metaURL string) string {
+	resp, err := client.GET(ctx, metaURL, nil)
+	if err != nil || !resp.IsSuccess() {
+		return ""
+	}
+	resource := resp.JSONField("resource")
+	if resource == "" {
+		return ""
+	}
+	parsed, err := url.Parse(resource)
+	if err != nil || !parsed.IsAbs() {
+		return ""
+	}
+	return parsed.String()
+}
+
+// runProbesAgainstEndpoint sends every probe to each candidate endpoint and
+// returns the outcomes for the first endpoint that produced any usable
+// response. Endpoints that error on every probe are skipped so a stray /api
+// path cannot hide a real /mcp finding.
+func runProbesAgainstEndpoint(ctx context.Context, client *attack.HTTPClient, baseURL string, probes []audienceProbe) (string, []probeOutcome, error) {
+	for _, ep := range endpointCandidates(baseURL) {
+		outcomes := make([]probeOutcome, 0, len(probes))
+		anyResponse := false
+		for _, p := range probes {
+			tok, err := forgeHS256JWT(map[string]interface{}{
+				"iss": "https://attacker.example.com",
+				"sub": "batesian-probe",
+				"aud": p.audClaim,
+				"iat": 1700000000,
+				"exp": 9999999999,
+			})
+			if err != nil {
+				return "", nil, fmt.Errorf("forging token for probe %s: %w", p.name, err)
+			}
+			resp, err := client.POST(ctx, ep, map[string]string{
+				"Authorization": "Bearer " + tok,
+				"Content-Type":  "application/json",
+			}, json.RawMessage(mcpInitBody))
+			if err != nil {
+				outcomes = append(outcomes, probeOutcome{
+					probe:   p,
+					verdict: verdictInconclusive,
+					tokenHP: jwtHeaderPayload(tok),
+				})
+				continue
+			}
+			anyResponse = true
+			outcomes = append(outcomes, probeOutcome{
+				probe:    p,
+				verdict:  classifyResponse(resp),
+				status:   resp.StatusCode,
+				bodySnip: snippetMCP(resp.Body),
+				tokenHP:  jwtHeaderPayload(tok),
+			})
+		}
+		if anyResponse {
+			return ep, outcomes, nil
+		}
+	}
+	return "", nil, nil
+}
+
+// classifyResponse maps an HTTP response into the verdict taxonomy.
+//
+// HTTP 200 + a JSON-RPC `result` envelope is the cleanest acceptance signal.
+// HTTP 200 + a JSON-RPC `error` envelope is treated as rejection because the
+// server is explicitly refusing the call. HTTP 200 with neither shape (empty
+// body, raw HTML, etc.) is ambiguous and downgrades the rule-level verdict.
+func classifyResponse(resp *attack.Response) audVerdict {
+	switch {
+	case resp.StatusCode == 200:
+		body := resp.BodyString()
+		// Strict precedence: an `error` envelope means the JSON-RPC layer
+		// rejected the call regardless of HTTP status.
+		if isJSONRPCError(body) {
+			return verdictRejected
+		}
+		if isJSONRPCResult(body) {
+			return verdictAcceptedVulnerable
+		}
+		return verdictAcceptedAmbiguous
+	case resp.StatusCode == 401, resp.StatusCode == 403:
+		return verdictRejected
+	case resp.StatusCode >= 400 && resp.StatusCode < 500:
+		return verdictRejected
+	default:
+		return verdictInconclusive
+	}
+}
+
+// isJSONRPCResult reports whether body parses as a JSON-RPC response with a
+// non-empty `result` field. We accept both the streamable-HTTP wrapped form
+// and a raw JSON envelope.
+func isJSONRPCResult(body string) bool {
+	if body == "" {
+		return false
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(body), &m); err != nil {
+		return false
+	}
+	if _, ok := m["result"]; ok {
+		return true
+	}
+	return false
+}
+
+func isJSONRPCError(body string) bool {
+	if body == "" {
+		return false
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(body), &m); err != nil {
+		return false
+	}
+	if _, ok := m["error"]; ok {
+		return true
+	}
+	return false
+}
+
+// coalesceOutcomes turns the per-probe results into a single rule-level
+// finding (or no finding) per §3 of the v2 design memo. Multiple accepted
+// probes do not inflate impact: they enrich the evidence of one finding.
+func coalesceOutcomes(rc attack.RuleContext, endpoint, expected string, outcomes []probeOutcome) *attack.Finding {
+	var (
+		vulnerable []probeOutcome
+		ambiguous  []probeOutcome
+	)
+	for _, o := range outcomes {
+		switch o.verdict {
+		case verdictAcceptedVulnerable:
+			vulnerable = append(vulnerable, o)
+		case verdictAcceptedAmbiguous:
+			ambiguous = append(ambiguous, o)
+		}
+	}
+
+	if len(vulnerable) == 0 && len(ambiguous) == 0 {
+		return nil
+	}
+
+	var (
+		confidence attack.Confidence
+		primary    probeOutcome
+	)
+	if len(vulnerable) > 0 {
+		confidence = attack.ConfirmedExploit
+		primary = vulnerable[0]
+	} else {
+		confidence = attack.RiskIndicator
+		primary = ambiguous[0]
+	}
+
+	return &attack.Finding{
+		RuleID:      rc.ID,
+		RuleName:    rc.Name,
+		Severity:    rc.Severity,
+		Confidence:  confidence,
+		Title:       fmt.Sprintf("MCP server %s", primary.probe.titleSuffix),
+		Description: primary.probe.descSuffix,
+		Evidence:    formatEvidence(endpoint, expected, vulnerable, ambiguous),
+		Remediation: rc.Remediation,
+		TargetURL:   endpoint,
+	}
+}
+
+// formatEvidence renders the per-probe evidence block. The operator-supplied
+// audience is summarized rather than echoed verbatim to avoid leaking
+// production identifiers into shared scan reports.
+func formatEvidence(endpoint, expected string, vulnerable, ambiguous []probeOutcome) string {
+	var sb strings.Builder
+	sb.WriteString("endpoint: ")
+	sb.WriteString(endpoint)
+	sb.WriteString("\nexpected aud (summary): ")
+	sb.WriteString(summarizeAudience(expected))
+	sb.WriteString("\n")
+
+	if len(vulnerable) > 0 {
+		sb.WriteString("\nAccepted probes (clear vulnerability signal):\n")
+		for _, o := range vulnerable {
+			writeOutcomeLine(&sb, o)
+		}
+	}
+	if len(ambiguous) > 0 {
+		sb.WriteString("\nAccepted probes (ambiguous response shape):\n")
+		for _, o := range ambiguous {
+			writeOutcomeLine(&sb, o)
+		}
+	}
+	return sb.String()
+}
+
+func writeOutcomeLine(sb *strings.Builder, o probeOutcome) {
+	fmt.Fprintf(sb, "  - %s: HTTP %d\n", o.probe.name, o.status)
+	fmt.Fprintf(sb, "      token header.payload: %s...[signature omitted]\n", o.tokenHP)
+	fmt.Fprintf(sb, "      response snippet: %s\n", oneLine(o.bodySnip))
+}
+
+// summarizeAudience returns a short, low-leakage description of the operator's
+// audience value: the scheme + first 12 characters of the host, plus the host
+// length. This is enough for an operator to recognize their own value while
+// keeping the full string out of report bodies.
+func summarizeAudience(expected string) string {
+	parsed, err := url.Parse(expected)
+	if err != nil || parsed.Host == "" {
+		// Fallback: redact most of the value, keep length.
+		return fmt.Sprintf("[len=%d, opaque]", len(expected))
+	}
+	host := parsed.Host
+	const headLen = 12
+	if len(host) <= headLen {
+		return fmt.Sprintf("%s://%s (host len=%d)", parsed.Scheme, host, len(host))
+	}
+	return fmt.Sprintf("%s://%s... (host len=%d)", parsed.Scheme, host[:headLen], len(host))
+}
+
+func oneLine(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	if len(s) > 200 {
+		s = s[:200] + "..."
+	}
+	return s
+}

--- a/internal/attack/mcp/oauth_audience_test.go
+++ b/internal/attack/mcp/oauth_audience_test.go
@@ -1,0 +1,300 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+const testExpectedAud = "https://api.acme.com/mcp"
+
+func oauthAudienceRC() attack.RuleContext {
+	return attack.RuleContext{
+		ID:          "mcp-oauth-audience-002",
+		Name:        "MCP OAuth Audience Matching Bug Probes",
+		Severity:    "high",
+		Remediation: "Compare aud strictly per RFC 7519 §4.1.3.",
+	}
+}
+
+func optsWithAudience(aud string) attack.Options {
+	return attack.Options{TimeoutSeconds: 5, AudienceClaim: aud}
+}
+
+// decodeJWTAud reads the `aud` claim from a Bearer token. Signature is
+// intentionally ignored: each test handler decides for itself whether the
+// audience-matching policy under test should accept the token.
+func decodeJWTAud(t *testing.T, authz string) interface{} {
+	t.Helper()
+	if !strings.HasPrefix(authz, "Bearer ") {
+		return nil
+	}
+	tok := strings.TrimPrefix(authz, "Bearer ")
+	parts := strings.Split(tok, ".")
+	if len(parts) < 2 {
+		return nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil
+	}
+	var claims map[string]interface{}
+	if err := json.Unmarshal(raw, &claims); err != nil {
+		return nil
+	}
+	return claims["aud"]
+}
+
+// initializeOK is the JSON-RPC envelope returned for accepted tokens.
+func initializeOK(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"result": map[string]interface{}{
+			"protocolVersion": "2024-11-05",
+			"serverInfo":      map[string]interface{}{"name": "ok", "version": "1.0"},
+		},
+	})
+}
+
+func challenge401(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusUnauthorized)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"error": "invalid_token"})
+}
+
+// audienceServer is a configurable httptest server whose /mcp handler applies
+// `acceptFn` to the decoded `aud` claim. Tests construct one with the
+// matching-bug variant they want to exercise.
+type audienceServer struct {
+	*httptest.Server
+}
+
+func newAudienceServer(t *testing.T, acceptFn func(aud interface{}) bool) audienceServer {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		aud := decodeJWTAud(t, r.Header.Get("Authorization"))
+		if acceptFn(aud) {
+			initializeOK(w)
+			return
+		}
+		challenge401(w)
+	})
+	return audienceServer{httptest.NewServer(mux)}
+}
+
+func TestOAuthAudience_VulnerableServer_SubstringMatch(t *testing.T) {
+	srv := newAudienceServer(t, func(aud interface{}) bool {
+		s, ok := aud.(string)
+		return ok && strings.Contains(s, testExpectedAud)
+	})
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC())
+	findings, err := exec.Execute(context.Background(), srv.URL, optsWithAudience(testExpectedAud))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 coalesced finding, got %d", len(findings))
+	}
+	if findings[0].Confidence != attack.ConfirmedExploit {
+		t.Errorf("expected ConfirmedExploit, got %q", findings[0].Confidence)
+	}
+	if !strings.Contains(findings[0].Evidence, "aud-substring-trap") {
+		t.Errorf("evidence missing substring-trap probe name: %s", findings[0].Evidence)
+	}
+}
+
+func TestOAuthAudience_VulnerableServer_CaseFold(t *testing.T) {
+	srv := newAudienceServer(t, func(aud interface{}) bool {
+		s, ok := aud.(string)
+		return ok && strings.EqualFold(s, testExpectedAud)
+	})
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC())
+	// Mixed-case expected value forces the executor to emit a lowercased trap
+	// probe, which is the variant a case-folding validator would accept.
+	mixedCase := "https://API.acme.com/mcp"
+	findings, err := exec.Execute(context.Background(), srv.URL, optsWithAudience(mixedCase))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 coalesced finding, got %d", len(findings))
+	}
+	if findings[0].Confidence != attack.ConfirmedExploit {
+		t.Errorf("expected ConfirmedExploit, got %q", findings[0].Confidence)
+	}
+	if !strings.Contains(findings[0].Evidence, "aud-case-canonicalization-trap") {
+		t.Errorf("evidence missing case-canonicalization probe name: %s", findings[0].Evidence)
+	}
+}
+
+func TestOAuthAudience_VulnerableServer_ArrayBranchSkip(t *testing.T) {
+	srv := newAudienceServer(t, func(aud interface{}) bool {
+		// Validator only handles string-form aud; array-form is treated as
+		// already validated and accepted.
+		if _, ok := aud.([]interface{}); ok {
+			return true
+		}
+		s, ok := aud.(string)
+		return ok && s == testExpectedAud
+	})
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC())
+	findings, err := exec.Execute(context.Background(), srv.URL, optsWithAudience(testExpectedAud))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 coalesced finding, got %d", len(findings))
+	}
+	if findings[0].Confidence != attack.ConfirmedExploit {
+		t.Errorf("expected ConfirmedExploit, got %q", findings[0].Confidence)
+	}
+	if !strings.Contains(findings[0].Evidence, "aud-array-canary-only") {
+		t.Errorf("evidence missing array-canary probe name: %s", findings[0].Evidence)
+	}
+}
+
+func TestOAuthAudience_SecureServer_AllRejected(t *testing.T) {
+	srv := newAudienceServer(t, func(aud interface{}) bool {
+		// Strict, case-sensitive, exact compare of string-form aud.
+		s, ok := aud.(string)
+		return ok && s == testExpectedAud
+	})
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC())
+	findings, err := exec.Execute(context.Background(), srv.URL, optsWithAudience(testExpectedAud))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings on secure server, got %d: %+v", len(findings), findings)
+	}
+}
+
+func TestOAuthAudience_PreconditionNotMet_NoAudience(t *testing.T) {
+	// Server responds 404 to everything: no advertisement, no metadata,
+	// no operator input. Rule must skip silently.
+	srv := httptest.NewServer(http.NotFoundHandler())
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC())
+	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings when audience cannot be resolved, got %d", len(findings))
+	}
+}
+
+func TestOAuthAudience_AutoDiscovery_FromResourceMetadata(t *testing.T) {
+	// Server advertises the resource via /.well-known/oauth-protected-resource
+	// and is vulnerable to substring matching. The executor should pick up
+	// the resource value via discovery (no AudienceClaim provided) and still
+	// produce a finding.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-protected-resource", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"resource":              testExpectedAud,
+			"authorization_servers": []string{"https://issuer.acme.com"},
+		})
+	})
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		aud := decodeJWTAud(t, r.Header.Get("Authorization"))
+		s, ok := aud.(string)
+		if ok && strings.Contains(s, testExpectedAud) {
+			initializeOK(w)
+			return
+		}
+		challenge401(w)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC())
+	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 coalesced finding via auto-discovery, got %d", len(findings))
+	}
+	if findings[0].Confidence != attack.ConfirmedExploit {
+		t.Errorf("expected ConfirmedExploit, got %q", findings[0].Confidence)
+	}
+}
+
+func TestOAuthAudience_Ambiguous200(t *testing.T) {
+	// Server returns 200 with no JSON-RPC envelope to every probe. This is
+	// signal-poor: cannot conclude exploit, but also cannot dismiss. The
+	// rule must downgrade to RiskIndicator.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC())
+	findings, err := exec.Execute(context.Background(), srv.URL, optsWithAudience(testExpectedAud))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 coalesced finding for ambiguous 200, got %d", len(findings))
+	}
+	if findings[0].Confidence != attack.RiskIndicator {
+		t.Errorf("expected RiskIndicator for ambiguous 200, got %q", findings[0].Confidence)
+	}
+}
+
+func TestOAuthAudience_EvidenceRedaction(t *testing.T) {
+	// The operator-supplied audience must not appear verbatim in finding
+	// evidence: only a length-tagged summary is allowed. This protects
+	// production identifiers when reports are shared across teams.
+	const sensitive = "https://internal-prod-mcp.acme-corp-confidential.example.com/mcp"
+	srv := newAudienceServer(t, func(aud interface{}) bool {
+		s, ok := aud.(string)
+		return ok && strings.Contains(s, sensitive)
+	})
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC())
+	findings, err := exec.Execute(context.Background(), srv.URL, optsWithAudience(sensitive))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if strings.Contains(findings[0].Evidence, sensitive) {
+		t.Errorf("evidence leaked operator audience %q: %s", sensitive, findings[0].Evidence)
+	}
+	// The evidence still needs to identify *this* run by length so the
+	// operator can correlate without the full string being present.
+	wantLenTag := fmt.Sprintf("host len=%d", len("internal-prod-mcp.acme-corp-confidential.example.com"))
+	if !strings.Contains(findings[0].Evidence, wantLenTag) {
+		t.Errorf("evidence missing length-tagged audience summary %q: %s", wantLenTag, findings[0].Evidence)
+	}
+}

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -66,6 +66,10 @@ func init() {
 	scanCmd.Flags().String("auth-url", "", "OAuth 2.0 authorization endpoint URL (enables PKCE flow)")
 	scanCmd.Flags().Int("redirect-port", 9876, "Local TCP port for the OAuth callback listener (PKCE flow)")
 	scanCmd.Flags().Bool("no-browser", false, "Do not auto-open the browser for PKCE consent (print URL only)")
+	// Rule-scoped flag for mcp-oauth-audience-002: expected JWT `aud` claim of the
+	// target MCP resource server. Distinct from --oauth-audience, which is a
+	// request-time parameter used during AS token acquisition (Auth0/Okta dialect).
+	scanCmd.Flags().String("audience-claim", "", "Expected JWT aud value for the target MCP server (used by mcp-oauth-audience-002)")
 	rootCmd.AddCommand(scanCmd)
 }
 
@@ -89,6 +93,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 	timeoutSecs, _ := cmd.Flags().GetInt("timeout")
 	skipTLS, _ := cmd.Flags().GetBool("skip-tls")
 	oobURL, _ := cmd.Flags().GetString("oob-url")
+	audienceClaim, _ := cmd.Flags().GetString("audience-claim")
 
 	if target == "" {
 		target = cfg.Target
@@ -122,6 +127,9 @@ func runScan(cmd *cobra.Command, args []string) error {
 	}
 	if oobURL == "" {
 		oobURL = cfg.OOBURL
+	}
+	if audienceClaim == "" {
+		audienceClaim = cfg.AudienceClaim
 	}
 
 	if target == "" {
@@ -202,6 +210,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 		TimeoutSeconds: timeoutSecs,
 		SkipTLS:        skipTLS,
 		Verbose:        verbose,
+		AudienceClaim:  audienceClaim,
 	}
 
 	eng := engine.New(opts)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,12 @@ type Config struct {
 
 	// OOBURL is the URL of a pre-configured external OOB listener.
 	OOBURL string `yaml:"oob_url"`
+
+	// AudienceClaim is the expected JWT `aud` value for the target MCP resource
+	// server. Used by mcp-oauth-audience-002 to construct canary-mismatch probes.
+	// When empty, batesian falls back to RFC 9728 protected-resource-metadata
+	// discovery before skipping the rule with Inconclusive.
+	AudienceClaim string `yaml:"audience_claim"`
 }
 
 // Load reads a config file from path. If path is empty, it searches
@@ -183,5 +189,12 @@ func Example() string {
 
 # External OOB listener URL (overrides oob: true).
 # oob_url: https://your-collaborator.net/token
+
+# Expected JWT 'aud' value for the target MCP resource server.
+# Consumed by mcp-oauth-audience-002 to derive canary-mismatch probes
+# (substring trap, case-canonicalization trap, array-shape trap).
+# When unset, batesian attempts RFC 9728 protected-resource-metadata
+# discovery; if that also fails, the rule reports Inconclusive.
+# audience_claim: https://api.example.com/mcp
 `
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -121,6 +121,8 @@ func resolveExecutor(r *rules.Rule) (attackpkg.Executor, error) {
 		return mcpattack.NewSamplingInjectExecutor(rc), nil
 	case "mcp-token-replay":
 		return mcpattack.NewTokenReplayExecutor(rc), nil
+	case "mcp-oauth-audience":
+		return mcpattack.NewOAuthAudienceExecutor(rc), nil
 	case "a2a-json-rpc-fuzz":
 		return a2aattack.NewJSONRPCFuzzExecutor(rc), nil
 	case "a2a-wellknown-hostinject":

--- a/rules/mcp/oauth-audience-002.yaml
+++ b/rules/mcp/oauth-audience-002.yaml
@@ -1,0 +1,131 @@
+id: mcp-oauth-audience-002
+info:
+  name: MCP OAuth Audience Matching Bug Probes
+  author: batesian
+  severity: high
+  description: |
+    Tests whether an MCP server's `aud` (audience) validation logic is robust to
+    common matching bugs that allow a clearly-mismatched token to be accepted.
+    This complements `mcp-token-replay-001`, which tests whether the server
+    enforces audience validation at all; this rule tests whether the matching
+    logic itself is correctly implemented when the operator's real audience
+    value is known or discoverable.
+
+    Three probes are constructed from the operator-supplied (or RFC 9728
+    auto-discovered) expected audience and submitted as forged HS256 JWTs:
+
+    - `aud-substring-trap`   — wraps the expected value in a clearly-different
+      string (e.g., `<expected>.canary-batesian-mismatch.invalid`). Catches
+      validators that use `strings.Contains` / `HasPrefix` / `HasSuffix`.
+    - `aud-case-canonicalization-trap` — submits the expected value lowercased
+      (or with default-port toggled when already lowercase). Catches validators
+      that lowercase or URL-canonicalize before comparing, contrary to RFC 7519's
+      strict StringOrURI compare semantics.
+    - `aud-array-canary-only` — submits `aud` as a JSON array of mismatched
+      canaries. Catches validators that only inspect string-form `aud` and skip
+      the array-shape branch entirely.
+
+    Honest scope: because probes are forged HS256 self-signed tokens, acceptance
+    indicates that **both** signature validation and audience matching are
+    inadequate. Catching servers that validate signatures correctly but still
+    mishandle `aud` matching (the Parse CVE-2026-30863 / RFC 7523-bis class)
+    requires a real validly-signed token from the same issuer with a different
+    audience and is tracked as a follow-up issue. If `mcp-token-replay-001` is
+    already firing on this target, fix those findings first; this rule's
+    results will likely be subsumed.
+
+    Audience input precedence:
+      1. `--audience-claim` flag / `audience_claim` config field
+      2. RFC 9728 auto-discovery via `WWW-Authenticate: resource_metadata=...`
+         on an unauth probe, then `/.well-known/oauth-protected-resource`
+      3. Otherwise the rule reports Inconclusive and skips.
+
+  references:
+    - https://www.rfc-editor.org/rfc/rfc7519
+    - https://www.rfc-editor.org/rfc/rfc9068
+    - https://www.rfc-editor.org/rfc/rfc8707
+    - https://www.rfc-editor.org/rfc/rfc9728
+    - https://www.rfc-editor.org/rfc/rfc9700
+    - https://modelcontextprotocol.io/docs/concepts/authorization
+    - https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1581
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-30863
+    - https://eprint.iacr.org/2025/629
+    - https://cwe.mitre.org/data/definitions/863.html
+
+  tags:
+    - mcp
+    - oauth
+    - jwt
+    - audience-validation
+    - rfc7519
+    - rfc9068
+    - rfc9728
+    - cwe-863
+
+attack:
+  protocol: mcp
+  type: mcp-oauth-audience
+
+  discover:
+    well_known_endpoints:
+      - "{{BaseURL}}/.well-known/oauth-protected-resource"
+      - "{{BaseURL}}/.well-known/oauth-authorization-server"
+    extract:
+      - resource
+
+  probes:
+    - name: aud-substring-trap
+      description: "Forged JWT whose aud wraps the expected value in a mismatched substring"
+      endpoint: "{{BaseURL}}/mcp"
+      method: POST
+      headers:
+        Authorization: "Bearer {{SubstringTrapToken}}"
+        Content-Type: "application/json"
+
+    - name: aud-case-canonicalization-trap
+      description: "Forged JWT whose aud is the expected value with case or default-port toggled"
+      endpoint: "{{BaseURL}}/mcp"
+      method: POST
+      headers:
+        Authorization: "Bearer {{CaseTrapToken}}"
+        Content-Type: "application/json"
+
+    - name: aud-array-canary-only
+      description: "Forged JWT whose aud is a JSON array of mismatched canaries"
+      endpoint: "{{BaseURL}}/mcp"
+      method: POST
+      headers:
+        Authorization: "Bearer {{ArrayCanaryToken}}"
+        Content-Type: "application/json"
+
+assert:
+  - condition: substring_trap_accepted
+    description: "Server accepted a JWT whose aud is a substring-wrapped mismatch of the expected audience"
+    severity: high
+
+  - condition: case_canonicalization_trap_accepted
+    description: "Server accepted a JWT whose aud differs from the expected audience only in case or default-port presence"
+    severity: high
+
+  - condition: array_canary_accepted
+    description: "Server accepted a JWT whose aud is a JSON array containing only mismatched canaries"
+    severity: high
+
+remediation: |
+  1. Compare the JWT `aud` claim to the resource server's identifier using a
+     strict, exact string compare per RFC 7519 §4.1.3 — no `Contains`,
+     `HasPrefix`, `HasSuffix`, lowercase, URL canonicalization, or other
+     normalization on either side of the comparison.
+  2. Handle both string-form and array-form `aud` claims: when `aud` is an
+     array, validation MUST require that the array contains the resource
+     server's identifier and reject otherwise. Do not branch out of the
+     validation path when the claim shape is an array.
+  3. Issue tokens audience-bound at the authorization server using RFC 8707
+     Resource Indicators so the resource server's expected `aud` value is the
+     concrete URI of the protected resource rather than a coarse API ID.
+  4. Reject JWTs where `alg` is "none" or any symmetric algorithm when the
+     server expects asymmetric tokens; use a vetted JWT library that enforces
+     algorithm allowlists by default.
+  5. Advertise a stable resource identifier via RFC 9728 protected resource
+     metadata (`/.well-known/oauth-protected-resource`) so clients and
+     scanners use the same audience value the server validates against.

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -31,11 +31,13 @@ pip install starlette uvicorn httpx mcp
 | `mcp_new_rules_server.py` | 3100 | `mcp-init-downgrade-001`, `mcp-cors-wildcard-001`, `mcp-prompt-unauth-001` |
 | `mcp_flood_namespace_sse_server.py` | 7781 | `mcp-context-flood-001`, `mcp-tool-namespace-001`, `mcp-sse-hijack-001` |
 | `mcp_injection_server.py` | 7783 | `mcp-init-instructions-inject-001`, `mcp-injection-params-001`, `mcp-ratelimit-absent-001`, `mcp-homoglyph-tool-001` |
+| `mcp_oauth_audience_server.py` | 7785 | `mcp-oauth-audience-002` |
 
 **Coverage.** All **18** bundled A2A rules (`a2a-*-001`) appear in the table
-above. Of the **16** bundled MCP rules (`mcp-*-001`), **13** are exercised by
-the Python servers listed here. The other **3** have no standalone Python
-server yet; they are validated only with `net/http/httptest` in Go unit tests:
+above. Of the **17** bundled MCP rules (16 `mcp-*-001` plus
+`mcp-oauth-audience-002`), **14** are exercised by the Python servers listed
+here. The other **3** have no standalone Python server yet; they are validated
+only with `net/http/httptest` in Go unit tests:
 
 | Rule ID | Go tests |
 |---------|----------|

--- a/testdata/mcp_oauth_audience_server.py
+++ b/testdata/mcp_oauth_audience_server.py
@@ -1,0 +1,162 @@
+"""
+Batesian MCP validation target: OAuth audience matching bug probes
+(mcp-oauth-audience-002).
+
+Exposes four MCP-shaped endpoints that share the same forged-token detection
+logic, each demonstrating a different aud-validation bug class plus a strict
+control. All endpoints accept POST /mcp with a Bearer JWT and an MCP
+initialize body, mirroring the wire shape the Go executor expects.
+
+Endpoint matrix:
+
+  /vulnerable-substring/mcp   --> aud check uses substring match
+                                  (`expected in token_aud`).
+  /vulnerable-casefold/mcp    --> aud check lowercases both sides before
+                                  comparing.
+  /vulnerable-array-skip/mcp  --> aud check inspects only string-form aud and
+                                  treats array-shape as already-validated.
+  /secure/mcp                 --> aud check is strict, exact, case-sensitive
+                                  per RFC 7519 §4.1.3.
+
+The expected audience advertised by every endpoint is
+`https://api.example.com/mcp` (also exposed at
+`/.well-known/oauth-protected-resource`) so a Batesian scan run with
+`--audience-claim https://api.example.com/mcp` (or no claim, relying on RFC
+9728 auto-discovery) exercises every probe.
+
+Run:
+    python testdata/mcp_oauth_audience_server.py
+
+Then scan with the rule:
+    batesian scan --target http://127.0.0.1:7785 \
+                  --rule-ids mcp-oauth-audience-002 \
+                  --audience-claim https://api.example.com/mcp -v
+
+This server is intentionally misconfigured. Do not run on a public network.
+"""
+import base64
+import json
+import uvicorn
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route
+
+EXPECTED_AUD = "https://api.example.com/mcp"
+PORT = 7785
+
+
+def _decode_jwt_payload(authorization: str | None) -> dict | None:
+    """Best-effort JWT payload decode. The deliberately vulnerable handlers
+    below skip signature verification on purpose; they exist to exercise the
+    audience-matching logic, not the signing path."""
+    if not authorization or not authorization.startswith("Bearer "):
+        return None
+    token = authorization.removeprefix("Bearer ")
+    parts = token.split(".")
+    if len(parts) < 2:
+        return None
+    try:
+        padded = parts[1] + "=" * (-len(parts[1]) % 4)
+        return json.loads(base64.urlsafe_b64decode(padded))
+    except Exception:
+        return None
+
+
+def _ok_initialize() -> JSONResponse:
+    return JSONResponse({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+            "protocolVersion": "2024-11-05",
+            "serverInfo": {
+                "name": "batesian-audience-testdata",
+                "version": "1.0",
+            },
+        },
+    })
+
+
+def _challenge() -> Response:
+    return Response(
+        content=json.dumps({"error": "invalid_token"}),
+        status_code=401,
+        media_type="application/json",
+        headers={
+            "WWW-Authenticate": (
+                'Bearer error="invalid_token", '
+                f'resource_metadata="http://127.0.0.1:{PORT}/.well-known/oauth-protected-resource"'
+            ),
+        },
+    )
+
+
+async def resource_metadata(request: Request) -> JSONResponse:
+    return JSONResponse({
+        "resource": EXPECTED_AUD,
+        "authorization_servers": [f"http://127.0.0.1:{PORT}"],
+    })
+
+
+async def vulnerable_substring(request: Request) -> Response:
+    payload = _decode_jwt_payload(request.headers.get("authorization"))
+    if not payload:
+        return _challenge()
+    aud = payload.get("aud")
+    if isinstance(aud, str) and EXPECTED_AUD in aud:
+        return _ok_initialize()
+    return _challenge()
+
+
+async def vulnerable_casefold(request: Request) -> Response:
+    payload = _decode_jwt_payload(request.headers.get("authorization"))
+    if not payload:
+        return _challenge()
+    aud = payload.get("aud")
+    if isinstance(aud, str) and aud.lower() == EXPECTED_AUD.lower():
+        return _ok_initialize()
+    return _challenge()
+
+
+async def vulnerable_array_skip(request: Request) -> Response:
+    payload = _decode_jwt_payload(request.headers.get("authorization"))
+    if not payload:
+        return _challenge()
+    aud = payload.get("aud")
+    if isinstance(aud, list):
+        return _ok_initialize()
+    if isinstance(aud, str) and aud == EXPECTED_AUD:
+        return _ok_initialize()
+    return _challenge()
+
+
+async def secure(request: Request) -> Response:
+    payload = _decode_jwt_payload(request.headers.get("authorization"))
+    if not payload:
+        return _challenge()
+    aud = payload.get("aud")
+    if isinstance(aud, str) and aud == EXPECTED_AUD:
+        return _ok_initialize()
+    if isinstance(aud, list) and EXPECTED_AUD in aud:
+        return _ok_initialize()
+    return _challenge()
+
+
+routes = [
+    Route("/.well-known/oauth-protected-resource", resource_metadata, methods=["GET"]),
+    Route("/vulnerable-substring/mcp", vulnerable_substring, methods=["POST"]),
+    Route("/vulnerable-casefold/mcp", vulnerable_casefold, methods=["POST"]),
+    Route("/vulnerable-array-skip/mcp", vulnerable_array_skip, methods=["POST"]),
+    Route("/secure/mcp", secure, methods=["POST"]),
+]
+
+app = Starlette(routes=routes)
+
+if __name__ == "__main__":
+    print(f"Starting MCP audience-validation testdata server on http://127.0.0.1:{PORT}")
+    print("  GET  /.well-known/oauth-protected-resource")
+    print("  POST /vulnerable-substring/mcp")
+    print("  POST /vulnerable-casefold/mcp")
+    print("  POST /vulnerable-array-skip/mcp")
+    print("  POST /secure/mcp")
+    uvicorn.run(app, host="127.0.0.1", port=PORT)


### PR DESCRIPTION
## Summary

Adds `mcp-oauth-audience-002`, a new MCP rule that probes whether the server's `aud` matching logic is robust to common implementation bugs once the operator's expected audience value is known. Complements `mcp-token-replay-001`, which tests whether audience validation happens at all.

Closes #20.

## Probes

Three forged HS256 JWT canaries, derived from the operator-supplied (or RFC 9728 auto-discovered) expected audience, sent to the first responsive MCP endpoint:

| Probe | `aud` shape | Bug class |
|---|---|---|
| `aud-substring-trap` | `<expected>.canary-batesian-mismatch.invalid` | `Contains` / `HasPrefix` / `HasSuffix` matching |
| `aud-case-canonicalization-trap` | `<expected>` lowercased or default-port toggled | Case folding / URL canonicalization before compare |
| `aud-array-canary-only` | JSON array of canaries | Validators that branch on claim shape and skip the array path |

Per-endpoint outcomes are coalesced into one rule-level finding so co-occurring bugs do not inflate impact.

## Audience input precedence

1. `--audience-claim` flag or `audience_claim` config field.
2. RFC 9728 auto-discovery via `WWW-Authenticate: resource_metadata=...` and `/.well-known/oauth-protected-resource`.
3. Otherwise the rule skips silently.

## Verdicts

- `ConfirmedExploit`: at least one probe got HTTP 200 with a JSON-RPC `result` envelope.
- `RiskIndicator`: only opaque 200s.
- No finding: every probe rejected.
- Silent skip: precondition not met.

## Honest scope

Probes are forged HS256 self-signed tokens, so any acceptance is a compound signature + audience failure. This rule does not catch the Parse CVE-2026-30863 / RFC 7523-bis class where signatures validate correctly but `aud` matching is wrong. That requires a real validly-signed cross-resource token and is filed as a follow-up. If `mcp-token-replay-001` is already firing on the target, fix those findings first; this rule's findings will likely be subsumed. Same caveat is repeated in the rule description, the docs row, and every finding's description.

## Changes

Commit 1, engine + rule + tests + plumbing:

- `rules/mcp/oauth-audience-002.yaml`
- `internal/attack/mcp/oauth_audience.go` (executor: discovery, JWT canary builders, response classification, coalescing, evidence redaction)
- `internal/attack/mcp/oauth_audience_test.go` (8 hermetic httptest cases)
- `internal/attack/executor.go` (`AudienceClaim` on `Options`)
- `internal/cli/scan.go` (`--audience-claim` flag)
- `internal/config/config.go` (`audience_claim` YAML field)
- `internal/engine/engine.go` (attack-type dispatch)
- `testdata/mcp_oauth_audience_server.py` (port 7785, vulnerable + secure variants, RFC 9728 metadata)
- `testdata/README.md`

Commit 2, docs:

- `README.md` (MCP rule count 16 to 17)
- `docs/rules-mcp.md` (catalog row + detail section with the honest-scope note)

## Convention exceptions

- Rule-scoped CLI flag (`--audience-claim`) instead of a generic `--oauth-*` namespace. Distinct from the existing `--oauth-audience` (request-time AS parameter, Auth0/Okta dialect). Vocabulary follows the JWT claim space the rule operates in; a future real-token path can use `--resource` (RFC 8707).
- Two-commit split (engine+rule, then docs), agreed in design.

## Follow-ups (filed separately)

- v1.1 real-token cross-resource probe.
- Engine-level finding dedup across overlapping rules.
- Migrate remaining testdata servers to the `77xx` port convention.