### PR TITLE
fix(cli): preserve explicit --timeout 10 over config

### DIFF
--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -120,9 +120,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 	if token == "" {
 		token = firstNonEmpty(cfg.Token, os.Getenv("BATESIAN_TOKEN"))
 	}
-	if timeoutSecs == 10 && cfg.TimeoutSeconds > 0 {
-		timeoutSecs = cfg.TimeoutSeconds
-	}
+	timeoutSecs = effectiveTimeout(cmd.Flags().Changed("timeout"), timeoutSecs, cfg.TimeoutSeconds)
 	if !skipTLS {
 		skipTLS = cfg.SkipTLS
 	}
@@ -365,6 +363,17 @@ func firstNonEmpty(vals ...string) string {
 		}
 	}
 	return ""
+}
+
+// effectiveTimeout resolves the per-request timeout from the --timeout flag and
+// the config file. An explicitly-set flag always wins, even when it equals the
+// default, so `--timeout 10` is never silently overridden by a config value.
+// Otherwise a positive config value is used; otherwise the flag value (default).
+func effectiveTimeout(flagChanged bool, flagVal, cfgVal int) int {
+	if !flagChanged && cfgVal > 0 {
+		return cfgVal
+	}
+	return flagVal
 }
 
 // fetchOAuthToken acquires a bearer token via client credentials grant.

--- a/internal/cli/scan_test.go
+++ b/internal/cli/scan_test.go
@@ -69,3 +69,28 @@ func TestBuildPrincipals_Empty(t *testing.T) {
 		t.Errorf("expected no principals, got %d", len(got))
 	}
 }
+
+func TestEffectiveTimeout(t *testing.T) {
+	tests := []struct {
+		name        string
+		flagChanged bool
+		flagVal     int
+		cfgVal      int
+		want        int
+	}{
+		// The bug this guards: an explicit --timeout 10 (equal to the default)
+		// must not be overridden by a config value.
+		{"explicit flag equal to default wins over config", true, 10, 30, 10},
+		{"explicit flag wins even when config is zero", true, 25, 0, 25},
+		{"config used when flag not set", false, 10, 30, 30},
+		{"flag default when neither set", false, 10, 0, 10},
+		{"non-positive config ignored", false, 10, -5, 10},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := effectiveTimeout(tc.flagChanged, tc.flagVal, tc.cfgVal); got != tc.want {
+				t.Errorf("effectiveTimeout(%v, %d, %d) = %d, want %d", tc.flagChanged, tc.flagVal, tc.cfgVal, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## A7: Preserve an explicit `--timeout 10` over config

### Problem
The flag/config merge used the flag's default value as its "unset" sentinel:
```go
if timeoutSecs == 10 && cfg.TimeoutSeconds > 0 {
    timeoutSecs = cfg.TimeoutSeconds
}
```
So an explicit `--timeout 10` is indistinguishable from the default `10` and gets **silently overridden** by a config `TimeoutSeconds` (e.g. config says 30, user passes `--timeout 10`, scan runs with 30). The sibling string flags don't have this problem because `""` is a real "unset" value; `timeout` is an int whose default collides with a legitimate user value.

### Fix
Replace the sentinel with cobra's `Flags().Changed("timeout")`, extracted into a pure `effectiveTimeout` helper (mirrors the existing `firstNonEmpty`). An explicitly-set flag always wins, even when it equals the default; otherwise a positive config value is used; otherwise the flag value.

### Test
Added `TestEffectiveTimeout` (table) covering the bug case and the normal precedence rules:
- `explicit flag equal to default wins over config` (true, 10, 30) → **10** (the bug)
- explicit wins when config is zero; config used when flag unset; flag default when neither set; non-positive config ignored.

**Proven fail-before**: temporarily restoring the old sentinel logic made the helper return `effectiveTimeout(true, 10, 30) = 30` (want 10), then reverted.

### Validation
Full gate green: `go build`, `go vet`, `go test ./...`, `golangci-lint run` (v2.11.4, 0 issues).

### Queued follow-up (not in this PR)
`--skip-tls` has the **same sentinel class**: `if !skipTLS { skipTLS = cfg.SkipTLS }`, so an explicit `--skip-tls=false` cannot override a config `skipTLS: true` (default-false is indistinguishable from explicit-false). The same `Flags().Changed("skip-tls")` fix applies, but it is a security-sensitive precedence change (TLS verification), so I left it out to raise with you first. Low severity (passing `--skip-tls=false` explicitly is unusual).
