### PR TITLE
feat(scan): add --dry-run to preview requests without sending traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ CLI for adversarial testing of [A2A](https://a2a-protocol.org) and [MCP](https:/
 
 ![Batesian demo](docs/demo.gif)
 
-> **Authorized use only.** Run Batesian only against systems you own or targets covered by explicit written permission. The CLI issues attack-shaped traffic. Use outside that scope is your responsibility.
+> **Authorized use only.** Run Batesian only against systems you own or targets covered by explicit written permission. The CLI issues attack-shaped traffic. Use outside that scope is your responsibility. To review the traffic a scan would generate before authorizing it, run `scan --dry-run`: it records and prints every request and sends nothing.
 >
 > **Secrets and TLS.** Prefer `BATESIAN_TOKEN` or your secret manager over embedding long-lived bearer material in shared terminals, config repos, or CI logs. Use `--skip-tls` only when you must hit a host with intentionally broken TLS, such as a local lab on self-signed certificates.
 >
@@ -66,6 +66,8 @@ batesian scan --target https://mcp.example.com \
 batesian scan --target https://agent.example.com \
   --principal name=tenant-a,token="$TOKEN_A",tenant=A \
   --principal name=tenant-b,token="$TOKEN_B",tenant=B
+
+batesian scan --target https://agent.example.com --dry-run
 
 batesian init
 ```

--- a/internal/attack/a2a/push_ssrf.go
+++ b/internal/attack/a2a/push_ssrf.go
@@ -40,18 +40,24 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 	listenerURL := opts.OOBListenerURL
 	var listener *oob.Listener
 	if listenerURL == "" {
-		// Spin up a local listener for this run.
-		listener = oob.New()
-		var err error
-		listenerURL, err = listener.Start()
-		if err != nil {
-			return nil, fmt.Errorf("push-ssrf: starting OOB listener: %w", err)
+		if opts.DryRun {
+			// A dry run must bind no socket; preview against a non-resolving
+			// placeholder so the recorded plan still shows a callback URL.
+			listenerURL = attack.DryRunOOBPlaceholderURL
+		} else {
+			// Spin up a local listener for this run.
+			listener = oob.New()
+			var err error
+			listenerURL, err = listener.Start()
+			if err != nil {
+				return nil, fmt.Errorf("push-ssrf: starting OOB listener: %w", err)
+			}
+			defer func() {
+				stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				defer cancel()
+				_ = listener.Stop(stopCtx)
+			}()
 		}
-		defer func() {
-			stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-			defer cancel()
-			_ = listener.Stop(stopCtx)
-		}()
 		vars = attack.NewVars(target, listenerURL)
 	}
 

--- a/internal/attack/a2a/push_ssrf_test.go
+++ b/internal/attack/a2a/push_ssrf_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"time"
 
 	"testing"
@@ -115,5 +116,38 @@ func TestPushSSRFExecutor_MethodNotFound(t *testing.T) {
 	}
 	if len(findings) != 0 {
 		t.Errorf("expected zero findings, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestPushSSRF_DryRunBindsNoListener verifies that a dry run previews the SSRF
+// probe against the non-resolving placeholder callback instead of binding a local
+// OOB listener. A dry run must open no socket, so the recorded plan must carry the
+// placeholder host and never a real listener address.
+func TestPushSSRF_DryRunBindsNoListener(t *testing.T) {
+	rec := &attack.Recorder{}
+	rec.SetCurrentRule("a2a-push-ssrf-001")
+	opts := attack.Options{DryRun: true, Recorder: rec}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := a2a.NewPushSSRFExecutor(testRuleCtx()).Execute(ctx, "http://target.invalid", opts); err != nil {
+		t.Fatalf("dry-run Execute returned error: %v", err)
+	}
+
+	reqs := rec.Requests()
+	if len(reqs) == 0 {
+		t.Fatal("dry run recorded no requests")
+	}
+	var sawPlaceholder bool
+	for _, r := range reqs {
+		if strings.Contains(r.Body, "oob.batesian.invalid") {
+			sawPlaceholder = true
+		}
+		if strings.Contains(r.Body, "127.0.0.1") || strings.Contains(r.Body, "0.0.0.0") {
+			t.Errorf("dry-run request body references a real listener address: %s", r.Body)
+		}
+	}
+	if !sawPlaceholder {
+		t.Error("dry-run plan never used the placeholder OOB callback URL")
 	}
 }

--- a/internal/attack/dryrun.go
+++ b/internal/attack/dryrun.go
@@ -1,0 +1,132 @@
+package attack
+
+import (
+	"bytes"
+	"crypto/tls"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// RecordedRequest is one outbound HTTP request captured during a dry run.
+type RecordedRequest struct {
+	RuleID  string
+	Method  string
+	URL     string
+	Headers map[string]string // Authorization value is redacted
+	Body    string
+}
+
+// Recorder collects the requests a dry run would have sent instead of sending
+// them. It is safe for concurrent use, though the engine drives rules
+// sequentially and stamps the active rule via SetCurrentRule.
+type Recorder struct {
+	mu      sync.Mutex
+	current string
+	reqs    []RecordedRequest
+}
+
+// SetCurrentRule labels subsequently recorded requests with ruleID. The engine
+// calls this before running each rule so the dry-run plan can group by rule.
+func (r *Recorder) SetCurrentRule(ruleID string) {
+	r.mu.Lock()
+	r.current = ruleID
+	r.mu.Unlock()
+}
+
+// Requests returns a copy of the recorded requests in capture order.
+func (r *Recorder) Requests() []RecordedRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]RecordedRequest, len(r.reqs))
+	copy(out, r.reqs)
+	return out
+}
+
+func (r *Recorder) record(method, rawURL string, header http.Header, body []byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.reqs = append(r.reqs, RecordedRequest{
+		RuleID:  r.current,
+		Method:  method,
+		URL:     rawURL,
+		Headers: redactHeaders(header),
+		Body:    string(body),
+	})
+}
+
+// redactHeaders flattens headers to a single-valued map and masks credentials so
+// a shared dry-run plan never leaks bearer tokens.
+func redactHeaders(h http.Header) map[string]string {
+	out := make(map[string]string, len(h))
+	for k, v := range h {
+		if strings.EqualFold(k, "Authorization") {
+			out[k] = "<redacted>"
+			continue
+		}
+		out[k] = strings.Join(v, ", ")
+	}
+	return out
+}
+
+// dryRunRoundTripper records each request and returns a benign synthetic response
+// without performing any network I/O. It holds no real transport, so it cannot
+// reach the network by construction; that is the dry-run safety guarantee.
+type dryRunRoundTripper struct {
+	rec *Recorder
+}
+
+func (d *dryRunRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	var body []byte
+	if req.Body != nil {
+		body, _ = io.ReadAll(req.Body)
+		_ = req.Body.Close()
+	}
+	rec := d.rec
+	if rec == nil {
+		rec = &Recorder{} // defensive: a dry run with no recorder still must not dial
+	}
+	// A forged Host lives in req.Host, not req.Header; surface it so the recorded
+	// plan shows the effective Host an executor set (e.g. host-injection probes).
+	header := req.Header.Clone()
+	if req.Host != "" {
+		header.Set("Host", req.Host)
+	}
+	rec.record(req.Method, req.URL.String(), header, body)
+	return syntheticResponse(req), nil
+}
+
+// syntheticResponse is the stand-in a dry run hands back to the caller: an empty
+// JSON 200 so executors can parse a response without anything being sent. Any
+// findings derived from it are discarded; a dry run reports the request plan, not
+// results.
+func syntheticResponse(req *http.Request) *http.Response {
+	body := []byte("{}")
+	return &http.Response{
+		StatusCode:    http.StatusOK,
+		Status:        "200 OK",
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        http.Header{"Content-Type": []string{"application/json"}},
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+		Request:       req,
+	}
+}
+
+// Transport returns the RoundTripper for a scan-path HTTP client. In a dry run it
+// returns a recording transport that sends nothing; otherwise a real
+// *http.Transport honoring opts.SkipTLS. Routing every scan-path client through
+// this one function is what makes the dry-run "send nothing" guarantee total.
+func Transport(opts Options) http.RoundTripper {
+	if opts.DryRun {
+		return &dryRunRoundTripper{rec: opts.Recorder}
+	}
+	tr := &http.Transport{}
+	if opts.SkipTLS {
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+	}
+	return tr
+}

--- a/internal/attack/dryrun.go
+++ b/internal/attack/dryrun.go
@@ -9,6 +9,13 @@ import (
 	"sync"
 )
 
+// DryRunOOBPlaceholderURL is the base callback URL substituted for a real OOB
+// listener during a dry run. SSRF executors normally bind a local listener to
+// catch callbacks; a dry run must bind no socket, so they use this non-resolving
+// placeholder instead. The .invalid TLD (RFC 6761) never resolves, and the
+// recorded plan still shows a representative callback URL.
+const DryRunOOBPlaceholderURL = "http://oob.batesian.invalid"
+
 // RecordedRequest is one outbound HTTP request captured during a dry run.
 type RecordedRequest struct {
 	RuleID  string

--- a/internal/attack/dryrun_test.go
+++ b/internal/attack/dryrun_test.go
@@ -1,0 +1,86 @@
+package attack
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// TestDryRunClientDoesNotDial is the core safety guarantee: a dry-run HTTP client
+// records the request it would send but never opens a connection, and it redacts
+// the bearer token so a shared plan cannot leak credentials.
+func TestDryRunClientDoesNotDial(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	var dialed int32
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			atomic.StoreInt32(&dialed, 1)
+			conn.Close()
+		}
+	}()
+
+	rec := &Recorder{}
+	rec.SetCurrentRule("test-rule")
+	opts := Options{DryRun: true, Recorder: rec, Token: "supersecret"}
+	c := NewHTTPClient(opts, NewVars("http://"+ln.Addr().String(), ""))
+
+	resp, err := c.POST(context.Background(), "{{BaseURL}}/initialize",
+		map[string]string{"X-Probe": "1"}, map[string]any{"jsonrpc": "2.0"})
+	if err != nil {
+		t.Fatalf("dry-run POST returned error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("synthetic response status = %d, want 200", resp.StatusCode)
+	}
+
+	if atomic.LoadInt32(&dialed) != 0 {
+		t.Fatal("dry run dialed the target; nothing should be sent")
+	}
+
+	reqs := rec.Requests()
+	if len(reqs) != 1 {
+		t.Fatalf("recorded %d requests, want 1", len(reqs))
+	}
+	r := reqs[0]
+	if r.RuleID != "test-rule" {
+		t.Errorf("RuleID = %q, want test-rule", r.RuleID)
+	}
+	if r.Method != http.MethodPost {
+		t.Errorf("Method = %q, want POST", r.Method)
+	}
+	if !strings.HasSuffix(r.URL, "/initialize") {
+		t.Errorf("URL = %q, want suffix /initialize", r.URL)
+	}
+	if !strings.Contains(r.Body, "jsonrpc") {
+		t.Errorf("Body = %q, missing request payload", r.Body)
+	}
+	if got := r.Headers["Authorization"]; got != "<redacted>" {
+		t.Errorf("Authorization = %q, want <redacted> (token must not leak into the plan)", got)
+	}
+	if r.Headers["X-Probe"] != "1" {
+		t.Errorf("custom header not recorded: %v", r.Headers)
+	}
+}
+
+// TestTransportSelectsByMode confirms the shared Transport factory returns the
+// recording transport only in a dry run, and a real *http.Transport otherwise.
+func TestTransportSelectsByMode(t *testing.T) {
+	if _, ok := Transport(Options{}).(*http.Transport); !ok {
+		t.Errorf("non-dry-run Transport = %T, want *http.Transport", Transport(Options{}))
+	}
+	if _, ok := Transport(Options{DryRun: true, Recorder: &Recorder{}}).(*dryRunRoundTripper); !ok {
+		t.Error("dry-run Transport should be the recording transport")
+	}
+}

--- a/internal/attack/executor.go
+++ b/internal/attack/executor.go
@@ -51,10 +51,19 @@ type Options struct {
 
 	// Principals are additional authenticated identities (each with its own token
 	// and optional tenant) that multi-step chained rules can act as. Cross-tenant
-	// and handoff rules (roadmap #27/#28) need at least two principals to prove
-	// that one identity cannot reach another's objects. Empty for single-principal
-	// scans, where Token is the only identity.
+	// and handoff rules need at least two principals to prove that one identity
+	// cannot reach another's objects. Empty for single-principal scans, where
+	// Token is the only identity.
 	Principals []Principal
+
+	// DryRun, when true, records every outbound request instead of sending it, so
+	// an operator can review the exact traffic a scan would generate before
+	// authorizing it. Every scan-path HTTP client honors this via Transport.
+	DryRun bool
+
+	// Recorder collects the requests captured during a dry run. It must be non-nil
+	// when DryRun is set; the engine stamps the active rule onto it per rule.
+	Recorder *Recorder
 }
 
 // Principal is an authenticated identity a chained rule can act as. Multi-tenant

--- a/internal/attack/http.go
+++ b/internal/attack/http.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -44,14 +43,10 @@ func NewHTTPClient(opts Options, vars Vars) *HTTPClient {
 	if timeout <= 0 {
 		timeout = 10 * time.Second
 	}
-	transport := &http.Transport{}
-	if opts.SkipTLS {
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
-	}
 	return &HTTPClient{
 		inner: &http.Client{
 			Timeout:   timeout,
-			Transport: transport,
+			Transport: Transport(opts),
 		},
 		vars:  vars,
 		token: opts.Token,

--- a/internal/attack/mcp/confused_deputy.go
+++ b/internal/attack/mcp/confused_deputy.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -190,12 +189,8 @@ func authorizeRedirectProbe(ctx context.Context, opts attack.Options, authorizat
 	}
 	req.Header.Set("User-Agent", "batesian/"+attack.Version+" (https://github.com/calbebop/batesian)")
 
-	tr := &http.Transport{}
-	if opts.SkipTLS {
-		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
-	}
 	hc := &http.Client{
-		Transport: tr,
+		Transport: attack.Transport(opts),
 		// Do not follow redirects: we need the first response's Location header.
 		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
 	}

--- a/internal/attack/mcp/oauth_metadata_ssrf.go
+++ b/internal/attack/mcp/oauth_metadata_ssrf.go
@@ -47,17 +47,23 @@ func (e *OAuthMetadataSSRFExecutor) Execute(ctx context.Context, target string, 
 	listenerURL := opts.OOBListenerURL
 	var listener *oob.Listener
 	if listenerURL == "" {
-		listener = oob.New()
-		var err error
-		listenerURL, err = listener.Start()
-		if err != nil {
-			return nil, fmt.Errorf("oauth-metadata-ssrf: starting OOB listener: %w", err)
+		if opts.DryRun {
+			// A dry run must bind no socket; preview against a non-resolving
+			// placeholder so the recorded plan still shows the seeded URLs.
+			listenerURL = attack.DryRunOOBPlaceholderURL
+		} else {
+			listener = oob.New()
+			var err error
+			listenerURL, err = listener.Start()
+			if err != nil {
+				return nil, fmt.Errorf("oauth-metadata-ssrf: starting OOB listener: %w", err)
+			}
+			defer func() {
+				stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				defer cancel()
+				_ = listener.Stop(stopCtx)
+			}()
 		}
-		defer func() {
-			stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-			defer cancel()
-			_ = listener.Stop(stopCtx)
-		}()
 	}
 
 	// Build a registration whose URL metadata fields all target the OOB listener,

--- a/internal/attack/mcp/sse_resume_replay.go
+++ b/internal/attack/mcp/sse_resume_replay.go
@@ -3,7 +3,6 @@ package mcp
 import (
 	"bufio"
 	"context"
-	"crypto/tls"
 	"fmt"
 	"net/http"
 	"strings"
@@ -196,11 +195,7 @@ func (e *SSEResumeReplayExecutor) sseCollect(ctx context.Context, client *http.C
 }
 
 func rawSSEClient(opts attack.Options) *http.Client {
-	tr := &http.Transport{}
-	if opts.SkipTLS {
-		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
-	}
-	return &http.Client{Transport: tr}
+	return &http.Client{Transport: attack.Transport(opts)}
 }
 
 // resumeCheckpoint selects the first id-bearing event as the resume cursor and

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -3,7 +3,10 @@ package cli
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/url"
 	"os"
+	"sort"
 	"strings"
 
 	batesian "github.com/calbebop/batesian"
@@ -70,6 +73,7 @@ func init() {
 	// Repeatable; appended to any principals defined in the config file.
 	scanCmd.Flags().StringArray("principal", nil, "Extra identity as name=...,token=...,tenant=... (repeatable; for multi-tenant rules)")
 	scanCmd.Flags().Bool("no-coalesce", false, "Do not coalesce overlapping findings from rules in the same vulnerability class")
+	scanCmd.Flags().Bool("dry-run", false, "Print the requests each rule would send and exit without sending any traffic")
 	rootCmd.AddCommand(scanCmd)
 }
 
@@ -95,6 +99,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 	oobURL, _ := cmd.Flags().GetString("oob-url")
 	audienceClaim, _ := cmd.Flags().GetString("audience-claim")
 	principalFlags, _ := cmd.Flags().GetStringArray("principal")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
 
 	if target == "" {
 		target = cfg.Target
@@ -138,7 +143,17 @@ func runScan(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--target is required")
 	}
 
-	if token == "" {
+	// A dry run must not reach the network at all, including the authorization
+	// server, so skip live OAuth token acquisition. Rules preview as unauthenticated.
+	if token == "" && dryRun {
+		tokenURL, _ := cmd.Flags().GetString("token-url")
+		authURL, _ := cmd.Flags().GetString("auth-url")
+		if tokenURL != "" || authURL != "" {
+			fmt.Fprintln(os.Stderr, "dry run: skipping OAuth token acquisition; rules preview as unauthenticated")
+		}
+	}
+
+	if token == "" && !dryRun {
 		tokenURL, _ := cmd.Flags().GetString("token-url")
 		authURL, _ := cmd.Flags().GetString("auth-url")
 		clientID, _ := cmd.Flags().GetString("client-id")
@@ -216,9 +231,22 @@ func runScan(cmd *cobra.Command, args []string) error {
 		Principals:     principals,
 	}
 
+	var recorder *attackpkg.Recorder
+	if dryRun {
+		recorder = &attackpkg.Recorder{}
+		opts.DryRun = true
+		opts.Recorder = recorder
+	}
+
 	eng := engine.New(opts)
 	ctx := context.Background()
 	results := eng.Run(ctx, target, filtered)
+
+	if dryRun {
+		// No traffic was sent; report the recorded request plan instead of findings.
+		printDryRunPlan(os.Stdout, target, recorder)
+		return nil
+	}
 
 	noCoalesce, _ := cmd.Flags().GetBool("no-coalesce")
 	if !noCoalesce {
@@ -421,6 +449,70 @@ func fetchOAuthTokenPKCE(ctx context.Context, authURL, tokenURL, clientID string
 		return "", err
 	}
 	return tok.AccessToken, nil
+}
+
+// printDryRunPlan writes the request plan captured during a dry run. Nothing was
+// sent; this is the preview an operator reviews before authorizing a real scan.
+// Requests are grouped by the rule that issued them, in execution order.
+func printDryRunPlan(out io.Writer, target string, rec *attackpkg.Recorder) {
+	reqs := rec.Requests()
+	fmt.Fprintf(out, "\nDry run: nothing was sent. The following %d request(s) would be issued against %s:\n\n", len(reqs), target)
+
+	hosts := map[string]bool{}
+	rulesSeen := map[string]bool{}
+	lastRule := "\x00" // sentinel so the first rule (even "") prints a header
+	for _, r := range reqs {
+		if r.RuleID != lastRule {
+			fmt.Fprintf(out, "[%s]\n", dryRunRuleLabel(r.RuleID))
+			lastRule = r.RuleID
+		}
+		rulesSeen[r.RuleID] = true
+		fmt.Fprintf(out, "  %s %s\n", r.Method, r.URL)
+		if u, err := url.Parse(r.URL); err == nil && u.Host != "" {
+			hosts[u.Host] = true
+		}
+		for _, k := range significantHeaderKeys(r.Headers) {
+			fmt.Fprintf(out, "      %s: %s\n", k, r.Headers[k])
+		}
+		if r.Body != "" {
+			fmt.Fprintf(out, "      body: %s\n", oneLine(r.Body, 300))
+		}
+	}
+
+	fmt.Fprintf(out, "\n%d request(s) across %d rule(s) to %d host(s). Nothing was sent.\n", len(reqs), len(rulesSeen), len(hosts))
+	fmt.Fprintln(out, "Note: requests built from live responses (chained follow-ups, acquired tokens, OOB callbacks) are not expanded in a dry run.")
+}
+
+// dryRunRuleLabel labels a recorded request's rule, naming the pre-rule setup
+// phase for requests captured before any rule was active.
+func dryRunRuleLabel(id string) string {
+	if id == "" {
+		return "setup"
+	}
+	return id
+}
+
+// significantHeaderKeys returns the request headers worth showing in a dry-run
+// plan, sorted. Constant headers (User-Agent, Accept) are omitted as noise.
+func significantHeaderKeys(h map[string]string) []string {
+	keys := make([]string, 0, len(h))
+	for k := range h {
+		if k == "User-Agent" || k == "Accept" {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// oneLine collapses whitespace runs and truncates s for single-line display.
+func oneLine(s string, max int) string {
+	s = strings.Join(strings.Fields(s), " ")
+	if len(s) > max {
+		return s[:max] + "..."
+	}
+	return s
 }
 
 // buildScanJSON creates the JSON representation of scan results.

--- a/internal/engine/dryrun_test.go
+++ b/internal/engine/dryrun_test.go
@@ -1,0 +1,67 @@
+package engine
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+
+	attackpkg "github.com/calbebop/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/rules"
+)
+
+// TestEngineDryRunSendsNothing runs every bundled rule through the engine in
+// dry-run mode against a listener that flags any accepted connection, and asserts
+// that no rule dialed the target while requests were still recorded. This is the
+// end-to-end proof that every scan-path HTTP client (including the two rules that
+// build their own client) routes through the non-dialing dry-run transport.
+func TestEngineDryRunSendsNothing(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	var dialed int32
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			atomic.StoreInt32(&dialed, 1)
+			conn.Close()
+		}
+	}()
+	target := "http://" + ln.Addr().String()
+
+	rs, _, err := rules.LoadDir("../../rules")
+	if err != nil {
+		t.Fatalf("load rules: %v", err)
+	}
+	if len(rs) == 0 {
+		t.Fatal("no rules loaded from ../../rules")
+	}
+
+	rec := &attackpkg.Recorder{}
+	opts := attackpkg.Options{
+		DryRun:         true,
+		Recorder:       rec,
+		Token:          "dummy-token",
+		TimeoutSeconds: 2,
+		// Two principals so the multi-tenant and handoff rules exercise their
+		// full request sequence rather than skipping for lack of identities.
+		Principals: []attackpkg.Principal{
+			{Name: "tenant-a", Token: "tok-a", Tenant: "A"},
+			{Name: "tenant-b", Token: "tok-b", Tenant: "B"},
+		},
+	}
+	New(opts).Run(context.Background(), target, rs)
+
+	if atomic.LoadInt32(&dialed) != 0 {
+		t.Fatal("dry run dialed the target; a scan-path client bypassed the dry-run transport")
+	}
+	if len(rec.Requests()) == 0 {
+		t.Fatal("dry run recorded no requests; executors did not issue any traffic")
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -104,6 +104,11 @@ func (e *Engine) runOne(ctx context.Context, target string, entry planEntry, bb 
 		}
 	}()
 
+	// In a dry run, label every request this rule records so the plan groups by rule.
+	if e.opts.Recorder != nil {
+		e.opts.Recorder.SetCurrentRule(r.ID)
+	}
+
 	var findings []attackpkg.Finding
 	var err error
 	if chained, ok := entry.executor.(attackpkg.ChainExecutor); ok {


### PR DESCRIPTION
## Summary

Adds `scan --dry-run`: it records every request a scan would issue, prints them grouped by rule, and sends **nothing**. This is the audit's top feature recommendation, aimed at the authorized-use workflow where an operator needs to review (or show a client) the exact traffic before authorizing it.

```
$ batesian scan --target https://mcp.example.com --token "$TOKEN" --dry-run --rule-ids mcp-confused-deputy-001,mcp-resources-unauth-001

Dry run: nothing was sent. The following 6 request(s) would be issued against https://mcp.example.com:

[mcp-confused-deputy-001]
  GET https://mcp.example.com/.well-known/oauth-authorization-server
      Authorization: <redacted>
      Host: mcp.example.com
  ...
[mcp-resources-unauth-001]
  POST https://mcp.example.com/mcp
      Content-Type: application/json
      body: {"id":1,"jsonrpc":"2.0","method":"initialize",...}
  ...

6 request(s) across 2 rule(s) to 1 host(s). Nothing was sent.
Note: requests built from live responses (chained follow-ups, acquired tokens, OOB callbacks) are not expanded in a dry run.
```

## How the "send nothing" guarantee is total

The scan path has three HTTP egress points: the shared attack client, and two rules that build their own `http.Client` for custom redirect/SSE handling (`confused_deputy.go`, `sse_resume_replay.go`). All three now get their transport from one factory, `attack.Transport(opts)`. In a dry run that factory returns a recording `RoundTripper` that captures the request and returns a benign synthetic response with **no network I/O**. It holds no real transport, so it **cannot dial by construction**. Live OAuth token acquisition is also skipped in a dry run, and bearer tokens are redacted in the printed plan.

As a side benefit, this centralizes the TLS/timeout transport config that was previously duplicated across those three sites.

## Known limitation (shown in the output)

Most requests are built from live responses (session ids, acquired tokens, OOB callbacks). With nothing sent, each rule reaches only its opening request(s) before the chain stalls on the synthetic response, so a dry run previews **each rule's opening move**, not a full chained transcript. The footer note states this plainly.

## Tests

- `internal/attack/dryrun_test.go`: the dry-run client records its request but **never dials** a live listener, and the bearer token is redacted in the recorded plan.
- `internal/engine/dryrun_test.go`: runs **all bundled rules** through the engine in dry-run against a listener that flags any accepted connection, asserting **zero egress** while requests are still recorded. This is the end-to-end proof that every scan-path client (including the two rule-local ones) routes through the non-dialing transport.

`go build`, `go vet`, `gofmt`, and `go test ./...` all pass.

## Scope

`--dry-run` is on `scan` (the command that issues attack traffic). `probe` is recon and out of scope here. A machine-readable (`--output json`) form of the plan is a reasonable follow-up.
