### PR TITLE
feat(a2a-jsonrpc-batch-bypass-001): detect JSON-RPC batch authentication bypass

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -114,7 +114,7 @@ release:
     ## Batesian {{.Version}}
 
     Adversarial red-team CLI for AI agent protocols (A2A and MCP).
-    29 bundled attack rules (14 A2A + 15 MCP). Single binary. No runtime dependencies.
+    30 bundled attack rules (15 A2A + 15 MCP). Single binary. No runtime dependencies.
 
     ### Install
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ CLI for adversarial testing of [A2A](https://a2a-protocol.org) and [MCP](https:/
 
 ## What ships
 
-Bundled rules: **14 A2A, 15 MCP (29 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
+Bundled rules: **15 A2A, 15 MCP (30 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
 
-- [A2A rules](docs/rules-a2a.md) (14)
+- [A2A rules](docs/rules-a2a.md) (15)
 - [MCP rules](docs/rules-mcp.md) (15)
 
 Coverage spans:

--- a/docs/rules-a2a.md
+++ b/docs/rules-a2a.md
@@ -1,6 +1,6 @@
 # A2A Attack Rules
 
-Batesian ships **14 rules** targeting the [Agent-to-Agent (A2A) protocol](https://a2a-protocol.org/).
+Batesian ships **15 rules** targeting the [Agent-to-Agent (A2A) protocol](https://a2a-protocol.org/).
 Every rule is an active probe: it sends crafted protocol traffic and judges the
 server's actual response. Rules are deliberately scoped to A2A-specific semantics
 (agent cards, JWS card signatures, tasks/contexts, push notifications, peer
@@ -29,6 +29,7 @@ Each finding carries a **confidence**:
 | `a2a-card-trust-001` | [Agent Card Trust Durability](#a2a-card-trust-001) | High / Medium | indicator | CWE-345 |
 | `a2a-extension-downgrade-001` | [Required-Extension Downgrade / Fail-Open](#a2a-extension-downgrade-001) | High | confirmed | CWE-636 |
 | `a2a-push-binding-001` | [Push/Webhook Control-Plane Not Bound to Task Owner](#a2a-push-binding-001) | High | confirmed | CWE-639 |
+| `a2a-jsonrpc-batch-bypass-001` | [JSON-RPC Batch Authentication Bypass](#a2a-jsonrpc-batch-bypass-001) | High | confirmed | CWE-288 |
 
 ---
 
@@ -305,3 +306,23 @@ webhook hijack if accepted). Distinct from `a2a-multitenant-isolation-001`
 another principal's task): here the vector is the push-config API itself, which
 can redirect a victim task's results to an attacker URL.
 
+---
+
+### a2a-jsonrpc-batch-bypass-001
+
+**JSON-RPC Batch Authentication Bypass** | Severity: High | CWE-288
+
+Tests whether authentication can be bypassed by wrapping a request in a JSON-RPC
+batch array. The gate inspects the top-level request object, but a batch is an
+array with no top-level method, so the check does not fire and the dispatcher runs
+each element. A2A enforces auth at the HTTP layer, so the bypass shows up as a
+single request rejected at the transport (HTTP 401/403) while the identical
+request, batch-wrapped, reaches HTTP 200 and is dispatched. Detection sends the
+**identical** request twice (single object then one-element array) for each
+protocol shape (v1.0 `GetTask`, then the v0.3 `tasks/get` fallback). A
+**confirmed** finding is raised only when the single object is rejected with
+401/403 but the batch reaches 200 and the dispatcher ran (the batch response
+carries a result or a non-auth application error such as `TaskNotFound`). The
+probe is a read-only `GetTask` for a non-existent task id, so nothing is sent,
+created, or mutated. A2A does not define batching, so a correct server should
+reject the array rather than dispatch it unauthenticated (CWE-288).

--- a/internal/attack/a2a/jsonrpc_batch_bypass.go
+++ b/internal/attack/a2a/jsonrpc_batch_bypass.go
@@ -1,0 +1,191 @@
+package a2a
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// BatchBypassExecutor tests whether an A2A server's authentication can be bypassed
+// by wrapping a request in a JSON-RPC batch array (rule a2a-jsonrpc-batch-bypass-001).
+//
+// The classic JSON-RPC batch bypass: an auth gate inspects the top-level request
+// object, but a JSON-RPC batch is an array with no top-level method, so the gate's
+// check does not fire and the array is handed to the dispatcher, which runs each
+// element. A2A enforces authentication at the HTTP layer (a rejected request
+// returns HTTP 401/403), so the bypass shows up as a single request being rejected
+// at the transport while the identical request, batch-wrapped, reaches HTTP 200 and
+// is dispatched.
+//
+// Detection sends the IDENTICAL request twice, differing only in batch wrapping,
+// for each protocol shape (A2A v1.0 GetTask, then the v0.3 tasks/get fallback):
+//   - Control: a plain JSON-RPC object, unauthenticated. It must be rejected with
+//     HTTP 401/403 for there to be an auth gate to bypass.
+//   - Test: the same object as a one-element batch array, unauthenticated. A
+//     CONFIRMED finding is raised only when it reaches HTTP 200 and the dispatcher
+//     ran (the batch response carries a result or a non-auth application error such
+//     as TaskNotFound).
+//
+// SAFETY: the probe is a read-only GetTask for a guaranteed non-existent task id.
+// It never sends a message, creates, or mutates a task.
+type BatchBypassExecutor struct {
+	rule attack.RuleContext
+}
+
+func init() {
+	attack.Register("a2a-jsonrpc-batch-bypass", func(rc attack.RuleContext) attack.Executor {
+		return NewBatchBypassExecutor(rc)
+	})
+}
+
+func NewBatchBypassExecutor(r attack.RuleContext) *BatchBypassExecutor {
+	return &BatchBypassExecutor{rule: r}
+}
+
+func (e *BatchBypassExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
+	vars := attack.NewVars(target, opts.OOBListenerURL)
+	endpoint := vars.BaseURL + "/"
+	// Deliberately unauthenticated: the rule tests whether a batch slips past the
+	// server's auth gate. Injecting opts.Token would mask the bypass.
+	client := attack.NewUnauthHTTPClient(opts, vars)
+
+	bogusTask := "batesian-nonexistent-" + vars.RandID
+
+	// Two protocol shapes, tried in order: A2A v1.0 (PascalCase method, A2A-Version
+	// header) then the v0.3 slash-method fallback. For each, the control and test
+	// use the IDENTICAL request object so the only variable is batch wrapping.
+	shapes := []struct {
+		label   string
+		headers map[string]string
+		obj     map[string]interface{}
+	}{
+		{
+			label:   "v1.0 GetTask",
+			headers: map[string]string{"A2A-Version": "1.0"},
+			obj: map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      "batesian-batch-" + vars.RandID,
+				"method":  "GetTask",
+				"params":  map[string]interface{}{"id": bogusTask, "historyLength": 1},
+			},
+		},
+		{
+			label:   "v0.3 tasks/get",
+			headers: nil,
+			obj: map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      "batesian-batch-" + vars.RandID,
+				"method":  "tasks/get",
+				"params":  map[string]interface{}{"id": bogusTask, "historyLength": 1},
+			},
+		},
+	}
+
+	for _, s := range shapes {
+		ctrl, err := client.POST(ctx, endpoint, s.headers, s.obj)
+		if err != nil {
+			continue
+		}
+		// An HTTP auth gate must reject the single request, otherwise there is no
+		// authentication to bypass for this shape.
+		if !isA2AAuthRejection(ctrl) {
+			continue
+		}
+		test, err := client.POST(ctx, endpoint, s.headers, []interface{}{s.obj})
+		if err != nil {
+			continue
+		}
+		if test.IsSuccess() && a2aBatchDispatched(test.Body) {
+			return e.finding(endpoint, s.label, ctrl, test), nil
+		}
+	}
+	return nil, nil
+}
+
+func (e *BatchBypassExecutor) finding(endpoint, shape string, ctrl, test *attack.Response) []attack.Finding {
+	return []attack.Finding{{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "high",
+		Confidence: attack.ConfirmedExploit,
+		Title:      "A2A authentication bypassed by JSON-RPC batch wrapping",
+		Description: fmt.Sprintf(
+			"At %s, a single unauthenticated JSON-RPC request was rejected at the HTTP layer, but the "+
+				"identical request wrapped in a one-element JSON-RPC batch array reached the dispatcher and "+
+				"was processed. A2A enforces authentication at the transport, yet the batch slipped past it, "+
+				"so an attacker reaches authenticated methods by array-wrapping them (CWE-288, authentication "+
+				"bypass via an alternate channel). A2A does not define batching, so a server should reject a "+
+				"JSON-RPC array rather than dispatch it unauthenticated.", endpoint),
+		Evidence: fmt.Sprintf(
+			"endpoint: %s\nshape: %s\nsingle request: HTTP %d (rejected, unauthenticated)\n"+
+				"batch [request]: HTTP %d (processed)\n%s",
+			endpoint, shape, ctrl.StatusCode, test.StatusCode, snippet(test.Body, 400)),
+		Remediation: e.rule.Remediation,
+		TargetURL:   endpoint,
+	}}
+}
+
+// isA2AAuthRejection reports whether a response is an A2A authentication rejection.
+// A2A enforces auth at the HTTP layer, so the primary signal is HTTP 401/403; a
+// JSON-RPC error envelope whose message reads as an auth failure is also accepted
+// for servers that wrap the rejection at 200. A2A application errors (TaskNotFound
+// at -32001, method-not-found, invalid params) are deliberately NOT counted.
+func isA2AAuthRejection(resp *attack.Response) bool {
+	if resp.StatusCode == 401 || resp.StatusCode == 403 {
+		return true
+	}
+	return errMessageIsAuth(resp.Body)
+}
+
+// a2aBatchDispatched reports whether body is a JSON-RPC batch response (a JSON
+// array) whose elements show the dispatcher ran: a result, or a non-auth
+// application error. An array element that is itself an auth rejection does not
+// count (the gate held for the batch too).
+func a2aBatchDispatched(body []byte) bool {
+	var arr []map[string]json.RawMessage
+	if err := json.Unmarshal(body, &arr); err != nil {
+		return false
+	}
+	for _, el := range arr {
+		if _, ok := el["result"]; ok {
+			return true
+		}
+		if rawErr, ok := el["error"]; ok && !errMessageIsAuthRaw(rawErr) {
+			return true
+		}
+	}
+	return false
+}
+
+// authKeywords are substrings that mark a JSON-RPC error message as an auth
+// failure. A2A has no numeric auth error code, so classification is message-based.
+var authKeywords = []string{"unauth", "authentic", "forbidden", "credential", "permission"}
+
+func errMessageIsAuth(body []byte) bool {
+	var obj struct {
+		Error json.RawMessage `json:"error"`
+	}
+	if err := json.Unmarshal(body, &obj); err != nil || len(obj.Error) == 0 {
+		return false
+	}
+	return errMessageIsAuthRaw(obj.Error)
+}
+
+func errMessageIsAuthRaw(rawErr json.RawMessage) bool {
+	var e struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(rawErr, &e); err != nil {
+		return false
+	}
+	msg := strings.ToLower(e.Message)
+	for _, kw := range authKeywords {
+		if strings.Contains(msg, kw) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/attack/a2a/jsonrpc_batch_bypass_test.go
+++ b/internal/attack/a2a/jsonrpc_batch_bypass_test.go
@@ -1,0 +1,136 @@
+package a2a_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	a2aattack "github.com/calbebop/batesian/internal/attack/a2a"
+)
+
+// batchServer builds a mock A2A JSON-RPC server whose auth behavior depends on
+// mode:
+//   - "bypass": a single request is rejected at the HTTP layer (401) when
+//     unauthenticated, but a batch array is dispatched without auth (the bug).
+//   - "secure": the 401 gate applies to single AND batch requests alike.
+//   - "open":   nothing is gated (every request reaches the handler).
+//   - "not-a2a": every request 404s.
+//
+// A dispatched GetTask/tasks/get for the probe's non-existent id returns a
+// TaskNotFound (-32001) application error, which is exactly what proves the
+// dispatcher ran past the auth gate.
+func batchServer(mode string) *httptest.Server {
+	taskNotFound := func(id interface{}) map[string]interface{} {
+		return map[string]interface{}{
+			"jsonrpc": "2.0", "id": id,
+			"error": map[string]interface{}{"code": -32001, "message": "Task not found"},
+		}
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if mode == "not-a2a" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		raw, _ := io.ReadAll(r.Body)
+		isBatch := len(bytes.TrimSpace(raw)) > 0 && bytes.TrimSpace(raw)[0] == '['
+		authed := r.Header.Get("Authorization") != ""
+		w.Header().Set("Content-Type", "application/json")
+
+		// gate: is the HTTP auth gate active for this request shape?
+		gate := !authed
+		if mode == "open" {
+			gate = false
+		}
+		// In "bypass" mode the gate is skipped for batches (the vulnerability); in
+		// "secure" mode it applies to batches too.
+		if isBatch && mode == "bypass" {
+			gate = false
+		}
+
+		if gate {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		if isBatch {
+			var objs []map[string]interface{}
+			_ = json.Unmarshal(raw, &objs)
+			arr := make([]interface{}, 0, len(objs))
+			for _, o := range objs {
+				arr = append(arr, taskNotFound(o["id"]))
+			}
+			_ = json.NewEncoder(w).Encode(arr)
+			return
+		}
+		var one map[string]interface{}
+		_ = json.Unmarshal(raw, &one)
+		_ = json.NewEncoder(w).Encode(taskNotFound(one["id"]))
+	}))
+}
+
+func runBatchBypass(t *testing.T, srv *httptest.Server) []attack.Finding {
+	t.Helper()
+	exec := a2aattack.NewBatchBypassExecutor(attack.RuleContext{
+		ID:   "a2a-jsonrpc-batch-bypass-001",
+		Name: "A2A JSON-RPC Batch Authentication Bypass",
+	})
+	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return findings
+}
+
+// TestBatchBypass_Bypassed: single request gated (401), batch dispatched => confirmed.
+func TestBatchBypass_Bypassed(t *testing.T) {
+	srv := batchServer("bypass")
+	defer srv.Close()
+
+	findings := runBatchBypass(t, srv)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Confidence != attack.ConfirmedExploit {
+		t.Errorf("expected ConfirmedExploit, got %v", f.Confidence)
+	}
+	if f.Severity != "high" {
+		t.Errorf("expected high severity, got %q", f.Severity)
+	}
+}
+
+// TestBatchBypass_SecureNoFinding: the gate applies to batches too => no finding.
+func TestBatchBypass_SecureNoFinding(t *testing.T) {
+	srv := batchServer("secure")
+	defer srv.Close()
+
+	if findings := runBatchBypass(t, srv); len(findings) != 0 {
+		t.Errorf("expected 0 findings when batches are gated too, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestBatchBypass_OpenNoFinding: nothing is gated, so there is no auth to bypass.
+func TestBatchBypass_OpenNoFinding(t *testing.T) {
+	srv := batchServer("open")
+	defer srv.Close()
+
+	if findings := runBatchBypass(t, srv); len(findings) != 0 {
+		t.Errorf("expected 0 findings when there is no auth gate, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestBatchBypass_NotA2A: a non-A2A endpoint that 404s must not produce a finding.
+func TestBatchBypass_NotA2A(t *testing.T) {
+	srv := batchServer("not-a2a")
+	defer srv.Close()
+
+	if findings := runBatchBypass(t, srv); len(findings) != 0 {
+		t.Errorf("expected 0 findings for a non-A2A endpoint, got %d", len(findings))
+	}
+}

--- a/rules/a2a/jsonrpc-batch-bypass-001.yaml
+++ b/rules/a2a/jsonrpc-batch-bypass-001.yaml
@@ -1,0 +1,63 @@
+id: a2a-jsonrpc-batch-bypass-001
+info:
+  name: A2A JSON-RPC Batch Authentication Bypass
+  author: batesian
+  severity: high
+  description: |
+    Tests whether an A2A server's authentication can be bypassed by wrapping a
+    request in a JSON-RPC batch array.
+
+    The classic JSON-RPC batch bypass: an auth gate inspects the top-level request
+    object, but a JSON-RPC batch is an array and has no top-level method, so the
+    gate's check does not fire and the array is handed to the dispatcher, which
+    runs each element (CWE-288, authentication bypass via an alternate channel).
+    A2A enforces authentication at the HTTP layer (a rejected request returns HTTP
+    401/403), so the bypass shows up as a single request being rejected at the
+    transport while the identical request, batch-wrapped, reaches HTTP 200 and is
+    dispatched.
+
+    Detection sends the IDENTICAL request twice, differing only in batch wrapping,
+    for each protocol shape (A2A v1.0 GetTask, then the v0.3 tasks/get fallback):
+
+      1. Control: a plain JSON-RPC object, unauthenticated. It must be rejected
+         with HTTP 401/403 for there to be an auth gate to bypass.
+      2. Test: the same object as a one-element batch array, unauthenticated. A
+         CONFIRMED finding is raised only when it reaches HTTP 200 and the
+         dispatcher ran (the batch response carries a result or a non-auth
+         application error such as TaskNotFound).
+
+    A server that rejects the batch the same way, or rejects the array outright,
+    produces no finding.
+
+    SAFETY: the probe is a read-only GetTask for a guaranteed non-existent task id.
+    It never sends a message, creates, or mutates a task.
+
+    Currency: A2A v1.0 does not define JSON-RPC batching, so behaviour is
+    implementation-dependent; a generic JSON-RPC library processes batches unless
+    explicitly disabled. The rule applies to any A2A server that dispatches a batch
+    it received without authentication.
+
+  references:
+    - https://www.jsonrpc.org/specification#batch
+    - https://a2a-protocol.org/latest/specification/
+    - https://cwe.mitre.org/data/definitions/288.html
+
+  tags:
+    - a2a
+    - auth
+    - json-rpc
+    - batch
+    - bypass
+    - cwe-288
+
+attack:
+  protocol: a2a
+  type: a2a-jsonrpc-batch-bypass
+
+remediation: |
+  1. Reject JSON-RPC batch arrays unless batching is explicitly supported and
+     every element is independently authenticated and authorized.
+  2. Enforce authentication in a layer that runs before request-shape parsing, so a
+     single object and a batch array are subject to the same gate.
+  3. Do not gate on the top-level request method; an array has none, and per-method
+     checks must run per element.

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -18,7 +18,7 @@ pip install starlette uvicorn httpx mcp
 
 ## Server Registry
 
-The bundled rule set is **14 A2A + 15 MCP = 29 rules**. Every rule's primary
+The bundled rule set is **15 A2A + 15 MCP = 30 rules**. Every rule's primary
 validation is an in-process `net/http/httptest` harness in its Go
 `*_test.go` (multiple server postures: vulnerable must fire / patched / open /
 benign must stay silent). The Python servers below are optional standalone
@@ -34,6 +34,7 @@ fixtures for live-validation / manual smoke testing.
 | `a2a_card_trust_server.py` | 3105 | `a2a-card-trust-001` |
 | `a2a_extension_downgrade_server.py` | 3106 | `a2a-extension-downgrade-001` |
 | `a2a_push_binding_server.py` | 3107 | `a2a-push-binding-001` (two principals; needs two `--principal`s) |
+| `a2a_batch_bypass_server.py` | 3108 | `a2a-jsonrpc-batch-bypass-001` |
 | `mcp_unauth_resources_server.py` | 7787 | `mcp-resources-unauth-001` |
 | `mcp_oauth_dcr_server.py` | 7788 | `mcp-oauth-dcr-001` |
 | `mcp_oauth_audience_server.py` | 7785 | `mcp-oauth-audience-002` |
@@ -47,7 +48,7 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_dns_rebind_origin_server.py` | 7794 | `mcp-dns-rebind-origin-001` |
 | `mcp_batch_bypass_server.py` | 7795 | `mcp-jsonrpc-batch-bypass-001` |
 
-**Coverage.** 28 of the 29 rules have a standalone Python fixture above. The
+**Coverage.** 29 of the 30 rules have a standalone Python fixture above. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
 (`internal/attack/mcp/token_replay_test.go`); the same is true of the per-rule
 edge-case harnesses for every other rule. `mockserver.go` is a Go helper used by

--- a/testdata/a2a_batch_bypass_server.py
+++ b/testdata/a2a_batch_bypass_server.py
@@ -1,0 +1,62 @@
+"""
+Deliberately vulnerable A2A server for validating:
+  - a2a-jsonrpc-batch-bypass-001: authentication is enforced at the HTTP layer for
+    a single JSON-RPC request (HTTP 401) but BYPASSED when the same request is
+    wrapped in a one-element JSON-RPC batch array (CWE-288).
+
+A single unauthenticated JSON-RPC request is rejected with HTTP 401. A batch array
+is dispatched without any auth check: the gate keys on the top-level request, and
+a JSON-RPC batch array has none. A2A does not define batching, so a correct server
+should reject the array rather than dispatch it unauthenticated.
+
+The dispatched GetTask / tasks/get returns a TaskNotFound (-32001) application
+error for the probe's non-existent id, which is what proves the dispatcher ran
+past the auth gate.
+
+Validate against it:
+  python testdata/a2a_batch_bypass_server.py
+  batesian scan --target http://127.0.0.1:3108 \\
+      --rule-ids a2a-jsonrpc-batch-bypass-001 -v
+
+Endpoint: http://127.0.0.1:3108/
+"""
+import json
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route
+import uvicorn
+
+PORT = 3108
+
+
+def _task_not_found(req_id):
+    return {"jsonrpc": "2.0", "id": req_id, "error": {"code": -32001, "message": "Task not found"}}
+
+
+async def rpc_endpoint(request: Request) -> Response:
+    raw = await request.body()
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        return JSONResponse(
+            {"jsonrpc": "2.0", "id": None, "error": {"code": -32700, "message": "parse error"}},
+            status_code=400,
+        )
+    authed = request.headers.get("authorization") is not None
+
+    # VULNERABILITY: the HTTP auth gate is enforced only for single request
+    # objects. A JSON-RPC batch array is dispatched element-by-element with no
+    # auth check at all.
+    if isinstance(payload, list):
+        return JSONResponse([_task_not_found(obj.get("id")) for obj in payload])
+
+    if not authed:
+        return Response(status_code=401)
+    return JSONResponse(_task_not_found(payload.get("id")))
+
+
+app = Starlette(routes=[Route("/", rpc_endpoint, methods=["POST"])])
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="127.0.0.1", port=PORT, log_level="warning")


### PR DESCRIPTION
## Summary

Adds `a2a-jsonrpc-batch-bypass-001`, the **A2A counterpart** to the MCP batch-bypass rule shipped in #77. Same vulnerability class (CWE-288, JSON-RPC batch authentication bypass), but it targets **current A2A servers**: unlike MCP (which removed batching in 2025-06-18), A2A v1.0 does not define batching, so a generic JSON-RPC implementation processes a batch array unless explicitly disabled.

### The vulnerability
An auth gate keyed on the top-level request is skipped when the request is wrapped in a batch array (an array has no top-level method), so the dispatcher runs the element unauthenticated. A2A enforces auth at the **HTTP layer**, so the bypass shows up as a single request rejected with HTTP 401/403 while the identical request, batch-wrapped, reaches HTTP 200 and is dispatched.

### Detection (confirmed, with a control)
Sends the **identical** request twice (single object, then one-element batch array) for each protocol shape (v1.0 `GetTask`, then the v0.3 `tasks/get` fallback, matching `a2a-task-idor-001`). A **confirmed** finding requires the single object to be rejected with **401/403** but the batch to reach **200** with a dispatched response (a result or a non-auth application error such as `TaskNotFound`). **Safety:** the probe is a read-only `GetTask` for a non-existent task id; nothing is sent, created, or mutated.

## Research / due diligence
- Confirmed against the A2A spec that **authentication is HTTP-level** ("Example error codes: HTTP 401 Unauthorized"), and that A2A defines **no JSON-RPC auth error code**. Critically, A2A's `-32001` is *TaskNotFound*, not "unauthorized" as in MCP, so the MCP auth classifier could **not** be reused: this rule keys on HTTP 401/403 and auth-flavored error messages, never on numeric codes.
- Traced `a2a-task-idor-001` for the exact v1.0/v0.3 request shapes, headers (`A2A-Version: 1.0`), and the `baseURL + "/"` endpoint, and modeled the executor on it.
- Confirmed A2A v1.0 neither documents nor forbids batching (so the rule applies to current servers, not a legacy window).

## Validation (CONTRIBUTING checklist)
- **Unit tests** (4 postures): bypass fires confirmed/high; secure (batch gated too), fully-open (no gate), and non-A2A all stay silent.
- **Testdata fixture**: added `testdata/a2a_batch_bypass_server.py` (port 3108), registry updated.
- **Live validation**: a real scan against the running fixture produced the confirmed finding:
  ```
  [!] HIGH  A2A authentication bypassed by JSON-RPC batch wrapping
     evidence:
       shape: v1.0 GetTask
       single request: HTTP 401 (rejected, unauthenticated)
       batch [request]: HTTP 200 (processed)
       [{"jsonrpc":"2.0","id":"...","error":{"code":-32001,"message":"Task not found"}}]
  ```
- **Build / test / vet / lint**: `go build`, `go test ./...` (forced; all 30 rules, incl. the engine zero-egress dry-run test), `go vet`, and `golangci-lint` all pass with 0 issues. `gofmt` clean, no em-dashes.

## Counts
Rule set is now **30 (15 A2A + 15 MCP)**. Updated README, the A2A catalog (intro + table row + detail section), `testdata/README.md` (registry + coverage), and the goreleaser release header.
