### PR TITLE
docs(sarif): set accurate expectations for GitHub Code Scanning

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,6 +1,9 @@
 # CI/CD Integration
 
-Batesian outputs SARIF, which GitHub natively ingests as Code Scanning alerts.
+Batesian outputs SARIF, consumed by SARIF tooling (DAST viewers, dashboards) and
+uploadable to GitHub Code Scanning. Note that Batesian findings are network
+targets, not files in the repository, so GitHub surfaces them as alerts without
+source-line annotations (it resolves SARIF locations as repository paths).
 Integrating into CI takes two lines on top of the scan command.
 
 ## GitHub Actions

--- a/internal/report/sarif.go
+++ b/internal/report/sarif.go
@@ -10,7 +10,10 @@ import (
 	"github.com/calbebop/batesian/internal/engine"
 )
 
-// SARIF v2.1.0 output for GitHub Security tab integration.
+// SARIF v2.1.0 output for SARIF consumers (DAST viewers, dashboards) and CI.
+// Findings are network targets (absolute URIs), not repository files, so when
+// uploaded to GitHub Code Scanning they appear as alerts without source-line
+// annotations - GitHub resolves SARIF locations as repository paths.
 // Spec: https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html
 // GitHub docs: https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning
 


### PR DESCRIPTION
## Set accurate expectations for SARIF on GitHub Code Scanning

The A5 queued docs item. The SARIF output was framed as "GitHub Security tab integration", but (as the #52 research found) GitHub Code Scanning is **repo-file-oriented**: it resolves `artifactLocation` URIs as repository paths and does not support network/web (DAST) targets. Batesian findings are absolute network URIs, so on GitHub they show up as alerts **without source-line annotations**.

### Change
- `sarif.go` header comment: reframed to "SARIF consumers (DAST viewers, dashboards) and CI", with the GitHub file-annotation caveat.
- `docs/ci-cd.md` intro: states that findings are network targets, not repo files, so GitHub surfaces them as alerts without source-line annotations.

This sets honest expectations without discouraging the GitHub upload (which still works for alert visibility). The underlying SARIF **schema** was already corrected in #52 (dropping the invalid `uriBaseId` on absolute URIs).

### Scope
Docs/comment only; no behavior change. `go build` passes; no em dashes. Deliberately does not touch `scan.go` (its terse cobra help strings) to avoid conflicting with the open #66.
