### PR TITLE
feat(a2a): discover the JSON-RPC endpoint from the agent card

### DIFF
--- a/internal/attack/a2a/artifact_tamper.go
+++ b/internal/attack/a2a/artifact_tamper.go
@@ -42,7 +42,7 @@ func (e *ArtifactTamperExecutor) Execute(ctx context.Context, target string, opt
 	vars := attack.NewVars(target, opts.OOBListenerURL)
 	client := attack.NewHTTPClient(opts, vars)
 
-	endpoint := vars.BaseURL + "/"
+	endpoint, _ := resolveA2AEndpoint(ctx, client, vars.BaseURL)
 	a2aHeaders := map[string]string{"A2A-Version": "1.0"}
 
 	// Use a stable, recognizable task ID so the test is reproducible.

--- a/internal/attack/a2a/context_fixation.go
+++ b/internal/attack/a2a/context_fixation.go
@@ -58,7 +58,7 @@ func (e *ContextFixationExecutor) ExecuteChained(ctx context.Context, target str
 	}
 
 	vars := attack.NewVars(target, opts.OOBListenerURL)
-	endpoint := vars.BaseURL + "/"
+	endpoint, _ := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
 
 	clientA := principalClient(opts, vars, a)
 	clientB := principalClient(opts, vars, b)

--- a/internal/attack/a2a/delegation_integrity.go
+++ b/internal/attack/a2a/delegation_integrity.go
@@ -57,7 +57,7 @@ func (e *DelegationIntegrityExecutor) ExecuteChained(ctx context.Context, target
 	}
 
 	vars := attack.NewVars(target, opts.OOBListenerURL)
-	endpoint := vars.BaseURL + "/"
+	endpoint, _ := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
 
 	clientA := principalClient(opts, vars, a)
 	clientB := principalClient(opts, vars, b)

--- a/internal/attack/a2a/endpoint.go
+++ b/internal/attack/a2a/endpoint.go
@@ -1,0 +1,161 @@
+package a2a
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"strings"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// A2A agent cards declare where the JSON-RPC transport actually lives; it is not
+// required to be at the target root. resolveA2AEndpoint discovers that endpoint
+// the way a real client would, instead of assuming the root path. Without this,
+// every JSON-RPC rule silently misses a spec-compliant server that mounts its
+// JSON-RPC handler at, for example, /a2a/jsonrpc.
+
+// a2aDiscoveryCard parses only the agent-card fields needed to locate the
+// JSON-RPC endpoint, across both the v1.0 and v0.3 card shapes.
+type a2aDiscoveryCard struct {
+	// v1.0: each entry carries a protocolBinding ("JSONRPC" | "GRPC" | "HTTP+JSON").
+	SupportedInterfaces []a2aDiscoveryInterface `json:"supportedInterfaces"`
+	// v0.3: each entry carries a transport with the same vocabulary.
+	AdditionalInterfaces []a2aDiscoveryInterface `json:"additionalInterfaces"`
+	// v0.3 top-level service URL, usable only when preferredTransport is JSONRPC.
+	PreferredTransport string `json:"preferredTransport"`
+	URL                string `json:"url"`
+}
+
+type a2aDiscoveryInterface struct {
+	URL string `json:"url"`
+	// ProtocolBinding is the v1.0 field name; Transport is the v0.3 field name.
+	ProtocolBinding string `json:"protocolBinding"`
+	Transport       string `json:"transport"`
+	ProtocolVersion string `json:"protocolVersion"`
+}
+
+func (i a2aDiscoveryInterface) isJSONRPC() bool {
+	return strings.EqualFold(i.ProtocolBinding, "JSONRPC") || strings.EqualFold(i.Transport, "JSONRPC")
+}
+
+// resolveA2AEndpoint returns the JSON-RPC endpoint to probe and whether a usable
+// endpoint was found. It prefers the URL the agent card declares for the JSON-RPC
+// transport; failing that, it probes a small set of conventional paths. The
+// returned endpoint is always pinned to the target's scheme+host (see
+// pinToTargetHost), so a card that points elsewhere never redirects traffic off
+// the operator's authorized target. When ok is false, no JSON-RPC endpoint
+// responded and callers should not report the target as tested.
+func resolveA2AEndpoint(ctx context.Context, client *attack.HTTPClient, baseURL string) (endpoint string, ok bool) {
+	if card, found := fetchDiscoveryCard(ctx, client, baseURL); found {
+		if cardURL := selectJSONRPCURL(card); cardURL != "" {
+			return pinToTargetHost(cardURL, baseURL), true
+		}
+	}
+	for _, ep := range candidateEndpoints(baseURL) {
+		if probeJSONRPCEndpoint(ctx, client, ep) {
+			return ep, true
+		}
+	}
+	return baseURL + "/", false
+}
+
+// fetchDiscoveryCard retrieves and parses the public agent card, trying the v1.0
+// well-known path then the v0.3 legacy path.
+func fetchDiscoveryCard(ctx context.Context, client *attack.HTTPClient, baseURL string) (a2aDiscoveryCard, bool) {
+	for _, path := range []string{"/.well-known/agent-card.json", "/.well-known/agent.json"} {
+		resp, err := client.GET(ctx, baseURL+path, nil)
+		if err != nil || !resp.IsSuccess() {
+			continue
+		}
+		var card a2aDiscoveryCard
+		if err := json.Unmarshal(resp.Body, &card); err != nil {
+			continue
+		}
+		return card, true
+	}
+	return a2aDiscoveryCard{}, false
+}
+
+// selectJSONRPCURL picks the JSON-RPC service URL from a card. It checks the v1.0
+// supportedInterfaces, then the v0.3 additionalInterfaces, then the v0.3
+// top-level url (only when preferredTransport is JSONRPC). Scheme-less entries
+// (e.g. a gRPC "host:port") are skipped, since the JSON-RPC probe needs http(s).
+func selectJSONRPCURL(card a2aDiscoveryCard) string {
+	for _, iface := range card.SupportedInterfaces {
+		if iface.isJSONRPC() && hasHTTPScheme(iface.URL) {
+			return iface.URL
+		}
+	}
+	for _, iface := range card.AdditionalInterfaces {
+		if iface.isJSONRPC() && hasHTTPScheme(iface.URL) {
+			return iface.URL
+		}
+	}
+	if strings.EqualFold(card.PreferredTransport, "JSONRPC") && hasHTTPScheme(card.URL) {
+		return card.URL
+	}
+	return ""
+}
+
+// pinToTargetHost keeps the operator's target scheme+host and applies only the
+// card URL's path when the card points at a different host. A same-host card URL
+// is used verbatim. This prevents a card from redirecting scan traffic to a host
+// the operator did not authorize.
+func pinToTargetHost(cardURL, baseURL string) string {
+	cu, err := url.Parse(cardURL)
+	if err != nil {
+		return baseURL + "/"
+	}
+	tu, err := url.Parse(baseURL)
+	if err != nil {
+		return cardURL
+	}
+	if strings.EqualFold(cu.Host, tu.Host) {
+		return cardURL
+	}
+	pinned := *tu
+	pinned.Path = cu.Path
+	pinned.RawQuery = ""
+	return pinned.String()
+}
+
+// candidateEndpoints lists JSON-RPC paths to probe when the card does not declare
+// one. Root is first so servers that mount JSON-RPC at the root keep working.
+func candidateEndpoints(baseURL string) []string {
+	return []string{
+		baseURL + "/",
+		baseURL + "/a2a/jsonrpc",
+		baseURL + "/a2a",
+		baseURL + "/rpc",
+	}
+}
+
+// probeJSONRPCEndpoint reports whether a path answers JSON-RPC. It sends a
+// read-only GetTask for a non-existent task id and treats a JSON-RPC envelope
+// (result or error) or an auth rejection (401/403) as a live endpoint; a 404 or
+// transport error means this is not the endpoint.
+func probeJSONRPCEndpoint(ctx context.Context, client *attack.HTTPClient, endpoint string) bool {
+	resp, err := client.POST(ctx, endpoint, map[string]string{"A2A-Version": "1.0"}, map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      "batesian-a2a-discovery",
+		"method":  "GetTask",
+		"params":  map[string]interface{}{"id": "batesian-discovery-nonexistent", "historyLength": 1},
+	})
+	if err != nil {
+		return false
+	}
+	if resp.StatusCode == 401 || resp.StatusCode == 403 {
+		return true
+	}
+	if resp.StatusCode == 404 {
+		return false
+	}
+	return isJSONRPCError(resp.Body) || resp.ContainsAny(`"jsonrpc"`, `"result"`)
+}
+
+// hasHTTPScheme reports whether rawURL is an absolute http(s) URL.
+func hasHTTPScheme(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	return err == nil && (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""
+}

--- a/internal/attack/a2a/endpoint_test.go
+++ b/internal/attack/a2a/endpoint_test.go
@@ -1,0 +1,158 @@
+package a2a
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// referenceCard mirrors the hybrid v1.0+v0.3 card the official a2a-python sample
+// serves: gRPC is listed first (scheme-less) and is the top-level preferred
+// transport, while the JSON-RPC interface is what we must select.
+const referenceCard = `{
+  "name": "Sample Agent",
+  "supportedInterfaces": [
+    {"url": "127.0.0.1:50051", "protocolBinding": "GRPC", "protocolVersion": "1.0"},
+    {"url": "http://HOST/a2a/jsonrpc", "protocolBinding": "JSONRPC", "protocolVersion": "1.0"}
+  ],
+  "additionalInterfaces": [
+    {"transport": "JSONRPC", "url": "http://HOST/a2a/jsonrpc"}
+  ],
+  "preferredTransport": "GRPC",
+  "url": "127.0.0.1:50052"
+}`
+
+func parseDiscoveryCard(t *testing.T, s string) a2aDiscoveryCard {
+	t.Helper()
+	var c a2aDiscoveryCard
+	if err := json.Unmarshal([]byte(s), &c); err != nil {
+		t.Fatalf("bad test card: %v", err)
+	}
+	return c
+}
+
+func TestSelectJSONRPCURL_PrefersJSONRPCOverPreferredGRPC(t *testing.T) {
+	got := selectJSONRPCURL(parseDiscoveryCard(t, strings.ReplaceAll(referenceCard, "HOST", "h")))
+	if got != "http://h/a2a/jsonrpc" {
+		t.Errorf("selectJSONRPCURL = %q, want the JSONRPC interface url (not the gRPC top-level url)", got)
+	}
+}
+
+func TestSelectJSONRPCURL_V03AdditionalInterfaces(t *testing.T) {
+	card := parseDiscoveryCard(t, `{"additionalInterfaces":[{"transport":"HTTP+JSON","url":"http://h/rest"},{"transport":"JSONRPC","url":"http://h/jr"}]}`)
+	if got := selectJSONRPCURL(card); got != "http://h/jr" {
+		t.Errorf("selectJSONRPCURL = %q, want http://h/jr", got)
+	}
+}
+
+func TestSelectJSONRPCURL_V03TopLevel(t *testing.T) {
+	card := parseDiscoveryCard(t, `{"preferredTransport":"JSONRPC","url":"http://h/agent"}`)
+	if got := selectJSONRPCURL(card); got != "http://h/agent" {
+		t.Errorf("selectJSONRPCURL = %q, want http://h/agent", got)
+	}
+}
+
+func TestSelectJSONRPCURL_NoUsableInterface(t *testing.T) {
+	// Only a scheme-less gRPC interface and a gRPC top-level url: nothing usable.
+	card := parseDiscoveryCard(t, `{"supportedInterfaces":[{"url":"127.0.0.1:50051","protocolBinding":"GRPC"}],"preferredTransport":"GRPC","url":"127.0.0.1:50052"}`)
+	if got := selectJSONRPCURL(card); got != "" {
+		t.Errorf("selectJSONRPCURL = %q, want empty (no http JSON-RPC interface)", got)
+	}
+}
+
+func TestPinToTargetHost(t *testing.T) {
+	// Same host: used verbatim.
+	if got := pinToTargetHost("http://h:8080/a2a/jsonrpc", "http://h:8080"); got != "http://h:8080/a2a/jsonrpc" {
+		t.Errorf("same-host pin = %q", got)
+	}
+	// Different host: keep target scheme+host, take card path.
+	if got := pinToTargetHost("http://other:9000/a2a/jsonrpc", "http://h:8080"); got != "http://h:8080/a2a/jsonrpc" {
+		t.Errorf("cross-host pin = %q, want path applied to target host", got)
+	}
+}
+
+func newClient(target string) *attack.HTTPClient {
+	return attack.NewUnauthHTTPClient(attack.Options{TimeoutSeconds: 5}, attack.NewVars(target, ""))
+}
+
+// a2aMock serves an optional card and answers JSON-RPC at rpcPath (a TaskNotFound
+// error), 404 elsewhere.
+func a2aMock(card string, rpcPath string) *httptest.Server {
+	mux := http.NewServeMux()
+	if card != "" {
+		mux.HandleFunc("/.well-known/agent-card.json", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(card))
+		})
+	}
+	if rpcPath != "" {
+		mux.HandleFunc(rpcPath, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32001,"message":"Task not found"}}`))
+		})
+	}
+	return httptest.NewServer(mux)
+}
+
+func TestResolveA2AEndpoint_FromCard(t *testing.T) {
+	// Serve a card (declaring its own host for the JSON-RPC interface) so the
+	// same-host path is exercised: discovery must select the JSON-RPC interface
+	// even though gRPC is listed first and is the preferred/top-level transport.
+	var host string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/agent-card.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(strings.ReplaceAll(referenceCard, "HOST", host)))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	host = strings.TrimPrefix(srv.URL, "http://")
+
+	ep, ok := resolveA2AEndpoint(context.Background(), newClient(srv.URL), srv.URL)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if ep != srv.URL+"/a2a/jsonrpc" {
+		t.Errorf("endpoint = %q, want %s/a2a/jsonrpc", ep, srv.URL)
+	}
+}
+
+func TestResolveA2AEndpoint_FallbackToCardlessPath(t *testing.T) {
+	// No card; JSON-RPC mounted at /a2a/jsonrpc. Discovery must probe and find it.
+	srv := a2aMock("", "/a2a/jsonrpc")
+	defer srv.Close()
+	ep, ok := resolveA2AEndpoint(context.Background(), newClient(srv.URL), srv.URL)
+	if !ok || ep != srv.URL+"/a2a/jsonrpc" {
+		t.Errorf("endpoint = %q ok = %v, want %s/a2a/jsonrpc true", ep, ok, srv.URL)
+	}
+}
+
+func TestResolveA2AEndpoint_FallbackToRoot(t *testing.T) {
+	// No card; JSON-RPC at root, like our existing fixtures. Must resolve to "/".
+	srv := a2aMock("", "/")
+	defer srv.Close()
+	ep, ok := resolveA2AEndpoint(context.Background(), newClient(srv.URL), srv.URL)
+	if !ok || ep != srv.URL+"/" {
+		t.Errorf("endpoint = %q ok = %v, want %s/ true", ep, ok, srv.URL)
+	}
+}
+
+func TestResolveA2AEndpoint_NothingReachable(t *testing.T) {
+	// Server 404s everything: no JSON-RPC endpoint, ok must be false.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	if _, ok := resolveA2AEndpoint(context.Background(), newClient(srv.URL), srv.URL); ok {
+		t.Error("expected ok=false when no JSON-RPC endpoint responds")
+	}
+}

--- a/internal/attack/a2a/extcard.go
+++ b/internal/attack/a2a/extcard.go
@@ -54,7 +54,8 @@ func (e *ExtCardExecutor) Execute(ctx context.Context, target string, opts attac
 	// JSON-RPC transport - the primary path in the current SDK. Both / and
 	// /v1/message:send are tried since the endpoint varies by binding type. One
 	// finding max, preferring the invalid-token (critical) signal.
-	for _, ep := range []string{vars.BaseURL + "/", vars.BaseURL + "/v1/message:send"} {
+	jsonrpcEP, _ := resolveA2AEndpoint(ctx, unauthClient, vars.BaseURL)
+	for _, ep := range []string{jsonrpcEP, vars.BaseURL + "/v1/message:send"} {
 		if resp, ok := e.probeJSONRPC(ctx, unauthClient, ep, invalidToken, vars.RandID); ok {
 			findings = append(findings, e.finding("JSON-RPC", ep, invalidToken, resp))
 			break

--- a/internal/attack/a2a/extension_downgrade.go
+++ b/internal/attack/a2a/extension_downgrade.go
@@ -60,7 +60,7 @@ func (e *ExtensionDowngradeExecutor) Execute(ctx context.Context, target string,
 	if len(required) == 0 {
 		return nil, nil // no required extension advertised => nothing to downgrade
 	}
-	endpoint := vars.BaseURL + "/"
+	endpoint, _ := resolveA2AEndpoint(ctx, client, vars.BaseURL)
 
 	for _, uri := range required {
 		// Control: activate the required extension. If even this is rejected we

--- a/internal/attack/a2a/jsonrpc_batch_bypass.go
+++ b/internal/attack/a2a/jsonrpc_batch_bypass.go
@@ -47,10 +47,10 @@ func NewBatchBypassExecutor(r attack.RuleContext) *BatchBypassExecutor {
 
 func (e *BatchBypassExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
 	vars := attack.NewVars(target, opts.OOBListenerURL)
-	endpoint := vars.BaseURL + "/"
 	// Deliberately unauthenticated: the rule tests whether a batch slips past the
 	// server's auth gate. Injecting opts.Token would mask the bypass.
 	client := attack.NewUnauthHTTPClient(opts, vars)
+	endpoint, _ := resolveA2AEndpoint(ctx, client, vars.BaseURL)
 
 	bogusTask := "batesian-nonexistent-" + vars.RandID
 

--- a/internal/attack/a2a/multitenant_isolation.go
+++ b/internal/attack/a2a/multitenant_isolation.go
@@ -57,7 +57,7 @@ func (e *MultiTenantIsolationExecutor) ExecuteChained(ctx context.Context, targe
 	}
 
 	vars := attack.NewVars(target, opts.OOBListenerURL)
-	endpoint := vars.BaseURL + "/"
+	endpoint, _ := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
 
 	clientA := principalClient(opts, vars, a)
 	clientB := principalClient(opts, vars, b)

--- a/internal/attack/a2a/peer_impersonation.go
+++ b/internal/attack/a2a/peer_impersonation.go
@@ -48,7 +48,7 @@ func (e *PeerImpersonationExecutor) Execute(ctx context.Context, target string, 
 	client := attack.NewHTTPClient(opts, vars)
 	unauthClient := attack.NewUnauthHTTPClient(opts, vars)
 
-	endpoint := vars.BaseURL + "/"
+	endpoint, _ := resolveA2AEndpoint(ctx, unauthClient, vars.BaseURL)
 
 	// Step 1: Probe the agent card to find a plausible agent name to impersonate.
 	agentName := "trusted-orchestrator"

--- a/internal/attack/a2a/push_binding.go
+++ b/internal/attack/a2a/push_binding.go
@@ -51,7 +51,7 @@ func (e *PushBindingExecutor) ExecuteChained(ctx context.Context, target string,
 	}
 
 	vars := attack.NewVars(target, opts.OOBListenerURL)
-	endpoint := vars.BaseURL + "/"
+	endpoint, _ := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
 	clientA := principalClient(opts, vars, a)
 	clientB := principalClient(opts, vars, b)
 	unauthClient := attack.NewUnauthHTTPClient(opts, attack.NewVars(target, opts.OOBListenerURL))

--- a/internal/attack/a2a/push_ssrf.go
+++ b/internal/attack/a2a/push_ssrf.go
@@ -62,6 +62,7 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 	}
 
 	client := attack.NewHTTPClient(opts, vars)
+	endpoint, _ := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
 	callbackURL := listenerURL + "/batesian-" + vars.RandID
 	token := "batesian-" + vars.RandID
 
@@ -74,7 +75,7 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 	a2aHeaders := map[string]string{"A2A-Version": "1.0"}
 
 	// Attempt 1: A2A-sdk v1.0 two-step: SendMessage then CreateTaskPushNotificationConfig
-	sendResp, err := client.POST(ctx, vars.BaseURL+"/", a2aHeaders, map[string]interface{}{
+	sendResp, err := client.POST(ctx, endpoint, a2aHeaders, map[string]interface{}{
 		"jsonrpc": "2.0",
 		"id":      "batesian-sm-" + vars.RandID,
 		"method":  "SendMessage",
@@ -90,7 +91,7 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 		// Got a task - try to register push notification config for it
 		taskID, _ := extractTaskContext(sendResp.Body)
 		if taskID != "" {
-			pushResp, pushErr := client.POST(ctx, vars.BaseURL+"/", a2aHeaders, map[string]interface{}{
+			pushResp, pushErr := client.POST(ctx, endpoint, a2aHeaders, map[string]interface{}{
 				"jsonrpc": "2.0",
 				"id":      "batesian-push-" + vars.RandID,
 				"method":  "CreateTaskPushNotificationConfig",
@@ -109,7 +110,7 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 
 	// Attempt 2: Legacy JSONRPC v0.3 tasks/send with embedded pushNotification config
 	if !taskAccepted {
-		jsonrpcResp, err2 := client.POST(ctx, vars.BaseURL+"/", map[string]string{}, buildJSONRPCRequest(callbackURL, token, vars.RandID))
+		jsonrpcResp, err2 := client.POST(ctx, endpoint, map[string]string{}, buildJSONRPCRequest(callbackURL, token, vars.RandID))
 		if err2 == nil && jsonrpcResp.IsSuccess() && !isJSONRPCError(jsonrpcResp.Body) &&
 			jsonrpcResp.ContainsAny(`"result"`) {
 			taskAccepted = true

--- a/internal/attack/a2a/session_smuggle.go
+++ b/internal/attack/a2a/session_smuggle.go
@@ -51,7 +51,8 @@ func (e *SessionSmuggleExecutor) Execute(ctx context.Context, target string, opt
 
 	// The A2A JSON-RPC endpoint is POST / in most implementations.
 	// Some HTTP+JSON bindings also use /v1/message:send.
-	endpoints := []string{vars.BaseURL + "/", vars.BaseURL + "/v1/message:send"}
+	jsonrpcEP, _ := resolveA2AEndpoint(ctx, client, vars.BaseURL)
+	endpoints := []string{jsonrpcEP, vars.BaseURL + "/v1/message:send"}
 
 	// A2A-sdk v1.0.x uses gRPC-style PascalCase methods and requires
 	// the A2A-Version: 1.0 header. Role is passed as an integer enum:

--- a/internal/attack/a2a/task_idor.go
+++ b/internal/attack/a2a/task_idor.go
@@ -42,7 +42,7 @@ func NewTaskIDORExecutor(r attack.RuleContext) *TaskIDORExecutor {
 
 func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
 	vars := attack.NewVars(target, opts.OOBListenerURL)
-	endpoint := vars.BaseURL + "/"
+	endpoint, _ := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
 	var findings []attack.Finding
 
 	authedClient := attack.NewHTTPClient(opts, vars)


### PR DESCRIPTION
## Summary

**PR 1 of 3** fixing the A2A effectiveness gaps found by validating against the official `a2a-python` reference server.

A2A JSON-RPC executors hardcoded the endpoint as `target + "/"`. Against a spec-compliant server that mounts JSON-RPC at a non-root path — e.g. `/a2a/jsonrpc`, which the official reference server uses and **declares in its agent card** — every JSON-RPC rule POSTed to root, got **404**, and silently found nothing. The scan then printed "appears clean" having tested nothing (a false negative by construction). Our own test suite never caught this because every fixture serves JSON-RPC at root, matching the executor's assumption.

## Fix

A shared `resolveA2AEndpoint` helper that discovers the endpoint the way a real client does:
1. Fetch the agent card (`/.well-known/agent-card.json`, then `/.well-known/agent.json`).
2. Select the **JSON-RPC** interface: v1.0 `supportedInterfaces[]` where `protocolBinding=="JSONRPC"`, then v0.3 `additionalInterfaces[]` where `transport=="JSONRPC"`, then the top-level `url` when `preferredTransport=="JSONRPC"`. Scheme-less entries (e.g. the gRPC interface, `host:port`) are skipped. *(This matters: in the reference card the top-level `url` is the gRPC endpoint, so a naive "use the card url" would break.)*
3. Fallback to conventional paths when no card declares one — `/`, `/a2a/jsonrpc`, `/a2a`, `/rpc` — **root first**, so existing root-mounted servers/fixtures keep working.

**Cross-host safety (per your decision):** a card URL pointing at a different host than `--target` is pinned to the target's scheme+host (only its path is used), so a card can never redirect scan traffic to a host the operator didn't authorize.

Wired into all 12 A2A JSON-RPC executors, replacing the hardcoded root.

## Validation
- **Unit:** 9 new tests for the helper (v1.0 / v0.3 selection, gRPC-skip, cross-host pinning, card-based + cardless-path + root fallback, nothing-reachable).
- **No regression:** the full A2A suite passes (fixtures fall through to the root candidate).
- **Live reference server:** before, the scan returned 1 finding and JSON-RPC rules hit root → 404. After, the rules reach `/a2a/jsonrpc` (**16 requests, all 200**) and surface a real finding — `a2a-session-smuggle-001` (HIGH), the reference server honoring a client-supplied `role:"agent"` message — that was previously invisible.
- `go build` / `vet` / `golangci-lint` (0 issues) / `go test ./...` all pass; no em-dashes.

## Scope
This is the endpoint-discovery fix only. PR2 will make reporting honest (distinguish "no endpoint reachable" from "tested clean", using the `ok` signal this helper already returns). PR3 will fix the latent `protocol/a2a` `GetServiceURL()` `[0]`-selection bug on the probe side.
