### PR TITLE
fix(protocol): make WithSkipTLSVerify robust to a nil TLS config

### DIFF
--- a/internal/protocol/a2a/client.go
+++ b/internal/protocol/a2a/client.go
@@ -61,9 +61,10 @@ func WithBearerToken(token string) ClientOption {
 func WithSkipTLSVerify() ClientOption {
 	return func(c *Client) {
 		if transport, ok := c.http.Transport.(*http.Transport); ok {
-			if transport.TLSClientConfig != nil {
-				transport.TLSClientConfig.InsecureSkipVerify = true //nolint:gosec
+			if transport.TLSClientConfig == nil {
+				transport.TLSClientConfig = &tls.Config{} //nolint:gosec
 			}
+			transport.TLSClientConfig.InsecureSkipVerify = true //nolint:gosec
 		}
 	}
 }

--- a/internal/protocol/a2a/client_test.go
+++ b/internal/protocol/a2a/client_test.go
@@ -1,0 +1,31 @@
+package a2a
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestWithSkipTLSVerify_TakesEffect confirms the security-relevant skip-TLS
+// option actually enables InsecureSkipVerify on a normally-constructed client.
+func TestWithSkipTLSVerify_TakesEffect(t *testing.T) {
+	c, err := NewClient("https://example.com", WithSkipTLSVerify())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	tr, ok := c.http.Transport.(*http.Transport)
+	if !ok || tr.TLSClientConfig == nil || !tr.TLSClientConfig.InsecureSkipVerify {
+		t.Error("WithSkipTLSVerify did not enable InsecureSkipVerify")
+	}
+}
+
+// TestWithSkipTLSVerify_NilConfig exercises a transport with no TLS config. The
+// option must create one and enable InsecureSkipVerify; before the fix this
+// silently no-oped, leaving skip-TLS unapplied.
+func TestWithSkipTLSVerify_NilConfig(t *testing.T) {
+	c := &Client{http: &http.Client{Transport: &http.Transport{}}} // nil TLSClientConfig
+	WithSkipTLSVerify()(c)
+	tr := c.http.Transport.(*http.Transport)
+	if tr.TLSClientConfig == nil || !tr.TLSClientConfig.InsecureSkipVerify {
+		t.Error("WithSkipTLSVerify should create a TLS config and enable InsecureSkipVerify")
+	}
+}

--- a/internal/protocol/mcp/client.go
+++ b/internal/protocol/mcp/client.go
@@ -49,6 +49,9 @@ func WithBearerToken(token string) ClientOption {
 func WithSkipTLSVerify() ClientOption {
 	return func(c *Client) {
 		if t, ok := c.http.Transport.(*http.Transport); ok {
+			if t.TLSClientConfig == nil {
+				t.TLSClientConfig = &tls.Config{} //nolint:gosec
+			}
 			t.TLSClientConfig.InsecureSkipVerify = true //nolint:gosec
 		}
 	}

--- a/internal/protocol/mcp/client_test.go
+++ b/internal/protocol/mcp/client_test.go
@@ -1,0 +1,31 @@
+package mcp
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestWithSkipTLSVerify_TakesEffect confirms the security-relevant skip-TLS
+// option actually enables InsecureSkipVerify on a normally-constructed client.
+func TestWithSkipTLSVerify_TakesEffect(t *testing.T) {
+	c, err := NewClient("https://example.com", WithSkipTLSVerify())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	tr, ok := c.http.Transport.(*http.Transport)
+	if !ok || tr.TLSClientConfig == nil || !tr.TLSClientConfig.InsecureSkipVerify {
+		t.Error("WithSkipTLSVerify did not enable InsecureSkipVerify")
+	}
+}
+
+// TestWithSkipTLSVerify_NilConfig exercises a transport with no TLS config. The
+// option must create one and enable InsecureSkipVerify; before the fix this
+// nil-dereferenced.
+func TestWithSkipTLSVerify_NilConfig(t *testing.T) {
+	c := &Client{http: &http.Client{Transport: &http.Transport{}}} // nil TLSClientConfig
+	WithSkipTLSVerify()(c)
+	tr := c.http.Transport.(*http.Transport)
+	if tr.TLSClientConfig == nil || !tr.TLSClientConfig.InsecureSkipVerify {
+		t.Error("WithSkipTLSVerify should create a TLS config and enable InsecureSkipVerify")
+	}
+}


### PR DESCRIPTION
## E2: Make `WithSkipTLSVerify` robust to a nil TLS config (both protocol clients)

### Problem
The two protocol clients' `WithSkipTLSVerify` options handled a nil `TLSClientConfig` differently, and both were wrong:
- **MCP** (`mcp/client.go`): `t.TLSClientConfig.InsecureSkipVerify = true` **nil-dereferences** if the transport has no TLS config.
- **A2A** (`a2a/client.go`): guarded `if TLSClientConfig != nil` but then **silently did nothing**, so a requested skip-TLS would not take effect.

Neither nil case is reachable today (both `NewClient`s set a non-nil `&tls.Config{}`), so this is forward-looking robustness, but the siblings were inconsistent and a future transport change could trip either.

### Fix
Both now create a `tls.Config` when absent, then set `InsecureSkipVerify`. This is strictly better than just copying A2A's guard (which silently no-ops): skip-TLS always takes effect, and neither panics. The two functions are now identical.

### Tests
Added `client_test.go` to **both** packages (the `mcp` protocol package had no tests at all):
- **Happy path**: `NewClient(..., WithSkipTLSVerify())` enables `InsecureSkipVerify`, pinning this security-relevant option's behavior.
- **Nil config**: applies the option to a transport with no TLS config. **Proven fail-before**: against the old code this test panics (MCP nil deref) / leaves the flag unset (A2A silent no-op); it passes after the fix. Verified by reverting only the two `client.go` files.

### Validation
Full gate green: `go build`, `go vet`, `go test ./...`, `golangci-lint run` (v2.11.4, 0 issues).
