### PR TITLE
fix: probe mcp-init-downgrade unauthenticated and broaden mcp-token-replay OAuth discovery

### DIFF
--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -27,7 +27,7 @@ JSON-RPC `error` (the common MCP rejection shape) is a rejection, not a finding.
 | `mcp-token-replay-001` | [OAuth Token Audience Validation Bypass](#mcp-token-replay-001) | High | confirmed | CWE-294 |
 | `mcp-resources-unauth-001` | [Unauthenticated Resource Read](#mcp-resources-unauth-001) | High / Critical | confirmed | CWE-862 |
 | `mcp-prompt-unauth-001` | [Prompt Templates Without Authentication](#mcp-prompt-unauth-001) | Medium | confirmed | CWE-862 |
-| `mcp-init-downgrade-001` | [Protocol Version Downgrade Auth Bypass](#mcp-init-downgrade-001) | High | confirmed | CWE-757 |
+| `mcp-init-downgrade-001` | [Protocol Version Downgrade Auth Bypass](#mcp-init-downgrade-001) | Critical | confirmed | CWE-757 |
 | `mcp-session-fixation-001` | [Session ID Fixation](#mcp-session-fixation-001) | High | confirmed | CWE-384 |
 | `mcp-header-body-split-001` | [Header/Body Routing Split-Brain (SEP-2243)](#mcp-header-body-split-001) | High | confirmed | CWE-444 |
 | `mcp-sse-resume-replay-001` | [SSE Resumption Cross-Session Replay](#mcp-sse-resume-replay-001) | High | confirmed | CWE-488 |
@@ -127,17 +127,19 @@ the prompts capability, produces no finding.
 
 ### mcp-init-downgrade-001
 
-**Protocol Version Downgrade Auth Bypass** | Severity: High | CWE-757
+**Protocol Version Downgrade Auth Bypass** | Severity: Critical | CWE-757
 
 Negotiating an older protocol version (`2024-11-05`, which predates the mandatory
 OAuth 2.1 authorization framework) is, by itself, **spec-compliant** and is *not*
 a finding. The rule confirms a true downgrade bypass with a discriminator: it
 calls `resources/list` under both a modern-version session and a legacy-version
-session and compares outcomes. A **confirmed** critical-impact finding is reported
-only when the modern session is rejected (auth enforced) but the legacy session
-succeeds. If both succeed, the server simply has no auth (owned by
-`mcp-resources-unauth-001`); if both are rejected, the server is secure - neither
-produces a finding here.
+session and compares outcomes. The probe runs **unauthenticated** (it ignores any
+`--token`): the bypass is the ability to reach protected functionality without
+credentials, so attaching a token would let an auth-enforcing server grant the
+modern path and mask the bug. A **confirmed** finding is reported only when the
+modern session is rejected (auth enforced) but the legacy session succeeds. If
+both succeed, the server simply has no auth (owned by `mcp-resources-unauth-001`);
+if both are rejected, the server is secure - neither produces a finding here.
 
 ---
 

--- a/internal/attack/mcp/init_downgrade.go
+++ b/internal/attack/mcp/init_downgrade.go
@@ -50,7 +50,14 @@ const (
 
 func (e *InitDowngradeExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
 	vars := attack.NewVars(target, opts.OOBListenerURL)
-	client := attack.NewHTTPClient(opts, vars)
+	// Probe UNAUTHENTICATED. This rule detects a server that enforces
+	// authorization under the modern protocol version but not under the legacy
+	// one. If we attached opts.Token, a server that gates the modern path on a
+	// valid token would grant it, so the discriminator (modern REJECTED + legacy
+	// GRANTED) could never fire - silently masking the very bug we look for. A
+	// downgrade auth bypass is, by definition, reaching protected functionality
+	// WITHOUT proper credentials, so the probe must run with no bearer token.
+	client := attack.NewUnauthHTTPClient(opts, vars)
 
 	for _, ep := range endpointCandidates(vars.BaseURL) {
 		findings := e.probeEndpoint(ctx, client, ep)

--- a/internal/attack/mcp/init_downgrade_test.go
+++ b/internal/attack/mcp/init_downgrade_test.go
@@ -100,6 +100,95 @@ func TestInitDowngrade_ConfirmedBypass(t *testing.T) {
 	}
 }
 
+// tokenGatedDowngradeServer models a REALISTIC downgrade bug: the modern-version
+// path enforces bearer-token auth on resources/list, but the legacy-version path
+// skips that check entirely. A server like this is the whole point of the rule,
+// and it is the case the old (authenticated) probe silently missed: if the rule
+// attached the caller's --token, the modern path would be granted and the
+// discriminator could never fire. The probe must run unauthenticated.
+func tokenGatedDowngradeServer(t *testing.T, validToken string) *httptest.Server {
+	t.Helper()
+	var mu sync.Mutex
+	sessions := map[string]string{} // sessionID -> protocolVersion
+	counter := 0
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		method, _ := req["method"].(string)
+		id := req["id"]
+		w.Header().Set("Content-Type", "application/json")
+
+		switch method {
+		case "initialize":
+			params, _ := req["params"].(map[string]interface{})
+			version, _ := params["protocolVersion"].(string)
+			mu.Lock()
+			counter++
+			sid := fmt.Sprintf("sess-%d", counter)
+			sessions[sid] = version
+			mu.Unlock()
+			w.Header().Set("Mcp-Session-Id", sid)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{
+					"protocolVersion": version,
+					"serverInfo":      map[string]interface{}{"name": "token-gated", "version": "1.0"},
+					"capabilities":    map[string]interface{}{"resources": map[string]interface{}{}},
+				},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "resources/list":
+			mu.Lock()
+			version := sessions[r.Header.Get("Mcp-Session-Id")]
+			mu.Unlock()
+			hasValidToken := r.Header.Get("Authorization") == "Bearer "+validToken
+			// Legacy path skips auth (the bug); modern path requires the token.
+			allow := version == legacyVer || (version == modernVer && hasValidToken)
+			if !allow {
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"jsonrpc": "2.0", "id": id,
+					"error": map[string]interface{}{"code": -32001, "message": "Unauthorized"},
+				})
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{
+					"resources": []interface{}{
+						map[string]interface{}{"uri": "file:///secret.txt", "name": "secret"},
+					},
+				},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// TestInitDowngrade_TokenDoesNotMaskBypass is the regression guard for the
+// authenticated-client bug: even when the caller supplies a valid --token, the
+// rule must still confirm the downgrade by probing the legacy path WITHOUT
+// credentials. With the old NewHTTPClient(opts,...) the token rode on the modern
+// probe, the modern path was granted, and this returned 0 findings.
+func TestInitDowngrade_TokenDoesNotMaskBypass(t *testing.T) {
+	srv := tokenGatedDowngradeServer(t, "valid-user-token")
+	defer srv.Close()
+
+	exec := mcpattack.NewInitDowngradeExecutor(attack.RuleContext{ID: "mcp-init-downgrade-001"})
+	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5, Token: "valid-user-token"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding despite --token (probe must run unauthenticated), got %d: %v", len(findings), findings)
+	}
+	if findings[0].Severity != "critical" || findings[0].Confidence != attack.ConfirmedExploit {
+		t.Errorf("expected critical/ConfirmedExploit, got %q/%q", findings[0].Severity, findings[0].Confidence)
+	}
+}
+
 // TestInitDowngrade_NoAuthAtAll: BOTH versions are granted access. This is an
 // open server (mcp-resources-unauth's job), NOT a downgrade bypass => silent.
 func TestInitDowngrade_NoAuthAtAll(t *testing.T) {

--- a/internal/attack/mcp/token_replay.go
+++ b/internal/attack/mcp/token_replay.go
@@ -17,8 +17,10 @@ import (
 // incoming OAuth 2.1 bearer tokens (rule mcp-token-replay-001).
 //
 // Attack sequence:
-//  1. Discover OAuth metadata via /.well-known/oauth-authorization-server.
-//     If absent, skip gracefully (the server does not use OAuth 2.1).
+//  1. Confirm the server participates in OAuth 2.1 / OIDC by probing the known
+//     discovery documents (RFC 9728 protected-resource-metadata, RFC 8414
+//     authorization-server metadata, and OIDC openid-configuration). If none is
+//     present, skip gracefully (the server does not appear to use OAuth).
 //  2. Forge three JWTs using stdlib only (no third-party JWT library):
 //     - no-aud: HS256 token with no aud claim
 //     - wrong-aud: HS256 token with aud pointing to a different server
@@ -49,10 +51,13 @@ func (e *TokenReplayExecutor) Execute(ctx context.Context, target string, opts a
 	vars := attack.NewVars(target, opts.OOBListenerURL)
 	client := attack.NewHTTPClient(opts, vars)
 
-	// Step 1: Discover OAuth metadata. Skip if the server does not use OAuth 2.1.
-	metaURL := vars.BaseURL + "/.well-known/oauth-authorization-server"
-	metaResp, err := client.GET(ctx, metaURL, nil)
-	if err != nil || !metaResp.IsSuccess() {
+	// Step 1: Confirm the server participates in OAuth 2.1 / OIDC before forging
+	// tokens against it. Probe every recognized discovery document, not just the
+	// RFC 8414 authorization-server path: an MCP resource server commonly exposes
+	// only RFC 9728 protected-resource-metadata (its authorization server may be a
+	// separate host), and OIDC deployments expose openid-configuration. Skip when
+	// none is present.
+	if !oauthMetadataPresent(ctx, client, vars.BaseURL) {
 		return nil, nil
 	}
 
@@ -168,6 +173,34 @@ func (e *TokenReplayExecutor) Execute(ctx context.Context, target string, opts a
 	}
 
 	return findings, nil
+}
+
+// oauthWellKnownPaths are the discovery documents that signal a server
+// participates in OAuth 2.1 / OIDC. Ordered by MCP relevance: an MCP resource
+// server most often exposes RFC 9728 protected-resource-metadata first; the
+// RFC 8414 authorization-server document and the OIDC openid-configuration
+// document follow. Probing only the authorization-server path produced a silent
+// false negative on the (common) OIDC-first and PRM-only deployments.
+var oauthWellKnownPaths = []string{
+	"/.well-known/oauth-protected-resource",
+	"/.well-known/oauth-authorization-server",
+	"/.well-known/openid-configuration",
+}
+
+// oauthMetadataPresent reports whether the target exposes any recognized OAuth /
+// OIDC discovery document. This is only a gate to avoid forging tokens against
+// servers that plainly do not use OAuth; the document contents are not used.
+func oauthMetadataPresent(ctx context.Context, client *attack.HTTPClient, baseURL string) bool {
+	for _, p := range oauthWellKnownPaths {
+		resp, err := client.GET(ctx, baseURL+p, nil)
+		if err != nil {
+			continue
+		}
+		if resp.IsSuccess() {
+			return true
+		}
+	}
+	return false
 }
 
 // forgeHS256JWT creates a signed JWT using a random HMAC-SHA256 secret.

--- a/internal/attack/mcp/token_replay_test.go
+++ b/internal/attack/mcp/token_replay_test.go
@@ -181,6 +181,67 @@ func TestTokenReplay_JSONRPCErrorIsRejection(t *testing.T) {
 	}
 }
 
+// tokenServerWithDiscovery models a vulnerable MCP resource server that exposes
+// its OAuth discovery document at a single well-known path (other than the
+// RFC 8414 authorization-server path) and accepts any bearer token on /mcp.
+// Before the multi-path discovery fix the rule skipped these servers entirely.
+func tokenServerWithDiscovery(t *testing.T, discoveryPath string) *httptest.Server {
+	t.Helper()
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		base := "http://" + srv.Listener.Addr().String()
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case discoveryPath:
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"issuer":         base,
+				"token_endpoint": base + "/token",
+			})
+		case "/mcp":
+			if strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"jsonrpc": "2.0", "id": 1,
+					"result": map[string]interface{}{
+						"protocolVersion": "2024-11-05",
+						"serverInfo":      map[string]interface{}{"name": "test-server", "version": "1.0"},
+					},
+				})
+				return
+			}
+			w.WriteHeader(http.StatusUnauthorized)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return srv
+}
+
+// TestTokenReplay_AlternateDiscoveryPaths is the regression guard for the
+// OIDC-only / PRM-only false negative: a vulnerable server that publishes its
+// discovery document at openid-configuration or oauth-protected-resource (but
+// not the RFC 8414 authorization-server path) must still be probed and flagged.
+func TestTokenReplay_AlternateDiscoveryPaths(t *testing.T) {
+	for _, path := range []string{
+		"/.well-known/openid-configuration",
+		"/.well-known/oauth-protected-resource",
+	} {
+		t.Run(path, func(t *testing.T) {
+			ts := tokenServerWithDiscovery(t, path)
+			defer ts.Close()
+
+			exec := mcpattack.NewTokenReplayExecutor(tokenReplayRC())
+			findings, err := exec.Execute(context.Background(), ts.URL, testOpts())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(findings) == 0 {
+				t.Fatalf("expected findings when discovery is at %s, got none", path)
+			}
+		})
+	}
+}
+
 func TestTokenReplay_NoOAuthMetadata(t *testing.T) {
 	ts := httptest.NewServer(http.NotFoundHandler())
 	defer ts.Close()

--- a/rules/mcp/init-downgrade-001.yaml
+++ b/rules/mcp/init-downgrade-001.yaml
@@ -2,7 +2,7 @@ id: mcp-init-downgrade-001
 info:
   name: MCP Protocol Version Downgrade Auth Bypass
   author: batesian
-  severity: high
+  severity: critical
   description: |
     Tests whether advertising a protocol version that predates the mandatory
     OAuth 2.1 authorization framework (specifically "2024-11-05", published


### PR DESCRIPTION
## Summary

Two P0 correctness fixes from the post-v1.0.0 critical review. Both rules were silently no-opping against exactly the servers they target.

- **`mcp-init-downgrade`**: the executor was built with `NewHTTPClient(opts, ...)`, so a supplied `--token` rode on *both* the modern and legacy probes. A real auth-enforcing server then granted the modern path too, making the discriminator (`modern REJECTED` and `legacy GRANTED`) impossible to satisfy. It now probes via `NewUnauthHTTPClient` (a downgrade bypass is, by definition, reaching protected functionality without credentials). Also reconciled a severity mismatch: the rule has a single confirmed outcome, so the catalog/docs now say `critical` to match the emitted finding (were `high`).
- **`mcp-token-replay`**: the OAuth discovery gate only probed `/.well-known/oauth-authorization-server`, silently skipping OIDC-first servers (`openid-configuration`) and - more importantly - MCP resource servers that expose RFC 9728 `oauth-protected-resource` (whose authorization server often lives on a separate host). A new `oauthMetadataPresent` helper probes all three. The gate stays a gate only; the finding oracle still requires a JSON-RPC `result` envelope, so there is no new false-positive surface.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` - clean
- [x] `go test ./...` - all packages green
- [x] New regression `TestInitDowngrade_TokenDoesNotMaskBypass` (token-gated server + `--token`: returns 0 findings under old code, 1 under fix)
- [x] New regression `TestTokenReplay_AlternateDiscoveryPaths` (OIDC-only and PRM-only vulnerable servers both fire; no-metadata server stays silent)
- [ ] CI runs `-race` on Linux (cgo unavailable locally on Windows; new fixtures are race-safe by construction)
