### PR TITLE
fix(mcp-token-replay-001): frame finding as signature-validation failure

### DIFF
--- a/internal/attack/mcp/token_replay.go
+++ b/internal/attack/mcp/token_replay.go
@@ -13,8 +13,12 @@ import (
 	"github.com/calbebop/batesian/internal/attack"
 )
 
-// TokenReplayExecutor tests whether an MCP server validates the `aud` claim on
-// incoming OAuth 2.1 bearer tokens (rule mcp-token-replay-001).
+// TokenReplayExecutor tests whether an MCP server accepts forged or unsigned
+// OAuth 2.1 bearer tokens (rule mcp-token-replay-001). The HS256 probes are
+// signed with a random secret the server cannot know, so acceptance proves the
+// server does not validate the token signature - which also defeats audience
+// binding and enables cross-audience replay. Audience-matching bugs on
+// signature-valid tokens are isolated separately by mcp-oauth-audience-002.
 //
 // Attack sequence:
 //  1. Confirm the server participates in OAuth 2.1 / OIDC by probing the known
@@ -107,20 +111,23 @@ func (e *TokenReplayExecutor) Execute(ctx context.Context, target string, opts a
 			name:      "no-aud",
 			token:     noAudToken,
 			severity:  "high",
-			titleSufx: "accepted JWT with missing aud claim",
-			descSufx: "The server accepted a bearer token that carries no `aud` (audience) claim. " +
-				"Per RFC 9068, a resource server must reject tokens where the audience is absent " +
-				"or does not include the server's own identifier. Tokens issued for any other " +
-				"service can be replayed against this server.",
+			titleSufx: "accepted a forged-signature JWT with no aud claim",
+			descSufx: "The server accepted a bearer token whose HMAC signature was computed with a " +
+				"random key the server cannot know, and which carries no `aud` (audience) claim. " +
+				"Acceptance proves the server does not verify the token signature; with signature " +
+				"validation absent, audience binding (RFC 9068) cannot be enforced and a token forged " +
+				"or issued for any other service can be replayed against this server.",
 		},
 		{
 			name:      "wrong-aud",
 			token:     wrongAudToken,
 			severity:  "high",
-			titleSufx: "accepted JWT with wrong aud claim",
-			descSufx: "The server accepted a bearer token whose `aud` claim names a completely " +
-				"different resource server (https://wrong-server.example.com). This means tokens " +
-				"issued for unrelated services can be replayed against this MCP endpoint.",
+			titleSufx: "accepted a forged-signature JWT with a wrong aud claim",
+			descSufx: "The server accepted a bearer token whose HMAC signature was computed with a " +
+				"random key the server cannot know, and whose `aud` claim names a different resource " +
+				"server (https://wrong-server.example.com). Acceptance proves the server does not " +
+				"verify the token signature, so any forged token - including one minted for another " +
+				"audience - is accepted and cross-service token replay is possible.",
 		},
 		{
 			name:      "alg-none",

--- a/rules/mcp/token-replay-001.yaml
+++ b/rules/mcp/token-replay-001.yaml
@@ -1,21 +1,21 @@
 id: mcp-token-replay-001
 info:
-  name: MCP OAuth Token Audience Validation Bypass
+  name: MCP OAuth Token Signature and Audience Validation Bypass
   author: batesian
   severity: high
   description: |
-    Tests whether an MCP server validates the `aud` (audience) claim on incoming
-    OAuth 2.1 bearer tokens. A compliant OAuth 2.1 resource server must reject
-    tokens whose `aud` claim is missing, empty, or does not match the resource
-    server's own identifier (RFC 9068 Section 4, RFC 8707).
+    Tests whether an MCP server accepts forged or unsigned OAuth 2.1 bearer
+    tokens. The probes are JWTs the server cannot have validated: two signed with
+    a random HMAC key (one with no `aud` claim, one with a wrong `aud`) and one
+    unsigned (alg:none). A compliant OAuth 2.1 resource server verifies the token
+    signature and the `aud` claim (RFC 9068 Section 4, RFC 8707) and rejects all
+    three.
 
-    A server that skips audience validation allows tokens issued for any other
-    resource server to be replayed against it. An attacker who obtains a token
-    for an unrelated service can present it to the MCP server and gain access.
-
-    Alg-none tokens are a special case: some JWT libraries that do not enforce
-    algorithm restrictions will accept a forged JWT with no signature at all,
-    completely bypassing cryptographic token verification.
+    Accepting any of them proves the server does not validate the token
+    signature. Without signature validation, audience binding cannot be enforced
+    either, so a token forged for any audience, or issued for an unrelated
+    service, can be replayed against this endpoint. Audience-matching bugs on
+    signature-valid tokens are isolated separately by mcp-oauth-audience-002.
 
     Acceptance is judged at the protocol layer: a probe counts as accepted only
     when the server returns HTTP 200 with a JSON-RPC `result` envelope. A 200


### PR DESCRIPTION
## B3: Frame `mcp-token-replay-001` as a signature-validation failure

### Problem
The rule was named "MCP OAuth Token **Audience** Validation Bypass" and the `no-aud` / `wrong-aud` findings claimed an audience-validation bug. But those two probes are HS256 JWTs **signed with a random secret the server cannot know** (`forgeHS256JWT`, line 222). A server that validates signatures rejects them regardless of `aud`. So acceptance proves the server does not validate the token **signature**, not specifically that it skips audience matching.

The tell: a server that validates signatures (RS256) but not audience would **not** be caught by these probes, because the forged signature fails verification first. So the rule cannot prove an audience-specific bug, yet its headline claimed exactly that.

### Fix (accuracy, not confidence)
Reframe the finding to state what is actually demonstrated: a forged or unsigned token was accepted, so signature validation is absent, which in turn defeats audience binding and enables cross-audience replay.

- Reworded the `no-aud` and `wrong-aud` probe titles/descriptions ("accepted a **forged-signature** JWT...") and the executor doc comment.
- Renamed the rule to "MCP OAuth Token Signature and Audience Validation Bypass" and reframed the YAML description.
- Pointed to `mcp-oauth-audience-002` (which *does* isolate audience-matching bugs on signature-valid tokens with a negative control) for the audience-specific case.
- The `alg-none` probe was already framed honestly ("bypasses cryptographic token verification"); unchanged.

### Why confidence stays `ConfirmedExploit`
Unlike B1/B2, this is **not** a confidence problem. A forged/unsigned token reaching method dispatch (HTTP 200 + JSON-RPC `result`) is a genuinely demonstrated exploit. Confidence and severities are unchanged; only the *claim* is corrected.

### Tests
No test changes needed: the tests assert on confidence and severity (both unchanged), not on the reworded titles. They still pass, confirming the findings still fire. The rule still loads (verified via `go run`).

### Validation
Full gate green: `go build`, `go vet`, `go test ./...`, `golangci-lint run` (v2.11.4, 0 issues).
