### PR TITLE
fix(mcp-header-body-split-001): cite the merged-spec error code -32020

### DIFF
--- a/internal/attack/mcp/header_body_split.go
+++ b/internal/attack/mcp/header_body_split.go
@@ -70,14 +70,15 @@ func (e *HeaderBodySplitExecutor) probe(ctx context.Context, client *attack.HTTP
 			Description: fmt.Sprintf(
 				"At %s, a tools/list request was REJECTED when the Mcp-Method header was omitted (the "+
 					"server enforces header presence), but a tools/list request with a MISMATCHED "+
-					"Mcp-Method: tools/call header was still EXECUTED as tools/list. SEP-2243 requires "+
-					"rejecting such a mismatch with 400 / -32001. Because the header is enforced for "+
+					"Mcp-Method: tools/call header was still EXECUTED as tools/list. The MCP Streamable "+
+					"HTTP spec requires rejecting such a mismatch with 400 / -32020 (HeaderMismatch). "+
+					"Because the header is enforced for "+
 					"presence but not value, an intermediary that routes or rate-limits on Mcp-Method can "+
 					"be bypassed by labelling a sensitive body operation with an innocuous method.",
 				ep),
 			Evidence: fmt.Sprintf(
 				"endpoint: %s\nomit Mcp-Method: rejected (presence enforced)\nMcp-Method: tools/list (match): executed\n"+
-					"Mcp-Method: tools/call (mismatch) + body tools/list: EXECUTED body (should be 400/-32001)",
+					"Mcp-Method: tools/call (mismatch) + body tools/list: EXECUTED body (should be 400/-32020)",
 				ep),
 			Remediation: e.rule.Remediation,
 			TargetURL:   ep,

--- a/internal/attack/mcp/header_body_split_test.go
+++ b/internal/attack/mcp/header_body_split_test.go
@@ -19,7 +19,7 @@ func hbsRuleCtx() attack.RuleContext {
 // splitServer models a Streamable HTTP MCP server. mode selects header handling
 // for tools/list (initialize always succeeds):
 //   - "split":     requires Mcp-Method presence but ignores its VALUE (vulnerable)
-//   - "strict":    rejects missing OR mismatched Mcp-Method with 400/-32001
+//   - "strict":    rejects missing OR mismatched Mcp-Method with 400/-32020
 //   - "unaware":   ignores Mcp-Method entirely (not SEP-2243-aware)
 func splitServer(mode string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -40,7 +40,7 @@ func splitServer(mode string) *httptest.Server {
 			w.WriteHeader(http.StatusBadRequest)
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"jsonrpc": "2.0", "id": id,
-				"error": map[string]interface{}{"code": -32001, "message": "HeaderMismatch"},
+				"error": map[string]interface{}{"code": -32020, "message": "HeaderMismatch"},
 			})
 		}
 

--- a/rules/mcp/header-body-split-001.yaml
+++ b/rules/mcp/header-body-split-001.yaml
@@ -7,8 +7,9 @@ info:
     Tests for the SEP-2243 "split-brain" class: an MCP Streamable HTTP server
     that ENFORCES the presence of the Mcp-Method routing header (so intermediaries
     route/police on it) but does NOT validate that the header value matches the
-    JSON-RPC body. SEP-2243 requires servers to reject a header/body mismatch with
-    400 Bad Request and JSON-RPC error -32001 (HeaderMismatch). A server that
+    JSON-RPC body. The MCP Streamable HTTP spec requires servers to reject a
+    header/body mismatch with 400 Bad Request and JSON-RPC error -32020
+    (HeaderMismatch; the original SEP-2243 draft used -32001). A server that
     requires the header but executes the body method regardless lets an attacker
     label a sensitive operation with an innocuous Mcp-Method, bypassing any
     gateway/rate-limiter that trusts the header - "policy on headers, execute on
@@ -22,7 +23,7 @@ info:
          SEP-2243-aware) - no finding.
       2. Mcp-Method: tools/list (matches body). Must be accepted (sanity).
       3. Mcp-Method: tools/call (mismatch). A compliant server MUST reject (400 /
-         -32001). If it executes the body's tools/list anyway, the server enforces
+         -32020). If it executes the body's tools/list anyway, the server enforces
          header PRESENCE but not header/body CONSISTENCY - reported CONFIRMED.
 
   references:
@@ -46,7 +47,8 @@ attack:
 remediation: |
   1. Per SEP-2243, validate that Mcp-Method (and Mcp-Name where applicable) match
      the corresponding request-body values; reject any mismatch with 400 Bad
-     Request and JSON-RPC error code -32001 (HeaderMismatch).
+     Request and JSON-RPC error code -32020 (HeaderMismatch; -32001 in the
+     original SEP-2243 draft).
   2. Do not enforce header PRESENCE while ignoring header VALUE - partial
      enforcement is worse than none, because intermediaries will trust a header
      the origin does not validate.

--- a/testdata/mcp_header_body_split_server.py
+++ b/testdata/mcp_header_body_split_server.py
@@ -6,7 +6,8 @@ Deliberately vulnerable MCP Streamable HTTP test server for validating:
     Mcp-Method: tools/call and body method tools/list is still executed as
     tools/list - a header/body "split-brain" (CWE-444).
 
-A compliant server MUST reject a mismatch with 400 + JSON-RPC error -32001.
+A compliant server MUST reject a mismatch with 400 + JSON-RPC error -32020
+(-32001 in the original SEP-2243 draft).
 
 Validate against it:
   python testdata/mcp_header_body_split_server.py
@@ -43,7 +44,7 @@ async def mcp(request: Request) -> Response:
         if not mcp_method:
             return JSONResponse(status_code=400, content={
                 "jsonrpc": "2.0", "id": req_id,
-                "error": {"code": -32001, "message": "HeaderMismatch: missing Mcp-Method"}})
+                "error": {"code": -32020, "message": "HeaderMismatch: missing Mcp-Method"}})
         return JSONResponse({"jsonrpc": "2.0", "id": req_id,
                              "result": {"tools": [{"name": "echo", "description": "echo"}]}})
     return JSONResponse(status_code=400, content={"jsonrpc": "2.0", "id": req_id,


### PR DESCRIPTION
## A4: Cite the merged-spec error code `-32020` in `mcp-header-body-split-001`

### What this turned out to be
The action item was "accept `-32020` alongside `-32001`." Source analysis changed the framing:

- **The two codes are the same requirement at different lifecycle stages.** [SEP-2243](https://modelcontextprotocol.io/community/seps/2243-http-standardization) (status: Final) used `-32001` (a placeholder in the JSON-RPC implementation-defined range `-32000..-32099`). When SEP-2243 was merged into the [Streamable HTTP spec (2026-07-28 draft)](https://modelcontextprotocol.io/specification/draft/basic/transports/streamable-http), the code was reallocated to the protocol-defined range as **`-32020` (`HeaderMismatch`)**, with a `HeaderMismatchError` schema type. So the rule's `-32001` is the pre-merge value; `-32020` is current normative.
- **There is no executor "acceptance" to broaden.** Detection is execution-based: `toolsList()` confirms the finding when the mismatched request *executes the body* (`result.tools` present). The error code only appeared in human-readable finding/fixture text, never in detection logic.

So A4 is correctly scoped as a documentation/fixture accuracy fix.

### Change
- Finding text (`Description`, `Evidence`), rule descriptor (`description`, `remediation`), and both fixtures (Go unit test + Python testdata) now cite `-32020`, keeping `-32001` as a documented note for servers implementing the original SEP draft.
- No detection logic changed.

### Validation
- `TestSplit_Strict` **still passes** with the strict fixture returning `-32020` instead of `-32001`, empirical proof the executor never gated on the code (rejection is detected via the `400` / error envelope, not the number).
- `TestSplit_Vulnerable` / `Unaware` / `NotMCP` unchanged.
- Full suite green: `go build`, `go vet`, `go test ./...`, `golangci-lint run` (v2.11.4, 0 issues). Python fixture not run locally (no interpreter); logic mirrors the unit-tested Go fixture.
- No new unit test added: the behavior is identical regardless of the code, so asserting the code string would be a tautological test.

### Queued follow-up (not in this PR)
While reading the executor I found a higher-impact latent no-op: it initializes with `protocolVersion: 2025-06-18` and never sends the `MCP-Protocol-Version` header. `Mcp-Method` enforcement is a 2026-07-28 feature, and a compliant current server **MAY** skip header enforcement when negotiating an older version (a strict one would reject the init for the missing `MCP-Protocol-Version` header). So against real current servers Probe 1 likely gets accepted and the rule reports "not SEP-2243-aware" with no finding. Per your call, this is queued to fix with the C2 version-aware-shaping work rather than expanded into this PR.
