### PR TITLE
feat(mcp-dns-rebind-origin-001): detect missing Origin validation (DNS rebinding)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ CLI for adversarial testing of [A2A](https://google.github.io/A2A/) and [MCP](ht
 
 ## What ships
 
-Bundled rules: **14 A2A, 12 MCP (26 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
+Bundled rules: **14 A2A, 13 MCP (27 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
 
 - [A2A rules](docs/rules-a2a.md) (14)
-- [MCP rules](docs/rules-mcp.md) (12)
+- [MCP rules](docs/rules-mcp.md) (13)
 
 Coverage spans:
 

--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -34,6 +34,7 @@ JSON-RPC `error` (the common MCP rejection shape) is a rejection, not a finding.
 | `mcp-oauth-metadata-ssrf-001` | [OAuth Discovery / Metadata-Fetch SSRF](#mcp-oauth-metadata-ssrf-001) | High | confirmed / indicator | CWE-918 |
 | `mcp-secret-canary-001` | [Credential Canary Reflected in Responses](#mcp-secret-canary-001) | Medium | confirmed | CWE-522 |
 | `mcp-confused-deputy-001` | [OAuth Confused Deputy via redirect_uri](#mcp-confused-deputy-001) | High / Medium | confirmed / indicator | CWE-441 |
+| `mcp-dns-rebind-origin-001` | [Origin Validation / DNS Rebinding](#mcp-dns-rebind-origin-001) | High | confirmed | CWE-350 |
 
 ---
 
@@ -274,3 +275,23 @@ check could not be disproven, an **indicator** is raised for the precondition.
 Servers with no DCR endpoint (e.g. 2025-11-25 Client ID Metadata Document
 deployments) or no authorization endpoint are out of scope and produce no
 finding.
+
+---
+
+### mcp-dns-rebind-origin-001
+
+**Origin Validation / DNS Rebinding** | Severity: High | CWE-350 / CWE-346
+
+The Streamable HTTP transport requires servers to validate the Origin header on
+every connection and respond `HTTP 403 Forbidden` to a present, invalid Origin,
+to prevent DNS rebinding. The rule first POSTs a normal `initialize` with no
+Origin (baseline: it must be accepted, confirming a responsive MCP endpoint),
+then POSTs the same `initialize` with a foreign Origin
+(`https://dns-rebind.batesian.invalid`, a non-resolving RFC 6761 host no server
+should allowlist) - the only difference is the Origin header. A **confirmed**
+finding is raised when the server still returns a JSON-RPC result for the
+foreign-Origin request instead of rejecting it with 403. DNS-rebinding
+exploitation additionally requires the server to be reachable from a victim's
+browser (a local or same-network bind), which the operator confirms for the
+deployment; this is the class behind the MCP Inspector RCE (CVE-2025-49596). A
+server that answers the foreign Origin with 403 produces no finding.

--- a/internal/attack/mcp/dns_rebind_origin.go
+++ b/internal/attack/mcp/dns_rebind_origin.go
@@ -1,0 +1,97 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// DNSRebindOriginExecutor tests whether an MCP Streamable HTTP server validates
+// the Origin header (rule mcp-dns-rebind-origin-001).
+//
+// The Streamable HTTP transport requires: "Servers MUST validate the Origin
+// header on all incoming connections to prevent DNS rebinding attacks. If the
+// Origin header is present and invalid, servers MUST respond with HTTP 403
+// Forbidden." A server that processes a request carrying a foreign Origin header
+// instead of rejecting it does not validate Origin; a local or same-network
+// server is then reachable from a malicious website that rebinds DNS to it
+// (driving tool calls and, on some servers, command execution).
+type DNSRebindOriginExecutor struct {
+	rule attack.RuleContext
+}
+
+func init() {
+	attack.Register("mcp-dns-rebind-origin", func(rc attack.RuleContext) attack.Executor {
+		return NewDNSRebindOriginExecutor(rc)
+	})
+}
+
+func NewDNSRebindOriginExecutor(r attack.RuleContext) *DNSRebindOriginExecutor {
+	return &DNSRebindOriginExecutor{rule: r}
+}
+
+// foreignOrigin is a clearly cross-origin, non-resolving value (RFC 6761
+// .invalid) that no server should have on its Origin allowlist.
+const foreignOrigin = "https://dns-rebind.batesian.invalid"
+
+func (e *DNSRebindOriginExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
+	vars := attack.NewVars(target, opts.OOBListenerURL)
+	client := attack.NewHTTPClient(opts, vars)
+
+	for _, ep := range endpointCandidates(vars.BaseURL) {
+		// Baseline: a normal initialize with no Origin must be accepted, so we know
+		// this endpoint is a responsive MCP server and the probe is meaningful.
+		if !e.initAccepted(ctx, client, ep, "") {
+			continue
+		}
+		// Probe: the same initialize with a foreign Origin. A compliant server
+		// rejects it with HTTP 403; a server that still processes it does not
+		// validate Origin. The only difference from the baseline is the Origin
+		// header, so acceptance isolates Origin handling.
+		if e.initAccepted(ctx, client, ep, foreignOrigin) {
+			return []attack.Finding{{
+				RuleID:     e.rule.ID,
+				RuleName:   e.rule.Name,
+				Severity:   e.rule.Severity,
+				Confidence: attack.ConfirmedExploit,
+				Title:      "MCP server does not validate the Origin header (DNS rebinding protection missing)",
+				Description: fmt.Sprintf(
+					"The MCP endpoint processed an initialize request carrying a foreign Origin header (%s) "+
+						"and returned a JSON-RPC result, instead of rejecting it with HTTP 403. The Streamable "+
+						"HTTP transport requires servers to validate the Origin header on every connection and "+
+						"respond 403 to an invalid Origin, to prevent DNS rebinding. A server bound to a local "+
+						"or private address is then reachable from a victim's browser via a malicious website "+
+						"that rebinds DNS to it, which can drive tool calls and, on some servers, reach command "+
+						"execution. Validate Origin against an allowlist and bind local servers to localhost.",
+					foreignOrigin),
+				Evidence: fmt.Sprintf(
+					"endpoint: %s\nbaseline initialize (no Origin): accepted\ninitialize with Origin %s: accepted (should be HTTP 403)",
+					ep, foreignOrigin),
+				Remediation: e.rule.Remediation,
+				TargetURL:   ep,
+			}}, nil
+		}
+		// Baseline accepted but the foreign-Origin probe was rejected: Origin is
+		// validated. No finding, and no need to try other endpoints.
+		return nil, nil
+	}
+	return nil, nil
+}
+
+// initAccepted sends an MCP initialize to ep (optionally with an Origin header)
+// and reports whether the server accepted it (HTTP 200 with a JSON-RPC result
+// rather than an error envelope or a 403).
+func (e *DNSRebindOriginExecutor) initAccepted(ctx context.Context, client *attack.HTTPClient, ep, origin string) bool {
+	headers := map[string]string{"Content-Type": "application/json"}
+	if origin != "" {
+		headers["Origin"] = origin
+	}
+	resp, err := client.POST(ctx, ep, headers, json.RawMessage(mcpInitBody))
+	if err != nil || resp.StatusCode != 200 {
+		return false
+	}
+	body := resp.BodyString()
+	return isJSONRPCResult(body) && !isJSONRPCError(body)
+}

--- a/internal/attack/mcp/dns_rebind_origin_test.go
+++ b/internal/attack/mcp/dns_rebind_origin_test.go
@@ -1,0 +1,98 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+func dnsRebindRC() attack.RuleContext {
+	return attack.RuleContext{
+		ID:          "mcp-dns-rebind-origin-001",
+		Name:        "MCP Origin Validation (DNS Rebinding)",
+		Severity:    "high",
+		Remediation: "Validate the Origin header and reject an invalid Origin with 403.",
+	}
+}
+
+// dnsRebindServer models an MCP Streamable HTTP endpoint. mode selects Origin
+// handling:
+//   - "vulnerable": processes initialize regardless of Origin (no validation)
+//   - "validates":  rejects a request carrying any Origin with HTTP 403
+//   - "not-mcp":    not an MCP endpoint (no JSON-RPC result)
+func dnsRebindServer(mode string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		if mode == "validates" && r.Header.Get("Origin") != "" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		if mode == "not-mcp" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": 1,
+			"result": map[string]interface{}{
+				"protocolVersion": "2025-06-18",
+				"serverInfo":      map[string]interface{}{"name": "rebind-fixture", "version": "1.0"},
+				"capabilities":    map[string]interface{}{},
+			},
+		})
+	}))
+}
+
+func runDNSRebind(t *testing.T, ts *httptest.Server) []attack.Finding {
+	t.Helper()
+	findings, err := mcpattack.NewDNSRebindOriginExecutor(dnsRebindRC()).Execute(context.Background(), ts.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return findings
+}
+
+// TestDNSRebind_Vulnerable: the server processes a foreign-Origin initialize.
+// MUST fire confirmed/high.
+func TestDNSRebind_Vulnerable(t *testing.T) {
+	ts := dnsRebindServer("vulnerable")
+	defer ts.Close()
+
+	findings := runDNSRebind(t, ts)
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly one finding, got %d: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Confidence != attack.ConfirmedExploit || f.Severity != "high" {
+		t.Errorf("want high/ConfirmedExploit, got %q/%q", f.Severity, f.Confidence)
+	}
+}
+
+// TestDNSRebind_ValidatesOrigin: the server rejects a foreign Origin with 403.
+// The rule MUST stay silent.
+func TestDNSRebind_ValidatesOrigin(t *testing.T) {
+	ts := dnsRebindServer("validates")
+	defer ts.Close()
+
+	if findings := runDNSRebind(t, ts); len(findings) != 0 {
+		t.Errorf("expected zero findings when the server validates Origin, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestDNSRebind_NotMCP: not an MCP endpoint. The rule does not apply.
+func TestDNSRebind_NotMCP(t *testing.T) {
+	ts := dnsRebindServer("not-mcp")
+	defer ts.Close()
+
+	if findings := runDNSRebind(t, ts); len(findings) != 0 {
+		t.Errorf("expected zero findings against a non-MCP server, got %d", len(findings))
+	}
+}

--- a/rules/mcp/dns-rebind-origin-001.yaml
+++ b/rules/mcp/dns-rebind-origin-001.yaml
@@ -1,0 +1,59 @@
+id: mcp-dns-rebind-origin-001
+info:
+  name: MCP Streamable HTTP Origin Validation (DNS Rebinding)
+  author: batesian
+  severity: high
+  description: |
+    Tests whether an MCP Streamable HTTP server validates the Origin header. The
+    transport spec requires: "Servers MUST validate the Origin header on all
+    incoming connections to prevent DNS rebinding attacks. If the Origin header is
+    present and invalid, servers MUST respond with HTTP 403 Forbidden." A server
+    that omits this check is reachable from a victim's browser when it is bound to
+    a local or private address: a malicious website rebinds DNS to the server and
+    drives its tools (the class behind the MCP Inspector RCE, CVE-2025-49596, and
+    the TypeScript/Python SDK DNS-rebinding advisories).
+
+    Detection (deterministic, black-box):
+
+      1. Baseline: POST a normal `initialize` with NO Origin header. It must be
+         accepted (HTTP 200 + a JSON-RPC result), confirming a responsive MCP
+         endpoint; otherwise the rule does not apply.
+      2. Probe: POST the same `initialize` with a foreign Origin
+         (`https://dns-rebind.batesian.invalid`, a non-resolving RFC 6761 host no
+         server should allowlist). The only difference from the baseline is the
+         Origin header.
+
+    A CONFIRMED finding is raised when the server still returns a JSON-RPC result
+    for the foreign-Origin request instead of rejecting it with HTTP 403, i.e. it
+    does not validate Origin. A server that answers the foreign Origin with 403
+    produces no finding. DNS-rebinding exploitation additionally requires the
+    server to be reachable from a victim's browser (a local or same-network bind),
+    which the operator should confirm for the deployment.
+
+  references:
+    - https://modelcontextprotocol.io/specification/2025-11-25/basic/transports
+    - https://www.oligo.security/blog/critical-rce-vulnerability-in-anthropic-mcp-inspector-cve-2025-49596
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-49596
+    - https://cwe.mitre.org/data/definitions/350.html
+    - https://cwe.mitre.org/data/definitions/346.html
+
+  tags:
+    - mcp
+    - streamable-http
+    - dns-rebinding
+    - origin
+    - cwe-350
+    - cwe-346
+
+attack:
+  protocol: mcp
+  type: mcp-dns-rebind-origin
+
+remediation: |
+  1. Validate the Origin header on every incoming connection against an allowlist
+     of expected origins; reject a present, non-allowlisted Origin with HTTP 403
+     Forbidden before processing the request.
+  2. When running locally, bind the server to localhost (127.0.0.1) rather than
+     all interfaces (0.0.0.0) so it is not reachable from other hosts.
+  3. Require authentication on all connections; do not rely on network position
+     alone for access control.

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -18,7 +18,7 @@ pip install starlette uvicorn httpx mcp
 
 ## Server Registry
 
-The bundled rule set is **14 A2A + 12 MCP = 26 rules**. Every rule's primary
+The bundled rule set is **14 A2A + 13 MCP = 27 rules**. Every rule's primary
 validation is an in-process `net/http/httptest` harness in its Go
 `*_test.go` (multiple server postures: vulnerable must fire / patched / open /
 benign must stay silent). The Python servers below are optional standalone
@@ -44,8 +44,9 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_oauth_metadata_ssrf_server.py` | 7791 | `mcp-oauth-metadata-ssrf-001` |
 | `mcp_secret_canary_server.py` | 7792 | `mcp-secret-canary-001` |
 | `mcp_confused_deputy_server.py` | 7793 | `mcp-confused-deputy-001` |
+| `mcp_dns_rebind_origin_server.py` | 7794 | `mcp-dns-rebind-origin-001` |
 
-**Coverage.** 25 of the 26 rules have a standalone Python fixture above. The
+**Coverage.** 26 of the 27 rules have a standalone Python fixture above. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
 (`internal/attack/mcp/token_replay_test.go`); the same is true of the per-rule
 edge-case harnesses for every other rule. `mockserver.go` is a Go helper used by

--- a/testdata/mcp_dns_rebind_origin_server.py
+++ b/testdata/mcp_dns_rebind_origin_server.py
@@ -1,0 +1,52 @@
+"""
+Deliberately vulnerable MCP Streamable HTTP test server for validating:
+  - mcp-dns-rebind-origin-001: the server does NOT validate the Origin header, so
+    it processes a request carrying a foreign Origin instead of rejecting it with
+    HTTP 403. A local/private-bound server is then reachable from a victim's
+    browser via DNS rebinding (CWE-350 / CWE-346; the class behind CVE-2025-49596).
+
+Flow the scanner drives:
+  - POST {/, /mcp} initialize with no Origin -> 200 + JSON-RPC result (baseline)
+  - POST initialize with Origin: https://...invalid -> 200 + result (VULNERABLE;
+    a compliant server returns HTTP 403 Forbidden for a present, invalid Origin)
+
+Validate against it:
+  python testdata/mcp_dns_rebind_origin_server.py
+  batesian scan --target http://127.0.0.1:7794 --rule-ids mcp-dns-rebind-origin-001 -v
+
+Run: python testdata/mcp_dns_rebind_origin_server.py
+"""
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route
+import uvicorn
+
+PORT = 7794
+
+
+async def mcp(request: Request) -> Response:
+    body = await request.json()
+    req_id = body.get("id")
+    method = body.get("method", "")
+    # VULNERABLE: the Origin header is never checked; the request is processed
+    # regardless of its value (a compliant server returns HTTP 403 for a present,
+    # invalid Origin).
+    if method == "initialize":
+        return JSONResponse({"jsonrpc": "2.0", "id": req_id, "result": {
+            "protocolVersion": "2025-06-18",
+            "serverInfo": {"name": "rebind-fixture", "version": "1.0"},
+            "capabilities": {},
+        }})
+    return JSONResponse({"jsonrpc": "2.0", "id": req_id, "result": {}})
+
+
+app = Starlette(routes=[
+    Route("/mcp", mcp, methods=["POST"]),
+    Route("/", mcp, methods=["POST"]),
+])
+
+if __name__ == "__main__":
+    print(f"[*] MCP DNS-rebinding (no Origin validation) vulnerable server on port {PORT}", flush=True)
+    print("[*] Vulnerability: processes any Origin instead of returning HTTP 403", flush=True)
+    uvicorn.run(app, host="127.0.0.1", port=PORT)


### PR DESCRIPTION
## F2: New rule `mcp-dns-rebind-origin-001` (Origin validation / DNS rebinding)

Second F-series rule, a CVE-backed gap with a clean deterministic oracle.

### The requirement
The MCP [2025-11-25 Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports) states verbatim: *"Servers **MUST** validate the `Origin` header on all incoming connections to prevent DNS rebinding attacks. If the `Origin` header is present and invalid, servers **MUST** respond with HTTP 403 Forbidden."* A server that omits this is reachable from a victim's browser when bound to a local/private address (a malicious site rebinds DNS and drives its tools); this is the class behind the MCP Inspector RCE, **CVE-2025-49596**.

### Detection (deterministic, black-box)
1. **Baseline**: POST a normal `initialize` with **no** Origin. It must be accepted (200 + JSON-RPC result) to confirm a responsive MCP endpoint, else the rule skips.
2. **Probe**: POST the same `initialize` with a foreign Origin (`https://dns-rebind.batesian.invalid`, a non-resolving RFC 6761 host no server should allowlist). The *only* difference from the baseline is the Origin header.
3. **CONFIRMED** when the foreign-Origin request still returns a JSON-RPC result instead of `HTTP 403`. A server that answers it with `403` produces no finding.

The baseline/probe discriminator isolates Origin handling and avoids false positives (a server that 403s everything, or that isn't MCP, never fires).

### Confidence rationale
`ConfirmedExploit` is appropriate: the server demonstrably accepts a cross-origin request it **MUST** reject, so the Origin-validation bypass succeeded. Unlike the B-series demotions (benign-default reflections / unproven token issuance), this is a demonstrated spec MUST-violation. The description is honest that the *DNS-rebinding exploit* additionally requires the server to be browser-reachable (local/same-network), which the operator confirms for the deployment.

### What ships
Executor + YAML + httptest harness (vulnerable → confirmed, validates-Origin → silent, non-MCP → silent) + Python testdata server (port 7794, `py_compile`-verified). Rule count updated to **27 (13 MCP)** across README, MCP catalog, testdata registry.

### Validation
Full gate green: build, vet, `go test ./...`, golangci-lint v2.11.4 (0 issues). Rule loads; suite reports 27.
