### PR TITLE
fix(oob): correlate SSRF callbacks by per-run marker

### DIFF
--- a/internal/attack/a2a/push_ssrf.go
+++ b/internal/attack/a2a/push_ssrf.go
@@ -128,7 +128,7 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 	// Wait for OOB callback.
 	var findings []attack.Finding
 	if listener != nil {
-		cb, received := listener.Wait(ctx, 10*time.Second)
+		cb, received := listener.WaitForMarker(ctx, 10*time.Second, token)
 		if received {
 			evidence := fmt.Sprintf(
 				"Target accepted task with pushNotificationConfig.url=%q (binding: %s)\n"+

--- a/internal/attack/mcp/oauth_metadata_ssrf.go
+++ b/internal/attack/mcp/oauth_metadata_ssrf.go
@@ -102,7 +102,7 @@ func (e *OAuthMetadataSSRFExecutor) Execute(ctx context.Context, target string, 
 	}
 
 	// Local OOB: wait for the server to fetch one of the seeded URLs.
-	cb, received := listener.Wait(ctx, 10*time.Second)
+	cb, received := listener.WaitForMarker(ctx, 10*time.Second, "batesian-"+vars.RandID)
 	if !received {
 		return nil, nil
 	}

--- a/internal/oob/listener.go
+++ b/internal/oob/listener.go
@@ -8,6 +8,12 @@
 // the Batesian host (e.g., same network, or target is on the public internet with a
 // routable IP). For testing targets that cannot reach the scanning host, use an
 // external OOB server (--oob-url flag) instead.
+//
+// The listener binds all interfaces and accepts any inbound request, so callers
+// MUST correlate a callback to their own probe via the per-run marker embedded in
+// the callback path (see WaitForMarker). An unrelated inbound request on the port
+// (a port scanner, another host) is otherwise indistinguishable from a genuine
+// target callback and would produce a false positive.
 package oob
 
 import (
@@ -16,6 +22,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 )
@@ -85,18 +92,28 @@ func (l *Listener) URL() string {
 	return fmt.Sprintf("http://%s:%s", ip, port)
 }
 
-// Wait blocks until a callback arrives, the context is cancelled, or timeout elapses.
-func (l *Listener) Wait(ctx context.Context, timeout time.Duration) (*Callback, bool) {
+// WaitForMarker blocks until a callback whose request URI contains marker
+// arrives, the context is cancelled, or timeout elapses. Callbacks that do not
+// contain the marker (stray inbound requests from other hosts, port scanners,
+// and the like) are ignored, so an unrelated request cannot consume the wait or
+// be mistaken for this probe's own callback. An empty marker matches any
+// callback. The timeout bounds the whole wait, not each ignored callback.
+func (l *Listener) WaitForMarker(ctx context.Context, timeout time.Duration, marker string) (*Callback, bool) {
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 
-	select {
-	case cb := <-l.callbacks:
-		return &cb, true
-	case <-timer.C:
-		return nil, false
-	case <-ctx.Done():
-		return nil, false
+	for {
+		select {
+		case cb := <-l.callbacks:
+			if marker == "" || strings.Contains(cb.URL, marker) {
+				return &cb, true
+			}
+			// Non-matching stray callback: keep waiting within the same window.
+		case <-timer.C:
+			return nil, false
+		case <-ctx.Done():
+			return nil, false
+		}
 	}
 }
 
@@ -121,7 +138,7 @@ func (l *Listener) handleCallback(w http.ResponseWriter, r *http.Request) {
 	select {
 	case l.callbacks <- cb:
 	default:
-		// Channel full - drop (shouldn't happen in practice with buffer=16)
+		// Channel full - drop (shouldn't happen in practice with buffer=64).
 	}
 	w.WriteHeader(http.StatusOK)
 }

--- a/internal/oob/listener_test.go
+++ b/internal/oob/listener_test.go
@@ -1,0 +1,47 @@
+package oob
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestWaitForMarker_IgnoresStrayCallbacks verifies that a stray inbound request
+// (no marker) does not consume the wait or get returned: the probe's own
+// marker-bearing callback is delivered instead. Before WaitForMarker, the stray
+// callback would be returned first and fire a false-positive SSRF finding.
+func TestWaitForMarker_IgnoresStrayCallbacks(t *testing.T) {
+	l := New()
+	l.callbacks <- Callback{Method: "GET", URL: "/unrelated-scan"}
+	l.callbacks <- Callback{Method: "POST", URL: "/batesian-abc123/jwks_uri"}
+
+	cb, ok := l.WaitForMarker(context.Background(), time.Second, "batesian-abc123")
+	if !ok {
+		t.Fatal("expected the marker-matching callback to be delivered")
+	}
+	if cb.URL != "/batesian-abc123/jwks_uri" {
+		t.Errorf("got callback %q, want the marker-bearing one", cb.URL)
+	}
+}
+
+// TestWaitForMarker_NoMatchTimesOut verifies that a stray-only stream produces no
+// hit, so an unrelated inbound request cannot be mistaken for a real callback.
+func TestWaitForMarker_NoMatchTimesOut(t *testing.T) {
+	l := New()
+	l.callbacks <- Callback{Method: "GET", URL: "/stray-only"}
+
+	if _, ok := l.WaitForMarker(context.Background(), 100*time.Millisecond, "batesian-xyz"); ok {
+		t.Error("expected no hit when nothing matches the marker")
+	}
+}
+
+// TestWaitForMarker_EmptyMarkerMatchesAny preserves the any-callback contract for
+// an empty marker.
+func TestWaitForMarker_EmptyMarkerMatchesAny(t *testing.T) {
+	l := New()
+	l.callbacks <- Callback{Method: "GET", URL: "/whatever"}
+
+	if _, ok := l.WaitForMarker(context.Background(), time.Second, ""); !ok {
+		t.Error("empty marker should match any callback")
+	}
+}


### PR DESCRIPTION
## E1: Correlate SSRF callbacks by per-run marker (fixes a false positive)

### Problem
This started as "harden the OOB listener" but the deeper read found a **false-positive in two `ConfirmedExploit` SSRF rules**.

The listener's `Wait` returned the *first* inbound request, and both rules fire on `received` alone:
- `a2a-push-ssrf-001`: `cb, received := listener.Wait(...); if received { <ConfirmedExploit finding> }`, where the per-run token is only printed in the evidence ("Callback token echoed: %v"), never gating.
- `mcp-oauth-metadata-ssrf-001`: same shape; `matchMarker` only labels the field (returns "unknown" on no match).

The listener binds `0.0.0.0` and accepts any path, so on a shared network **a stray request to its port during the 10s window (a port scanner, another host) fires a confirmed SSRF finding** the target never made. A stray arriving *before* the real callback also consumes the wait and masks it (false negative).

### Fix
Replaced `Wait` with `WaitForMarker(ctx, timeout, marker)`, which ignores callbacks whose request URI doesn't contain the marker and keeps waiting within the same window. Both rules already embed `batesian-<RandID>` in the callback URL path, so they pass that as the marker. An unrelated request can no longer fire or mask a finding.

- `internal/oob`: `WaitForMarker` replaces `Wait`; the package doc now states the open-listener correlation requirement; the stale `buffer=16` comment is corrected to `64`.
- `push_ssrf` / `oauth_metadata_ssrf`: wait on the per-run marker.

### Tests
The `oob` package had **no tests**. Added `listener_test.go`:
- A stray callback is ignored and the marker-bearing one is delivered (the exact bug).
- A stray-only stream yields no hit (no false positive).
- An empty marker matches any callback (preserves the old contract).

These directly demonstrate the stray-ignoring behavior; before this change `Wait` returned the stray first.

### Validation
Full gate green: `go build`, `go vet`, `go test ./...`, `golangci-lint run` (v2.11.4, 0 issues). The SSRF rule tests still pass because their mock targets call back on the marker path. No residual `Wait`.
