### PR TITLE
feat(mcp-confused-deputy-001): detect OAuth redirect_uri confused deputy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ CLI for adversarial testing of [A2A](https://google.github.io/A2A/) and [MCP](ht
 
 ## What ships
 
-Bundled rules: **14 A2A, 11 MCP (25 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
+Bundled rules: **14 A2A, 12 MCP (26 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
 
 - [A2A rules](docs/rules-a2a.md) (14)
-- [MCP rules](docs/rules-mcp.md) (11)
+- [MCP rules](docs/rules-mcp.md) (12)
 
 Coverage spans:
 

--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -33,6 +33,7 @@ JSON-RPC `error` (the common MCP rejection shape) is a rejection, not a finding.
 | `mcp-sse-resume-replay-001` | [SSE Resumption Cross-Session Replay](#mcp-sse-resume-replay-001) | High | confirmed | CWE-488 |
 | `mcp-oauth-metadata-ssrf-001` | [OAuth Discovery / Metadata-Fetch SSRF](#mcp-oauth-metadata-ssrf-001) | High | confirmed / indicator | CWE-918 |
 | `mcp-secret-canary-001` | [Credential Canary Reflected in Responses](#mcp-secret-canary-001) | Medium | confirmed | CWE-522 |
+| `mcp-confused-deputy-001` | [OAuth Confused Deputy via redirect_uri](#mcp-confused-deputy-001) | High / Medium | confirmed / indicator | CWE-441 |
 
 ---
 
@@ -244,3 +245,27 @@ that rejects or errors without echoing the token produces no finding. The canary
 is unique per run, so a substring match cannot false-positive. This is the
 black-box-observable half of secret leakage; verifying secrets never reach
 external log/trace sinks additionally requires access to those sinks.
+
+---
+
+### mcp-confused-deputy-001
+
+**OAuth Confused Deputy via redirect_uri Validation** | Severity: High / Medium | CWE-441 / CWE-601
+
+An MCP server that proxies OAuth to a third-party authorization server with a
+static client_id, while forwarding a client-supplied redirect_uri, is open to a
+confused deputy attack: once the upstream consent screen is skipped (a consent
+cookie for the static client_id), an attacker who supplies their own redirect_uri
+harvests the authorization code. The MCP Security Best Practices require exact
+redirect_uri matching and per-client consent, and RFC 6749 Section 4.1.2.1
+requires the server to reject a mismatching redirect_uri and not redirect to it.
+The check registers a client via DCR with an off-origin redirect, then requests
+`/authorize` with a different, unregistered off-origin redirect (both on the
+reserved `.invalid` TLD, so they never resolve and no code is ever harvested). A
+**confirmed** finding is raised only when the server answers with a 3xx whose
+Location host is the unregistered redirect - a direct exact-match violation. If
+DCR instead accepted the arbitrary off-origin redirect but the authorize-time
+check could not be disproven, an **indicator** is raised for the precondition.
+Servers with no DCR endpoint (e.g. 2025-11-25 Client ID Metadata Document
+deployments) or no authorization endpoint are out of scope and produce no
+finding.

--- a/internal/attack/mcp/confused_deputy.go
+++ b/internal/attack/mcp/confused_deputy.go
@@ -1,0 +1,222 @@
+package mcp
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// ConfusedDeputyExecutor tests whether an MCP server's OAuth authorization
+// endpoint enforces exact redirect_uri validation (rule mcp-confused-deputy-001).
+//
+// The MCP "confused deputy" problem: a server that proxies OAuth to a third-party
+// authorization server with a static client_id, while forwarding a client-supplied
+// redirect_uri, lets an attacker harvest authorization codes once the upstream
+// consent screen is skipped (a consent cookie set for the static client_id). The
+// MCP Security Best Practices require the proxy to validate that redirect_uri
+// "exactly matches the registered URI" using exact string matching, and RFC 6749
+// section 4.1.2.1 requires the authorization server to NOT redirect to a missing,
+// invalid, or mismatching redirect_uri.
+//
+// Black-box detection (no browser, user, or consent cookie):
+//   - Register a client via DCR with an off-origin redirect R1.
+//   - Request /authorize with a DIFFERENT, unregistered off-origin redirect R2.
+//   - CONFIRMED: the server answers with a 3xx whose Location host is R2's host;
+//     it is redirecting to a redirect_uri that was never registered for the
+//     client (a direct RFC 6749 4.1.2.1 violation, the open-redirect primitive
+//     that enables the confused deputy).
+//   - INDICATOR: DCR accepted the arbitrary off-origin redirect R1 (the confused
+//     deputy precondition) but the authorize-time check could not be confirmed
+//     (e.g. the endpoint deferred validation behind a login page).
+//
+// Redirect targets use the reserved .invalid TLD (RFC 6761) with a per-run
+// marker, so they never resolve and the flow is never completed: the probe only
+// reads the server's redirect decision, it does not harvest any code.
+type ConfusedDeputyExecutor struct {
+	rule attack.RuleContext
+}
+
+func init() {
+	attack.Register("mcp-confused-deputy", func(rc attack.RuleContext) attack.Executor {
+		return NewConfusedDeputyExecutor(rc)
+	})
+}
+
+func NewConfusedDeputyExecutor(r attack.RuleContext) *ConfusedDeputyExecutor {
+	return &ConfusedDeputyExecutor{rule: r}
+}
+
+func (e *ConfusedDeputyExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
+	vars := attack.NewVars(target, opts.OOBListenerURL)
+	client := attack.NewHTTPClient(opts, vars)
+	unauthClient := attack.NewUnauthHTTPClient(opts, vars)
+
+	regEP, authEP := discoverOAuthEndpoints(ctx, client, vars.BaseURL)
+	if authEP == "" || regEP == "" {
+		// No authorization endpoint, or no DCR endpoint to obtain a client_id.
+		// CIMD-only (2025-11-25) and non-OAuth servers land here: not applicable.
+		return nil, nil
+	}
+
+	// Register a client with an off-origin redirect. We use a domain unrelated to
+	// the target's own origin so a server with a redirect allowlist rejects it.
+	registeredRedirect := fmt.Sprintf("https://batesian-%s-registered.invalid/cb", vars.RandID)
+	clientID, dcrEchoedRedirect := registerDCRClient(ctx, unauthClient, regEP, registeredRedirect, vars.RandID)
+	if clientID == "" {
+		// Registration was rejected or required auth: cannot drive the authorize
+		// probe, and an enforced-DCR server is correct behaviour. No finding.
+		return nil, nil
+	}
+
+	// Authorize with a DIFFERENT, unregistered off-origin redirect.
+	attackerHost := fmt.Sprintf("batesian-%s-attacker.invalid", vars.RandID)
+	attackerRedirect := "https://" + attackerHost + "/cb"
+	loc, status := authorizeRedirectProbe(ctx, opts, authEP, clientID, attackerRedirect, vars.RandID)
+
+	if redirectsToHost(status, loc, attackerHost) {
+		return []attack.Finding{{
+			RuleID:     e.rule.ID,
+			RuleName:   e.rule.Name,
+			Severity:   e.rule.Severity,
+			Confidence: attack.ConfirmedExploit,
+			Title:      "MCP OAuth authorization endpoint redirects to an unregistered redirect_uri (confused deputy)",
+			Description: "The authorization endpoint issued a redirect to a redirect_uri that was never " +
+				"registered for the client. RFC 6749 section 4.1.2.1 requires the server to reject a missing, " +
+				"invalid, or mismatching redirect_uri and to NOT redirect to it, and the MCP Security Best " +
+				"Practices require exact-match validation. Because the endpoint forwards the user agent to an " +
+				"attacker-supplied URI, an attacker can harvest authorization codes; combined with a static " +
+				"proxy client_id and a skipped upstream consent screen this is the confused deputy account-" +
+				"takeover primitive.",
+			Evidence: fmt.Sprintf(
+				"authorization_endpoint: %s\nregistered redirect_uri: %s\nunregistered redirect_uri sent: %s\n"+
+					"server response: HTTP %d, Location: %s",
+				authEP, registeredRedirect, attackerRedirect, status, loc),
+			Remediation: e.rule.Remediation,
+			TargetURL:   authEP,
+		}}, nil
+	}
+
+	if dcrEchoedRedirect {
+		return []attack.Finding{{
+			RuleID:     e.rule.ID,
+			RuleName:   e.rule.Name,
+			Severity:   "medium",
+			Confidence: attack.RiskIndicator,
+			Title:      "MCP OAuth DCR accepts an arbitrary off-origin redirect_uri (confused deputy precondition)",
+			Description: "Dynamic client registration accepted a client whose redirect_uri is an arbitrary " +
+				"off-origin host unrelated to the server. This is the precondition for the confused deputy " +
+				"attack: an attacker can register their own redirect target. The authorization endpoint did " +
+				"not redirect to an unregistered URI in this probe, so exact-match enforcement was not " +
+				"disproven. Manually verify that the proxy stores per-client consent and does not skip the " +
+				"upstream consent screen for the static client_id.",
+			Evidence: fmt.Sprintf(
+				"registration_endpoint: %s\naccepted off-origin redirect_uri: %s\nauthorize probe: HTTP %d, Location: %s",
+				regEP, registeredRedirect, status, loc),
+			Remediation: e.rule.Remediation,
+			TargetURL:   regEP,
+		}}, nil
+	}
+
+	return nil, nil
+}
+
+// discoverOAuthEndpoints reads the authorization-server metadata and returns the
+// registration_endpoint and authorization_endpoint. It tries the RFC 8414
+// authorization-server document first, then the OIDC openid-configuration.
+func discoverOAuthEndpoints(ctx context.Context, client *attack.HTTPClient, baseURL string) (registrationEndpoint, authorizationEndpoint string) {
+	for _, p := range []string{"/.well-known/oauth-authorization-server", "/.well-known/openid-configuration"} {
+		resp, err := client.GET(ctx, baseURL+p, nil)
+		if err != nil || !resp.IsSuccess() {
+			continue
+		}
+		reg := resp.JSONField("registration_endpoint")
+		authz := resp.JSONField("authorization_endpoint")
+		if authz != "" {
+			return reg, authz
+		}
+	}
+	return "", ""
+}
+
+// registerDCRClient registers a client via DCR with the given redirect_uri and
+// returns the issued client_id plus whether the response echoed the off-origin
+// redirect back (i.e. DCR accepted an arbitrary external redirect target).
+func registerDCRClient(ctx context.Context, client *attack.HTTPClient, registrationEndpoint, redirectURI, randID string) (clientID string, echoedRedirect bool) {
+	resp, err := client.POST(ctx, registrationEndpoint, nil, map[string]interface{}{
+		"client_name":    "batesian-cd-" + randID,
+		"redirect_uris":  []string{redirectURI},
+		"grant_types":    []string{"authorization_code"},
+		"response_types": []string{"code"},
+	})
+	if err != nil || (resp.StatusCode != 200 && resp.StatusCode != 201) {
+		return "", false
+	}
+	clientID = resp.JSONField("client_id")
+	echoedRedirect = strings.Contains(resp.BodyString(), redirectURI)
+	return clientID, echoedRedirect
+}
+
+// authorizeRedirectProbe issues a single authorization request with the given
+// (unregistered) redirect_uri and returns the response's Location header and
+// status code WITHOUT following the redirect, so the server's redirect decision
+// can be inspected directly.
+func authorizeRedirectProbe(ctx context.Context, opts attack.Options, authorizationEndpoint, clientID, redirectURI, randID string) (location string, status int) {
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", clientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("state", "batesian-"+randID)
+	q.Set("scope", "openid")
+	// OAuth 2.1 requires PKCE; include a well-formed S256 challenge (43-char
+	// base64url, RFC 7636) so the request is not rejected for malformed PKCE
+	// before redirect_uri is evaluated.
+	q.Set("code_challenge", "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+	q.Set("code_challenge_method", "S256")
+
+	sep := "?"
+	if strings.Contains(authorizationEndpoint, "?") {
+		sep = "&"
+	}
+	reqURL := authorizationEndpoint + sep + q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return "", 0
+	}
+	req.Header.Set("User-Agent", "batesian/"+attack.Version+" (https://github.com/calbebop/batesian)")
+
+	tr := &http.Transport{}
+	if opts.SkipTLS {
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+	}
+	hc := &http.Client{
+		Transport: tr,
+		// Do not follow redirects: we need the first response's Location header.
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return "", 0
+	}
+	defer resp.Body.Close()
+	return resp.Header.Get("Location"), resp.StatusCode
+}
+
+// redirectsToHost reports whether a 3xx response carries a Location header whose
+// host equals wantHost. Comparing the host (not the body) avoids the common false
+// positive where a rejection page merely displays the rejected URI as text.
+func redirectsToHost(status int, location, wantHost string) bool {
+	if status < 300 || status >= 400 || location == "" {
+		return false
+	}
+	u, err := url.Parse(location)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(u.Hostname(), wantHost)
+}

--- a/internal/attack/mcp/confused_deputy_test.go
+++ b/internal/attack/mcp/confused_deputy_test.go
@@ -1,0 +1,152 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+func confusedDeputyRC() attack.RuleContext {
+	return attack.RuleContext{
+		ID:          "mcp-confused-deputy-001",
+		Name:        "MCP OAuth Confused Deputy",
+		Severity:    "high",
+		Remediation: "Validate redirect_uri with exact string matching.",
+	}
+}
+
+// confusedDeputyServer models an MCP OAuth authorization server. mode selects
+// redirect_uri handling:
+//   - "vulnerable":     /authorize redirects to ANY supplied redirect_uri
+//   - "exact-match":    DCR accepts the off-origin redirect, but /authorize rejects
+//     an unregistered redirect_uri (only the DCR-precondition indicator can fire)
+//   - "dcr-restricted": DCR rejects an off-origin redirect (allowlist enforced)
+//   - "not-oauth":      no authorization-server metadata
+func confusedDeputyServer(mode string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		base := "http://" + r.Host
+		writeJSON := func(code int, v map[string]interface{}) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(code)
+			_ = json.NewEncoder(w).Encode(v)
+		}
+		switch {
+		case r.URL.Path == "/.well-known/oauth-authorization-server":
+			if mode == "not-oauth" {
+				http.NotFound(w, r)
+				return
+			}
+			writeJSON(http.StatusOK, map[string]interface{}{
+				"issuer":                 base,
+				"registration_endpoint":  base + "/register",
+				"authorization_endpoint": base + "/authorize",
+				"token_endpoint":         base + "/token",
+			})
+		case r.URL.Path == "/register" && r.Method == http.MethodPost:
+			var body map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			redirects, _ := body["redirect_uris"].([]interface{})
+			if mode == "dcr-restricted" && hasInvalidTLDRedirect(redirects) {
+				writeJSON(http.StatusBadRequest, map[string]interface{}{"error": "invalid_redirect_uri"})
+				return
+			}
+			writeJSON(http.StatusCreated, map[string]interface{}{
+				"client_id":     "cd-client-123",
+				"redirect_uris": redirects,
+			})
+		case r.URL.Path == "/authorize" && r.Method == http.MethodGet:
+			redirectURI := r.URL.Query().Get("redirect_uri")
+			if mode == "vulnerable" {
+				// No exact-match: redirect to whatever was supplied.
+				http.Redirect(w, r, redirectURI+"?code=fake", http.StatusFound)
+				return
+			}
+			// exact-match / dcr-restricted: the probe's redirect_uri was never
+			// registered for this client, so reject WITHOUT redirecting to it.
+			writeJSON(http.StatusBadRequest, map[string]interface{}{"error": "invalid_request"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func hasInvalidTLDRedirect(redirects []interface{}) bool {
+	for _, ru := range redirects {
+		if s, _ := ru.(string); strings.Contains(s, ".invalid") {
+			return true
+		}
+	}
+	return false
+}
+
+func runConfusedDeputy(t *testing.T, ts *httptest.Server) []attack.Finding {
+	t.Helper()
+	findings, err := mcpattack.NewConfusedDeputyExecutor(confusedDeputyRC()).Execute(context.Background(), ts.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return findings
+}
+
+// TestConfusedDeputy_Vulnerable: /authorize redirects to an unregistered
+// off-origin redirect_uri. MUST fire confirmed/high.
+func TestConfusedDeputy_Vulnerable(t *testing.T) {
+	ts := confusedDeputyServer("vulnerable")
+	defer ts.Close()
+
+	findings := runConfusedDeputy(t, ts)
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly one finding, got %d: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Confidence != attack.ConfirmedExploit || f.Severity != "high" {
+		t.Errorf("want high/ConfirmedExploit, got %q/%q", f.Severity, f.Confidence)
+	}
+	if !strings.Contains(f.Title, "confused deputy") {
+		t.Errorf("unexpected title: %q", f.Title)
+	}
+}
+
+// TestConfusedDeputy_DCRPreconditionIsIndicator: DCR accepts the off-origin
+// redirect but /authorize enforces exact match. Only the precondition indicator
+// fires (medium/RiskIndicator).
+func TestConfusedDeputy_DCRPreconditionIsIndicator(t *testing.T) {
+	ts := confusedDeputyServer("exact-match")
+	defer ts.Close()
+
+	findings := runConfusedDeputy(t, ts)
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly one indicator finding, got %d: %+v", len(findings), findings)
+	}
+	if findings[0].Confidence != attack.RiskIndicator || findings[0].Severity != "medium" {
+		t.Errorf("want medium/RiskIndicator, got %q/%q", findings[0].Severity, findings[0].Confidence)
+	}
+}
+
+// TestConfusedDeputy_DCRRestricted: DCR rejects the off-origin redirect (the
+// server enforces a redirect allowlist). The rule MUST stay silent.
+func TestConfusedDeputy_DCRRestricted(t *testing.T) {
+	ts := confusedDeputyServer("dcr-restricted")
+	defer ts.Close()
+
+	if findings := runConfusedDeputy(t, ts); len(findings) != 0 {
+		t.Errorf("expected zero findings when DCR rejects an off-origin redirect, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestConfusedDeputy_NotOAuth: no authorization-server metadata. The rule does
+// not apply and MUST stay silent.
+func TestConfusedDeputy_NotOAuth(t *testing.T) {
+	ts := confusedDeputyServer("not-oauth")
+	defer ts.Close()
+
+	if findings := runConfusedDeputy(t, ts); len(findings) != 0 {
+		t.Errorf("expected zero findings against a non-OAuth server, got %d", len(findings))
+	}
+}

--- a/rules/mcp/confused-deputy-001.yaml
+++ b/rules/mcp/confused-deputy-001.yaml
@@ -1,0 +1,71 @@
+id: mcp-confused-deputy-001
+info:
+  name: MCP OAuth Confused Deputy via redirect_uri Validation
+  author: batesian
+  severity: high
+  description: |
+    Tests whether an MCP server's OAuth authorization endpoint enforces exact
+    redirect_uri validation. An MCP server that proxies OAuth to a third-party
+    authorization server with a static client_id, while forwarding a client
+    supplied redirect_uri, is vulnerable to a confused deputy attack: once the
+    upstream consent screen is skipped (a consent cookie set for the static
+    client_id), an attacker who supplies their own redirect_uri harvests the
+    authorization code and can take over the account.
+
+    The MCP Security Best Practices require the proxy to validate that the
+    redirect_uri "exactly matches the registered URI" using exact string matching,
+    and to maintain per-client consent. RFC 6749 Section 4.1.2.1 requires the
+    authorization server to reject a missing, invalid, or mismatching redirect_uri
+    and to NOT redirect the user agent to it.
+
+    Detection (black-box, no browser, user, or consent cookie):
+
+      1. Discover the authorization and registration endpoints from the
+         authorization-server metadata. If there is no DCR registration endpoint
+         (e.g. a 2025-11-25 server that uses Client ID Metadata Documents) or no
+         authorization endpoint, the rule does not apply (no finding).
+      2. Register a client via DCR with an off-origin redirect R1.
+      3. Request /authorize with a DIFFERENT, unregistered off-origin redirect R2.
+         A CONFIRMED finding is raised only when the server answers with a 3xx
+         whose Location host is R2's host - it is redirecting to a redirect_uri
+         that was never registered for the client. If instead DCR accepted the
+         arbitrary off-origin R1 but the authorize check could not be disproven,
+         an INDICATOR is raised (confused deputy precondition).
+
+    Redirect targets use the reserved .invalid TLD (RFC 6761) with a per-run
+    marker, so they never resolve and the flow is never completed: the probe only
+    reads the server's redirect decision and never harvests a code.
+
+  references:
+    - https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices
+    - https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization
+    - https://www.rfc-editor.org/rfc/rfc6749#section-4.1.2.1
+    - https://www.rfc-editor.org/rfc/rfc9700
+    - https://cwe.mitre.org/data/definitions/441.html
+    - https://cwe.mitre.org/data/definitions/601.html
+
+  tags:
+    - mcp
+    - oauth
+    - confused-deputy
+    - redirect-uri
+    - authorization
+    - cwe-441
+    - cwe-601
+
+attack:
+  protocol: mcp
+  type: mcp-confused-deputy
+
+remediation: |
+  1. Validate that the redirect_uri in every authorization request exactly matches
+     a redirect URI registered for that client; use exact string matching, never
+     pattern or wildcard matching, and reject any mismatch with an error rather
+     than redirecting to the supplied URI (RFC 6749 Section 4.1.2.1).
+  2. For a proxy using a static upstream client_id, maintain a per-client consent
+     registry and obtain the user's consent for each dynamically registered client
+     before forwarding to the third-party authorization server; do not rely on the
+     upstream consent cookie.
+  3. Restrict the redirect URIs that dynamic client registration will accept to
+     those appropriate for the deployment rather than accepting arbitrary
+     off-origin hosts.

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -18,7 +18,7 @@ pip install starlette uvicorn httpx mcp
 
 ## Server Registry
 
-The bundled rule set is **14 A2A + 11 MCP = 25 rules**. Every rule's primary
+The bundled rule set is **14 A2A + 12 MCP = 26 rules**. Every rule's primary
 validation is an in-process `net/http/httptest` harness in its Go
 `*_test.go` (multiple server postures: vulnerable must fire / patched / open /
 benign must stay silent). The Python servers below are optional standalone
@@ -43,8 +43,9 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_sse_resume_replay_server.py` | 7790 | `mcp-sse-resume-replay-001` |
 | `mcp_oauth_metadata_ssrf_server.py` | 7791 | `mcp-oauth-metadata-ssrf-001` |
 | `mcp_secret_canary_server.py` | 7792 | `mcp-secret-canary-001` |
+| `mcp_confused_deputy_server.py` | 7793 | `mcp-confused-deputy-001` |
 
-**Coverage.** 24 of the 25 rules have a standalone Python fixture above. The
+**Coverage.** 25 of the 26 rules have a standalone Python fixture above. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
 (`internal/attack/mcp/token_replay_test.go`); the same is true of the per-rule
 edge-case harnesses for every other rule. `mockserver.go` is a Go helper used by

--- a/testdata/mcp_confused_deputy_server.py
+++ b/testdata/mcp_confused_deputy_server.py
@@ -1,0 +1,68 @@
+"""
+Deliberately vulnerable MCP OAuth proxy test server for validating:
+  - mcp-confused-deputy-001: the authorization endpoint does NOT enforce exact
+    redirect_uri validation, so it redirects the user agent to an unregistered,
+    attacker-supplied redirect_uri. This violates RFC 6749 Section 4.1.2.1 (the
+    server must reject a mismatching redirect_uri and must not redirect to it) and
+    is the confused-deputy authorization-code-harvest primitive (CWE-441/CWE-601).
+
+Flow the scanner drives:
+  - GET /.well-known/oauth-authorization-server -> registration + authorization endpoints
+  - POST /register (DCR) -> 201, accepts and echoes ANY redirect_uris (no allowlist)
+  - GET /authorize?...&redirect_uri=<R> -> 302 Location: <R> (no exact-match check)
+
+A compliant server validates that redirect_uri exactly matches a URI registered
+for the client and rejects a mismatch with an error instead of redirecting to it.
+
+Validate against it:
+  python testdata/mcp_confused_deputy_server.py
+  batesian scan --target http://127.0.0.1:7793 --rule-ids mcp-confused-deputy-001 -v
+
+Run: python testdata/mcp_confused_deputy_server.py
+"""
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, RedirectResponse, Response
+from starlette.routing import Route
+import uvicorn
+
+PORT = 7793
+
+
+async def metadata(request: Request) -> Response:
+    base = str(request.base_url).rstrip("/")
+    return JSONResponse({
+        "issuer": base,
+        "registration_endpoint": f"{base}/register",
+        "authorization_endpoint": f"{base}/authorize",
+        "token_endpoint": f"{base}/token",
+    })
+
+
+async def register(request: Request) -> Response:
+    body = await request.json()
+    # VULNERABLE: accept any redirect_uris with no allowlist; echo them back.
+    return JSONResponse(
+        {"client_id": "static-proxy-client", "redirect_uris": body.get("redirect_uris", [])},
+        status_code=201,
+    )
+
+
+async def authorize(request: Request) -> Response:
+    redirect_uri = request.query_params.get("redirect_uri", "")
+    # VULNERABLE: no exact-match validation; redirect to whatever was supplied.
+    if redirect_uri:
+        return RedirectResponse(redirect_uri + "?code=fake-auth-code", status_code=302)
+    return JSONResponse({"error": "invalid_request"}, status_code=400)
+
+
+app = Starlette(routes=[
+    Route("/.well-known/oauth-authorization-server", metadata, methods=["GET"]),
+    Route("/register", register, methods=["POST"]),
+    Route("/authorize", authorize, methods=["GET"]),
+])
+
+if __name__ == "__main__":
+    print(f"[*] MCP confused-deputy vulnerable OAuth proxy on port {PORT}", flush=True)
+    print("[*] Vulnerability: /authorize redirects to any (unregistered) redirect_uri", flush=True)
+    uvicorn.run(app, host="127.0.0.1", port=PORT)


### PR DESCRIPTION
## F1: New rule `mcp-confused-deputy-001` (OAuth redirect_uri confused deputy)

First of the F-series new rules, targeting the **single most-documented MCP OAuth gap** Batesian didn't cover.

### The threat
An MCP server that proxies OAuth to a third-party AS with a **static client_id**, while forwarding a client-supplied `redirect_uri`, is open to a confused deputy attack: once the upstream consent screen is skipped (a consent cookie for the static client_id), an attacker who supplies their own `redirect_uri` harvests the authorization code (one-click account takeover, e.g. FastMCP #3037, Obsidian's Square write-up). The MCP Security Best Practices require **exact** redirect_uri matching + per-client consent; RFC 6749 §4.1.2.1 requires rejecting a mismatching redirect_uri and **not** redirecting to it.

### Detection (deterministic, black-box, safe)
1. Discover the `authorization_endpoint` + `registration_endpoint` from AS metadata. No DCR endpoint (e.g. 2025-11-25 CIMD-only) or no authorize endpoint → **not applicable, no finding**.
2. Register a client via DCR with an off-origin redirect `R1`.
3. Request `/authorize` with a **different, unregistered** off-origin redirect `R2`, without following redirects.
4. Oracle:
   - **CONFIRMED** (high): the server returns a `3xx` whose `Location` **host** is `R2`'s host, meaning it redirected to an unregistered redirect_uri (direct §4.1.2.1 violation).
   - **INDICATOR** (medium): DCR accepted the arbitrary off-origin redirect (the precondition) but the authorize check couldn't be disproven (e.g. validation deferred behind login).
   - **No finding**: redirect rejected, or no DCR/authorize endpoint.

### Safety + false-positive guards (from the research)
- Redirect targets use the reserved `.invalid` TLD (RFC 6761) with a per-run marker, so they never resolve and **the flow is never completed**: no code is ever harvested; the probe only reads the redirect decision.
- Compares the `Location` **host**, never the body, so a rejection page that merely *displays* the URI (a common naive-scanner false positive) is not flagged.
- Uses a non-loopback host (RFC 9700 loopback-port exception avoided) and a well-formed S256 PKCE challenge so the request isn't rejected for malformed PKCE first.

### What ships
Executor + YAML + httptest harness (vulnerable → confirmed, DCR-precondition → indicator, DCR-restricted / non-OAuth → silent) + a Python testdata server (port 7793). Rule count updated to **26 (12 MCP)** in the README, the MCP catalog, and the testdata registry.

### Validation
Full gate green: `go build`, `go vet`, `go test ./...`, `golangci-lint run` (v2.11.4, 0 issues); `py_compile` on the testdata server. The rule loads and the suite reports 26 rules.

### Noted follow-up (separate PR)
While updating `docs/rules-mcp.md` I found the catalog drifted during the B-series (the `mcp-oauth-dcr-001` row still says "confirmed" post-#58; the `mcp-token-replay-001` row has the pre-#59 name; `docs/rules-a2a.md` likely has the same for card-trust/hostinject post-#57). I left that out of this PR to keep it focused and will do a dedicated doc-sync. Recorded in my notes.
