### PR TITLE
docs: fix stale MCP rule count and drop dead issue references

### DIFF
--- a/docs/rules-a2a.md
+++ b/docs/rules-a2a.md
@@ -1,6 +1,6 @@
 # A2A Attack Rules
 
-Batesian ships **14 rules** targeting the [Agent-to-Agent (A2A) protocol](https://google.github.io/A2A/).
+Batesian ships **14 rules** targeting the [Agent-to-Agent (A2A) protocol](https://a2a-protocol.org/).
 Every rule is an active probe: it sends crafted protocol traffic and judges the
 server's actual response. Rules are deliberately scoped to A2A-specific semantics
 (agent cards, JWS card signatures, tasks/contexts, push notifications, peer

--- a/docs/rules-a2a.md
+++ b/docs/rules-a2a.md
@@ -192,8 +192,8 @@ provenance trail attached to the finding.
 
 **Delegation Chain-of-Custody Break (Wrong-Principal Continuation)** | Severity: High | CWE-863
 
-A **chained CONSUMER** rule (roadmap #24) - the first rule that consumes another
-rule's blackboard output. It declares `Requires(task-id)`, so the engine runs it
+A **chained CONSUMER** rule - the first rule that consumes another rule's
+blackboard output. It declares `Requires(task-id)`, so the engine runs it
 after any task-id producer (e.g. `a2a-multitenant-isolation-001`) and it reuses
 that upstream task-id; run standalone it falls back to creating its own delegator
 task. Needs two principals with valid, distinct credentials.
@@ -215,8 +215,8 @@ the task was consumed from an upstream rule or created locally.
 
 **Context ID Fixation (Client-Supplied contextId Across Principals)** | Severity: High | CWE-384
 
-The A2A half of the session/task-ID fixation concern (roadmap #27; the MCP half
-is `mcp-session-fixation-001`). A2A groups a conversation by `contextId`; the
+The A2A half of the session/task-ID fixation concern (the MCP half is
+`mcp-session-fixation-001`). A2A groups a conversation by `contextId`; the
 server should mint it and scope each context to its participants. This **chained,
 multi-principal** rule confirms a server that adopts a client-chosen contextId
 **and** merges a different principal's messages under it. Needs two principals

--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -1,6 +1,6 @@
 # MCP Attack Rules
 
-Batesian ships **11 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
+Batesian ships **13 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
 Every rule is an active probe: it sends crafted protocol traffic and judges the
 server's actual response. Rules are deliberately scoped to MCP-specific semantics
 (OAuth 2.1 authorization, DCR, audience binding, discovery-chain metadata-fetch
@@ -154,8 +154,8 @@ if both are rejected, the server is secure - neither produces a finding here.
 
 **Session ID Fixation** | Severity: High | CWE-384
 
-A **stateful, chained** rule (roadmap #27, the MCP half of the session/task-ID
-fixation story). The Streamable HTTP transport requires the server to assign the
+A **stateful, chained** rule (the MCP half of the session/task-ID fixation
+story). The Streamable HTTP transport requires the server to assign the
 `Mcp-Session-Id` at initialize and to reject an unrecognized id with HTTP 404; a
 server that instead **adopts a client-chosen id** is vulnerable to session
 fixation. The rule confirms the failure with a control to avoid false positives
@@ -173,7 +173,7 @@ A **confirmed** finding is raised only when the pre-seeded id is accepted while
 the un-initialized id is rejected - proving sessions are enforced yet a
 client-supplied identifier was trusted. When two principals are configured, a
 fourth provenance hop shows the pre-seeded session being borrowed by a different
-principal. The A2A handoff variant of #27 is tracked separately.
+principal. The A2A counterpart is `a2a-context-fixation-001`.
 
 ---
 

--- a/internal/attack/blackboard.go
+++ b/internal/attack/blackboard.go
@@ -45,8 +45,7 @@ type Artifact struct {
 	Value string
 	// Principal names the identity/tenant this artifact belongs to. Empty means
 	// anonymous / the default principal. Multi-principal and multi-tenant rules
-	// (roadmap #27/#28) use this to keep one principal's artifacts distinct from
-	// another's.
+	// use this to keep one principal's artifacts distinct from another's.
 	Principal string
 	// Producer is the rule ID that published the artifact, for provenance.
 	Producer string

--- a/internal/attack/executor.go
+++ b/internal/attack/executor.go
@@ -51,9 +51,9 @@ type Options struct {
 
 	// Principals are additional authenticated identities (each with its own token
 	// and optional tenant) that multi-step chained rules can act as. Cross-tenant
-	// and handoff rules (roadmap #27/#28) need at least two principals to prove
-	// that one identity cannot reach another's objects. Empty for single-principal
-	// scans, where Token is the only identity.
+	// and handoff rules need at least two principals to prove that one identity
+	// cannot reach another's objects. Empty for single-principal scans, where
+	// Token is the only identity.
 	Principals []Principal
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,8 +62,8 @@ type Config struct {
 	AudienceClaim string `yaml:"audience_claim"`
 
 	// Principals are additional authenticated identities for multi-tenant and
-	// handoff chained rules (roadmap #27/#28). Each needs a valid token; cross-
-	// tenant isolation rules use two or more to attempt access that must fail.
+	// handoff chained rules. Each needs a valid token; cross-tenant isolation
+	// rules use two or more to attempt access that must fail.
 	Principals []PrincipalConfig `yaml:"principals"`
 }
 

--- a/internal/engine/coalesce.go
+++ b/internal/engine/coalesce.go
@@ -15,8 +15,8 @@ import (
 // class), so this can only ever merge intentionally-overlapping rules.
 var vulnClass = map[string]string{
 	// A server that fails both JWT signature validation (token-replay) and
-	// audience binding (oauth-audience) is one broken token validator (roadmap
-	// #41 / #20), not two separate issues.
+	// audience binding (oauth-audience) is one broken token validator, not two
+	// separate issues.
 	"mcp-token-replay-001":   "mcp-token-validation",
 	"mcp-oauth-audience-002": "mcp-token-validation",
 }

--- a/rules/a2a/artifact-tamper-001.yaml
+++ b/rules/a2a/artifact-tamper-001.yaml
@@ -21,7 +21,7 @@ info:
     with Agent B directly.
 
   references:
-    - https://google.github.io/A2A/specification/
+    - https://a2a-protocol.org/latest/specification/
     - https://owasp.org/www-project-top-10-for-large-language-model-applications/
     - https://cwe.mitre.org/data/definitions/284.html
     - https://cwe.mitre.org/data/definitions/639.html

--- a/rules/a2a/card-trust-001.yaml
+++ b/rules/a2a/card-trust-001.yaml
@@ -36,7 +36,7 @@ info:
          the past is still being served (CONFIRMED stale signature).
 
   references:
-    - https://google.github.io/A2A/specification/
+    - https://a2a-protocol.org/latest/specification/
     - https://www.rfc-editor.org/rfc/rfc9111.html
     - https://cwe.mitre.org/data/definitions/345.html
     - https://cwe.mitre.org/data/definitions/347.html

--- a/rules/a2a/context-fixation-001.yaml
+++ b/rules/a2a/context-fixation-001.yaml
@@ -35,7 +35,7 @@ info:
     the fixed context.
 
   references:
-    - https://google.github.io/A2A/specification/
+    - https://a2a-protocol.org/latest/specification/
     - https://owasp.org/www-community/attacks/Session_fixation
     - https://cwe.mitre.org/data/definitions/384.html
 

--- a/rules/a2a/delegation-integrity-001.yaml
+++ b/rules/a2a/delegation-integrity-001.yaml
@@ -38,7 +38,7 @@ info:
     workflow that should have stayed bound to the original delegator.
 
   references:
-    - https://google.github.io/A2A/specification/
+    - https://a2a-protocol.org/latest/specification/
     - https://owasp.org/www-project-top-ten/2021/A01_2021-Broken_Access_Control
     - https://cwe.mitre.org/data/definitions/863.html
     - https://cwe.mitre.org/data/definitions/269.html

--- a/rules/a2a/extension-downgrade-001.yaml
+++ b/rules/a2a/extension-downgrade-001.yaml
@@ -29,7 +29,7 @@ info:
          closed (secure) - no finding.
 
   references:
-    - https://google.github.io/A2A/specification/
+    - https://a2a-protocol.org/latest/specification/
     - https://a2a-protocol.org/latest/topics/extensions/
     - https://cwe.mitre.org/data/definitions/636.html
     - https://cwe.mitre.org/data/definitions/757.html

--- a/rules/a2a/multitenant-isolation-001.yaml
+++ b/rules/a2a/multitenant-isolation-001.yaml
@@ -34,7 +34,7 @@ info:
     its own valid credentials and a task ID.
 
   references:
-    - https://google.github.io/A2A/specification/
+    - https://a2a-protocol.org/latest/specification/
     - https://owasp.org/www-project-top-ten/2021/A01_2021-Broken_Access_Control
     - https://owasp.org/www-project-api-security/
     - https://cwe.mitre.org/data/definitions/639.html

--- a/rules/a2a/push-binding-001.yaml
+++ b/rules/a2a/push-binding-001.yaml
@@ -29,7 +29,7 @@ info:
          read leak if B's response echoes A's marker URL).
 
   references:
-    - https://google.github.io/A2A/specification/
+    - https://a2a-protocol.org/latest/specification/
     - https://cwe.mitre.org/data/definitions/639.html
     - https://cwe.mitre.org/data/definitions/862.html
     - https://cwe.mitre.org/data/definitions/441.html

--- a/rules/a2a/wellknown-hostinject-001.yaml
+++ b/rules/a2a/wellknown-hostinject-001.yaml
@@ -31,7 +31,7 @@ info:
 
   references:
     - https://portswigger.net/web-security/host-header
-    - https://google.github.io/A2A/specification/
+    - https://a2a-protocol.org/latest/specification/
     - https://cwe.mitre.org/data/definitions/601.html
     - https://cwe.mitre.org/data/definitions/16.html
 


### PR DESCRIPTION
## Summary

Accuracy fixes surfaced by an external audit (and a couple found while verifying it). Docs, comments, and rule metadata only, no behavior change.

### 1. Stale MCP rule count
`docs/rules-mcp.md` opened with "ships **11 rules**" while the table directly below it, the README, and `testdata/README.md` all say **13**. Corrected to 13.

### 2. Dead issue references
Several code comments and rule-doc sections cited GitHub issues that do not exist in this repo:
- `internal/attack/executor.go`, `internal/attack/blackboard.go`, `internal/config/config.go` cited "roadmap #27/#28"
- `internal/engine/coalesce.go` cited "#41 / #20"
- `docs/rules-mcp.md` and `docs/rules-a2a.md` cited "roadmap #24" and "roadmap #27"

These were doubly wrong: the features they described (multi-tenant isolation, delegation handoff, session/context fixation) **already ship as rules**, so "roadmap #NN" was both dangling and stale. Reworded to present tense, pointing to the concrete sibling rule (e.g. `a2a-context-fixation-001`) where that's more useful than an issue number.

### 3. Remaining dead `google.github.io/A2A` links
The README link was fixed previously, but the same dead host survived in the A2A catalog intro and in the `references:` block of **eight A2A rule YAMLs** (which ship to users). `google.github.io/A2A` now 404s. Repointed the catalog to `a2a-protocol.org` and each rule reference to `a2a-protocol.org/latest/specification/`.

## Verification
`go build`, `go vet`, `go test ./...` (incl. `./internal/rules`) all pass. No functional code changed.

## Not included
The audit also recommended a `--dry-run` flag. That's a genuine feature with a safety-critical surface (six separate HTTP egress points must be intercepted to guarantee zero traffic, two of them inside individual rules), so it's being handled in its own focused PR rather than bundled here.
