### PR TITLE
fix(mcp-oauth-dcr-001): downgrade scope-echo finding to indicator

### DIFF
--- a/internal/attack/mcp/oauth_dcr.go
+++ b/internal/attack/mcp/oauth_dcr.go
@@ -14,7 +14,7 @@ import (
 // authorized for high-privilege scopes (rule mcp-oauth-dcr-001).
 //
 // Scope is deliberately narrow. Open/anonymous DCR is permitted by RFC 7591 and
-// encouraged by the MCP authorization spec, so it is NOT reported on its own.
+// supported by the MCP authorization spec, so it is NOT reported on its own.
 // Redirect-URI shape is also not judged at registration time: loopback redirects
 // are endorsed by RFC 8252 and a client's own external callback cannot be deemed
 // malicious by the server. The single high-value, protocol-specific failure is
@@ -26,6 +26,11 @@ import (
 //  3. Fire only when the server returns a granted `scope` containing a
 //     privileged scope token - i.e. it registered an anonymous client as
 //     authorized for those scopes.
+//
+// This is registration-time evidence only: a permissive granted `scope` shows
+// the server did not restrict the requested scopes, but whether a privileged
+// token is actually issued depends on the grant/consent step. The finding is
+// therefore a RiskIndicator, not a demonstrated escalation.
 type OAuthDCRExecutor struct {
 	rule attack.RuleContext
 }
@@ -88,14 +93,15 @@ func (e *OAuthDCRExecutor) Execute(ctx context.Context, target string, opts atta
 	return []attack.Finding{{
 		RuleID:     e.rule.ID,
 		RuleName:   e.rule.Name,
-		Severity:   "critical",
-		Confidence: attack.ConfirmedExploit,
+		Severity:   e.rule.Severity,
+		Confidence: attack.RiskIndicator,
 		Title:      "MCP OAuth DCR registered an unauthenticated client with admin/write scopes",
 		Description: fmt.Sprintf("The dynamic client registration endpoint at %s accepted an unauthenticated "+
 			"registration and returned a granted scope set containing privileged scopes %v. The authorization "+
 			"server registered an anonymous client as authorized to request admin/write access; per RFC 7591 the "+
-			"server's registration policy must restrict the scopes it grants. (Whether a token is ultimately issued "+
-			"still depends on the grant/consent step, but the registration-time scope policy has demonstrably failed.)",
+			"server's registration policy should restrict the scopes it grants. Whether a privileged token is "+
+			"actually issued depends on the grant/consent step, so manually verify whether the authorization "+
+			"server issues a token with these scopes to the anonymous client.",
 			registrationEndpoint, granted),
 		Evidence:    fmt.Sprintf("Requested: %q\nGranted: %q\nPrivileged tokens granted: %v\nHTTP %d from %s\n%s", escalatedScope, grantedScope, granted, escalatedResp.StatusCode, registrationEndpoint, snippetMCP(escalatedResp.Body)),
 		Remediation: e.rule.Remediation,

--- a/internal/attack/mcp/oauth_dcr_test.go
+++ b/internal/attack/mcp/oauth_dcr_test.go
@@ -148,8 +148,9 @@ func authGatedDCRServer(t *testing.T) *httptest.Server {
 }
 
 // TestOAuthDCR_VulnerableScopeEscalation: anonymous registration is accepted and
-// admin/write scopes are granted. The rule MUST fire with a single critical
-// confirmed finding.
+// admin/write scopes are granted. The rule MUST fire with a single finding at the
+// declared severity, as an indicator (registration-time evidence; token issuance
+// is not demonstrated).
 func TestOAuthDCR_VulnerableScopeEscalation(t *testing.T) {
 	ts := vulnerableOAuthServer(t)
 	defer ts.Close()
@@ -162,11 +163,11 @@ func TestOAuthDCR_VulnerableScopeEscalation(t *testing.T) {
 		t.Fatalf("expected exactly one finding, got %d: %+v", len(findings), findings)
 	}
 	f := findings[0]
-	if f.Severity != "critical" {
-		t.Errorf("want critical severity, got %q", f.Severity)
+	if f.Severity != oauthRC().Severity {
+		t.Errorf("want declared severity %q, got %q", oauthRC().Severity, f.Severity)
 	}
-	if f.Confidence != attack.ConfirmedExploit {
-		t.Errorf("want ConfirmedExploit, got %q", f.Confidence)
+	if f.Confidence != attack.RiskIndicator {
+		t.Errorf("want RiskIndicator, got %q", f.Confidence)
 	}
 	if f.RuleID != oauthRC().ID {
 		t.Errorf("RuleID = %q, want %q", f.RuleID, oauthRC().ID)


### PR DESCRIPTION
## B2: Downgrade the OAuth DCR scope-echo finding to `indicator`

### Problem
`mcp-oauth-dcr-001` fired `ConfirmedExploit` / `critical` when an unauthenticated registration returned a granted `scope` containing privileged tokens. That overstates what was demonstrated:

- Per RFC 7591, the granted `scope` in a registration response shows the AS did not restrict the requested scopes at registration time. It does **not** prove a privileged *token* is ever issued, which depends on the grant/consent step. The finding's own description already admitted "Whether a token is ultimately issued still depends on the grant/consent step."
- Many authorization servers echo the requested `scope` non-authoritatively and enforce scope at the token endpoint, so a privileged scope in the registration response is a policy *smell*, not a demonstrated escalation.
- No token is obtained and no access is shown, so by the project's definition this is a `RiskIndicator`.

### Fix
- **Confidence**: `ConfirmedExploit` to `RiskIndicator`.
- **Severity**: the finding hardcoded `"critical"` while the rule declares `high` (in both the YAML descriptor and the test `RuleContext`). Switched to `e.rule.Severity` so the finding follows the declared severity and the inconsistency is gone.
- **Description**: now recommends manually verifying that a token with these scopes is actually issued to the anonymous client.
- **Doc comment**: notes the registration-time-only nature, and aligns "encouraged" to "supported" to match the rule descriptor updated in #50 (DCR is now a `MAY`).

### Why these are coupled
Confidence (is exploitation proven?) and the severity inconsistency (`critical` in code vs `high` declared) both contributed to overstating this finding; fixing them together makes it self-consistent and honest.

### Tests
`TestOAuthDCR_VulnerableScopeEscalation` now asserts the declared severity and `RiskIndicator`. The finding **still fires** (it still asserts exactly one finding), so detection is unchanged. The scope-restricting / auth-gated / no-OAuth negative tests are unaffected.

### Validation
Full gate green: `go build`, `go vet`, `go test ./...`, `golangci-lint run` (v2.11.4, 0 issues). No residual `ConfirmedExploit` or hardcoded `critical` in the executor.
