### PR TITLE
fix(a2a-extension-downgrade-001): send A2A-Extensions header (v1.0), keep legacy name

### DIFF
--- a/docs/rules-a2a.md
+++ b/docs/rules-a2a.md
@@ -271,13 +271,14 @@ checks:
 
 A2A agent cards advertise protocol extensions under `capabilities.extensions[]`,
 each with a `uri` and a `required` flag; clients activate one via the
-`X-A2A-Extensions` request header. A required extension is a capability the
-server states clients MUST activate, so the server must reject requests that do
-not. This rule is card-driven and confirms a fail-open downgrade only with a
+`A2A-Extensions` request header (the legacy `X-A2A-Extensions` name, used through
+v0.3.0, is also sent for older servers). A required extension is a capability the
+server states clients must activate, so the spec requires the server to reject
+requests that do not (`ExtensionSupportRequiredError`). This rule is card-driven and confirms a fail-open downgrade only with a
 control/test pair: it reads the card, and for each `required: true` extension it
 (1) sends a `SendMessage` that **activates** the extension (control - must be
 accepted or the rule can't test), then (2) sends an identical `SendMessage` with
-the `X-A2A-Extensions` header **omitted**. A **confirmed** finding is raised only
+the `A2A-Extensions` header **omitted**. A **confirmed** finding is raised only
 when the omission is also accepted - the server does not enforce its own required
 extension, so its policy/capability guarantees can be bypassed by simply not
 sending the header. A server that rejects the un-activated request fails closed

--- a/internal/attack/a2a/extension_downgrade.go
+++ b/internal/attack/a2a/extension_downgrade.go
@@ -13,7 +13,9 @@ import (
 // a2a-extension-downgrade-001).
 //
 // A2A cards advertise capabilities.extensions[] with a `uri` and `required`
-// flag; clients activate an extension via the X-A2A-Extensions request header.
+// flag; clients activate an extension via the A2A-Extensions request header
+// (pre-1.0 servers, through v0.3.0, used X-A2A-Extensions; both are sent so the
+// activation control works across server versions).
 // A server that processes requests which omit its own required extension has
 // silently downgraded the negotiated capability set. The executor only reports a
 // CONFIRMED downgrade when an extension-activating control request is accepted
@@ -32,7 +34,23 @@ func NewExtensionDowngradeExecutor(r attack.RuleContext) *ExtensionDowngradeExec
 	return &ExtensionDowngradeExecutor{rule: r}
 }
 
-const a2aExtensionsHeader = "X-A2A-Extensions"
+// a2aExtensionsHeader is the v1.0+ extension-activation header. The pre-1.0 name
+// (a2aExtensionsHeaderLegacy, used through v0.3.0) is still sent alongside it so
+// the activation control request lands on servers of either era.
+const (
+	a2aExtensionsHeader       = "A2A-Extensions"
+	a2aExtensionsHeaderLegacy = "X-A2A-Extensions"
+)
+
+// activationHeaders returns the activation header set for the given extension
+// URI: both the v1.0 and legacy header names so the control works regardless of
+// which A2A version the target implements.
+func activationHeaders(uri string) map[string]string {
+	return map[string]string{
+		a2aExtensionsHeader:       uri,
+		a2aExtensionsHeaderLegacy: uri,
+	}
+}
 
 func (e *ExtensionDowngradeExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
 	vars := attack.NewVars(target, opts.OOBListenerURL)
@@ -47,7 +65,7 @@ func (e *ExtensionDowngradeExecutor) Execute(ctx context.Context, target string,
 	for _, uri := range required {
 		// Control: activate the required extension. If even this is rejected we
 		// cannot exercise the rule (e.g. messaging needs creds we lack).
-		accepted, shape := e.sendMessage(ctx, client, endpoint, map[string]string{a2aExtensionsHeader: uri}, vars.RandID, "")
+		accepted, shape := e.sendMessage(ctx, client, endpoint, activationHeaders(uri), vars.RandID, "")
 		if !accepted {
 			continue
 		}
@@ -143,12 +161,12 @@ func (e *ExtensionDowngradeExecutor) finding(endpoint, uri, shape string) attack
 		Title:      "A2A server does not enforce its own required extension (negotiation downgrade)",
 		Description: fmt.Sprintf(
 			"The agent card marks extension %q as required, but the server accepted a SendMessage that "+
-				"OMITTED the X-A2A-Extensions activation header while rejecting nothing. A request that "+
-				"activates the extension and an identical request that does not are both processed, so the "+
-				"required extension's policy or capability guarantees can be bypassed simply by not "+
-				"sending the header.", uri),
+				"OMITTED the A2A-Extensions activation header. A request that activates the extension and an "+
+				"identical request that does not are both processed, so the required extension's policy or "+
+				"capability guarantees can be bypassed simply by not sending the header. The A2A spec requires "+
+				"a server to reject a request that does not activate a required extension (ExtensionSupportRequiredError).", uri),
 		Evidence: fmt.Sprintf(
-			"endpoint: %s (shape %s)\nrequired extension: %s\nwith X-A2A-Extensions: accepted\nwithout X-A2A-Extensions: accepted (should be rejected)",
+			"endpoint: %s (shape %s)\nrequired extension: %s\nwith A2A-Extensions activation: accepted\nwithout activation header: accepted (spec requires rejection: ExtensionSupportRequiredError)",
 			endpoint, shape, uri),
 		Remediation: e.rule.Remediation,
 		TargetURL:   endpoint,

--- a/internal/attack/a2a/extension_downgrade_test.go
+++ b/internal/attack/a2a/extension_downgrade_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/calbebop/batesian/internal/attack"
@@ -17,7 +18,7 @@ const reqExtURI = "https://ext.example/required-policy/v1"
 // extensionServer models an A2A server whose card declares reqExtURI as a
 // required extension. mode controls enforcement:
 //   - "failopen": SendMessage is accepted whether or not the header is present.
-//   - "failclosed": SendMessage without the X-A2A-Extensions header is rejected.
+//   - "failclosed": SendMessage without the A2A-Extensions header is rejected.
 //   - "noauth-msg": SendMessage is always rejected (control can't succeed).
 func extensionServer(mode string, required bool) *httptest.Server {
 	mux := http.NewServeMux()
@@ -39,7 +40,8 @@ func extensionServer(mode string, required bool) *httptest.Server {
 			http.NotFound(w, r)
 			return
 		}
-		activated := strings.Contains(r.Header.Get("X-A2A-Extensions"), reqExtURI)
+		// Model a v1.0 server: activation is read from the A2A-Extensions header.
+		activated := strings.Contains(r.Header.Get("A2A-Extensions"), reqExtURI)
 		reqID := func() interface{} {
 			var b map[string]interface{}
 			_ = json.NewDecoder(r.Body).Decode(&b)
@@ -131,5 +133,54 @@ func TestExtDowngrade_NotACardServer(t *testing.T) {
 
 	if findings := runExtDowngrade(t, ts); len(findings) != 0 {
 		t.Errorf("expected zero findings against a non-card server, got %d", len(findings))
+	}
+}
+
+// TestExtDowngrade_SendsModernHeader asserts the activation control request
+// carries the v1.0 A2A-Extensions header (and the legacy X-A2A-Extensions name
+// for older servers). Guards against regressing to the deprecated name only.
+func TestExtDowngrade_SendsModernHeader(t *testing.T) {
+	// atomic: the handler runs on the server's goroutine while the assertions
+	// run on the test goroutine; loopback socket I/O is not a happens-before edge.
+	var gotModern, gotLegacy atomic.Bool
+	card := map[string]interface{}{
+		"name": "Ext Agent",
+		"url":  "https://agent.example/",
+		"capabilities": map[string]interface{}{
+			"extensions": []interface{}{map[string]interface{}{"uri": reqExtURI, "required": true}},
+		},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/agent-card.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(card)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("A2A-Extensions"), reqExtURI) {
+			gotModern.Store(true)
+		}
+		if strings.Contains(r.Header.Get("X-A2A-Extensions"), reqExtURI) {
+			gotLegacy.Store(true)
+		}
+		var b map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&b)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": b["id"], "result": map[string]interface{}{"id": "task-1"},
+		})
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	// Fail-open server: the rule fires, and the control must have activated the
+	// extension via both header names.
+	if findings := runExtDowngrade(t, ts); len(findings) == 0 {
+		t.Fatal("expected a finding against a fail-open server")
+	}
+	if !gotModern.Load() {
+		t.Error("activation control did not send the A2A-Extensions header")
+	}
+	if !gotLegacy.Load() {
+		t.Error("activation control did not send the legacy X-A2A-Extensions header")
 	}
 }

--- a/rules/a2a/extension-downgrade-001.yaml
+++ b/rules/a2a/extension-downgrade-001.yaml
@@ -7,11 +7,12 @@ info:
     Tests whether an A2A server fails OPEN on an extension it declares as
     REQUIRED. A2A agent cards advertise protocol extensions under
     capabilities.extensions[], each with a `uri` and a `required` flag. A
-    required extension is a capability the server states clients MUST activate
-    (via the X-A2A-Extensions request header); the server must reject requests
-    that do not activate it. If the server processes requests that omit its own
-    required extension, the extension's policy/capability guarantees can be
-    silently bypassed - a negotiation downgrade.
+    required extension is a capability the server states clients must activate
+    (via the A2A-Extensions request header); the spec requires the server to
+    reject requests that do not activate it (ExtensionSupportRequiredError). If
+    the server processes requests that omit its own required extension, the
+    extension's policy/capability guarantees can be silently bypassed - a
+    negotiation downgrade.
 
     The check is card-driven and skips cleanly when nothing can be proven:
 
@@ -19,10 +20,10 @@ info:
          the card declares no required extension, there is nothing to downgrade
          (no finding).
       2. Control: send a SendMessage that ACTIVATES the required extension
-         (X-A2A-Extensions: <uri>). If this is rejected too (e.g. messaging
+         (A2A-Extensions: <uri>). If this is rejected too (e.g. messaging
          needs credentials we do not hold), the rule cannot test and emits no
          finding.
-      3. Test: send the same SendMessage but OMIT the X-A2A-Extensions header.
+      3. Test: send the same SendMessage but OMIT the A2A-Extensions header.
          If the control succeeded and this request is also accepted, the server
          does not enforce its own required extension - reported CONFIRMED. If the
          omission is rejected with a required-extension error, the server fails
@@ -49,10 +50,10 @@ attack:
 remediation: |
   1. Enforce required extensions fail-closed: reject any request that does not
      activate an extension the agent card marks `required: true`, with a clear
-     error (e.g. the X-A2A-Extensions header must list the required URI).
+     error (e.g. the A2A-Extensions header must list the required URI).
   2. Do not treat a required extension as advisory - never process the request's
      side effects before confirming the required extension was activated.
-  3. Echo activated extensions in the X-A2A-Extensions response header so clients
+  3. Echo activated extensions in the A2A-Extensions response header so clients
      can detect silent downgrades.
   4. Keep the agent card's `required` flags in sync with actual enforcement; an
      extension advertised as required but not enforced is worse than not

--- a/testdata/a2a_extension_downgrade_server.py
+++ b/testdata/a2a_extension_downgrade_server.py
@@ -2,7 +2,7 @@
 Deliberately vulnerable A2A test server for validating:
   - a2a-extension-downgrade-001: the agent card declares an extension as
     REQUIRED, but the server processes SendMessage requests that OMIT the
-    X-A2A-Extensions activation header (fail-open negotiation downgrade,
+    A2A-Extensions activation header (fail-open negotiation downgrade,
     CWE-636/757).
 
 The card advertises capabilities.extensions[] with required=true for
@@ -47,7 +47,7 @@ async def card(request: Request) -> JSONResponse:
 async def rpc(request: Request) -> Response:
     body = await request.json()
     req_id = body.get("id")
-    # VULNERABLE: never checks the X-A2A-Extensions header, so a request that
+    # VULNERABLE: never checks the A2A-Extensions header, so a request that
     # omits the required extension is processed exactly like one that activates it.
     result = {"id": "task-1", "contextId": "ctx-1", "status": "working"}
     return JSONResponse({"jsonrpc": "2.0", "id": req_id, "result": result})


### PR DESCRIPTION
## Problem

`a2a-extension-downgrade-001` hardcoded the activation header as `X-A2A-Extensions`. A2A renamed it to `A2A-Extensions` at v1.0 (the `X-` form was used through v0.3.0). The reference SDK (`a2a-python` main) emits `A2A-Extensions`. The rule's control request, finding text, YAML, and docs all referenced the outdated name.

Note: this does not flip verdicts (a fail-open server is detected regardless of the activation header), so it is a correctness/credibility fix, not a false-negative fix.

## Change

- Control request now activates via **both** `A2A-Extensions` (v1.0+) and `X-A2A-Extensions` (pre-1.0, through v0.3.0) so it lands on servers of either era. Extra/legacy headers are safe: recipients ignore unrecognized fields (RFC 9110).
- Finding description, evidence, YAML, and docs updated to `A2A-Extensions` and to the spec's actual requirement: a server MUST reject a request that does not activate a required extension (`ExtensionSupportRequiredError`).
- Test mock now models a v1.0 server (reads `A2A-Extensions`); new `TestExtDowngrade_SendsModernHeader` asserts the control sends both header names, guarding against regressing to the deprecated name. Shared flags use `atomic.Bool` for race-safety.

## Validation

- Header name/format, the v0.3.0->v1.0 rename, HTTP case-insensitivity (Go canonicalizes to `A2a-Extensions`; Starlette/a2a-python matches case-insensitively over HTTP; the gRPC lowercase constraint in a2a-python #656 is gRPC-only), dual-header safety, and the MUST normative keyword were each verified against primary sources (a2a-protocol.org spec, a2aproject/A2A specification.md, a2a-python, RFC 9110).
- `go build`, `go vet`, full `go test ./...`, `go test -race`, and `golangci-lint` (0 issues) all pass.