### PR TITLE
fix(testdata): MCP lab servers on 77xx, registry test, and CI branch pushes (#42)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,19 @@
 name: CI
 
+# Default: read-only token for jobs that do not declare their own permissions.
+permissions:
+  contents: read
+
 on:
   push:
-    branches: [main, dev]
+    branches:
+      - main
+      - dev
+      # Same-repo feature work: CI on push without widening to arbitrary branch names.
+      - 'fix/**'
+      - 'feat/**'
+      - 'chore/**'
+      - 'docs/**'
     tags: ['v*']
   pull_request:
     branches: [main, dev]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,9 +146,10 @@ Add the routes that exercise the vulnerability to a Python server in
 [`testdata/README.md`](testdata/README.md) when the protocol and theme match;
 add a new file only if no existing server is a natural host. Either way:
 
-- Bind to a documented port. New Starlette/uvicorn servers should pick the next
-  free port in the `77xx` range, FastMCP servers in `87xx`, and "new style"
-  servers in `31xx` (see `testdata/README.md`).
+- Bind to a documented port. Pick the next free port documented in
+  [`testdata/README.md`](testdata/README.md); prefer `77xx` for uvicorn-bound
+  servers in `testdata/`, and use the `31xx` or `9998` bands only when matching
+  an existing convention there.
 - Print startup confirmation lines so the caller can wait for readiness.
 - Implement only the minimum routes needed to trigger the rule(s).
 - Stay within the project test-server dependency set:

--- a/internal/repocheck/doc.go
+++ b/internal/repocheck/doc.go
@@ -1,0 +1,3 @@
+// Package repocheck holds repository-level invariant tests (for example
+// consistency of documented test server ports in testdata/README.md).
+package repocheck

--- a/internal/repocheck/server_registry_test.go
+++ b/internal/repocheck/server_registry_test.go
@@ -1,0 +1,56 @@
+package repocheck
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestTestdataReadmeServerRegistryUniquePorts fails if testdata/README.md Server
+// Registry assigns the same port to more than one server file.
+func TestTestdataReadmeServerRegistryUniquePorts(t *testing.T) {
+	t.Helper()
+	readme := readTestdataREADME(t)
+	// Markdown table rows: | `server.py` | <port> | ...
+	row := regexp.MustCompile(`(?m)^\|\s*` + "`([^`]+)`" + `\s*\|\s*(\d+)\s*\|`)
+	byPort := make(map[int][]string)
+	for _, m := range row.FindAllStringSubmatch(string(readme), -1) {
+		file := strings.TrimSpace(m[1])
+		port, err := strconv.Atoi(strings.TrimSpace(m[2]))
+		if err != nil {
+			t.Fatalf("parse port %q: %v", m[2], err)
+		}
+		if !strings.HasSuffix(file, ".py") {
+			continue
+		}
+		byPort[port] = append(byPort[port], file)
+	}
+	var dups []string
+	for port, files := range byPort {
+		if len(files) > 1 {
+			dups = append(dups, strconv.Itoa(port)+": "+strings.Join(files, ", "))
+		}
+	}
+	if len(dups) > 0 {
+		t.Fatalf("duplicate ports in testdata/README.md Server Registry:\n%s", strings.Join(dups, "\n"))
+	}
+}
+
+func readTestdataREADME(t *testing.T) []byte {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+	p := filepath.Join(repoRoot, "testdata", "README.md")
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read %s: %v", p, err)
+	}
+	return b
+}

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -105,7 +105,7 @@ scanner = Scanner(
     token_url="https://auth.example.com/oauth/token",
     client_id="my-client-id",
     oauth_scopes=["mcp:read"],
-    redirect_port=8765,
+    redirect_port=9876,
     no_browser=True,
 )
 results = scanner.run()

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -25,9 +25,9 @@ pip install starlette uvicorn httpx mcp
 | `a2a_skill_url_server.py` | 7780 | `a2a-skill-poison-001`, `a2a-url-mismatch-001` |
 | `a2a_tls_capinflation_server.py` | 7782 | `a2a-tls-downgrade-001`, `a2a-capability-inflation-001` |
 | `a2a_remaining_rules_server.py` | 7784 | `a2a-security-headers-001`, `a2a-registry-poison-001`, `a2a-circular-delegation-001` |
-| `mcp_poison_server.py` | 8765 | `mcp-tool-poison-001` |
-| `mcp_unauth_resources_server.py` | 8766 | `mcp-resources-unauth-001` |
-| `mcp_oauth_dcr_server.py` | 8767 | `mcp-oauth-dcr-001` |
+| `mcp_poison_server.py` | 7786 | `mcp-tool-poison-001` |
+| `mcp_unauth_resources_server.py` | 7787 | `mcp-resources-unauth-001` |
+| `mcp_oauth_dcr_server.py` | 7788 | `mcp-oauth-dcr-001` |
 | `mcp_new_rules_server.py` | 3100 | `mcp-init-downgrade-001`, `mcp-cors-wildcard-001`, `mcp-prompt-unauth-001` |
 | `mcp_flood_namespace_sse_server.py` | 7781 | `mcp-context-flood-001`, `mcp-tool-namespace-001`, `mcp-sse-hijack-001` |
 | `mcp_injection_server.py` | 7783 | `mcp-init-instructions-inject-001`, `mcp-injection-params-001`, `mcp-ratelimit-absent-001`, `mcp-homoglyph-tool-001` |
@@ -70,9 +70,11 @@ batesian scan --target http://127.0.0.1:9998 --rule-ids a2a-push-ssrf-001 -v
 
 ## Port allocation
 
-When adding a new test server, use the next available port in the `77xx` range
-for Starlette/uvicorn servers. FastMCP servers use `87xx`. New-style servers may
-use `31xx`. Document the port in this table before merging.
+When adding a new test server, pick the next free port, document it in the
+Server Registry table above before merging. Prefer the `77xx` band for servers
+in this directory that bind with uvicorn (Starlette or FastMCP). The `31xx`
+band is used for selected multi-rule MCP/A2A servers; `9998` is reserved for
+the main A2A lab server. Do not reuse a port already listed in the registry.
 
 ---
 

--- a/testdata/mcp_oauth_dcr_server.py
+++ b/testdata/mcp_oauth_dcr_server.py
@@ -11,8 +11,8 @@ Run:
     python testdata/mcp_oauth_dcr_server.py
 
 Endpoints:
-    GET  http://localhost:8767/.well-known/oauth-authorization-server
-    POST http://localhost:8767/register
+    GET  http://localhost:7788/.well-known/oauth-authorization-server
+    POST http://localhost:7788/register
 """
 import json
 import secrets
@@ -24,7 +24,7 @@ from starlette.routing import Route
 
 
 async def oauth_metadata(request: Request) -> JSONResponse:
-    base = "http://localhost:8767"
+    base = "http://localhost:7788"
     return JSONResponse({
         "issuer": base,
         "authorization_endpoint": f"{base}/authorize",
@@ -64,7 +64,7 @@ routes = [
 app = Starlette(routes=routes)
 
 if __name__ == "__main__":
-    print("Starting vulnerable OAuth DCR server on http://localhost:8767")
+    print("Starting vulnerable OAuth DCR server on http://localhost:7788")
     print("  GET  /.well-known/oauth-authorization-server")
     print("  POST /register  (no auth, accepts any scopes and redirect URIs)")
-    uvicorn.run(app, host="127.0.0.1", port=8767)
+    uvicorn.run(app, host="127.0.0.1", port=7788)

--- a/testdata/mcp_poison_server.py
+++ b/testdata/mcp_poison_server.py
@@ -7,7 +7,7 @@ so that mcp-tool-poison-001 fires. It is the ground-truth positive test case.
 Run:
     python testdata/mcp_poison_server.py
 
-Endpoint: http://localhost:8765/mcp
+Endpoint: http://localhost:7786/mcp
 """
 from mcp.server.fastmcp import FastMCP
 
@@ -51,5 +51,5 @@ def summarize_document(content: str) -> str:
 
 if __name__ == "__main__":
     import uvicorn
-    print("Starting MCP poison server on http://localhost:8765/mcp")
-    uvicorn.run(mcp.streamable_http_app(), host="127.0.0.1", port=8765)
+    print("Starting MCP poison server on http://localhost:7786/mcp")
+    uvicorn.run(mcp.streamable_http_app(), host="127.0.0.1", port=7786)

--- a/testdata/mcp_unauth_resources_server.py
+++ b/testdata/mcp_unauth_resources_server.py
@@ -7,7 +7,7 @@ returns a simulated database connection string containing credentials.
 Run:
     python testdata/mcp_unauth_resources_server.py
 
-Endpoint: http://localhost:8766/mcp
+Endpoint: http://localhost:7787/mcp
 """
 from mcp.server.fastmcp import FastMCP
 
@@ -47,5 +47,5 @@ def ping() -> str:
 
 if __name__ == "__main__":
     import uvicorn
-    print("Starting MCP unauthenticated resources server on http://localhost:8766/mcp")
-    uvicorn.run(mcp.streamable_http_app(), host="127.0.0.1", port=8766)
+    print("Starting MCP unauthenticated resources server on http://localhost:7787/mcp")
+    uvicorn.run(mcp.streamable_http_app(), host="127.0.0.1", port=7787)


### PR DESCRIPTION
## Summary

- Closes **#42**: move MCP lab servers (`mcp_poison_server`, `mcp_unauth_resources_server`, `mcp_oauth_dcr_server`) from **8765–8767** to **7786–7788**, align `testdata/README.md` port policy with the **77xx** convention, sync `CONTRIBUTING.md`, and use a neutral **`redirect_port`** in `sdk/python/README.md` so it does not collide with fixture ports.
- Add **`internal/repocheck`**: a test that fails if **`testdata/README.md`** Server Registry assigns the same port to more than one **`.py`** server.
- **CI:** run workflow on **`push`** to `fix/**`, `feat/**`, `chore/**`, and `docs/**` (in addition to `main`/`dev`/`v*`), and set workflow-default **`permissions: contents: read`** (release job keeps its own write/OIDC permissions).

## Type of change

- [ ] New attack rule(s)
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run` passes (CI enforces this)
- [ ] New rules include a vulnerable test server in `testdata/` and a unit test in `internal/attack/` *(N/A: no new attack rules; existing servers moved ports only.)*

## Related issues

Closes #42