### PR TITLE
docs(mcp): add currency notes for session-fixation and sse-resume

### DIFF
--- a/rules/mcp/session-fixation-001.yaml
+++ b/rules/mcp/session-fixation-001.yaml
@@ -31,7 +31,13 @@ info:
     When two principals are configured, the rule additionally shows a second
     principal borrowing the pre-seeded session, with hop-by-hop provenance.
 
+    Currency: the Mcp-Session-Id mechanism is normative in revisions 2025-03-26
+    through 2025-11-25; the 2026-07-28 revision removes protocol-level sessions, so
+    this rule applies to servers on the earlier revisions (the deployed majority as
+    of mid-2026).
+
   references:
+    - https://modelcontextprotocol.io/specification/2025-11-25/basic/transports
     - https://modelcontextprotocol.io/specification/2025-03-26/basic/transports
     - https://owasp.org/www-community/attacks/Session_fixation
     - https://cwe.mitre.org/data/definitions/384.html

--- a/rules/mcp/sse-resume-replay-001.yaml
+++ b/rules/mcp/sse-resume-replay-001.yaml
@@ -28,7 +28,13 @@ info:
          session B. A server that replays only the requester's own events, or that
          ignores Last-Event-ID, produces no finding.
 
+    Currency: GET-stream resumption via Last-Event-ID is normative in revisions
+    2025-03-26 through 2025-11-25; the 2026-07-28 revision removes the GET stream
+    and Last-Event-ID resumability, so this rule applies to servers on the earlier
+    revisions (the deployed majority as of mid-2026).
+
   references:
+    - https://modelcontextprotocol.io/specification/2025-11-25/basic/transports
     - https://modelcontextprotocol.io/specification/2025-06-18/basic/transports
     - https://cwe.mitre.org/data/definitions/488.html
     - https://cwe.mitre.org/data/definitions/294.html


### PR DESCRIPTION
## C1: Currency notes for session-fixation and sse-resume

Two MCP rules test mechanisms that the **2026-07-28** revision removes:
- `mcp-session-fixation-001` relies on `Mcp-Session-Id` (protocol-level sessions).
- `mcp-sse-resume-replay-001` relies on the GET stream + `Last-Event-ID` resumption.

Both are normative in revisions **2025-03-26 through 2025-11-25** (the deployed majority as of mid-2026) and removed in 2026-07-28. Added a dated **Currency** note to each rule's description so operators know the rule targets pre-2026-07-28 servers, and added the current `2025-11-25` transports reference to each.

### Scope
Descriptor metadata only; no detection change. Both rules still load and validate (`go test ./internal/rules`, `go run ... --rule-ids ...` → "Running 2 rule(s)"). No em dashes.

This completes the agreed endgame (SARIF note in #67 + this currency note). With #66, #67, and this merged, the remaining backlog is the larger **C2 version-aware-shaping** refactor (deferred until 2026-07-28 ships), which is recorded in my notes for later.
