### PR TITLE
fix(mcp-oauth-dcr-001): correct DCR spec characterization and date

### DIFF
--- a/rules/mcp/oauth-dcr-001.yaml
+++ b/rules/mcp/oauth-dcr-001.yaml
@@ -6,7 +6,7 @@ info:
   description: |
     Tests whether an MCP server's OAuth 2.1 dynamic client registration (DCR)
     endpoint enforces a permitted-scope policy. Open/anonymous DCR is permitted by
-    RFC 7591 and encouraged by the MCP authorization spec, so it is NOT flagged on
+    RFC 7591 and supported by the MCP authorization spec, so it is NOT flagged on
     its own. The rule sends a single UNAUTHENTICATED registration requesting
     admin/write scopes and reports a finding only when the server returns a granted
     scope set that still contains a privileged scope token - i.e. it registered an
@@ -19,11 +19,15 @@ info:
     at registration time (loopback redirects are endorsed by RFC 8252, and a
     client's own external callback cannot be deemed malicious by the server).
 
-    This is the primary authorization attack surface in the MCP 2025-11-05 spec,
-    which mandates OAuth 2.1 with PKCE and DCR for all remote MCP servers.
+    DCR is an optional part of MCP's OAuth 2.1 authorization model: the 2025-06-18
+    spec says clients and authorization servers SHOULD support RFC 7591, and the
+    2025-11-25 revision relaxes that to MAY (preferring Client ID Metadata
+    Documents). Where a server exposes open DCR, granting an anonymous client
+    privileged scopes is the attack surface this rule probes.
 
   references:
-    - https://modelcontextprotocol.io/docs/concepts/authorization
+    - https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization
+    - https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization
     - https://www.rfc-editor.org/rfc/rfc7591
     - https://www.rfc-editor.org/rfc/rfc9700
     - https://owasp.org/www-project-api-security/


### PR DESCRIPTION
## A3: Correct the DCR spec characterization in `mcp-oauth-dcr-001`

### Problem
The rule description made an inaccurate spec claim:
> This is the primary authorization attack surface in the MCP **2025-11-05** spec, which **mandates** OAuth 2.1 with PKCE and **DCR** for all remote MCP servers.

### Verification against the live specs
- **No `2025-11-05` MCP revision exists.** Real revisions: 2024-11-05, 2025-03-26, 2025-06-18, 2025-11-25.
- **DCR is never mandated.** The [2025-06-18 authorization spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization) states clients and authorization servers **SHOULD** support RFC 7591 DCR. The [2025-11-25 revision](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization) relaxed that to **MAY**, with Client ID Metadata Documents now preferred (SEP-991).
- **Authorization is OPTIONAL in MCP**, so "for all remote MCP servers" overclaims. OAuth 2.1 + PKCE are MUST, but only when a server supports authorization.
- This also contradicted line 9 of the same file, which already called DCR "encouraged" (SHOULD).

### Fix (metadata only)
- Rewrote the closing paragraph to state DCR's actual optional status (SHOULD in 2025-06-18, MAY in 2025-11-25), with correct dates, dropping the "mandates DCR" and "primary attack surface" overclaims.
- Changed line 9 "encouraged" to "supported" so the file is internally consistent (DCR is MAY now, no longer encouraged).
- Replaced the generic `/docs/concepts/authorization` reference with the dated 2025-11-25 and 2025-06-18 authorization spec pages that back the corrected claims.

### Validation
- `2025-11-05` appears nowhere else in the repo and the executor has no date dependency (grep-confirmed); this is purely descriptor text.
- The rule **loads and validates** (`go run ... --rule-ids mcp-oauth-dcr-001` → "Running 1 rule(s)", no malformed-rule warning); total still **25 rules**.
- Full suite green: `go test ./...` (includes the `internal/rules` schema-validation test). No Go changed, so no new unit test is warranted; asserting a YAML string would be a tautological test.

### Scope
The separate concern that the executor returns `ConfirmedExploit`/critical for a registration-time scope echo (overstated confidence) is tracked as item **B2**; this PR is only the spec-accuracy fix.

Sources: [MCP 2025-06-18 authorization](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization), [MCP 2025-11-25 authorization](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization).
