### PR TITLE
fix(report): rune-safe truncation for table and SARIF output

### DIFF
--- a/internal/report/printer.go
+++ b/internal/report/printer.go
@@ -450,12 +450,35 @@ func (p *Printer) PrintMCPProbeTable(r *MCPProbeResult) {
 	fmt.Fprintln(p.w)
 }
 
-// printFinding renders a single finding to the terminal (evidence shown in verbose mode).
-
-func truncate(s string, max int) string {
-	s = strings.ReplaceAll(s, "\n", " ")
+// truncateRunes shortens s to at most max bytes without splitting a multibyte
+// UTF-8 rune, appending "..." when it truncates. Slicing a string at an
+// arbitrary byte index can cut a rune mid-sequence and yield invalid UTF-8 in
+// JSON/SARIF output, so the cut is moved back to the nearest rune boundary.
+func truncateRunes(s string, max int) string {
 	if len(s) <= max {
 		return s
 	}
-	return s[:max-3] + "..."
+	budget := max
+	ellipsis := ""
+	if max >= 3 {
+		budget = max - 3
+		ellipsis = "..."
+	}
+	// range over a string yields the byte offset of each rune start; keep the
+	// largest offset that still fits the budget so s[:cut] ends on a boundary.
+	cut := 0
+	for i := range s {
+		if i > budget {
+			break
+		}
+		cut = i
+	}
+	return s[:cut] + ellipsis
+}
+
+// truncate collapses newlines to spaces (for single-line table cells) and then
+// rune-safely shortens s to at most max bytes.
+func truncate(s string, max int) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	return truncateRunes(s, max)
 }

--- a/internal/report/sarif.go
+++ b/internal/report/sarif.go
@@ -105,7 +105,7 @@ func buildSARIF(results []engine.RunResult, toolVersion string) sarifLog {
 				ID:               r.Rule.ID,
 				Name:             r.Rule.Info.Name,
 				ShortDescription: sarifMessage{Text: r.Rule.Info.Name},
-				FullDescription:  sarifMessage{Text: trimDescription(r.Rule.Info.Description)},
+				FullDescription:  sarifMessage{Text: truncateRunes(r.Rule.Info.Description, 500)},
 				Properties: sarifRuleProperties{
 					Tags:     tags,
 					Severity: severityScore(r.Rule.Info.Severity),
@@ -220,12 +220,4 @@ func severityScore(sev string) string {
 	default:
 		return "1.0"
 	}
-}
-
-// trimDescription strips leading/trailing whitespace from multi-line YAML descriptions.
-func trimDescription(s string) string {
-	if len(s) > 500 {
-		return s[:497] + "..."
-	}
-	return s
 }

--- a/internal/report/truncate_test.go
+++ b/internal/report/truncate_test.go
@@ -1,0 +1,45 @@
+package report
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// TestTruncateRunes_MultibyteStaysValid is the regression guard: byte-index
+// truncation can cut a multibyte rune mid-sequence and emit invalid UTF-8. The
+// output must always be valid UTF-8 and within the byte budget.
+func TestTruncateRunes_MultibyteStaysValid(t *testing.T) {
+	s := strings.Repeat("世", 60) // 180 bytes; each rune is 3 bytes
+	for _, max := range []int{4, 10, 11, 12, 13, 80, 179} {
+		out := truncateRunes(s, max)
+		if !utf8.ValidString(out) {
+			t.Errorf("truncateRunes(max=%d) produced invalid UTF-8: %q", max, out)
+		}
+		if len(out) > max {
+			t.Errorf("truncateRunes(max=%d) len=%d exceeds budget", max, len(out))
+		}
+	}
+}
+
+func TestTruncateRunes_ShortStringUnchanged(t *testing.T) {
+	if got := truncateRunes("héllo", 80); got != "héllo" {
+		t.Errorf("short string changed: %q", got)
+	}
+}
+
+func TestTruncateRunes_ASCIIEllipsis(t *testing.T) {
+	got := truncateRunes(strings.Repeat("a", 100), 10)
+	if want := strings.Repeat("a", 7) + "..."; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if len(got) != 10 {
+		t.Errorf("len=%d, want 10", len(got))
+	}
+}
+
+func TestTruncate_CollapsesNewlines(t *testing.T) {
+	if got := truncate("a\nb\nc", 80); got != "a b c" {
+		t.Errorf("newlines not collapsed: %q", got)
+	}
+}


### PR DESCRIPTION
## A8: Rune-safe truncation for table and SARIF output

### Problem
Two helpers truncated strings by slicing at a byte index:
- `truncate` (printer.go): `return s[:max-3] + "..."`
- `trimDescription` (sarif.go): `return s[:497] + "..."`

If the cut lands in the middle of a multibyte UTF-8 rune, the result is **invalid UTF-8** in the emitted JSON/SARIF (and garbled table cells). This is reachable: callers truncate attacker-influenced `evidence` and multi-line rule `descriptions`, which can contain non-ASCII bytes.

### Fix
- Added `truncateRunes`: byte-budget truncation that moves the cut back to the nearest rune boundary (so the output is always valid UTF-8 and within `max` bytes).
- `truncate` now collapses newlines (for single-line table cells) and delegates to `truncateRunes`.
- `trimDescription` was a near-duplicate of `truncate(s, 500)` minus the newline-collapse, and its doc comment wrongly claimed it "strips leading/trailing whitespace" (it truncates). Replaced its single call site with `truncateRunes(s, 500)` (preserving the no-newline-collapse behavior for SARIF `fullDescription`) and deleted it. Also removed a stray orphaned `// printFinding` comment.

### Test (new file `truncate_test.go`)
- **Multibyte regression guard**: truncates a string of 3-byte runes at several cut points and asserts the output is valid UTF-8 (`utf8.ValidString`) and within the byte budget.
- ASCII ellipsis, short-string-unchanged, and newline-collapse cases.
- **Proven fail-before**: temporarily restored the byte-slice and the guard failed with invalid UTF-8 (e.g. a 3-byte rune cut mid-sequence), then reverted.

The test is an internal `package report` file because `truncateRunes`/`truncate` are unexported (the existing `printer_test.go` is the external `report_test` package).

### Validation
Full gate green: `go build`, `go vet`, `go test ./...`, `golangci-lint run` (v2.11.4, 0 issues). No residual `trimDescription`.
