### PR TITLE
fix(mcp-sse-resume-replay-001): resume with the opaque event id, not arithmetic

### DIFF
--- a/internal/attack/mcp/sse_resume_replay.go
+++ b/internal/attack/mcp/sse_resume_replay.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -60,10 +59,12 @@ func (e *SSEResumeReplayExecutor) probe(ctx context.Context, client *attack.HTTP
 		return nil // not MCP here, or server mints no session ids (can't prove cross-session)
 	}
 
-	// A's checkpoint: open A's stream and capture an id-bearing, A-specific event.
+	// A's checkpoint: open A's stream and capture an id-bearing event plus the
+	// data of the events that follow it (the session-A-specific markers a resume
+	// from the checkpoint would replay).
 	aEvents := e.sseCollect(ctx, raw, ep, tokenA, sessionA, "", 3*time.Second)
-	checkpointID, marker := firstIDAndMarker(aEvents)
-	if checkpointID == "" || marker == "" {
+	checkpointID, markers := resumeCheckpoint(aEvents)
+	if checkpointID == "" || len(markers) == 0 {
 		return nil // no resumable event surface to test
 	}
 
@@ -72,11 +73,13 @@ func (e *SSEResumeReplayExecutor) probe(ctx context.Context, client *attack.HTTP
 		return nil // need a second, distinct server-minted session
 	}
 
-	// As B, resume from before A's checkpoint and see whether A's event is replayed.
-	resumeFrom := lowerEventID(checkpointID)
-	bEvents := e.sseCollect(ctx, raw, ep, tokenB, sessionB, resumeFrom, 3*time.Second)
+	// As B, resume from A's checkpoint id and see whether A's later events are
+	// replayed into B's session. MCP event ids are opaque (spec: Streamable HTTP
+	// resumability), so the checkpoint id is sent verbatim, with no arithmetic.
+	bEvents := e.sseCollect(ctx, raw, ep, tokenB, sessionB, checkpointID, 3*time.Second)
 	for _, ev := range bEvents {
-		if ev.data == marker {
+		if markers[ev.data] {
+			marker := ev.data
 			return []attack.Finding{{
 				RuleID:     e.rule.ID,
 				RuleName:   e.rule.Name,
@@ -89,11 +92,11 @@ func (e *SSEResumeReplayExecutor) probe(ctx context.Context, client *attack.HTTP
 						"scoped to the originating session, so a client can replay another session's "+
 						"messages - leaking conversation data, tool outputs, or notifications across "+
 						"sessions. The spec requires that resumption MUST NOT replay a different stream's "+
-						"messages.", ep, resumeFrom, marker),
+						"messages.", ep, checkpointID, marker),
 				Evidence: fmt.Sprintf(
 					"endpoint: %s\nsession A: %s (checkpoint event id %s)\nsession B: %s\n"+
 						"B resumed Last-Event-ID: %s\nA's event marker delivered to B: %s",
-					ep, sessionA, checkpointID, sessionB, resumeFrom, marker),
+					ep, sessionA, checkpointID, sessionB, checkpointID, marker),
 				Remediation: e.rule.Remediation,
 				TargetURL:   ep,
 			}}
@@ -200,22 +203,29 @@ func rawSSEClient(opts attack.Options) *http.Client {
 	return &http.Client{Transport: tr}
 }
 
-// firstIDAndMarker returns the id of the first event and the data of the last
-// event (the session-specific marker the server buffered).
-func firstIDAndMarker(events []sseEvent) (id, marker string) {
-	if len(events) == 0 {
-		return "", ""
+// resumeCheckpoint selects the first id-bearing event as the resume cursor and
+// collects the data of every later event as session-specific markers. Resuming
+// from the cursor's exact id asks the server for the events after it, so a
+// vulnerable server replays those markers into a different session. MCP event
+// ids are opaque (spec: Streamable HTTP resumability), so the cursor id is used
+// verbatim with no arithmetic. It returns an empty id when no event carries an
+// id, or no markers when nothing follows the checkpoint (nothing to replay).
+func resumeCheckpoint(events []sseEvent) (checkpointID string, markers map[string]bool) {
+	markers = map[string]bool{}
+	idx := -1
+	for i, ev := range events {
+		if ev.id != "" {
+			idx = i
+			break
+		}
 	}
-	id = events[0].id
-	marker = events[len(events)-1].data
-	return id, marker
-}
-
-// lowerEventID returns an event id one below the given numeric id so a resume
-// asks for everything after it; non-numeric ids fall back to "0".
-func lowerEventID(id string) string {
-	if n, err := strconv.Atoi(id); err == nil && n > 0 {
-		return strconv.Itoa(n - 1)
+	if idx == -1 {
+		return "", markers
 	}
-	return "0"
+	for _, ev := range events[idx+1:] {
+		if ev.data != "" {
+			markers[ev.data] = true
+		}
+	}
+	return events[idx].id, markers
 }

--- a/internal/attack/mcp/sse_resume_replay_test.go
+++ b/internal/attack/mcp/sse_resume_replay_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -20,7 +19,7 @@ func sseRuleCtx() attack.RuleContext {
 }
 
 type sseLogEntry struct {
-	eid  int
+	eid  string
 	sid  string
 	data string
 }
@@ -68,37 +67,54 @@ func resumeServer(mode string) *httptest.Server {
 		leid := r.Header.Get("Last-Event-ID")
 		w.Header().Set("Content-Type", "text/event-stream")
 		flusher, _ := w.(http.Flusher)
-		writeEvent := func(eid int, data string) {
-			fmt.Fprintf(w, "id: %d\ndata: %s\n\n", eid, data)
+		writeEvent := func(eid, data string) {
+			fmt.Fprintf(w, "id: %s\ndata: %s\n\n", eid, data)
 			if flusher != nil {
 				flusher.Flush()
 			}
 		}
 
 		if leid == "" {
+			// Emit two session-specific events with OPAQUE (non-numeric) ids, so a
+			// resume from the first event's id can replay the second. Real MCP SDKs
+			// mint opaque ids; the spec does not guarantee numeric ones.
 			mu.Lock()
-			eventCounter++
-			eid := eventCounter
-			data := fmt.Sprintf(`{"sid":%q,"secret":"S-%s-%d"}`, sid, sid, eid)
-			log = append(log, sseLogEntry{eid: eid, sid: sid, data: data})
+			var fresh []sseLogEntry
+			for i := 0; i < 2; i++ {
+				eventCounter++
+				eid := fmt.Sprintf("evt-%s-%d", sid, eventCounter)
+				data := fmt.Sprintf(`{"sid":%q,"secret":"S-%s-%d"}`, sid, sid, eventCounter)
+				entry := sseLogEntry{eid: eid, sid: sid, data: data}
+				log = append(log, entry)
+				fresh = append(fresh, entry)
+			}
 			mu.Unlock()
-			writeEvent(eid, data)
+			for _, ev := range fresh {
+				writeEvent(ev.eid, ev.data)
+			}
 			return
 		}
 
-		L, err := strconv.Atoi(leid)
-		if err != nil {
-			L = -1
+		if mode == "ignore" {
+			return // never replays on resume
 		}
 		mu.Lock()
 		snapshot := append([]sseLogEntry(nil), log...)
 		mu.Unlock()
-		for _, ev := range snapshot {
-			if ev.eid <= L || mode == "ignore" {
-				continue
+		// Resume after the event whose opaque id matches Last-Event-ID.
+		start := -1
+		for i, ev := range snapshot {
+			if ev.eid == leid {
+				start = i
+				break
 			}
+		}
+		if start == -1 {
+			return // unknown checkpoint id: nothing to replay
+		}
+		for _, ev := range snapshot[start+1:] {
 			if mode == "secure" && ev.sid != sid {
-				continue
+				continue // compliant: only replay the requester's own events
 			}
 			writeEvent(ev.eid, ev.data)
 		}
@@ -128,6 +144,29 @@ func TestResume_Vulnerable(t *testing.T) {
 	}
 	if !strings.Contains(findings[0].Title, "cross-session") {
 		t.Errorf("expected cross-session in title, got %q", findings[0].Title)
+	}
+}
+
+// TestResume_OpaqueEventIDs locks in the opaque-id behaviour. The fixture mints
+// non-numeric event ids, so the executor must resume with the captured id
+// verbatim. The previous numeric-decrement approach resumed from "0", which an
+// opaque-id server does not recognise, so the cross-session replay went
+// undetected (false negative). This test fails against that old behaviour.
+func TestResume_OpaqueEventIDs(t *testing.T) {
+	ts := resumeServer("vulnerable")
+	defer ts.Close()
+
+	findings := runResume(t, ts)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding against opaque-id server, got %d: %+v", len(findings), findings)
+	}
+	// The evidence must show B resumed with A's opaque checkpoint id, not "0".
+	ev := findings[0].Evidence
+	if !strings.Contains(ev, "evt-sess-1-1") {
+		t.Errorf("expected evidence to reference opaque checkpoint id 'evt-sess-1-1', got:\n%s", ev)
+	}
+	if strings.Contains(ev, "Last-Event-ID: 0") {
+		t.Errorf("evidence shows a numeric '0' resume cursor; the opaque id was not used verbatim:\n%s", ev)
 	}
 }
 

--- a/rules/mcp/sse-resume-replay-001.yaml
+++ b/rules/mcp/sse-resume-replay-001.yaml
@@ -16,13 +16,15 @@ info:
     cross-session leak:
 
       1. Initialize session A; open A's SSE stream (no Last-Event-ID) and capture
-         a checkpoint event id plus a session-A-specific data marker. If the
-         server does not mint distinct session ids or emits no id-bearing event,
-         the rule cannot test (no finding).
+         an id-bearing checkpoint event plus the data of a later session-A event
+         as a marker. If the server does not mint distinct session ids, or emits
+         no id-bearing event with a later event to replay, the rule cannot test
+         (no finding).
       2. Initialize session B; confirm B's session id differs from A's.
-      3. As session B, resume from BEFORE A's checkpoint (Last-Event-ID below A's
-         id). A CONFIRMED finding is raised only when B's resumed stream delivers
-         A's exact data marker - i.e., the server replayed session A's event to
+      3. As session B, resume with A's checkpoint id (Last-Event-ID set to A's
+         exact event id; the spec treats event ids as opaque, so no arithmetic is
+         applied). A CONFIRMED finding is raised only when B's resumed stream
+         delivers A's data marker - i.e., the server replayed session A's event to
          session B. A server that replays only the requester's own events, or that
          ignores Last-Event-ID, produces no finding.
 

--- a/testdata/mcp_sse_resume_replay_server.py
+++ b/testdata/mcp_sse_resume_replay_server.py
@@ -6,10 +6,10 @@ Deliberately vulnerable MCP Streamable HTTP test server for validating:
 
 Flow the scanner drives:
   - initialize (POST) -> server mints a distinct Mcp-Session-Id per session
-  - GET (Accept: text/event-stream) with no Last-Event-ID -> emits one
-    session-specific event (id + data) and records it in a GLOBAL log
-  - GET with Last-Event-ID=N -> VULNERABLE: replays every logged event with
-    id > N regardless of which session created it
+  - GET (Accept: text/event-stream) with no Last-Event-ID -> emits two
+    session-specific events with opaque ids and records them in a GLOBAL log
+  - GET with Last-Event-ID=<opaque id> -> VULNERABLE: replays every logged event
+    after that id regardless of which session created it
 
 A compliant server replays only the requesting session's own events.
 
@@ -57,24 +57,31 @@ async def mcp_get(request: Request) -> Response:
     leid = request.headers.get("last-event-id", "")
 
     if leid == "":
-        _events += 1
-        eid = _events
-        data = json.dumps({"sid": sid, "secret": f"S-{sid}-{eid}"})
-        LOG.append({"eid": eid, "sid": sid, "data": data})
+        # Emit two session-specific events with OPAQUE (non-numeric) ids, so a
+        # resume from the first event's id can replay the second. Real MCP SDKs
+        # mint opaque ids; the spec does not guarantee numeric ones.
+        fresh = []
+        for _ in range(2):
+            _events += 1
+            eid = f"evt-{sid}-{_events}"
+            data = json.dumps({"sid": sid, "secret": f"S-{sid}-{_events}"})
+            entry = {"eid": eid, "sid": sid, "data": data}
+            LOG.append(entry)
+            fresh.append(entry)
 
         def gen_new():
-            yield f"id: {eid}\ndata: {data}\n\n"
+            for ev in fresh:
+                yield f"id: {ev['eid']}\ndata: {ev['data']}\n\n"
         return StreamingResponse(gen_new(), media_type="text/event-stream")
 
-    try:
-        last = int(leid)
-    except ValueError:
-        last = -1
+    # Resume after the event whose opaque id matches Last-Event-ID.
+    snapshot = list(LOG)
+    start = next((i for i, ev in enumerate(snapshot) if ev["eid"] == leid), -1)
 
     def gen_resume():
-        # VULNERABLE: replay every buffered event after `last`, any session.
-        for ev in list(LOG):
-            if ev["eid"] > last:
+        # VULNERABLE: replay every buffered event after the checkpoint, any session.
+        if start != -1:
+            for ev in snapshot[start + 1:]:
                 yield f"id: {ev['eid']}\ndata: {ev['data']}\n\n"
     return StreamingResponse(gen_resume(), media_type="text/event-stream")
 


### PR DESCRIPTION
## A2: Resume with the opaque event id in `mcp-sse-resume-replay-001`

### Problem
The SSE resumption-replay rule produces a **false negative against real MCP servers**. It only detects cross-session replay when the server happens to use numeric event ids.

### Root cause
The executor captured an event id and computed a "lower" id to resume from:
```go
func lowerEventID(id string) string {
    if n, err := strconv.Atoi(id); err == nil && n > 0 { return strconv.Itoa(n - 1) }
    return "0"
}
```
MCP event ids are **opaque** per the Streamable HTTP resumability spec ("event IDs ... MUST be globally unique ... act as a cursor"), and the reference TS/Python SDKs mint opaque ids. So `strconv.Atoi` fails and `lowerEventID` returns `"0"`, which no real server recognizes as a cursor. The resume delivers nothing and the replay goes undetected.

### Fix (use the exact id, no arithmetic)
- **Executor**: replaced `firstIDAndMarker` + `lowerEventID` with `resumeCheckpoint`, which selects the first id-bearing event as the cursor and collects the data of the events that follow it as markers. Session B now resumes with the **exact opaque checkpoint id** (events after it are what a vulnerable server replays), no arithmetic.
- **Unit fixture**: now mints opaque ids, resumes by matching the id, and emits two events per stream so a resume from the first replays the second. Added `TestResume_OpaqueEventIDs`.
- **Testdata server**: same opaque-id model, for live validation.
- **Rule descriptor**: dropped the "Last-Event-ID below A's id" arithmetic wording from step 3 (it encoded the bug).

### Validation
- `TestResume_Vulnerable` and `TestResume_OpaqueEventIDs`: **fail under the old numeric-decrement executor** against the opaque-id fixture (`got 0` findings), **pass after** the fix. Verified by stashing only the executor and re-running.
- `TestResume_Secure`, `TestResume_Ignore`, `TestResume_NotMCP` still pass (no false positives).
- Full suite green: `go build`, `go vet`, `go test ./...`, `golangci-lint run` (v2.11.4, 0 issues). `-race` runs in CI.
- Python fixture not run locally (no interpreter on this machine); its logic mirrors the unit-tested Go fixture.

### Behavior change worth noting
Single-event streams are no longer testable by this rule: you cannot reference a cursor *before* the only event without arithmetic, which is inherent to opaque ids. Real active sessions emit multiple events, so this trades a numeric-only edge case (not guaranteed by the spec) for correct detection against real servers.

### Scope
Pinning this rule to a dated spec revision and noting the 2026-07-28 resumability deprecation is a separate item (**C1**); this PR is only the opaque-id correctness fix.
