### PR TITLE
feat(mcp-jsonrpc-batch-bypass-001): detect JSON-RPC batch authentication bypass

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -114,7 +114,7 @@ release:
     ## Batesian {{.Version}}
 
     Adversarial red-team CLI for AI agent protocols (A2A and MCP).
-    27 bundled attack rules (14 A2A + 13 MCP). Single binary. No runtime dependencies.
+    29 bundled attack rules (14 A2A + 15 MCP). Single binary. No runtime dependencies.
 
     ### Install
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ CLI for adversarial testing of [A2A](https://a2a-protocol.org) and [MCP](https:/
 
 ## What ships
 
-Bundled rules: **14 A2A, 14 MCP (28 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
+Bundled rules: **14 A2A, 15 MCP (29 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
 
 - [A2A rules](docs/rules-a2a.md) (14)
-- [MCP rules](docs/rules-mcp.md) (14)
+- [MCP rules](docs/rules-mcp.md) (15)
 
 Coverage spans:
 

--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -1,6 +1,6 @@
 # MCP Attack Rules
 
-Batesian ships **14 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
+Batesian ships **15 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
 Every rule is an active probe: it sends crafted protocol traffic and judges the
 server's actual response. Rules are deliberately scoped to MCP-specific semantics
 (OAuth 2.1 authorization, DCR, audience binding, discovery-chain metadata-fetch
@@ -36,6 +36,7 @@ JSON-RPC `error` (the common MCP rejection shape) is a rejection, not a finding.
 | `mcp-secret-canary-001` | [Credential Canary Reflected in Responses](#mcp-secret-canary-001) | Medium | confirmed | CWE-522 |
 | `mcp-confused-deputy-001` | [OAuth Confused Deputy via redirect_uri](#mcp-confused-deputy-001) | High / Medium | confirmed / indicator | CWE-441 |
 | `mcp-dns-rebind-origin-001` | [Origin Validation / DNS Rebinding](#mcp-dns-rebind-origin-001) | High | confirmed | CWE-350 |
+| `mcp-jsonrpc-batch-bypass-001` | [JSON-RPC Batch Authentication Bypass](#mcp-jsonrpc-batch-bypass-001) | High | confirmed | CWE-288 |
 
 ---
 
@@ -315,3 +316,28 @@ exploitation additionally requires the server to be reachable from a victim's
 browser (a local or same-network bind), which the operator confirms for the
 deployment; this is the class behind the MCP Inspector RCE (CVE-2025-49596). A
 server that answers the foreign Origin with 403 produces no finding.
+
+---
+
+### mcp-jsonrpc-batch-bypass-001
+
+**JSON-RPC Batch Authentication Bypass** | Severity: High | CWE-288
+
+Tests whether authentication can be bypassed by wrapping a request in a JSON-RPC
+batch array. The classic failure: an auth gate inspects the top-level request
+object (for example "allow initialize, require auth for everything else", keyed on
+`body.method`); a batch is an array with no top-level method, so the gate does not
+fire and the dispatcher runs each element. Detection sends the **identical**
+request twice, differing only in batch wrapping: a single object (control) and a
+one-element array (test). A **confirmed** finding is raised only when the control
+is rejected (HTTP 401/403 or a JSON-RPC auth error) but the batch is processed and
+returns a result. Two gate shapes are probed: an auth gate on `initialize`, and a
+per-method gate on `tools/resources/prompts` list when `initialize` is open. A
+server that rejects the batch the same way, or rejects the array outright,
+produces no finding. The rule only sends `initialize` and `*list` requests; it
+never invokes a tool or mutates state.
+
+Currency: JSON-RPC batching is normative in revisions 2024-11-05 and 2025-03-26
+and was removed in 2025-06-18, so a compliant current server rejects batches. The
+rule targets servers on the earlier revisions and any later server that still
+processes batches (non-compliant), where the bypass is exploitable.

--- a/internal/attack/mcp/jsonrpc_batch_bypass.go
+++ b/internal/attack/mcp/jsonrpc_batch_bypass.go
@@ -1,0 +1,235 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// BatchBypassExecutor tests whether an MCP server's authentication can be bypassed
+// by wrapping a request in a JSON-RPC batch array (rule mcp-jsonrpc-batch-bypass-001).
+//
+// The classic JSON-RPC batch bypass: an auth/method gate inspects the top-level
+// request object (e.g. "allow initialize, require auth for everything else" keyed
+// on body.method). A JSON-RPC batch is an array, so it has no top-level method;
+// the gate's check does not fire, and the array is handed to the dispatcher, which
+// executes each element. An attacker reaches a gated method by array-wrapping it.
+//
+// Detection sends the IDENTICAL request twice, differing only in batch wrapping:
+//   - Control: the request as a plain JSON-RPC object, unauthenticated.
+//   - Test:    the same request as a one-element batch array, unauthenticated.
+//
+// A CONFIRMED finding is raised only when the control is rejected (the gate holds
+// for a single object) but the batch is processed and returns a result (the gate
+// is bypassed). If both are rejected, or the server rejects the array outright
+// (the compliant behaviour: batching was removed in MCP revision 2025-06-18), no
+// finding is raised. Two gate shapes are probed: an HTTP/auth gate on initialize,
+// and a per-method gate on tools/resources/prompts list when initialize is open.
+//
+// SAFETY: the rule only sends initialize and *list (enumeration) methods. It never
+// invokes a tool, sends a message, or mutates state.
+type BatchBypassExecutor struct {
+	rule attack.RuleContext
+}
+
+func init() {
+	attack.Register("mcp-jsonrpc-batch-bypass", func(rc attack.RuleContext) attack.Executor {
+		return NewBatchBypassExecutor(rc)
+	})
+}
+
+func NewBatchBypassExecutor(r attack.RuleContext) *BatchBypassExecutor {
+	return &BatchBypassExecutor{rule: r}
+}
+
+func (e *BatchBypassExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
+	vars := attack.NewVars(target, opts.OOBListenerURL)
+	// Deliberately unauthenticated: the rule tests whether a batch slips past the
+	// server's auth gate. Injecting opts.Token would mask the bypass.
+	client := attack.NewUnauthHTTPClient(opts, vars)
+
+	for _, ep := range endpointCandidates(vars.BaseURL) {
+		if f := e.probeEndpoint(ctx, client, ep); f != nil {
+			return f, nil
+		}
+	}
+	return nil, nil
+}
+
+// probeEndpoint runs the bypass check against a single candidate endpoint.
+func (e *BatchBypassExecutor) probeEndpoint(ctx context.Context, client *attack.HTTPClient, ep string) []attack.Finding {
+	initObj := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      1,
+		// 2025-03-26 is the last revision that supports batching; initialize at that
+		// version so a legacy server engages its batch path.
+		"method": "initialize",
+		"params": map[string]interface{}{
+			"protocolVersion": "2025-03-26",
+			"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+			"clientInfo":      map[string]interface{}{"name": "batesian", "version": "1.0"},
+		},
+	}
+
+	ctrl, err := client.POST(ctx, ep, nil, initObj)
+	if err != nil {
+		return nil // endpoint unreachable
+	}
+
+	switch {
+	case isAuthRejection(ctrl):
+		// The server gates initialize itself. Does a one-element batch slip past?
+		test, err := client.POST(ctx, ep, nil, []interface{}{initObj})
+		if err != nil {
+			return nil
+		}
+		if test.IsSuccess() && batchHasResult(test.Body) && bodyLooksMCP(test.Body) {
+			detail := fmt.Sprintf(
+				"single initialize: HTTP %d (rejected, unauthenticated)\n"+
+					"batch [initialize]: HTTP %d (processed, returned an MCP initialize result)",
+				ctrl.StatusCode, test.StatusCode)
+			return e.finding(ep, "initialize", detail)
+		}
+		return nil
+
+	case isMCPInitialize(ctrl):
+		// initialize is open; look for a per-method gate that the batch bypasses.
+		session := mcpSession{Endpoint: ep, SessionID: ctrl.Headers.Get("Mcp-Session-Id"), RawInit: ctrl.Body}
+		_, _ = client.POST(ctx, ep, session.header(), map[string]interface{}{
+			"jsonrpc": "2.0",
+			"method":  "notifications/initialized",
+		})
+		return e.probeMethodGate(ctx, client, session)
+
+	default:
+		return nil // not an MCP endpoint
+	}
+}
+
+// probeMethodGate looks for a list method that is auth-gated for a single request
+// but reachable when batch-wrapped. It only tests capabilities the server actually
+// advertised, so it never probes methods the server does not implement.
+func (e *BatchBypassExecutor) probeMethodGate(ctx context.Context, client *attack.HTTPClient, session mcpSession) []attack.Finding {
+	candidates := []struct{ capability, method string }{
+		{"tools", "tools/list"},
+		{"resources", "resources/list"},
+		{"prompts", "prompts/list"},
+	}
+	for _, c := range candidates {
+		if !session.ServerSupports(c.capability) {
+			continue
+		}
+		obj := map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      2,
+			"method":  c.method,
+			"params":  map[string]interface{}{},
+		}
+		ctrl, err := client.POST(ctx, session.Endpoint, session.header(), obj)
+		if err != nil {
+			continue
+		}
+		// Only a gated method is a bypass target: if the single request already
+		// succeeds, there is no auth to bypass (that is mcp-tools-unauth territory).
+		if !isAuthRejection(ctrl) {
+			continue
+		}
+		test, err := client.POST(ctx, session.Endpoint, session.header(), []interface{}{obj})
+		if err != nil {
+			continue
+		}
+		if test.IsSuccess() && batchHasResult(test.Body) {
+			detail := fmt.Sprintf(
+				"single %s: HTTP %d (rejected, unauthenticated)\n"+
+					"batch [%s]: HTTP %d (processed, returned a result)",
+				c.method, ctrl.StatusCode, c.method, test.StatusCode)
+			return e.finding(session.Endpoint, c.method, detail)
+		}
+	}
+	return nil
+}
+
+func (e *BatchBypassExecutor) finding(ep, method, detail string) []attack.Finding {
+	return []attack.Finding{{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "high",
+		Confidence: attack.ConfirmedExploit,
+		Title:      "MCP authentication bypassed by JSON-RPC batch wrapping",
+		Description: fmt.Sprintf(
+			"At %s, the JSON-RPC method %q was rejected without credentials when sent as a plain request "+
+				"object, but the identical request was processed when wrapped in a one-element JSON-RPC batch "+
+				"array. Authentication is enforced on single requests yet bypassed for batches, so an attacker "+
+				"reaches gated methods by array-wrapping them (CWE-288, authentication bypass via an alternate "+
+				"channel). JSON-RPC batching was removed in MCP revision 2025-06-18, so a server still "+
+				"processing batches is also non-compliant with current revisions.", ep, method),
+		Evidence:    fmt.Sprintf("endpoint: %s\ngated method: %s\n%s", ep, method, detail),
+		Remediation: e.rule.Remediation,
+		TargetURL:   ep,
+	}}
+}
+
+// isAuthRejection reports whether a response is an authentication/authorization
+// rejection: an HTTP 401/403, or a JSON-RPC error carrying auth semantics (some
+// servers answer 200 with an error envelope). A non-auth rejection (parse error,
+// invalid request) is deliberately not counted, so the rule never attributes an
+// unrelated failure to an auth bypass.
+func isAuthRejection(resp *attack.Response) bool {
+	if resp.StatusCode == 401 || resp.StatusCode == 403 {
+		return true
+	}
+	var obj struct {
+		Error *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(resp.Body, &obj); err != nil || obj.Error == nil {
+		return false
+	}
+	// -32001/-32002 are the codes this project uses for unauthenticated/forbidden.
+	if obj.Error.Code == -32001 || obj.Error.Code == -32002 {
+		return true
+	}
+	msg := strings.ToLower(obj.Error.Message)
+	for _, kw := range []string{"unauth", "authentic", "authoriz", "forbidden", "token", "credential", "permission"} {
+		if strings.Contains(msg, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// isMCPInitialize reports whether a response is a successful MCP initialize result.
+func isMCPInitialize(resp *attack.Response) bool {
+	return resp.IsSuccess() && resp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`)
+}
+
+// batchHasResult reports whether body is a JSON-RPC batch response (a JSON array)
+// in which at least one element carries a result (and no error). A non-array body
+// means the server did not process the input as a batch, so it is not a bypass.
+func batchHasResult(body []byte) bool {
+	var arr []map[string]json.RawMessage
+	if err := json.Unmarshal(body, &arr); err != nil {
+		return false
+	}
+	for _, el := range arr {
+		_, hasErr := el["error"]
+		_, hasRes := el["result"]
+		if hasRes && !hasErr {
+			return true
+		}
+	}
+	return false
+}
+
+// bodyLooksMCP reports whether body resembles an MCP initialize result, used to
+// confirm the bypassed initialize batch reached a real MCP server rather than an
+// unrelated endpoint that happens to return 401 then 200.
+func bodyLooksMCP(body []byte) bool {
+	s := string(body)
+	return strings.Contains(s, `"protocolVersion"`) || strings.Contains(s, `"serverInfo"`)
+}

--- a/internal/attack/mcp/jsonrpc_batch_bypass_test.go
+++ b/internal/attack/mcp/jsonrpc_batch_bypass_test.go
@@ -1,0 +1,195 @@
+package mcp_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+// batchServer builds a mock MCP server whose auth behavior depends on mode:
+//   - "bypass-init":   single initialize is gated (401) but a batch [initialize]
+//     is processed (the auth gate bypass at the handshake).
+//   - "bypass-method": initialize is open, but single tools/list is gated (401)
+//     while a batch [tools/list] is processed (the per-method gate bypass).
+//   - "secure":        the auth gate applies to single AND batch requests alike.
+//   - "open":          nothing is gated (no auth to bypass).
+//   - "not-mcp":       every request 404s.
+//
+// The vulnerability is modeled by enforcing the gate only on non-batch requests
+// in the two "bypass" modes, exactly the real-world bug where a gate inspects the
+// top-level method and an array has none.
+func batchServer(mode string) *httptest.Server {
+	initResult := func(id interface{}) map[string]interface{} {
+		return map[string]interface{}{
+			"jsonrpc": "2.0", "id": id,
+			"result": map[string]interface{}{
+				"protocolVersion": "2025-03-26",
+				"serverInfo":      map[string]interface{}{"name": "batch-srv", "version": "1.0"},
+				"capabilities":    map[string]interface{}{"tools": map[string]interface{}{"listChanged": false}},
+			},
+		}
+	}
+	toolsResult := func(id interface{}) map[string]interface{} {
+		return map[string]interface{}{
+			"jsonrpc": "2.0", "id": id,
+			"result": map[string]interface{}{"tools": []interface{}{map[string]interface{}{"name": "echo"}}},
+		}
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if mode == "not-mcp" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		raw, _ := io.ReadAll(r.Body)
+		isBatch := len(bytes.TrimSpace(raw)) > 0 && bytes.TrimSpace(raw)[0] == '['
+		authed := r.Header.Get("Authorization") != ""
+		w.Header().Set("Content-Type", "application/json")
+
+		var objs []map[string]interface{}
+		if isBatch {
+			_ = json.Unmarshal(raw, &objs)
+		} else {
+			var one map[string]interface{}
+			_ = json.Unmarshal(raw, &one)
+			objs = []map[string]interface{}{one}
+		}
+
+		// enforce: is the auth gate active for this request shape?
+		enforce := !isBatch
+		if mode == "secure" {
+			enforce = true
+		}
+		if mode == "open" {
+			enforce = false
+		}
+
+		// respond returns the response object and HTTP status for one request.
+		respond := func(req map[string]interface{}) (map[string]interface{}, int) {
+			method, _ := req["method"].(string)
+			id := req["id"]
+			switch method {
+			case "initialize":
+				if (mode == "bypass-init" || mode == "secure") && enforce && !authed {
+					return nil, http.StatusUnauthorized
+				}
+				return initResult(id), http.StatusOK
+			case "notifications/initialized":
+				return nil, http.StatusAccepted
+			case "tools/list":
+				if (mode == "bypass-method" || mode == "secure") && enforce && !authed {
+					return nil, http.StatusUnauthorized
+				}
+				return toolsResult(id), http.StatusOK
+			default:
+				return map[string]interface{}{"jsonrpc": "2.0", "id": id,
+					"error": map[string]interface{}{"code": -32601, "message": "method not found"}}, http.StatusOK
+			}
+		}
+
+		if isBatch {
+			var arr []interface{}
+			for _, req := range objs {
+				resp, st := respond(req)
+				if st == http.StatusUnauthorized {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				if resp != nil {
+					arr = append(arr, resp)
+				}
+			}
+			_ = json.NewEncoder(w).Encode(arr)
+			return
+		}
+
+		resp, st := respond(objs[0])
+		if st != http.StatusOK {
+			w.WriteHeader(st)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func runBatchBypass(t *testing.T, srv *httptest.Server) []attack.Finding {
+	t.Helper()
+	exec := mcpattack.NewBatchBypassExecutor(attack.RuleContext{
+		ID:   "mcp-jsonrpc-batch-bypass-001",
+		Name: "MCP JSON-RPC Batch Authentication Bypass",
+	})
+	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return findings
+}
+
+// TestBatchBypass_InitializeGate: initialize is gated for a single request but a
+// batch [initialize] is processed => confirmed high finding.
+func TestBatchBypass_InitializeGate(t *testing.T) {
+	srv := batchServer("bypass-init")
+	defer srv.Close()
+
+	findings := runBatchBypass(t, srv)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Confidence != attack.ConfirmedExploit {
+		t.Errorf("expected ConfirmedExploit, got %v", f.Confidence)
+	}
+	if f.Severity != "high" {
+		t.Errorf("expected high severity, got %q", f.Severity)
+	}
+}
+
+// TestBatchBypass_MethodGate: initialize is open but tools/list is gated for a
+// single request while a batch [tools/list] is processed => confirmed finding.
+func TestBatchBypass_MethodGate(t *testing.T) {
+	srv := batchServer("bypass-method")
+	defer srv.Close()
+
+	if findings := runBatchBypass(t, srv); len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestBatchBypass_SecureNoFinding: the gate applies to batches too => no finding.
+func TestBatchBypass_SecureNoFinding(t *testing.T) {
+	srv := batchServer("secure")
+	defer srv.Close()
+
+	if findings := runBatchBypass(t, srv); len(findings) != 0 {
+		t.Errorf("expected 0 findings when batches are gated too, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestBatchBypass_FullyOpenNoFinding: nothing is gated, so there is no auth to
+// bypass (that posture belongs to mcp-tools-unauth-001) => no finding.
+func TestBatchBypass_FullyOpenNoFinding(t *testing.T) {
+	srv := batchServer("open")
+	defer srv.Close()
+
+	if findings := runBatchBypass(t, srv); len(findings) != 0 {
+		t.Errorf("expected 0 findings when there is no auth gate, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestBatchBypass_NotMCP: a non-MCP endpoint that 401s then is probed must not
+// produce a finding (the bypassed batch must return a real MCP result).
+func TestBatchBypass_NotMCP(t *testing.T) {
+	srv := batchServer("not-mcp")
+	defer srv.Close()
+
+	if findings := runBatchBypass(t, srv); len(findings) != 0 {
+		t.Errorf("expected 0 findings for a non-MCP endpoint, got %d", len(findings))
+	}
+}

--- a/rules/mcp/jsonrpc-batch-bypass-001.yaml
+++ b/rules/mcp/jsonrpc-batch-bypass-001.yaml
@@ -1,0 +1,66 @@
+id: mcp-jsonrpc-batch-bypass-001
+info:
+  name: MCP JSON-RPC Batch Authentication Bypass
+  author: batesian
+  severity: high
+  description: |
+    Tests whether an MCP server's authentication can be bypassed by wrapping a
+    request in a JSON-RPC batch array.
+
+    The classic JSON-RPC batch bypass: an auth or method gate inspects the
+    top-level request object (for example "allow initialize, require auth for
+    everything else", keyed on body.method). A JSON-RPC batch is an array and has
+    no top-level method, so the gate's check does not fire and the array is handed
+    to the dispatcher, which executes each element. An attacker reaches a gated
+    method by array-wrapping it (CWE-288, authentication bypass via an alternate
+    channel).
+
+    Detection sends the IDENTICAL request twice, differing only in batch wrapping,
+    and confirms a bypass only when the wrapping is the deciding factor:
+
+      1. Control: the request as a plain JSON-RPC object, unauthenticated. The
+         server must REJECT it (HTTP 401/403 or a JSON-RPC auth error) for there
+         to be a gate to bypass.
+      2. Test: the same request as a one-element batch array, unauthenticated. A
+         CONFIRMED finding is raised only when the batch is PROCESSED and returns a
+         result while the single object was rejected.
+
+    Two gate shapes are probed: an auth gate on initialize itself, and a per-method
+    gate on tools/resources/prompts list when initialize is open. A server that
+    rejects the batch the same way, or rejects the array outright (the compliant
+    behaviour), produces no finding.
+
+    SAFETY: the rule only sends initialize and *list (enumeration) requests. It
+    never invokes a tool, sends a message, or mutates state.
+
+    Currency: JSON-RPC batching is normative in revisions 2024-11-05 and
+    2025-03-26; the 2025-06-18 revision REMOVED batch support, so a compliant
+    current server rejects batches outright (no finding). This rule therefore
+    targets servers on the earlier revisions and any later server that still
+    processes batches (non-compliant), where the bypass is exploitable.
+
+  references:
+    - https://www.jsonrpc.org/specification#batch
+    - https://modelcontextprotocol.io/specification/2025-03-26/basic/transports
+    - https://modelcontextprotocol.io/specification/2025-06-18/changelog
+    - https://cwe.mitre.org/data/definitions/288.html
+
+  tags:
+    - mcp
+    - auth
+    - json-rpc
+    - batch
+    - bypass
+    - cwe-288
+
+attack:
+  protocol: mcp
+  type: mcp-jsonrpc-batch-bypass
+
+remediation: |
+  1. Apply authentication and authorization to every element of a JSON-RPC batch,
+     not just the top-level request object; never gate on body.method alone.
+  2. On current revisions (2025-06-18 and later), reject JSON-RPC batch arrays
+     outright, since batching was removed from the spec.
+  3. Enforce the auth check in a layer that runs before request-shape parsing, so a
+     single object and a batch array are subject to the same gate.

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -18,7 +18,7 @@ pip install starlette uvicorn httpx mcp
 
 ## Server Registry
 
-The bundled rule set is **14 A2A + 14 MCP = 28 rules**. Every rule's primary
+The bundled rule set is **14 A2A + 15 MCP = 29 rules**. Every rule's primary
 validation is an in-process `net/http/httptest` harness in its Go
 `*_test.go` (multiple server postures: vulnerable must fire / patched / open /
 benign must stay silent). The Python servers below are optional standalone
@@ -45,8 +45,9 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_secret_canary_server.py` | 7792 | `mcp-secret-canary-001` |
 | `mcp_confused_deputy_server.py` | 7793 | `mcp-confused-deputy-001` |
 | `mcp_dns_rebind_origin_server.py` | 7794 | `mcp-dns-rebind-origin-001` |
+| `mcp_batch_bypass_server.py` | 7795 | `mcp-jsonrpc-batch-bypass-001` |
 
-**Coverage.** 27 of the 28 rules have a standalone Python fixture above. The
+**Coverage.** 28 of the 29 rules have a standalone Python fixture above. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
 (`internal/attack/mcp/token_replay_test.go`); the same is true of the per-rule
 edge-case harnesses for every other rule. `mockserver.go` is a Go helper used by

--- a/testdata/mcp_batch_bypass_server.py
+++ b/testdata/mcp_batch_bypass_server.py
@@ -1,0 +1,109 @@
+"""
+Deliberately vulnerable MCP server for validating:
+  - mcp-jsonrpc-batch-bypass-001: authentication is enforced on a single JSON-RPC
+    request object but BYPASSED when the same request is wrapped in a one-element
+    JSON-RPC batch array (CWE-288, auth bypass via an alternate channel).
+
+initialize is open (capability discovery). tools/list requires a bearer token for
+a single request (HTTP 401 without one), but a batch [tools/list] is processed
+without any token: the auth gate keys on the top-level method, and a JSON-RPC
+batch array has none, so the gate is skipped and every element runs.
+
+JSON-RPC batching was removed in MCP revision 2025-06-18; this fixture emulates a
+legacy / non-compliant server that still processes batches.
+
+Validate against it:
+  python testdata/mcp_batch_bypass_server.py
+  batesian scan --target http://127.0.0.1:7795 \\
+      --rule-ids mcp-jsonrpc-batch-bypass-001 -v
+
+Endpoint: http://127.0.0.1:7795/mcp
+"""
+import json
+import uuid
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route
+import uvicorn
+
+PORT = 7795
+
+
+def _init_result(req_id):
+    return {
+        "jsonrpc": "2.0", "id": req_id,
+        "result": {
+            "protocolVersion": "2025-03-26",
+            "serverInfo": {"name": "batch-bypass-lab", "version": "1.0"},
+            "capabilities": {"tools": {"listChanged": False}},
+        },
+    }
+
+
+def _tools_result(req_id):
+    return {
+        "jsonrpc": "2.0", "id": req_id,
+        "result": {"tools": [
+            {"name": "run_query", "description": "Run a database query"},
+            {"name": "read_file", "description": "Read a file from disk"},
+        ]},
+    }
+
+
+def _dispatch(obj):
+    """Dispatch a single request object with no auth check (used for batch
+    elements, which is exactly where this server fails to re-apply the gate)."""
+    method = obj.get("method", "")
+    req_id = obj.get("id")
+    if method == "initialize":
+        return _init_result(req_id)
+    if method == "notifications/initialized":
+        return None
+    if method == "tools/list":
+        return _tools_result(req_id)
+    return {"jsonrpc": "2.0", "id": req_id,
+            "error": {"code": -32601, "message": "method not found"}}
+
+
+async def mcp_endpoint(request: Request) -> Response:
+    raw = await request.body()
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        return JSONResponse(
+            {"jsonrpc": "2.0", "id": None, "error": {"code": -32700, "message": "parse error"}},
+            status_code=400,
+        )
+    authed = request.headers.get("authorization") is not None
+
+    # VULNERABILITY: the gate below runs only for single objects. A batch array is
+    # dispatched element-by-element with no auth check at all.
+    if isinstance(payload, list):
+        responses = [r for r in (_dispatch(obj) for obj in payload) if r is not None]
+        return JSONResponse(responses)
+
+    method = payload.get("method", "")
+    req_id = payload.get("id")
+
+    if method == "initialize":
+        # Open for capability discovery; mint a session id server-side.
+        return JSONResponse(_init_result(req_id), headers={"Mcp-Session-Id": uuid.uuid4().hex})
+    if method == "notifications/initialized":
+        return Response(status_code=202)
+    if method == "tools/list" and not authed:
+        # The gate that the batch path fails to apply.
+        return JSONResponse(
+            {"jsonrpc": "2.0", "id": req_id, "error": {"code": -32001, "message": "Unauthorized"}},
+            status_code=401,
+        )
+    result = _dispatch(payload)
+    if result is None:
+        return Response(status_code=202)
+    return JSONResponse(result)
+
+
+app = Starlette(routes=[Route("/mcp", mcp_endpoint, methods=["POST"])])
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="127.0.0.1", port=PORT, log_level="warning")


### PR DESCRIPTION
## Summary

Adds a new MCP rule, `mcp-jsonrpc-batch-bypass-001`, for the classic **JSON-RPC batch authentication bypass** (CWE-288). This fills one of the coverage gaps an external audit flagged, and it sits squarely at Batesian's layer (JSON-RPC envelope handling) rather than being generic web hygiene.

### The vulnerability
An auth or method gate inspects the top-level request object (a common pattern: "allow `initialize`, require auth for everything else", keyed on `body.method`). A JSON-RPC **batch is an array** and has no top-level method, so the gate's check doesn't fire and the dispatcher runs each element unauthenticated. An attacker reaches a gated method by array-wrapping it. This is a documented JSON-RPC framework bug class (cf. CVEs in cpp-ethereum `miner_start`, Arista MOS, CryptoNote).

### Detection (confirmed, with a control)
The rule sends the **identical** request twice, differing only in batch wrapping:
- **Control**: the request as a plain JSON-RPC object, unauthenticated. Must be **rejected** (HTTP 401/403 or a JSON-RPC auth error) for a gate to exist.
- **Test**: the same request as a one-element batch array, unauthenticated.

A **confirmed** finding is raised only when the control is rejected but the batch is **processed and returns a result**. Two gate shapes are probed: an auth gate on `initialize`, and a per-method gate on `tools`/`resources`/`prompts` `list` when `initialize` is open. If the server rejects the batch the same way, or rejects the array outright, no finding is raised. **Safety:** only `initialize` and `*list` requests are sent; no tool is invoked and no state is mutated.

### Scope / currency
JSON-RPC batching was **removed in MCP 2025-06-18**, so a compliant current server rejects batches and the rule no-ops. It targets the earlier revisions (2024-11-05, 2025-03-26) and any later server that still processes batches (non-compliant), where the bypass is exploitable. This mirrors the existing `session-fixation`/`sse-resume` legacy-currency rules, and the rule carries a Currency note.

## Research / due diligence
- Confirmed batching's removal in the **MCP 2025-06-18 changelog**, and that it was normative in 2025-03-26 (the protocol version the rule initializes at).
- Confirmed the **A2A v1.0** JSON-RPC binding neither documents nor forbids batching (so a generic A2A server may also process it); an A2A variant is a reasonable follow-up, kept out of this PR for focus.
- Validated the vuln class against JSON-RPC security guidance and prior CVEs.
- Traced the existing MCP executor conventions (`session.go`, `initializeMCP`, `endpointCandidates`, `ServerSupports`) and modeled the executor on them.

## Validation (CONTRIBUTING checklist)
- **Unit tests** (5 postures): initialize-gate bypass and method-gate bypass both fire confirmed/high; secure (batch gated too), fully-open (no gate), and non-MCP all stay silent.
- **Testdata fixture**: added `testdata/mcp_batch_bypass_server.py` (port 7795), registry updated.
- **Live validation**: a real scan against the running fixture produced the confirmed finding:
  ```
  [!] HIGH  MCP authentication bypassed by JSON-RPC batch wrapping
     evidence:
       gated method: tools/list
       single tools/list: HTTP 401 (rejected, unauthenticated)
       batch [tools/list]: HTTP 200 (processed, returned a result)
  ```
- **Build / test / vet**: `go build`, `go test ./...`, `go vet` all pass. The engine zero-egress dry-run test now exercises all 29 rules and still passes.
- **Lint**: `golangci-lint run` reports 0 issues. `gofmt` clean. No em-dashes.
- **Step 6 (reference impl, best effort)**: a compliant reference server (2025-06-18+) rejects batches outright, so the rule correctly produces no finding there; that no-false-positive-on-compliant-server case is covered by the `secure` unit test. The positive case is live-validated against the fixture above.

## Counts
Rule set is now **29 (14 A2A + 15 MCP)**. Updated README, the MCP catalog (intro + table row + detail section), `testdata/README.md` (registry + coverage), and the goreleaser release header (which was additionally still stale at "27 / 13 MCP" and is now corrected).
