### PR TITLE
fix(a2a-task-idor-001): restore v0.3 fallback on create and read paths

### DIFF
--- a/internal/attack/a2a/task_idor.go
+++ b/internal/attack/a2a/task_idor.go
@@ -68,7 +68,7 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 				},
 			},
 		})
-		if err != nil || (!resp.IsSuccess() && isJSONRPCError(resp.Body)) {
+		if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
 			resp, err = c.POST(ctx, endpoint, nil, map[string]interface{}{
 				"jsonrpc": "2.0",
 				"id":      "batesian-create-" + vars.RandID,
@@ -107,16 +107,24 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 	_, anonAccepted := sendCreate(unauthClient)
 	authEnforcedOnCreate := !anonAccepted
 
-	// Step 3: Read the owner's task from an unauthenticated connection.
+	// Step 3: Read the owner's task from an unauthenticated connection, trying the
+	// v1.0 GetTask shape first and falling back to the v0.3 tasks/get shape so the
+	// read works against either protocol version (mirrors sendCreate above).
+	getParams := map[string]interface{}{"id": taskID, "historyLength": 10}
 	getResp, err := unauthClient.POST(ctx, endpoint, map[string]string{"A2A-Version": "1.0"}, map[string]interface{}{
 		"jsonrpc": "2.0",
 		"id":      "batesian-get-" + vars.RandID,
 		"method":  "GetTask",
-		"params": map[string]interface{}{
-			"id":            taskID,
-			"historyLength": 10,
-		},
+		"params":  getParams,
 	})
+	if err != nil || !getResp.IsSuccess() || isJSONRPCError(getResp.Body) {
+		getResp, err = unauthClient.POST(ctx, endpoint, nil, map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      "batesian-get-" + vars.RandID,
+			"method":  "tasks/get",
+			"params":  getParams,
+		})
+	}
 	unauthReadSucceeded := err == nil && getResp.IsSuccess() && !isJSONRPCError(getResp.Body) &&
 		getResp.ContainsAny(`"history"`, `"contextId"`, taskID, contextID)
 

--- a/internal/attack/a2a/task_idor_test.go
+++ b/internal/attack/a2a/task_idor_test.go
@@ -113,6 +113,52 @@ func TestTaskIDOR_Vulnerable(t *testing.T) {
 	}
 }
 
+// TestTaskIDOR_Vulnerable_V03Only verifies the rule still fires against a server
+// that speaks only the v0.3 slash-method binding: it rejects the v1.0 PascalCase
+// methods (SendMessage, GetTask) with a JSON-RPC error over HTTP 200 and accepts
+// only message/send and tasks/get. This exercises the v1.0->v0.3 fallback on both
+// the create and the read path. Without the fallback the create guard short-
+// circuits on the 200+error and the rule never fires (false negative).
+func TestTaskIDOR_Vulnerable_V03Only(t *testing.T) {
+	const taskID, ctxID = "task-v03-abc", "ctx-v03-xyz"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		method, id := decodeRPC(r)
+		switch method {
+		case "message/send":
+			if !hasOwnerAuth(r) {
+				rpcErr(w, id, -32600, "authentication required") // creation is auth-gated
+				return
+			}
+			taskResult(w, id, taskID, ctxID)
+		case "tasks/get":
+			taskWithHistory(w, id, taskID, ctxID) // BUG: no ownership check
+		default:
+			// v1.0 PascalCase methods are unknown to this v0.3-only server:
+			// HTTP 200 carrying a JSON-RPC method-not-found error.
+			rpcErr(w, id, -32601, "Method not found")
+		}
+	}))
+	defer ts.Close()
+
+	findings, err := a2a.NewTaskIDORExecutor(testRuleCtx()).Execute(context.Background(), ts.URL, idorOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly one IDOR finding against v0.3-only server, got %d: %+v", len(findings), findings)
+	}
+	if findings[0].Confidence != attack.ConfirmedExploit {
+		t.Errorf("want ConfirmedExploit, got %q", findings[0].Confidence)
+	}
+	if findings[0].Severity != "high" {
+		t.Errorf("want high severity, got %q", findings[0].Severity)
+	}
+}
+
 // TestTaskIDOR_Patched: creation is auth-gated AND tasks/get enforces ownership
 // (rejects unauthenticated reads). The rule MUST stay silent.
 func TestTaskIDOR_Patched(t *testing.T) {


### PR DESCRIPTION
## A1 — Restore the v0.3 fallback in `a2a-task-idor-001`

### Problem
The task-IDOR rule produces **zero findings against a genuinely vulnerable v0.3-only A2A server** (false negative). It only fires against servers that accept the v1.0 PascalCase methods.

### Root cause (two gaps, same class)
The executor tries the A2A **v1.0** request shape (`SendMessage` + `A2A-Version: 1.0`) and is supposed to fall back to the **v0.3** slash shape (`message/send`). A conformant v0.3-only JSON-RPC server answers an unknown v1.0 method with **HTTP 200 + a JSON-RPC `-32601` error** (transport success, application-level error, standard JSON-RPC).

1. **Create guard (`task_idor.go:71`)** used `err != nil || (!resp.IsSuccess() && isJSONRPCError(...))`. On a `200 + error` the `&&` is false, so the fallback never fired. The sibling `multitenant_isolation.go:116` already uses the correct `|| !resp.IsSuccess() || isJSONRPCError(...)`, and this file's own acceptance check at line 85 uses `||` too. Line 71 was the outlier.
2. **Read path (step 3)** only ever sent `GetTask` (v1.0) with **no `tasks/get` fallback**. So even with the create fixed, the read-back on a v0.3-only server returns `-32601` and the IDOR is never confirmed.

Both had to be fixed for the rule to work end-to-end against v0.3-only servers.

### Fix
- Create guard: `&&` to `||` (matches `multitenant_isolation.go` and line 85).
- Read path: try `GetTask` (v1.0), fall back to `tasks/get` (v0.3), mirroring `sendCreate`.

### Why existing tests missed it
All three prior IDOR tests handle `"SendMessage"` and `"message/send"` in the **same `case` arm**, so the v1.0 attempt always succeeded and the fallback was never exercised. The new `TestTaskIDOR_Vulnerable_V03Only` simulates a real v0.3-only server (v1.0 PascalCase returns `200 + -32601`; only `message/send`/`tasks/get` work).

### Validation
- `TestTaskIDOR_Vulnerable_V03Only`: **fails before** this change (`got 0` findings), **passes after**, verified by stashing only the `.go` fix and re-running.
- Full suite green: `go build`, `go vet`, `go test ./...`, `golangci-lint run` (v2.11.4, 0 issues). `-race` runs in CI (no local C toolchain).

### Scope / slop notes
- Deliberately scoped to this rule's fallback correctness. The broader refactor (centralizing version detection so every A2A executor sends one target-matched shape, removing the try-both duplication) is tracked separately as item **C2**; the v1.0 `GetTask` param shape (`name` vs `id`) will be harmonized there.
- No AI-slop cleanup needed in these files: no em dashes present, and the existing comments explain *why* (the auth-enforcement discriminator), not the *what*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
