### PR TITLE
refactor(a2a): replace hand-rolled string-contains helpers with strings.Contains

### DIFF
--- a/internal/attack/a2a/delegation_integrity_test.go
+++ b/internal/attack/a2a/delegation_integrity_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -211,20 +212,7 @@ func TestDelegation_ConsumesBlackboardTaskID(t *testing.T) {
 	if len(findings) != 1 {
 		t.Fatalf("expected 1 finding consuming the blackboard task-id, got %d: %+v", len(findings), findings)
 	}
-	if c := findings[0].Chain; len(c) != 2 || !containsSub(c[0].Action, preTask) || !containsSub(c[0].Action, "consumed from blackboard") {
+	if c := findings[0].Chain; len(c) != 2 || !strings.Contains(c[0].Action, preTask) || !strings.Contains(c[0].Action, "consumed from blackboard") {
 		t.Errorf("expected hop 1 to cite the consumed blackboard task, got %+v", c)
 	}
-}
-
-func containsSub(s, sub string) bool {
-	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
-}
-
-func indexOf(s, sub string) int {
-	for i := 0; i+len(sub) <= len(s); i++ {
-		if s[i:i+len(sub)] == sub {
-			return i
-		}
-	}
-	return -1
 }

--- a/internal/attack/a2a/push_binding.go
+++ b/internal/attack/a2a/push_binding.go
@@ -3,6 +3,7 @@ package a2a
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/calbebop/batesian/internal/attack"
 )
@@ -80,7 +81,7 @@ func (e *PushBindingExecutor) ExecuteChained(ctx context.Context, target string,
 	// Step 3: cross-principal control-plane access as B. Read FIRST (so B sees
 	// A's marker before any write overwrites it), then attempt the write hijack.
 	var findings []attack.Finding
-	if body, ok := e.getPush(ctx, clientB, endpoint, b.Headers, taskID, vars.RandID); ok && contains(body, markerURL) {
+	if body, ok := e.getPush(ctx, clientB, endpoint, b.Headers, taskID, vars.RandID); ok && strings.Contains(body, markerURL) {
 		findings = append(findings, e.readFinding(endpoint, a, b, taskID, markerURL, consumed))
 	}
 	attackerURL := "https://batesian-attacker-" + vars.RandID + ".example/cb"

--- a/internal/attack/a2a/push_ssrf.go
+++ b/internal/attack/a2a/push_ssrf.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/calbebop/batesian/internal/attack"
@@ -227,19 +228,7 @@ func containsToken(cb *oob.Callback, token string) bool {
 	var m map[string]interface{}
 	if err := json.Unmarshal(cb.Body, &m); err == nil {
 		b, _ := json.Marshal(m)
-		return contains(string(b), token)
+		return strings.Contains(string(b), token)
 	}
-	return contains(string(cb.Body), token)
-}
-
-func contains(s, substr string) bool {
-	return len(s) > 0 && len(substr) > 0 && (s == substr || len(s) >= len(substr) &&
-		func() bool {
-			for i := 0; i <= len(s)-len(substr); i++ {
-				if s[i:i+len(substr)] == substr {
-					return true
-				}
-			}
-			return false
-		}())
+	return strings.Contains(string(cb.Body), token)
 }

--- a/internal/attack/a2a/session_smuggle.go
+++ b/internal/attack/a2a/session_smuggle.go
@@ -262,15 +262,13 @@ func extractTaskContext(body []byte) (taskID, contextID string) {
 	return taskID, contextID
 }
 
-// containsAnyStr reports whether s contains any of the substrings.
+// containsAnyStr reports whether s contains any of the non-empty substrings.
+// Empty substrings are skipped: strings.Contains(s, "") is always true, which
+// would let an absent/optional value match any input.
 func containsAnyStr(s string, subs ...string) bool {
 	for _, sub := range subs {
-		if len(s) >= len(sub) {
-			for i := 0; i <= len(s)-len(sub); i++ {
-				if s[i:i+len(sub)] == sub {
-					return true
-				}
-			}
+		if sub != "" && strings.Contains(s, sub) {
+			return true
 		}
 	}
 	return false


### PR DESCRIPTION
## D1: Replace hand-rolled string-contains helpers with `strings.Contains`

Four helpers were manual byte-loop reimplementations of `strings.Contains` (a recurring AI-texture tic flagged in the original review):

- `contains` (`push_ssrf.go`): a 10-line inline-closure substring search.
- `containsSub` + `indexOf` (`delegation_integrity_test.go`): a test helper pair.
- the byte-loop body of `containsAnyStr` (`session_smuggle.go`).

### Change
- **Deleted** `contains`; its callers in `push_ssrf.go` and `push_binding.go` use `strings.Contains`.
- **Deleted** `containsSub`/`indexOf`; the delegation test uses `strings.Contains`.
- **Rewrote** `containsAnyStr` as a thin `strings.Contains` loop. It keeps its name (a "contains any of N substrings" convenience, used 3x, with no stdlib equivalent since `strings.ContainsAny` matches any *char*, not substring) but drops the manual byte loop and adds a `sub != ""` guard, matching the `Response.ContainsAny` fix from #56 so an empty needle no longer matches everything.

### Behavior preservation
This is a pure refactor. `strings.Contains(s, "")` returns true whereas the old `contains`/`containsAnyStr` returned false for an empty needle, but **no caller passes an empty substring** (they pass push tokens, marker URLs, and string literals), so behavior is identical for all real input. The `containsAnyStr` empty-guard preserves the old false-on-empty behavior and closes the latent bug noted in the backlog.

### Verification
The existing rule tests (push-ssrf, push-binding, session-smuggle, delegation) exercise all these paths and pass unchanged, which is the right verification for a behavior-preserving refactor. No new test added (asserting a stdlib wrapper would be tautological).

Full gate green: `go build`, `go vet`, `go test ./...`, `golangci-lint run` (v2.11.4, 0 issues). The only `func contains*` left is the intentionally-kept `containsAnyStr` wrapper.
