### PR TITLE
fix(cli): preserve explicit --skip-tls over config

### DIFF
--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -121,9 +121,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 		token = firstNonEmpty(cfg.Token, os.Getenv("BATESIAN_TOKEN"))
 	}
 	timeoutSecs = effectiveTimeout(cmd.Flags().Changed("timeout"), timeoutSecs, cfg.TimeoutSeconds)
-	if !skipTLS {
-		skipTLS = cfg.SkipTLS
-	}
+	skipTLS = effectiveSkipTLS(cmd.Flags().Changed("skip-tls"), skipTLS, cfg.SkipTLS)
 	if oobURL == "" {
 		oobURL = cfg.OOBURL
 	}
@@ -374,6 +372,17 @@ func effectiveTimeout(flagChanged bool, flagVal, cfgVal int) int {
 		return cfgVal
 	}
 	return flagVal
+}
+
+// effectiveSkipTLS resolves --skip-tls from the flag and config. An explicitly-set
+// flag always wins, so `--skip-tls=false` overrides a config `skipTLS: true`
+// instead of being masked by the false-is-default sentinel; otherwise the config
+// value is used.
+func effectiveSkipTLS(flagChanged, flagVal, cfgVal bool) bool {
+	if flagChanged {
+		return flagVal
+	}
+	return cfgVal
 }
 
 // fetchOAuthToken acquires a bearer token via client credentials grant.

--- a/internal/cli/scan_test.go
+++ b/internal/cli/scan_test.go
@@ -94,3 +94,27 @@ func TestEffectiveTimeout(t *testing.T) {
 		})
 	}
 }
+
+func TestEffectiveSkipTLS(t *testing.T) {
+	tests := []struct {
+		name        string
+		flagChanged bool
+		flagVal     bool
+		cfgVal      bool
+		want        bool
+	}{
+		// The bug this guards: an explicit --skip-tls=false must override a config
+		// that sets skipTLS: true.
+		{"explicit false overrides config true", true, false, true, false},
+		{"explicit true used", true, true, false, true},
+		{"config used when flag not set", false, false, true, true},
+		{"both unset", false, false, false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := effectiveSkipTLS(tc.flagChanged, tc.flagVal, tc.cfgVal); got != tc.want {
+				t.Errorf("effectiveSkipTLS(%v, %v, %v) = %v, want %v", tc.flagChanged, tc.flagVal, tc.cfgVal, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Preserve an explicit `--skip-tls` over config

The A7 sibling, flagged during #54. The flag/config merge used the bool's default (`false`) as its "unset" sentinel:
```go
if !skipTLS {
    skipTLS = cfg.SkipTLS
}
```
So an explicit `--skip-tls=false` is indistinguishable from the default and **cannot override** a config that sets `skipTLS: true` (the more dangerous setting silently wins). Same sentinel class as the `--timeout` bug.

### Fix
Resolve it with cobra's `Flags().Changed("skip-tls")`, via an `effectiveSkipTLS` helper next to `effectiveTimeout`: an explicitly-set flag always wins; otherwise the config value is used. Security-relevant precedence: an operator who passes `--skip-tls=false` now reliably gets TLS verification on, regardless of config.

### Test
`TestEffectiveSkipTLS` (table) covers the bug case (explicit `false` over config `true`) plus the normal precedence rules.

### Validation
Full gate green: `go build`, `go vet`, `go test ./...`, `golangci-lint run` (v2.11.4, 0 issues).
