### PR TITLE
fix(sarif): drop uriBaseId on absolute target URIs

### DIFF
--- a/internal/report/sarif.go
+++ b/internal/report/sarif.go
@@ -175,9 +175,11 @@ func findingToSARIF(f attackpkg.Finding) sarifResult {
 		Locations: []sarifLocation{
 			{
 				PhysicalLocation: sarifPhysicalLocation{
+					// Batesian targets are network endpoints, so TargetURL is an
+					// absolute URI. Per SARIF 2.1.0 an absolute uri MUST NOT carry a
+					// uriBaseId (and %SRCROOT% would be an undefined base id anyway).
 					ArtifactLocation: sarifArtifactLocation{
-						URI:       f.TargetURL,
-						URIBaseID: "%SRCROOT%",
+						URI: f.TargetURL,
 					},
 				},
 			},

--- a/internal/report/sarif_test.go
+++ b/internal/report/sarif_test.go
@@ -1,0 +1,80 @@
+package report_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/engine"
+	"github.com/calbebop/batesian/internal/report"
+	"github.com/calbebop/batesian/internal/rules"
+)
+
+// sarifFixture builds a one-finding result set with an absolute network target,
+// which is the only shape Batesian ever produces (scan targets are URLs).
+func sarifFixture() []engine.RunResult {
+	r := &rules.Rule{}
+	r.ID = "mcp-test-001"
+	r.Info.Name = "Test Rule"
+	r.Info.Severity = "high"
+	return []engine.RunResult{{
+		Rule: r,
+		Findings: []attack.Finding{{
+			RuleID:      "mcp-test-001",
+			RuleName:    "Test Rule",
+			Severity:    "high",
+			Confidence:  attack.ConfirmedExploit,
+			Title:       "Test finding",
+			Description: "Test description",
+			TargetURL:   "https://agent.example.com/mcp",
+		}},
+	}}
+}
+
+// sarifDoc is a minimal view of the parts of a SARIF document this test inspects.
+type sarifDoc struct {
+	Runs []struct {
+		Results []struct {
+			Locations []struct {
+				PhysicalLocation struct {
+					ArtifactLocation map[string]any `json:"artifactLocation"`
+				} `json:"physicalLocation"`
+			} `json:"locations"`
+		} `json:"results"`
+	} `json:"runs"`
+}
+
+// TestWriteSARIF_AbsoluteURIHasNoUriBaseId verifies the artifactLocation for a
+// network target carries the absolute target URL and NO uriBaseId. Per SARIF
+// 2.1.0: "if the uri property contains an absolute URI, the uriBaseId property
+// SHALL be absent." The previous output paired the absolute URI with a
+// %SRCROOT% uriBaseId, violating the spec.
+func TestWriteSARIF_AbsoluteURIHasNoUriBaseId(t *testing.T) {
+	var buf bytes.Buffer
+	if err := report.WriteSARIF(&buf, "https://agent.example.com", sarifFixture(), "test"); err != nil {
+		t.Fatalf("WriteSARIF: %v", err)
+	}
+
+	// Guard against the literal markers slipping back into the output.
+	if strings.Contains(buf.String(), "uriBaseId") || strings.Contains(buf.String(), "SRCROOT") {
+		t.Fatalf("SARIF must not contain uriBaseId/SRCROOT for an absolute target URI:\n%s", buf.String())
+	}
+
+	var doc sarifDoc
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("SARIF is not valid JSON: %v", err)
+	}
+	if len(doc.Runs) != 1 || len(doc.Runs[0].Results) != 1 || len(doc.Runs[0].Results[0].Locations) != 1 {
+		t.Fatalf("expected one run with one located result, got: %+v", doc)
+	}
+
+	al := doc.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation
+	if al["uri"] != "https://agent.example.com/mcp" {
+		t.Errorf("artifactLocation.uri = %v, want the absolute target URL", al["uri"])
+	}
+	if _, present := al["uriBaseId"]; present {
+		t.Errorf("artifactLocation must not contain uriBaseId for an absolute URI, got: %v", al)
+	}
+}


### PR DESCRIPTION
## A5: Drop `uriBaseId` on absolute target URIs in SARIF output

### Problem
`findingToSARIF` emitted:
```json
"artifactLocation": { "uri": "https://agent.example.com/mcp", "uriBaseId": "%SRCROOT%" }
```
Two defects, both grounded in the specs:
- **SARIF 2.1.0 violation.** [The spec](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html): "if the uri property contains an absolute URI, the uriBaseId property **SHALL** be absent." Batesian's `TargetURL` is always an absolute network URL, so the `uriBaseId` is a mandatory-violation. (Known anti-pattern: kubeshop/monokle-core#448.)
- **Dangling base id.** GitHub additionally requires `%SRCROOT%` to be declared in `originalUriBaseIds`, which this output never did.

### Fix
Emit just the absolute `uri` with no `uriBaseId`, which is what DAST/web SARIF producers do. The `uriBaseId` struct field is left in place (valid SARIF member, `omitempty`) with a comment explaining why it must stay unset for network targets.

### Test (closing a coverage gap)
The SARIF writer had **no test at all**. Added `sarif_test.go`:
- Asserts the `artifactLocation` carries the absolute target URL and **no** `uriBaseId`, and that the document is valid JSON.
- Verified fail-before / pass-after by stashing only `sarif.go` and re-running (old output with `%SRCROOT%` fails the test).

### Validation
Full gate green: `go build`, `go vet`, `go test ./...`, `golangci-lint run` (v2.11.4, 0 issues).

### Queued follow-up (not in this PR)
Researching GitHub's ingestion surfaced a bigger truth: **GitHub code scanning is repo-file-only.** It converts absolute `artifactLocation.uri` values to repo-relative paths to match committed files and [does not support network/web (DAST) targets](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning). Batesian findings live at absolute URLs, so they will not annotate real files in the GitHub Security tab regardless of this fix; the SARIF's real audience is generic SARIF consumers (DAST viewers, dashboards). The file/README "GitHub Security tab integration" framing is therefore optimistic. I've queued this as a docs-accuracy item rather than expand this PR. This fix is still correct and necessary for every SARIF consumer.
