### PR TITLE
feat(mcp-tools-unauth-001): add unauthenticated tools/list + tools/call rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ CLI for adversarial testing of [A2A](https://a2a-protocol.org) and [MCP](https:/
 
 ## What ships
 
-Bundled rules: **14 A2A, 13 MCP (27 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
+Bundled rules: **14 A2A, 14 MCP (28 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
 
 - [A2A rules](docs/rules-a2a.md) (14)
-- [MCP rules](docs/rules-mcp.md) (13)
+- [MCP rules](docs/rules-mcp.md) (14)
 
 Coverage spans:
 
@@ -31,7 +31,7 @@ Coverage spans:
 - **Request & task integrity** - task IDOR, agent-role injection, artifact tampering, SEP-2243 header/body routing, SSE resumption replay
 - **Multi-party isolation** - cross-tenant isolation, session/context fixation, delegation chain-of-custody
 - **SSRF & secret leakage** - push-notification SSRF, push control-plane binding, OAuth discovery/metadata SSRF, credential leakage into responses
-- **Unauthenticated & cross-origin access** - exposed MCP resources and prompt templates, Streamable HTTP Origin validation (DNS rebinding)
+- **Unauthenticated & cross-origin access** - exposed MCP tools, resources, and prompt templates, Streamable HTTP Origin validation (DNS rebinding)
 
 ## Install
 

--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -1,11 +1,11 @@
 # MCP Attack Rules
 
-Batesian ships **13 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
+Batesian ships **14 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
 Every rule is an active probe: it sends crafted protocol traffic and judges the
 server's actual response. Rules are deliberately scoped to MCP-specific semantics
 (OAuth 2.1 authorization, DCR, audience binding, discovery-chain metadata-fetch
-SSRF, protocol-version negotiation, prompts/resources access control, session-id
-handling, SEP-2243 Streamable HTTP header/body routing, SSE resumption,
+SSRF, protocol-version negotiation, tools/prompts/resources access control,
+session-id handling, SEP-2243 Streamable HTTP header/body routing, SSE resumption,
 credential leakage into responses) rather than generic web hygiene.
 
 Each finding carries a **confidence**:
@@ -27,6 +27,7 @@ JSON-RPC `error` (the common MCP rejection shape) is a rejection, not a finding.
 | `mcp-token-replay-001` | [OAuth Token Signature and Audience Validation Bypass](#mcp-token-replay-001) | High | confirmed | CWE-294 |
 | `mcp-resources-unauth-001` | [Unauthenticated Resource Read](#mcp-resources-unauth-001) | High / Critical | confirmed | CWE-862 |
 | `mcp-prompt-unauth-001` | [Prompt Templates Without Authentication](#mcp-prompt-unauth-001) | Medium | confirmed | CWE-862 |
+| `mcp-tools-unauth-001` | [Tools Accessible Without Authentication](#mcp-tools-unauth-001) | High / Medium | confirmed | CWE-862 |
 | `mcp-init-downgrade-001` | [Protocol Version Downgrade Auth Bypass](#mcp-init-downgrade-001) | Critical | confirmed | CWE-757 |
 | `mcp-session-fixation-001` | [Session ID Fixation](#mcp-session-fixation-001) | High | confirmed | CWE-384 |
 | `mcp-header-body-split-001` | [Header/Body Routing Split-Brain (SEP-2243)](#mcp-header-body-split-001) | High | confirmed | CWE-444 |
@@ -129,6 +130,25 @@ public. The prompts capability is confirmed structurally from the captured
 body. A list-only disclosure is **medium**; retrieving template content as well is
 **high** - both **confirmed**. A server that requires auth, or does not advertise
 the prompts capability, produces no finding.
+
+---
+
+### mcp-tools-unauth-001
+
+**Tools Accessible Without Authentication** | Severity: High / Medium | CWE-862
+
+Tools are the primary MCP attack surface: a tool is a server-side function a
+caller can invoke, not just data or a template. The tools capability is confirmed
+structurally from the captured `initialize` result (`ServerSupports`). The rule
+confirms two failures: an unauthenticated `tools/list` discloses the executable
+surface and each tool's input schema (**medium**); and the `tools/call` dispatch
+path being reachable without auth (**high**) - both **confirmed**. To prove
+call-path reachability **without executing anything**, the rule calls a guaranteed
+non-existent tool name, which the spec answers with a `-32602` "Unknown tool"
+protocol error; reaching that error (or any result envelope) shows the call was
+dispatched without credentials. It **never invokes a real or advertised tool** -
+destructive tool-argument fuzzing is out of scope. A server that requires auth, or
+does not advertise the tools capability, produces no finding.
 
 ---
 

--- a/internal/attack/mcp/tools_unauth.go
+++ b/internal/attack/mcp/tools_unauth.go
@@ -1,0 +1,171 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// ToolsUnauthExecutor probes whether MCP tools are accessible without
+// authentication (rule mcp-tools-unauth-001).
+//
+// Tools are the primary MCP attack surface: unlike resources (data) or prompts
+// (templates), tools are server-side functions a caller can invoke. The MCP spec
+// requires servers to "implement proper access controls", so an unauthenticated
+// tools/list disclosure (the executable surface plus input schemas) and a
+// reachable tools/call dispatch are access-control failures.
+//
+// SAFETY: this rule NEVER invokes a real or advertised tool. It confirms that
+// the tools/call path is reachable without auth by calling a guaranteed
+// non-existent tool name, which the spec answers with a -32602 "Unknown tool"
+// protocol error and zero execution. Destructive tool-argument fuzzing is out of
+// scope.
+type ToolsUnauthExecutor struct {
+	rule attack.RuleContext
+}
+
+// NewToolsUnauthExecutor creates an executor for the mcp-tools-unauth attack type.
+func init() {
+	attack.Register("mcp-tools-unauth", func(rc attack.RuleContext) attack.Executor { return NewToolsUnauthExecutor(rc) })
+}
+
+func NewToolsUnauthExecutor(r attack.RuleContext) *ToolsUnauthExecutor {
+	return &ToolsUnauthExecutor{rule: r}
+}
+
+func (e *ToolsUnauthExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
+	vars := attack.NewVars(target, opts.OOBListenerURL)
+	// Deliberately omit the bearer token - the rule tests whether tools are
+	// accessible WITHOUT authentication. Injecting opts.Token would mask the finding.
+	client := attack.NewUnauthHTTPClient(opts, vars)
+
+	session, err := initializeMCP(ctx, client, vars.BaseURL)
+	if err != nil {
+		return nil, nil // not an MCP server
+	}
+
+	// Skip servers that do not advertise the tools capability; probing them would
+	// produce meaningless noise. Read from the captured handshake capabilities
+	// rather than substring-matching the body.
+	if !session.ServerSupports("tools") {
+		return nil, nil
+	}
+
+	// Step 1: tools/list without any auth token.
+	listResp, err := client.POST(ctx, session.Endpoint, session.header(), map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      3,
+		"method":  "tools/list",
+		"params":  map[string]interface{}{},
+	})
+	if err != nil || !listResp.IsSuccess() {
+		return nil, nil
+	}
+
+	var listBody map[string]interface{}
+	if err := json.Unmarshal(listResp.Body, &listBody); err != nil {
+		return nil, nil
+	}
+
+	// A JSON-RPC error means auth is enforced on tool methods - not vulnerable.
+	if _, hasErr := listBody["error"]; hasErr {
+		return nil, nil
+	}
+
+	result, _ := listBody["result"].(map[string]interface{})
+	toolsRaw, _ := result["tools"].([]interface{})
+	if len(toolsRaw) == 0 {
+		return nil, nil
+	}
+
+	// Collect tool names for evidence.
+	var names []string
+	for _, t := range toolsRaw {
+		if tm, ok := t.(map[string]interface{}); ok {
+			if name, ok := tm["name"].(string); ok {
+				names = append(names, name)
+			}
+		}
+	}
+
+	findings := []attack.Finding{{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "medium",
+		Confidence: attack.ConfirmedExploit,
+		Title:      fmt.Sprintf("MCP tools/list returned %d tool(s) without authentication", len(names)),
+		Description: fmt.Sprintf(
+			"tools/list at %s returned %d tool(s) without any authentication, disclosing the server's "+
+				"executable surface and each tool's input schema to an anonymous caller. The MCP spec "+
+				"requires servers to implement proper access controls; an attacker can map the callable "+
+				"functions and craft targeted invocations.", session.Endpoint, len(names)),
+		Evidence:    fmt.Sprintf("HTTP %d from %s\ntools (%d): %v", listResp.StatusCode, session.Endpoint, len(names), names),
+		Remediation: e.rule.Remediation,
+		TargetURL:   session.Endpoint,
+	}}
+
+	// Step 2: confirm the tools/call dispatch path is reachable without auth,
+	// WITHOUT executing any real tool. Calling a guaranteed non-existent tool name
+	// yields a -32602 "Unknown tool" protocol error (per the MCP spec) and runs
+	// nothing. Reaching that error proves the invocation path accepts
+	// unauthenticated calls; an auth-enforcing server rejects with 401/403 or an
+	// auth error before tool dispatch.
+	bogusTool := "batesian-nonexistent-" + vars.RandID
+	callResp, err := client.POST(ctx, session.Endpoint, session.header(), map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      4,
+		"method":  "tools/call",
+		"params":  map[string]interface{}{"name": bogusTool, "arguments": map[string]interface{}{}},
+	})
+	if err != nil || !callResp.IsSuccess() {
+		return findings, nil // auth gate (401/403) or unreachable; the list finding stands
+	}
+
+	var callBody map[string]interface{}
+	if err := json.Unmarshal(callResp.Body, &callBody); err != nil {
+		return findings, nil
+	}
+
+	reachable, reason := callDispatchReachable(callBody)
+	if !reachable {
+		return findings, nil
+	}
+
+	findings = append(findings, attack.Finding{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "high",
+		Confidence: attack.ConfirmedExploit,
+		Title:      "MCP tools/call dispatch reachable without authentication",
+		Description: fmt.Sprintf(
+			"tools/call at %s accepted an unauthenticated invocation request (probed with a non-existent "+
+				"tool name, so nothing was executed). The invocation path to the server's tools is open to "+
+				"anonymous callers, so any listed tool can be invoked without credentials.", session.Endpoint),
+		Evidence:    fmt.Sprintf("HTTP %d from %s\nprobe tool (non-existent): %s\n%s", callResp.StatusCode, session.Endpoint, bogusTool, reason),
+		Remediation: e.rule.Remediation,
+		TargetURL:   session.Endpoint,
+	})
+
+	return findings, nil
+}
+
+// callDispatchReachable reports whether a tools/call response for a non-existent
+// tool shows the invocation path was reached without auth. A -32602 ("unknown
+// tool" / invalid params) protocol error or any result envelope means the server
+// dispatched the call; a -32601 (method not found) or auth-flavored error does
+// not. The returned reason is used as finding evidence.
+func callDispatchReachable(body map[string]interface{}) (bool, string) {
+	if errObj, ok := body["error"].(map[string]interface{}); ok {
+		code, _ := errObj["code"].(float64)
+		if int(code) == -32602 {
+			return true, "JSON-RPC error -32602 (unknown tool) returned for a non-existent tool, so the call was dispatched without auth"
+		}
+		return false, ""
+	}
+	if _, ok := body["result"]; ok {
+		return true, "tools/call returned a result envelope for a non-existent tool, so the call was dispatched without auth"
+	}
+	return false, ""
+}

--- a/internal/attack/mcp/tools_unauth_test.go
+++ b/internal/attack/mcp/tools_unauth_test.go
@@ -1,0 +1,154 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+// toolsUnauthServer builds a mock MCP server. callBehavior controls how
+// tools/call answers an unknown tool name:
+//   - "unknown": JSON-RPC -32602 "Unknown tool" (dispatch reached, no auth)
+//   - "authgate": JSON-RPC -32001 "Unauthorized" (call gated behind auth)
+//
+// When advertiseTools is false the server omits the tools capability. When
+// listAuth is true tools/list itself returns an auth error.
+func toolsUnauthServer(advertiseTools, listAuth bool, callBehavior string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		method, _ := req["method"].(string)
+		w.Header().Set("Content-Type", "application/json")
+		enc := func(v map[string]interface{}) { _ = json.NewEncoder(w).Encode(v) }
+
+		switch method {
+		case "initialize":
+			caps := map[string]interface{}{"resources": map[string]interface{}{}}
+			if advertiseTools {
+				caps["tools"] = map[string]interface{}{"listChanged": false}
+			}
+			enc(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req["id"],
+				"result": map[string]interface{}{
+					"protocolVersion": "2025-03-26",
+					"serverInfo":      map[string]interface{}{"name": "tools-srv", "version": "1.0"},
+					"capabilities":    caps,
+				},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			if listAuth {
+				enc(map[string]interface{}{"jsonrpc": "2.0", "id": req["id"],
+					"error": map[string]interface{}{"code": -32001, "message": "Unauthorized"}})
+				return
+			}
+			enc(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req["id"],
+				"result": map[string]interface{}{
+					"tools": []interface{}{
+						map[string]interface{}{"name": "echo", "description": "Echo input"},
+						map[string]interface{}{"name": "run_query", "description": "Run a database query"},
+					},
+				},
+			})
+		case "tools/call":
+			if callBehavior == "authgate" {
+				enc(map[string]interface{}{"jsonrpc": "2.0", "id": req["id"],
+					"error": map[string]interface{}{"code": -32001, "message": "Unauthorized"}})
+				return
+			}
+			// "unknown": the scanner only ever calls a non-existent tool name.
+			enc(map[string]interface{}{"jsonrpc": "2.0", "id": req["id"],
+				"error": map[string]interface{}{"code": -32602, "message": "Unknown tool: " + paramName(req)}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func paramName(req map[string]interface{}) string {
+	params, _ := req["params"].(map[string]interface{})
+	name, _ := params["name"].(string)
+	return name
+}
+
+func runToolsUnauth(t *testing.T, srv *httptest.Server) []attack.Finding {
+	t.Helper()
+	exec := mcpattack.NewToolsUnauthExecutor(attack.RuleContext{ID: "mcp-tools-unauth-001"})
+	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return findings
+}
+
+// TestToolsUnauth_ToolsExposed: tools/list leaks tools and tools/call dispatch
+// is reachable unauthenticated => medium list finding + high call finding.
+func TestToolsUnauth_ToolsExposed(t *testing.T) {
+	srv := toolsUnauthServer(true, false, "unknown")
+	defer srv.Close()
+
+	findings := runToolsUnauth(t, srv)
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings (list + call), got %d: %+v", len(findings), findings)
+	}
+	hasMedium, hasHigh := false, false
+	for _, f := range findings {
+		if f.Confidence != attack.ConfirmedExploit {
+			t.Errorf("expected ConfirmedExploit, got %v", f.Confidence)
+		}
+		switch f.Severity {
+		case "medium":
+			hasMedium = true
+		case "high":
+			hasHigh = true
+		}
+	}
+	if !hasMedium {
+		t.Error("expected medium finding for tools/list")
+	}
+	if !hasHigh {
+		t.Error("expected high finding for tools/call reachability")
+	}
+}
+
+// TestToolsUnauth_ListExposedCallEnforced: tools/list leaks but tools/call is
+// auth-gated => only the medium list finding fires.
+func TestToolsUnauth_ListExposedCallEnforced(t *testing.T) {
+	srv := toolsUnauthServer(true, false, "authgate")
+	defer srv.Close()
+
+	findings := runToolsUnauth(t, srv)
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 finding (list only), got %d: %+v", len(findings), findings)
+	}
+	if findings[0].Severity != "medium" {
+		t.Errorf("expected medium list finding, got %q", findings[0].Severity)
+	}
+}
+
+// TestToolsUnauth_AuthEnforced: tools/list itself requires auth => no findings.
+func TestToolsUnauth_AuthEnforced(t *testing.T) {
+	srv := toolsUnauthServer(true, true, "authgate")
+	defer srv.Close()
+
+	if findings := runToolsUnauth(t, srv); len(findings) != 0 {
+		t.Errorf("expected 0 findings when auth is enforced, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestToolsUnauth_NoToolsCapability: server does not advertise tools => skip.
+func TestToolsUnauth_NoToolsCapability(t *testing.T) {
+	srv := toolsUnauthServer(false, false, "unknown")
+	defer srv.Close()
+
+	if findings := runToolsUnauth(t, srv); len(findings) != 0 {
+		t.Errorf("expected 0 findings for a server without the tools capability, got %d", len(findings))
+	}
+}

--- a/rules/mcp/tools-unauth-001.yaml
+++ b/rules/mcp/tools-unauth-001.yaml
@@ -1,0 +1,49 @@
+id: mcp-tools-unauth-001
+info:
+  name: MCP Tools Accessible Without Authentication
+  author: batesian
+  severity: high
+  description: |
+    Tests whether an MCP server exposes its tools without authentication, via
+    tools/list (enumeration) and tools/call (invocation dispatch).
+
+    Tools are the primary MCP attack surface: unlike resources (data) or prompts
+    (templates), a tool is a server-side function a caller can invoke - querying
+    databases, calling APIs, reading files, or running commands. The MCP spec
+    requires servers to implement proper access controls on tools.
+
+    The rule confirms two distinct failures:
+      1. tools/list returns the tool set (names plus input schemas) to an
+         unauthenticated caller - the executable surface is disclosed
+         (reported MEDIUM).
+      2. tools/call dispatch is reachable without authentication (reported HIGH).
+
+    SAFETY: the rule never invokes a real or advertised tool. It confirms the
+    invocation path is open by calling a guaranteed non-existent tool name, which
+    the spec answers with a -32602 "Unknown tool" protocol error and zero
+    execution. A server that requires authentication rejects with 401/403 or an
+    auth error before reaching tool dispatch, and produces no finding.
+
+  references:
+    - https://modelcontextprotocol.io/specification/2025-06-18/server/tools
+    - https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization
+    - https://cwe.mitre.org/data/definitions/862.html
+
+  tags:
+    - mcp
+    - auth
+    - tools
+    - access-control
+    - cwe-862
+
+attack:
+  protocol: mcp
+  type: mcp-tools-unauth
+
+remediation: |
+  1. Require authentication (OAuth 2.1 bearer token) before responding to
+     tools/list and tools/call requests.
+  2. Return a JSON-RPC error (code -32001) for unauthenticated tools/* calls,
+     and enforce the auth check before tool lookup or dispatch.
+  3. Apply per-tool authorization: a valid token for one scope should not grant
+     invocation of every tool the server exposes.

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -18,7 +18,7 @@ pip install starlette uvicorn httpx mcp
 
 ## Server Registry
 
-The bundled rule set is **14 A2A + 13 MCP = 27 rules**. Every rule's primary
+The bundled rule set is **14 A2A + 14 MCP = 28 rules**. Every rule's primary
 validation is an in-process `net/http/httptest` harness in its Go
 `*_test.go` (multiple server postures: vulnerable must fire / patched / open /
 benign must stay silent). The Python servers below are optional standalone
@@ -37,7 +37,7 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_unauth_resources_server.py` | 7787 | `mcp-resources-unauth-001` |
 | `mcp_oauth_dcr_server.py` | 7788 | `mcp-oauth-dcr-001` |
 | `mcp_oauth_audience_server.py` | 7785 | `mcp-oauth-audience-002` |
-| `mcp_new_rules_server.py` | 3100 | `mcp-init-downgrade-001`, `mcp-prompt-unauth-001` |
+| `mcp_new_rules_server.py` | 3100 | `mcp-init-downgrade-001`, `mcp-prompt-unauth-001`, `mcp-tools-unauth-001` |
 | `mcp_session_fixation_server.py` | 7786 | `mcp-session-fixation-001` |
 | `mcp_header_body_split_server.py` | 7789 | `mcp-header-body-split-001` |
 | `mcp_sse_resume_replay_server.py` | 7790 | `mcp-sse-resume-replay-001` |
@@ -46,7 +46,7 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_confused_deputy_server.py` | 7793 | `mcp-confused-deputy-001` |
 | `mcp_dns_rebind_origin_server.py` | 7794 | `mcp-dns-rebind-origin-001` |
 
-**Coverage.** 26 of the 27 rules have a standalone Python fixture above. The
+**Coverage.** 27 of the 28 rules have a standalone Python fixture above. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
 (`internal/attack/mcp/token_replay_test.go`); the same is true of the per-rule
 edge-case harnesses for every other rule. `mockserver.go` is a Go helper used by

--- a/testdata/mcp_new_rules_server.py
+++ b/testdata/mcp_new_rules_server.py
@@ -2,6 +2,7 @@
 Deliberately vulnerable MCP test server for validating:
   - mcp-init-downgrade-001: accepts legacy protocol version 2024-11-05
   - mcp-prompt-unauth-001: exposes prompt templates without auth
+  - mcp-tools-unauth-001: exposes tools/list and tools/call dispatch without auth
 
 (May still carry a legacy CORS route from a pruned rule; only the rules listed
 above are part of the current rule set.)
@@ -97,6 +98,17 @@ async def mcp_endpoint(request: Request) -> Response:
     # All subsequent methods: no auth check (vulnerable)
     if method == "tools/list":
         result = {"tools": TOOLS}
+    elif method == "tools/call":
+        # No auth check (vulnerable): the dispatch path is reachable anonymously.
+        # An unknown tool name returns a -32602 protocol error per the MCP spec
+        # (the scanner only ever calls a non-existent tool, so nothing executes).
+        name = params.get("name", "")
+        tool_names = {t["name"] for t in TOOLS}
+        if name not in tool_names:
+            return Response(json.dumps({"jsonrpc": "2.0", "id": req_id,
+                                        "error": {"code": -32602, "message": f"Unknown tool: {name}"}}),
+                            media_type="application/json", headers={**cors, "Content-Type": "application/json"})
+        result = {"content": [{"type": "text", "text": "simulated tool output"}], "isError": False}
     elif method == "resources/list":
         result = {"resources": RESOURCES}
     elif method == "resources/read":
@@ -125,5 +137,5 @@ app = Starlette(routes=[
 
 if __name__ == "__main__":
     print(f"[*] MCP new-rules vulnerable server on port {PORT}", flush=True)
-    print("[*] Vulnerabilities: protocol downgrade, CORS origin reflection, unauthenticated prompts", flush=True)
+    print("[*] Vulnerabilities: protocol downgrade, CORS origin reflection, unauthenticated prompts and tools", flush=True)
     uvicorn.run(app, host="127.0.0.1", port=PORT)


### PR DESCRIPTION
## What

New rule `mcp-tools-unauth-001`. Tools are the primary MCP attack surface, but the scanner had `resources-unauth` and `prompt-unauth` with no tools equivalent. This closes that gap.

## Detection

1. Unauthenticated `initialize`, then skip unless the server advertises the `tools` capability (`ServerSupports`).
2. `tools/list` without a token. A returned tool set (names + input schemas) is a **medium** confirmed finding: the executable surface is disclosed to an anonymous caller.
3. Safe `tools/call` reachability probe: call a guaranteed non-existent tool name. Per the MCP spec this returns a `-32602` "Unknown tool" protocol error and executes nothing. Reaching that error (or any result envelope) proves the invocation path is open without auth, a **high** confirmed finding. An auth-enforcing server rejects with 401/403 or an auth error before dispatch and produces no finding.

**Safety:** the rule never invokes a real or advertised tool. Destructive tool-argument fuzzing is out of scope.

## Severity

`tools/list` disclosure = medium (capability metadata, consistent with `prompts/list`); `tools/call` reachable = high (invocation path to executable functions open). Both confirmed, CWE-862.

## Validation

- Unit tests (4, pass under `-race`): exposed (2 findings) / list-only-call-gated (1) / auth-enforced (0) / no-tools-capability (0).
- Live run against `testdata/mcp_new_rules_server.py` (port 3100, extended with a `tools/call` -> `-32602` route): produced the expected HIGH + MEDIUM findings, confirming the non-existent probe tool was used and nothing executed.
- `go build`, full `go test -race ./...`, `golangci-lint` (0 issues), `gofmt` all clean.
- Method names verified stable since 2024-11-05 against the MCP spec (2025-06-18/server/tools), so no version-scoping needed.

## Docs

Rule count bumped to 14 MCP / 28 total across README, docs/rules-mcp.md (with a rule-detail section), and testdata/README.md (registry row + coverage line).