### PR TITLE
docs(ci-cd): fix phantom --oob flag and misleading basic-scan heading

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -5,7 +5,7 @@ Integrating into CI takes two lines on top of the scan command.
 
 ## GitHub Actions
 
-### Basic scan -- fail on high+ findings
+### Basic scan (upload SARIF to Code Scanning)
 
 ```yaml
 # .github/workflows/agent-security.yml
@@ -106,25 +106,26 @@ Set these in **Settings > Secrets and variables > Actions**.
 
 ## OOB / SSRF detection in CI
 
-The push-notification SSRF rule (`a2a-push-ssrf-001`) requires an
-out-of-band callback listener. In CI, start the OOB listener with `--oob`:
+The push-notification SSRF rule (`a2a-push-ssrf-001`) and the OAuth metadata
+SSRF rule (`mcp-oauth-metadata-ssrf-001`) confirm findings via an out-of-band
+callback. Each rule starts a local HTTP listener automatically for the run, so
+no extra flag is needed:
 
 ```yaml
-      - name: Run scan with OOB listener
+      - name: Run scan (OOB SSRF detection is automatic)
         run: |
           batesian scan \
             --target ${{ vars.AGENT_TARGET_URL }} \
-            --oob \
             --output sarif \
             > results.sarif
 ```
 
-The `--oob` flag starts a local HTTP listener on a random port and derives the
-callback URL from the host's detected outbound interface IP (typically a private
-or RFC 1918 address). On GitHub Actions runners, this IP is not publicly
-routable, so the target agent must be on the same network as the runner to
-receive the callback. For production CI where the target is external, use
-`--oob-url` to point to a pre-configured externally reachable listener instead.
+The local listener binds a random port and derives the callback URL from the
+host's detected outbound interface IP (typically a private or RFC 1918 address).
+On GitHub Actions runners this IP is not publicly routable, so the target agent
+must be on the same network as the runner to deliver the callback. For
+production CI where the target is external, pass `--oob-url` to point at a
+pre-configured, externally reachable listener instead.
 
 ## GitLab CI
 


### PR DESCRIPTION
## A6: Fix the phantom `--oob` flag (and a misleading heading) in `docs/ci-cd.md`

### Problem
The "OOB / SSRF detection in CI" section instructed users to start the OOB listener with a `--oob` flag:
```yaml
batesian scan --target ... --oob --output sarif > results.sarif
```
**There is no `--oob` flag.** The binary rejects it (`error: unknown flag: --oob`), so the copy-pasted CI step fails. And no flag is needed: the `a2a-push-ssrf-001` and `mcp-oauth-metadata-ssrf-001` executors **start a local OOB listener automatically** when `--oob-url` is not set (`push_ssrf.go:41-55`). `--oob-url` is only the override for an external, reachable listener.

### Fix
- Rewrote the section to describe the automatic local-listener behavior (no flag needed), keeping the CI networking caveat and `--oob-url` as the external override. Also named the second SSRF rule that uses OOB.
- Fixed the heading `### Basic scan -- fail on high+ findings`: that section only uploads SARIF and does **not** fail the build (the failing example is the separate section below). Retitled to `### Basic scan (upload SARIF to Code Scanning)`.

### Verification (real, not a string assertion)
- The binary **rejects** `--oob` (`unknown flag`) and **accepts** the corrected command, confirming the doc was wrong and the fix is right.
- Confirmed **every flag** the doc references (`--target`, `--output`, `--timeout`, `--protocol`, `--rule-ids`, `--oob-url`) exists in the CLI source.
- No residual standalone `--oob`, no em dashes.
- Docs-only; no code changed (Go build/tests unaffected, CI will run them anyway).

### Note
I verified repo-wide that the OOB listener is genuinely wired up (it lives in the executors, not the CLI), so the "automatic" behavior the rewrite describes is accurate, not aspirational.
