### PR TITLE
fix(attack): skip empty substrings in Response.ContainsAny

### DIFF
--- a/internal/attack/a2a/task_idor_test.go
+++ b/internal/attack/a2a/task_idor_test.go
@@ -226,6 +226,51 @@ func TestTaskIDOR_OpenServerIsNotIDOR(t *testing.T) {
 	}
 }
 
+// TestTaskIDOR_NoContextIdNullRead_NoFalsePositive guards the empty-substring
+// false positive. The server auth-gates creation but returns a task WITHOUT a
+// contextId (so the executor's contextID is ""), and answers the unauthenticated
+// read with a null result (HTTP 200, no JSON-RPC error) rather than denying it.
+// The unauth read returned none of the owner's data, so the rule MUST stay
+// silent. Before the ContainsAny empty-needle fix, the "" contextID matched any
+// body and this fired a false IDOR finding.
+func TestTaskIDOR_NoContextIdNullRead_NoFalsePositive(t *testing.T) {
+	const taskID = "task-nocontext-1"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		method, id := decodeRPC(r)
+		switch method {
+		case "SendMessage", "message/send":
+			if !hasOwnerAuth(r) {
+				rpcErr(w, id, -32600, "authentication required") // creation is auth-gated
+				return
+			}
+			// Created task carries an id but no contextId.
+			writeJSON(w, map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{"id": taskID, "status": "working"},
+			})
+		case "GetTask", "tasks/get":
+			// Secure: a task the caller cannot see comes back as a null result,
+			// not an error, and discloses none of the owner's data.
+			writeJSON(w, map[string]interface{}{"jsonrpc": "2.0", "id": id, "result": nil})
+		default:
+			rpcErr(w, id, -32601, "Method not found")
+		}
+	}))
+	defer ts.Close()
+
+	findings, err := a2a.NewTaskIDORExecutor(testRuleCtx()).Execute(context.Background(), ts.URL, idorOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings (null read discloses nothing), got %d: %+v", len(findings), findings)
+	}
+}
+
 // TestTaskIDOR_UnauthTaskList: the server exposes GET /v1/tasks without auth,
 // disclosing all tasks server-wide. The rule MUST fire (critical).
 func TestTaskIDOR_UnauthTaskList(t *testing.T) {

--- a/internal/attack/http.go
+++ b/internal/attack/http.go
@@ -116,10 +116,13 @@ func (r *Response) JSONField(path string) string {
 }
 
 // ContainsAny returns true if the body contains any of the given substrings.
+// Empty substrings are skipped: strings.Contains(body, "") is always true, so an
+// empty needle (e.g. an optional, absent value like a missing contextId) must not
+// be treated as a match against any body.
 func (r *Response) ContainsAny(substrings ...string) bool {
 	body := r.BodyString()
 	for _, s := range substrings {
-		if strings.Contains(body, s) {
+		if s != "" && strings.Contains(body, s) {
 			return true
 		}
 	}

--- a/internal/attack/http_test.go
+++ b/internal/attack/http_test.go
@@ -61,3 +61,20 @@ func TestUserAgent_IncludesVersion(t *testing.T) {
 		t.Errorf("expected User-Agent to contain batesian/0.99.0-test, got %q", seen)
 	}
 }
+
+// TestResponseContainsAny_SkipsEmptySubstring guards against the empty-needle
+// false positive: strings.Contains(body, "") is always true, so an optional,
+// absent value (e.g. a missing contextId) must not match any body.
+func TestResponseContainsAny_SkipsEmptySubstring(t *testing.T) {
+	r := &attack.Response{Body: []byte(`{"jsonrpc":"2.0","result":null}`)}
+
+	if r.ContainsAny("") {
+		t.Error(`ContainsAny("") matched; empty needle must be skipped`)
+	}
+	if r.ContainsAny("", "absent") {
+		t.Error(`ContainsAny("", "absent") matched; neither needle is present`)
+	}
+	if !r.ContainsAny("", "result") {
+		t.Error(`ContainsAny("", "result") did not match a present non-empty needle`)
+	}
+}


### PR DESCRIPTION
## Fix: skip empty substrings in `Response.ContainsAny`

Found during the A-series retrospective audit.

### Problem
`strings.Contains(body, "")` is always `true`, so passing an empty needle to `ContainsAny` makes it match **any** body. Three rules pass a possibly-empty `contextID` into `ContainsAny`:
- `task_idor.go:129`
- `multitenant_isolation.go:168`
- `delegation_integrity.go:188`

`extractTaskContext` returns `contextID == ""` whenever a created task has no `contextId` field. So a **secure** server that auth-gates creation but answers an unauthenticated read with a null result (HTTP 200, no JSON-RPC error, disclosing nothing) was falsely **confirmed** as cross-principal access (IDOR / isolation break / delegation hijack). That undermines the credibility of three of the suite's strongest rules.

### Fix
Guard the match with `s != ""` in `ContainsAny`. Fixing the shared method clears all three call sites (and any future caller) centrally; an empty needle is never a meaningful "contains" match.

### Tests
- `TestResponseContainsAny_SkipsEmptySubstring` (unit): empty needle must not match; a present non-empty needle alongside an empty one still matches.
- `TestTaskIDOR_NoContextIdNullRead_NoFalsePositive` (rule-level): a server that auth-gates creation, returns a task with no `contextId`, and answers the unauth read with a null result must **not** fire.

**Proven fail-before**: both tests fail against the old `ContainsAny`. The IDOR test fired a false finding whose evidence literally read `returned task task-nocontext-1 (contextId )` (empty contextId, "including its history") against a server that disclosed nothing. Verified by reverting only `http.go`.

### Validation
Full gate green: `go build`, `go vet`, `go test ./...`, `golangci-lint run` (v2.11.4, 0 issues).

### Queued follow-up (not in this PR)
`containsAnyStr` (session_smuggle.go) has the same latent empty-needle bug but is **not currently reachable** (its callers pass non-empty markers and string literals). I'll add the same guard when D1 replaces the hand-rolled `containsAnyStr`/`contains` helpers with `strings.Contains`. (The hand-rolled `contains` in push_ssrf.go already guards against empty.)
