### PR TITLE
docs(rules): sync MCP/A2A catalogs with B-series confidence changes

### DIFF
--- a/docs/rules-a2a.md
+++ b/docs/rules-a2a.md
@@ -19,14 +19,14 @@ Each finding carries a **confidence**:
 | `a2a-push-ssrf-001` | [Push Notification SSRF](#a2a-push-ssrf-001) | High | confirmed | CWE-918 |
 | `a2a-task-idor-001` | [Task IDOR via Unauthenticated tasks/get](#a2a-task-idor-001) | High | confirmed | CWE-639 |
 | `a2a-session-smuggle-001` | [Agent Role Injection / Session Smuggling](#a2a-session-smuggle-001) | High | confirmed / indicator | CWE-384 |
-| `a2a-wellknown-hostinject-001` | [Agent Card Host Header Injection](#a2a-wellknown-hostinject-001) | High / Medium | confirmed / indicator | CWE-601 |
+| `a2a-wellknown-hostinject-001` | [Agent Card Host Header Injection](#a2a-wellknown-hostinject-001) | High / Medium | indicator | CWE-601 |
 | `a2a-jws-algconf-001` | [AgentCard JWS Algorithm Confusion](#a2a-jws-algconf-001) | Critical | indicator | CWE-327 |
 | `a2a-peer-impersonation-001` | [Peer Agent Impersonation via Forged JWT](#a2a-peer-impersonation-001) | Critical | confirmed | CWE-290 |
 | `a2a-artifact-tamper-001` | [Task Artifact Tampering via Task ID Reuse](#a2a-artifact-tamper-001) | High | confirmed / indicator | CWE-284 |
 | `a2a-multitenant-isolation-001` | [Multi-Tenant Task Isolation Breach](#a2a-multitenant-isolation-001) | High | confirmed | CWE-639 |
 | `a2a-delegation-integrity-001` | [Delegation Chain-of-Custody Break](#a2a-delegation-integrity-001) | High | confirmed | CWE-863 |
 | `a2a-context-fixation-001` | [Context ID Fixation](#a2a-context-fixation-001) | High | confirmed | CWE-384 |
-| `a2a-card-trust-001` | [Agent Card Trust Durability](#a2a-card-trust-001) | High / Medium | confirmed / indicator | CWE-345 |
+| `a2a-card-trust-001` | [Agent Card Trust Durability](#a2a-card-trust-001) | High / Medium | indicator | CWE-345 |
 | `a2a-extension-downgrade-001` | [Required-Extension Downgrade / Fail-Open](#a2a-extension-downgrade-001) | High | confirmed | CWE-636 |
 | `a2a-push-binding-001` | [Push/Webhook Control-Plane Not Bound to Task Owner](#a2a-push-binding-001) | High | confirmed | CWE-639 |
 
@@ -114,7 +114,7 @@ Requests the agent card with a synthetic canary host (`evil.batesian.invalid`)
 injected via `Host`, `X-Forwarded-Host`, `X-Original-Host`, and `X-Forwarded-For`,
 then checks where the canary is reflected in the returned card. Severity is graded
 by **where** it lands: reflection into an authority/URL field (`url`, `endpoint`,
-any `*.url`/`*.uri`, or any value that is itself a URL) is **high / confirmed** -
+any `*.url`/`*.uri`, or any value that is itself a URL) is **high / indicator** -
 that is the advertised service location peers and registries trust. Reflection
 that only lands in a non-URL field (e.g. `description`) is a real injection
 primitive but lower direct impact, reported as **medium / indicator**.
@@ -251,7 +251,7 @@ checks:
   `/.well-known/agent-card.json` and the legacy `/.well-known/agent.json`. If one
   path serves a **signed** card and the other an **unsigned** one, an attacker can
   steer verification to the unsigned path to strip the signature requirement -
-  reported **confirmed (high)**. If both are signed but their `url` differs,
+  reported **indicator (high)**. If both are signed but their `url` differs,
   reported as an **indicator (medium)** (routing ambiguity).
 - **Stale-cache trust.** The card response's `Cache-Control` is parsed. A long
   `max-age` (>= 1h) or `immutable` without `no-cache`/`must-revalidate` keeps the
@@ -260,8 +260,8 @@ checks:
   `no-store`/`no-cache`/`must-revalidate`/`max-age=0` produce no finding.
 - **Signature freshness.** When the card carries signatures, each protected
   header is decoded: no `exp` means the signature never expires (**indicator,
-  medium**); an `exp` already in the past that is still served is a **confirmed**
-  stale signature.
+  medium**); an `exp` already in the past that is still served is an **indicator**
+  (a compliant verifier rejects an expired signature).
 
 ---
 

--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -22,9 +22,9 @@ JSON-RPC `error` (the common MCP rejection shape) is a rejection, not a finding.
 
 | Rule ID | Attack | Severity | Confidence | CWE |
 |---|---|:---:|:---:|---|
-| `mcp-oauth-dcr-001` | [OAuth DCR Scope Escalation](#mcp-oauth-dcr-001) | High | confirmed | CWE-284 |
+| `mcp-oauth-dcr-001` | [OAuth DCR Scope Escalation](#mcp-oauth-dcr-001) | High | indicator | CWE-284 |
 | `mcp-oauth-audience-002` | [OAuth Audience Matching Bug Probes](#mcp-oauth-audience-002) | High | confirmed / indicator | CWE-863 |
-| `mcp-token-replay-001` | [OAuth Token Audience Validation Bypass](#mcp-token-replay-001) | High | confirmed | CWE-294 |
+| `mcp-token-replay-001` | [OAuth Token Signature and Audience Validation Bypass](#mcp-token-replay-001) | High | confirmed | CWE-294 |
 | `mcp-resources-unauth-001` | [Unauthenticated Resource Read](#mcp-resources-unauth-001) | High / Critical | confirmed | CWE-862 |
 | `mcp-prompt-unauth-001` | [Prompt Templates Without Authentication](#mcp-prompt-unauth-001) | Medium | confirmed | CWE-862 |
 | `mcp-init-downgrade-001` | [Protocol Version Downgrade Auth Bypass](#mcp-init-downgrade-001) | Critical | confirmed | CWE-757 |
@@ -45,12 +45,14 @@ JSON-RPC `error` (the common MCP rejection shape) is a rejection, not a finding.
 
 Sends a single **unauthenticated** dynamic client registration (DCR) requesting
 admin/write scopes, then inspects the *granted* scope set. Open/anonymous DCR is
-permitted by RFC 7591 and encouraged by the MCP spec, so it is **not** flagged on
+permitted by RFC 7591 and supported by the MCP spec, so it is **not** flagged on
 its own - and neither is redirect-URI shape (loopback redirects are endorsed by
-RFC 8252). The rule fires a **confirmed** critical-impact finding only when the
-granted scopes still contain a privileged token, compared per whitespace-delimited
-scope token (RFC 6749 section 3.3), not by substring. A server that rejects the
-registration or reduces the grant to read-only produces no finding.
+RFC 8252). The rule fires an **indicator** finding only when the granted scopes
+still contain a privileged token, compared per whitespace-delimited scope token
+(RFC 6749 section 3.3), not by substring. This is registration-time evidence: the
+scope policy is permissive, but whether a privileged token is actually issued
+depends on the grant/consent step, so manual verification is recommended. A server
+that rejects the registration or reduces the grant to read-only produces no finding.
 
 ---
 
@@ -85,15 +87,18 @@ token and is tracked as a follow-up.
 
 ### mcp-token-replay-001
 
-**OAuth Token Audience Validation Bypass** | Severity: High | CWE-294
+**OAuth Token Signature and Audience Validation Bypass** | Severity: High | CWE-294
 
-Crafts bearer tokens with a mismatched `aud` claim (and an `alg: none` variant)
-and submits them to the MCP endpoint. A compliant OAuth 2.1 resource server must
-reject tokens whose audience does not match its own identifier (RFC 9068, RFC
-8707). Acceptance is judged at the protocol layer - HTTP 200 + a JSON-RPC `result`
-- so a 200 carrying an `invalid_token` JSON-RPC error is correctly treated as a
-rejection. A **confirmed** finding means a token for an unrelated resource (or an
-unsigned token) was accepted, allowing replay.
+Submits forged bearer tokens the server cannot have validated: two HS256 tokens
+signed with a random key (one with no `aud`, one with a wrong `aud`) and one
+unsigned (`alg: none`). A compliant OAuth 2.1 resource server verifies the token
+signature and the `aud` claim (RFC 9068, RFC 8707) and rejects all three.
+Acceptance is judged at the protocol layer - HTTP 200 + a JSON-RPC `result` - so a
+200 carrying an `invalid_token` JSON-RPC error is correctly treated as a rejection.
+A **confirmed** finding means a forged or unsigned token was accepted: signature
+validation is absent, which also defeats audience binding and enables replay.
+Audience-matching bugs on signature-valid tokens are isolated by
+`mcp-oauth-audience-002`.
 
 ---
 


### PR DESCRIPTION
## Doc-sync: reconcile rule catalogs with the B-series

The human-maintained rule catalogs (`docs/rules-mcp.md`, `docs/rules-a2a.md`) drifted because #57/#58/#59 changed rule confidence and a rule name without updating the docs. I noticed this while adding the catalog entry in #63. This reconciles both catalogs with the current executor/YAML state.

| Rule | PR | Catalog was | Now |
|---|---|---|---|
| `mcp-oauth-dcr-001` | #58 | confirmed (+ "critical-impact", "encouraged") | indicator (+ registration-time note, "supported") |
| `mcp-token-replay-001` | #59 | "OAuth Token **Audience** Validation Bypass" | "OAuth Token **Signature and Audience** Validation Bypass" + signature-framed detail |
| `a2a-card-trust-001` | #57 | confirmed / indicator | indicator |
| `a2a-wellknown-hostinject-001` | #57 | confirmed / indicator | indicator |

Both the summary-table rows and the per-rule detail prose are updated (e.g. the card-trust "signed/unsigned path split" and "expired signature" lines, and the hostinject URL-field line, now read **indicator** instead of **confirmed**, matching the read-only-posture rationale from #57).

`mcp-token-replay-001` confidence stays **confirmed** (a forged token reaching dispatch is a real exploit); only its name and the audience-vs-signature framing changed in #59.

### Scope
Docs only, no rule behavior change. `go build` and `go test ./...` pass (unaffected). No em dashes.
