### PR TITLE
fix(a2a): downgrade card-trust and hostinject posture findings to indicator

### DIFF
--- a/internal/attack/a2a/card_trust.go
+++ b/internal/attack/a2a/card_trust.go
@@ -25,9 +25,10 @@ const (
 // well-known paths, cache/TTL of the trust anchor, and signature freshness.
 //
 // It only reads what the server exposes (it does not forge or verify
-// signatures), so most findings are RiskIndicators; the cases it can demonstrate
-// outright - a signed-vs-unsigned path split, or an already-expired signature
-// still being served - are reported as ConfirmedExploit.
+// signatures), so every finding is a RiskIndicator: it observes a weak or
+// inconsistent trust posture (a signed-vs-unsigned path split, an already-expired
+// signature still being served, long-lived caching) but cannot demonstrate that
+// a verifier is actually bypassed. Each finding recommends manual verification.
 type CardTrustExecutor struct {
 	rule attack.RuleContext
 }
@@ -90,13 +91,14 @@ func (e *CardTrustExecutor) checkCanonicalization(primaryURL string, primaryBody
 			RuleID:     e.rule.ID,
 			RuleName:   e.rule.Name,
 			Severity:   "high",
-			Confidence: attack.ConfirmedExploit,
+			Confidence: attack.RiskIndicator,
 			Title:      "A2A agent card is signed on one well-known path but unsigned on the other (signature stripping)",
 			Description: fmt.Sprintf(
 				"%s serves a card WITH JWS signatures while %s serves the same agent's card WITHOUT "+
-					"signatures. An attacker or MITM can steer a client to the unsigned path to bypass "+
-					"signature verification entirely, then substitute forged routing, capability, or "+
-					"security-scheme fields.", signedURL, unsignedURL),
+					"signatures. An attacker or MITM who can steer a client to the unsigned path could "+
+					"bypass signature verification entirely, then substitute forged routing, capability, or "+
+					"security-scheme fields. Manually verify whether clients resolve the unsigned path and "+
+					"skip signature verification.", signedURL, unsignedURL),
 			Evidence:    fmt.Sprintf("signed path: %s\nunsigned path: %s", signedURL, unsignedURL),
 			Remediation: e.rule.Remediation,
 			TargetURL:   unsignedURL,
@@ -210,12 +212,13 @@ func (e *CardTrustExecutor) checkSignatureFreshness(cardURL string, cardBody []b
 				RuleID:     e.rule.ID,
 				RuleName:   e.rule.Name,
 				Severity:   "medium",
-				Confidence: attack.ConfirmedExploit,
+				Confidence: attack.RiskIndicator,
 				Title:      fmt.Sprintf("A2A agent card signatures[%d] is expired but still served", i),
 				Description: fmt.Sprintf(
 					"The card signature's protected header declares exp=%d, which is in the past, yet the "+
-						"server still serves this signature as the live card. A verifier that ignores exp "+
-						"will trust a signature that should no longer be valid.", exp),
+						"server still serves this signature as the live card. A compliant verifier rejects an "+
+						"expired signature; this is exploitable only against a verifier that ignores exp. "+
+						"Manually verify whether the target's clients enforce signature expiry.", exp),
 				Evidence:    fmt.Sprintf("signatures[%d].protected exp=%d (now=%d, expired %ds ago)", i, exp, now, now-exp),
 				Remediation: e.rule.Remediation,
 				TargetURL:   cardURL,

--- a/internal/attack/a2a/card_trust_test.go
+++ b/internal/attack/a2a/card_trust_test.go
@@ -83,14 +83,15 @@ func onlyFinding(t *testing.T, findings []attack.Finding) attack.Finding {
 }
 
 // TestCardTrust_SignatureStripping: signed on primary path, unsigned on legacy.
-// MUST fire confirmed/high.
+// MUST fire indicator/high (a read-only analyzer observes the unsigned path but
+// cannot prove a verifier is bypassed).
 func TestCardTrust_SignatureStripping(t *testing.T) {
 	ts := cardServer(signedCard("https://agent.example/", future()), unsignedCard("https://agent.example/"), "no-store")
 	defer ts.Close()
 
 	f := onlyFinding(t, runCardTrust(t, ts))
-	if f.Confidence != attack.ConfirmedExploit || f.Severity != "high" {
-		t.Errorf("want high/ConfirmedExploit, got %q/%q", f.Severity, f.Confidence)
+	if f.Confidence != attack.RiskIndicator || f.Severity != "high" {
+		t.Errorf("want high/RiskIndicator, got %q/%q", f.Severity, f.Confidence)
 	}
 }
 
@@ -145,15 +146,16 @@ func TestCardTrust_NoExpirySignature(t *testing.T) {
 }
 
 // TestCardTrust_ExpiredSignature: consistent signed card whose signature exp is
-// in the past. MUST fire confirmed/medium.
+// in the past. MUST fire indicator/medium (a compliant verifier rejects it; the
+// scanner cannot prove the target's verifier ignores exp).
 func TestCardTrust_ExpiredSignature(t *testing.T) {
 	card := signedCard("https://agent.example/", past())
 	ts := cardServer(card, card, "no-store")
 	defer ts.Close()
 
 	f := onlyFinding(t, runCardTrust(t, ts))
-	if f.Confidence != attack.ConfirmedExploit || f.Severity != "medium" {
-		t.Errorf("want medium/ConfirmedExploit, got %q/%q", f.Severity, f.Confidence)
+	if f.Confidence != attack.RiskIndicator || f.Severity != "medium" {
+		t.Errorf("want medium/RiskIndicator, got %q/%q", f.Severity, f.Confidence)
 	}
 }
 

--- a/internal/attack/a2a/wellknown_hostinject.go
+++ b/internal/attack/a2a/wellknown_hostinject.go
@@ -80,9 +80,11 @@ func (e *WellKnownHostInjectExecutor) Execute(ctx context.Context, target string
 			// canary landing in an authority/URL field (url, endpoint, *.url, or
 			// any value that is itself a URL) - that is the agent's advertised
 			// service location which other agents and registries trust and cache.
-			// Reflection into a non-URL field (e.g. name, description) is a real
-			// injection primitive but far lower direct impact, so it is reported
-			// as a RiskIndicator rather than a confirmed host-injection exploit.
+			// Both cases are RiskIndicators: the scanner proves only that the
+			// server reflects the header into the card, not that an attacker can
+			// set that header for a victim or that a cache serves the poisoned
+			// card. A URL-field reflection carries higher severity because its
+			// impact, if the header is influenceable, is service-URL takeover.
 			var urlPaths, otherPaths []string
 			for _, rf := range reflections {
 				if isAuthorityField(rf.path) || strings.Contains(rf.value, "://") {
@@ -96,7 +98,7 @@ func (e *WellKnownHostInjectExecutor) Execute(ctx context.Context, target string
 			impact := "a non-URL field, which is a reflection primitive but not directly a " +
 				"service-URL takeover; verify whether any consumer trusts this field"
 			if len(urlPaths) > 0 {
-				severity, confidence, reflectedIn = "high", attack.ConfirmedExploit, urlPaths
+				severity, confidence, reflectedIn = "high", attack.RiskIndicator, urlPaths
 				impact = "an authority/URL field. An attacker who can influence this header " +
 					"(via a caching layer, HTTP request smuggling, or cache poisoning) can make " +
 					"other agents or registries that cache this card resolve the agent's service " +

--- a/internal/attack/a2a/wellknown_hostinject_test.go
+++ b/internal/attack/a2a/wellknown_hostinject_test.go
@@ -41,8 +41,8 @@ func TestWellKnownHostInject_XForwardedHostReflected(t *testing.T) {
 		if f.Severity != "high" {
 			t.Errorf("expected high severity, got %s", f.Severity)
 		}
-		if f.Confidence != attack.ConfirmedExploit {
-			t.Errorf("expected ConfirmedExploit, got %v", f.Confidence)
+		if f.Confidence != attack.RiskIndicator {
+			t.Errorf("expected RiskIndicator, got %v", f.Confidence)
 		}
 	}
 }
@@ -72,7 +72,8 @@ func TestWellKnownHostInject_HardcodedURL(t *testing.T) {
 
 // TestWellKnownHostInject_HostHeaderReflected verifies the forged Host header
 // actually reaches the server (req.Host plumbing) and a reflection into the url
-// field is reported as a high/ConfirmedExploit.
+// field is reported as a high/RiskIndicator (reflection is proven; the
+// attacker-influences-header precondition is not).
 func TestWellKnownHostInject_HostHeaderReflected(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Only trusts the real Host header (not X-Forwarded-*).
@@ -94,8 +95,8 @@ func TestWellKnownHostInject_HostHeaderReflected(t *testing.T) {
 	if len(findings) == 0 {
 		t.Fatal("expected a finding when the forged Host header is reflected into url")
 	}
-	if findings[0].Severity != "high" || findings[0].Confidence != attack.ConfirmedExploit {
-		t.Errorf("expected high/ConfirmedExploit, got %q/%q", findings[0].Severity, findings[0].Confidence)
+	if findings[0].Severity != "high" || findings[0].Confidence != attack.RiskIndicator {
+		t.Errorf("expected high/RiskIndicator, got %q/%q", findings[0].Severity, findings[0].Confidence)
 	}
 }
 


### PR DESCRIPTION
## B1: Downgrade card-trust and host-injection posture findings to `indicator`

The project defines `ConfirmedExploit` as "the attack demonstrably succeeded" and `RiskIndicator` as "a suspicious pattern detected, but exploitability is not proven (always include a note recommending manual verification)." Two rules labelled posture observations as confirmed when they only observe a weak posture.

### `a2a-card-trust-001`
This executor explicitly "does not forge or verify signatures," so by construction it cannot demonstrate an exploit. Yet two findings were `ConfirmedExploit`:
- **Signed-vs-unsigned path split**: proves an unsigned card is served at a well-known path, not that any verifier accepts it (no client was involved, no verification bypassed).
- **Expired signature still served**: a *compliant* verifier rejects an expired signature; the finding's own description says "a verifier that **ignores** exp will trust...", which is conditional, i.e. unproven.

Both are now `RiskIndicator` (severities unchanged: high / medium), the executor doc comment no longer claims it can confirm, and each finding got a manual-verification note. This matches how the sibling `a2a-jws-algconf-001` (also read-only) is already, honestly, all-indicator.

### `a2a-wellknown-hostinject-001`
The `ConfirmedExploit` branch (Host/X-Forwarded-Host reflected into a URL field) only proves the **reflection primitive**: the server echoes *our* Host header into *our* card response. Its own impact text is conditional: "An attacker **who can influence this header** (via a caching layer, HTTP request smuggling, or cache poisoning) can make...". Reflecting your own Host into your own response is common, benign-by-default web behavior; it's exploitable only with a shared cache or a header-injection path that the scanner never demonstrates. Now a **high-severity `RiskIndicator`** (severity still reflects impact-if-exploitable); the misleading comment was corrected.

### Why no severity change
Demoting confidence (how sure we are it's exploitable) is independent of severity (impact if it is). A signature-stripping surface is still high-impact; we're just honest that exploitability isn't proven.

### Tests
Updated the assertions in `card_trust_test.go` and `wellknown_hostinject_test.go` to expect the corrected confidence. The findings **still fire** (each test still asserts exactly one finding via `onlyFinding`), so the rules detect the same postures, just labelled honestly. No residual `ConfirmedExploit` remains in either executor.

### Validation
Full gate green: `go build`, `go vet`, `go test ./...`, `golangci-lint run` (v2.11.4, 0 issues).
