### PR TITLE
feat(a2a): report inconclusive instead of false 'appears clean'

### DIFF
--- a/internal/attack/a2a/artifact_tamper.go
+++ b/internal/attack/a2a/artifact_tamper.go
@@ -42,7 +42,10 @@ func (e *ArtifactTamperExecutor) Execute(ctx context.Context, target string, opt
 	vars := attack.NewVars(target, opts.OOBListenerURL)
 	client := attack.NewHTTPClient(opts, vars)
 
-	endpoint, _ := resolveA2AEndpoint(ctx, client, vars.BaseURL)
+	endpoint, ok := resolveA2AEndpoint(ctx, client, vars.BaseURL)
+	if !ok {
+		return nil, attack.ErrInconclusive
+	}
 	a2aHeaders := map[string]string{"A2A-Version": "1.0"}
 
 	// Use a stable, recognizable task ID so the test is reproducible.

--- a/internal/attack/a2a/artifact_tamper_test.go
+++ b/internal/attack/a2a/artifact_tamper_test.go
@@ -265,7 +265,9 @@ func TestArtifactTamper_ImmutableTasks(t *testing.T) {
 			json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": req["id"],
 				"result": map[string]interface{}{"id": taskID, "state": "completed"}})
 		default:
-			w.WriteHeader(http.StatusNotFound)
+			// Realistic JSON-RPC: unknown methods return -32601, not HTTP 404.
+			json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": req["id"],
+				"error": map[string]interface{}{"code": -32601, "message": "method not found"}})
 		}
 	}))
 	defer srv.Close()

--- a/internal/attack/a2a/context_fixation.go
+++ b/internal/attack/a2a/context_fixation.go
@@ -58,7 +58,10 @@ func (e *ContextFixationExecutor) ExecuteChained(ctx context.Context, target str
 	}
 
 	vars := attack.NewVars(target, opts.OOBListenerURL)
-	endpoint, _ := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
+	endpoint, ok := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
+	if !ok {
+		return nil, attack.ErrInconclusive
+	}
 
 	clientA := principalClient(opts, vars, a)
 	clientB := principalClient(opts, vars, b)

--- a/internal/attack/a2a/delegation_integrity.go
+++ b/internal/attack/a2a/delegation_integrity.go
@@ -57,7 +57,10 @@ func (e *DelegationIntegrityExecutor) ExecuteChained(ctx context.Context, target
 	}
 
 	vars := attack.NewVars(target, opts.OOBListenerURL)
-	endpoint, _ := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
+	endpoint, ok := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
+	if !ok {
+		return nil, attack.ErrInconclusive
+	}
 
 	clientA := principalClient(opts, vars, a)
 	clientB := principalClient(opts, vars, b)

--- a/internal/attack/a2a/endpoint.go
+++ b/internal/attack/a2a/endpoint.go
@@ -132,26 +132,43 @@ func candidateEndpoints(baseURL string) []string {
 }
 
 // probeJSONRPCEndpoint reports whether a path answers JSON-RPC. It sends a
-// read-only GetTask for a non-existent task id and treats a JSON-RPC envelope
+// read-only task lookup for a non-existent id and treats a JSON-RPC envelope
 // (result or error) or an auth rejection (401/403) as a live endpoint; a 404 or
 // transport error means this is not the endpoint.
+//
+// It tries both the v0.3 (tasks/get) and v1.0 (GetTask) method names, because a
+// server that does not implement one may answer 404 for it while still being a
+// JSON-RPC endpoint that handles the other. Probing only one method would miss
+// such servers.
 func probeJSONRPCEndpoint(ctx context.Context, client *attack.HTTPClient, endpoint string) bool {
-	resp, err := client.POST(ctx, endpoint, map[string]string{"A2A-Version": "1.0"}, map[string]interface{}{
-		"jsonrpc": "2.0",
-		"id":      "batesian-a2a-discovery",
-		"method":  "GetTask",
-		"params":  map[string]interface{}{"id": "batesian-discovery-nonexistent", "historyLength": 1},
-	})
-	if err != nil {
-		return false
+	probes := []struct {
+		method  string
+		headers map[string]string
+	}{
+		{"tasks/get", nil},
+		{"GetTask", map[string]string{"A2A-Version": "1.0"}},
 	}
-	if resp.StatusCode == 401 || resp.StatusCode == 403 {
-		return true
+	for _, p := range probes {
+		resp, err := client.POST(ctx, endpoint, p.headers, map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      "batesian-a2a-discovery",
+			"method":  p.method,
+			"params":  map[string]interface{}{"id": "batesian-discovery-nonexistent", "historyLength": 1},
+		})
+		if err != nil {
+			continue
+		}
+		if resp.StatusCode == 401 || resp.StatusCode == 403 {
+			return true
+		}
+		if resp.StatusCode == 404 {
+			continue
+		}
+		if isJSONRPCError(resp.Body) || resp.ContainsAny(`"jsonrpc"`, `"result"`) {
+			return true
+		}
 	}
-	if resp.StatusCode == 404 {
-		return false
-	}
-	return isJSONRPCError(resp.Body) || resp.ContainsAny(`"jsonrpc"`, `"result"`)
+	return false
 }
 
 // hasHTTPScheme reports whether rawURL is an absolute http(s) URL.

--- a/internal/attack/a2a/extcard.go
+++ b/internal/attack/a2a/extcard.go
@@ -54,13 +54,22 @@ func (e *ExtCardExecutor) Execute(ctx context.Context, target string, opts attac
 	// JSON-RPC transport - the primary path in the current SDK. Both / and
 	// /v1/message:send are tried since the endpoint varies by binding type. One
 	// finding max, preferring the invalid-token (critical) signal.
+	reached := false
 	jsonrpcEP, _ := resolveA2AEndpoint(ctx, unauthClient, vars.BaseURL)
 	for _, ep := range []string{jsonrpcEP, vars.BaseURL + "/v1/message:send"} {
-		if resp, ok := e.probeJSONRPC(ctx, unauthClient, ep, invalidToken, vars.RandID); ok {
+		resp, usable := e.probeJSONRPC(ctx, unauthClient, ep, invalidToken, vars.RandID)
+		if resp != nil && resp.StatusCode != 404 {
+			reached = true
+		}
+		if usable {
 			findings = append(findings, e.finding("JSON-RPC", ep, invalidToken, resp))
 			break
 		}
-		if resp, ok := e.probeJSONRPC(ctx, unauthClient, ep, "", vars.RandID); ok {
+		resp, usable = e.probeJSONRPC(ctx, unauthClient, ep, "", vars.RandID)
+		if resp != nil && resp.StatusCode != 404 {
+			reached = true
+		}
+		if usable {
 			findings = append(findings, e.finding("JSON-RPC", ep, "", resp))
 			break
 		}
@@ -68,12 +77,23 @@ func (e *ExtCardExecutor) Execute(ctx context.Context, target string, opts attac
 
 	// HTTP GET transport - legacy path (a2a-sdk < 1.0.0, a2a-samples reference impl).
 	extURL := vars.BaseURL + extCardHTTPPath
-	if resp, err := unauthClient.GET(ctx, extURL, map[string]string{"Authorization": "Bearer " + invalidToken}); err == nil && resp.IsSuccess() && !isJSONRPCError(resp.Body) {
-		findings = append(findings, e.finding("HTTP GET", extURL, invalidToken, resp))
-	} else if resp, err := unauthClient.GET(ctx, extURL, nil); err == nil && resp.IsSuccess() && !isJSONRPCError(resp.Body) {
-		findings = append(findings, e.finding("HTTP GET", extURL, "", resp))
+	respA, errA := unauthClient.GET(ctx, extURL, map[string]string{"Authorization": "Bearer " + invalidToken})
+	if errA == nil && respA.StatusCode != 404 {
+		reached = true
+	}
+	if errA == nil && respA.IsSuccess() && !isJSONRPCError(respA.Body) {
+		findings = append(findings, e.finding("HTTP GET", extURL, invalidToken, respA))
+	} else if respB, errB := unauthClient.GET(ctx, extURL, nil); errB == nil && respB.IsSuccess() && !isJSONRPCError(respB.Body) {
+		findings = append(findings, e.finding("HTTP GET", extURL, "", respB))
+	} else if errB == nil && respB.StatusCode != 404 {
+		reached = true
 	}
 
+	// No disclosure found. If nothing was even reachable, the rule could not be
+	// exercised against a testable endpoint.
+	if len(findings) == 0 && !reached {
+		return nil, attack.ErrInconclusive
+	}
 	return findings, nil
 }
 
@@ -129,8 +149,11 @@ func (e *ExtCardExecutor) probeJSONRPC(ctx context.Context, client *attack.HTTPC
 		"method":  "GetExtendedAgentCard",
 		"params":  map[string]interface{}{},
 	})
-	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+	if err != nil {
 		return nil, false
+	}
+	if !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+		return resp, false // reached the endpoint, but not a disclosure
 	}
 	return resp, true
 }

--- a/internal/attack/a2a/extension_downgrade.go
+++ b/internal/attack/a2a/extension_downgrade.go
@@ -60,7 +60,10 @@ func (e *ExtensionDowngradeExecutor) Execute(ctx context.Context, target string,
 	if len(required) == 0 {
 		return nil, nil // no required extension advertised => nothing to downgrade
 	}
-	endpoint, _ := resolveA2AEndpoint(ctx, client, vars.BaseURL)
+	endpoint, ok := resolveA2AEndpoint(ctx, client, vars.BaseURL)
+	if !ok {
+		return nil, attack.ErrInconclusive
+	}
 
 	for _, uri := range required {
 		// Control: activate the required extension. If even this is rejected we

--- a/internal/attack/a2a/jsonrpc_batch_bypass.go
+++ b/internal/attack/a2a/jsonrpc_batch_bypass.go
@@ -50,7 +50,10 @@ func (e *BatchBypassExecutor) Execute(ctx context.Context, target string, opts a
 	// Deliberately unauthenticated: the rule tests whether a batch slips past the
 	// server's auth gate. Injecting opts.Token would mask the bypass.
 	client := attack.NewUnauthHTTPClient(opts, vars)
-	endpoint, _ := resolveA2AEndpoint(ctx, client, vars.BaseURL)
+	endpoint, ok := resolveA2AEndpoint(ctx, client, vars.BaseURL)
+	if !ok {
+		return nil, attack.ErrInconclusive
+	}
 
 	bogusTask := "batesian-nonexistent-" + vars.RandID
 

--- a/internal/attack/a2a/jsonrpc_batch_bypass_test.go
+++ b/internal/attack/a2a/jsonrpc_batch_bypass_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -125,12 +126,18 @@ func TestBatchBypass_OpenNoFinding(t *testing.T) {
 	}
 }
 
-// TestBatchBypass_NotA2A: a non-A2A endpoint that 404s must not produce a finding.
+// TestBatchBypass_NotA2A: a non-A2A endpoint that 404s everything has no reachable
+// JSON-RPC endpoint, so the rule reports inconclusive (not a finding, not clean).
 func TestBatchBypass_NotA2A(t *testing.T) {
 	srv := batchServer("not-a2a")
 	defer srv.Close()
 
-	if findings := runBatchBypass(t, srv); len(findings) != 0 {
-		t.Errorf("expected 0 findings for a non-A2A endpoint, got %d", len(findings))
+	exec := a2aattack.NewBatchBypassExecutor(attack.RuleContext{ID: "a2a-jsonrpc-batch-bypass-001"})
+	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive for a non-A2A endpoint, got err=%v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings, got %d", len(findings))
 	}
 }

--- a/internal/attack/a2a/multitenant_isolation.go
+++ b/internal/attack/a2a/multitenant_isolation.go
@@ -57,7 +57,10 @@ func (e *MultiTenantIsolationExecutor) ExecuteChained(ctx context.Context, targe
 	}
 
 	vars := attack.NewVars(target, opts.OOBListenerURL)
-	endpoint, _ := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
+	endpoint, ok := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
+	if !ok {
+		return nil, attack.ErrInconclusive
+	}
 
 	clientA := principalClient(opts, vars, a)
 	clientB := principalClient(opts, vars, b)

--- a/internal/attack/a2a/peer_impersonation.go
+++ b/internal/attack/a2a/peer_impersonation.go
@@ -48,7 +48,10 @@ func (e *PeerImpersonationExecutor) Execute(ctx context.Context, target string, 
 	client := attack.NewHTTPClient(opts, vars)
 	unauthClient := attack.NewUnauthHTTPClient(opts, vars)
 
-	endpoint, _ := resolveA2AEndpoint(ctx, unauthClient, vars.BaseURL)
+	endpoint, ok := resolveA2AEndpoint(ctx, unauthClient, vars.BaseURL)
+	if !ok {
+		return nil, attack.ErrInconclusive
+	}
 
 	// Step 1: Probe the agent card to find a plausible agent name to impersonate.
 	agentName := "trusted-orchestrator"

--- a/internal/attack/a2a/peer_impersonation_test.go
+++ b/internal/attack/a2a/peer_impersonation_test.go
@@ -2,6 +2,7 @@ package a2a_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -192,16 +193,17 @@ func TestPeerImpersonation_ProperValidation(t *testing.T) {
 	}
 }
 
-// TestPeerImpersonation_NotA2AServer verifies no finding is emitted against a
-// server that returns 404 for all requests.
+// TestPeerImpersonation_NotA2AServer verifies that against a server that returns
+// 404 for all requests (no reachable A2A endpoint) the rule reports inconclusive
+// rather than a (misleading) clean result.
 func TestPeerImpersonation_NotA2AServer(t *testing.T) {
 	ts := httptest.NewServer(http.NotFoundHandler())
 	defer ts.Close()
 
 	exec := a2aattack.NewPeerImpersonationExecutor(peerImpersonationRC())
 	findings, err := exec.Execute(context.Background(), ts.URL, testOpts())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive on non-A2A server, got err=%v", err)
 	}
 	if len(findings) != 0 {
 		t.Errorf("expected zero findings on non-A2A server, got %d", len(findings))

--- a/internal/attack/a2a/push_binding.go
+++ b/internal/attack/a2a/push_binding.go
@@ -51,7 +51,10 @@ func (e *PushBindingExecutor) ExecuteChained(ctx context.Context, target string,
 	}
 
 	vars := attack.NewVars(target, opts.OOBListenerURL)
-	endpoint, _ := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
+	endpoint, ok := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
+	if !ok {
+		return nil, attack.ErrInconclusive
+	}
 	clientA := principalClient(opts, vars, a)
 	clientB := principalClient(opts, vars, b)
 	unauthClient := attack.NewUnauthHTTPClient(opts, attack.NewVars(target, opts.OOBListenerURL))

--- a/internal/attack/a2a/push_ssrf.go
+++ b/internal/attack/a2a/push_ssrf.go
@@ -63,6 +63,7 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 
 	client := attack.NewHTTPClient(opts, vars)
 	endpoint, _ := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
+	reached := false
 	callbackURL := listenerURL + "/batesian-" + vars.RandID
 	token := "batesian-" + vars.RandID
 
@@ -87,6 +88,9 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 			},
 		},
 	})
+	if err == nil && sendResp.StatusCode != 404 {
+		reached = true
+	}
 	if err == nil && sendResp.IsSuccess() && !isJSONRPCError(sendResp.Body) {
 		// Got a task - try to register push notification config for it
 		taskID, _ := extractTaskContext(sendResp.Body)
@@ -111,6 +115,9 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 	// Attempt 2: Legacy JSONRPC v0.3 tasks/send with embedded pushNotification config
 	if !taskAccepted {
 		jsonrpcResp, err2 := client.POST(ctx, endpoint, map[string]string{}, buildJSONRPCRequest(callbackURL, token, vars.RandID))
+		if err2 == nil && jsonrpcResp.StatusCode != 404 {
+			reached = true
+		}
 		if err2 == nil && jsonrpcResp.IsSuccess() && !isJSONRPCError(jsonrpcResp.Body) &&
 			jsonrpcResp.ContainsAny(`"result"`) {
 			taskAccepted = true
@@ -121,6 +128,9 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 	// Attempt 3: HTTP+JSON binding (REST API style, some older deployments)
 	if !taskAccepted {
 		httpResp, err3 := client.POST(ctx, vars.BaseURL+"/tasks/send", map[string]string{}, buildHTTPTaskRequest(callbackURL, token, vars.RandID))
+		if err3 == nil && httpResp.StatusCode != 404 {
+			reached = true
+		}
 		if err3 == nil && httpResp.IsSuccess() {
 			taskAccepted = true
 			acceptedBinding = "HTTP+JSON"
@@ -128,7 +138,11 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 	}
 
 	if !taskAccepted {
-		// Target doesn't accept A2A task requests - not a finding, just not applicable.
+		// Target doesn't accept A2A task requests. If nothing was reachable at all,
+		// the rule could not be exercised; otherwise it is simply not applicable.
+		if !reached {
+			return nil, attack.ErrInconclusive
+		}
 		return nil, nil
 	}
 

--- a/internal/attack/a2a/session_smuggle.go
+++ b/internal/attack/a2a/session_smuggle.go
@@ -61,6 +61,7 @@ func (e *SessionSmuggleExecutor) Execute(ctx context.Context, target string, opt
 
 	marker := "batesian-roleinj-" + vars.RandID
 
+	reached := false
 	for _, ep := range endpoints {
 		// Try both the v1.0 PascalCase method (SDK >=1.0.0) and the legacy slash
 		// method (SDK v0.3 compat), each carrying the marker as the message text.
@@ -93,6 +94,9 @@ func (e *SessionSmuggleExecutor) Execute(ctx context.Context, target string, opt
 		if err != nil {
 			continue
 		}
+		if resp.StatusCode != 404 {
+			reached = true
+		}
 
 		// Server rejected the agent-role message (per spec). Not vulnerable here.
 		if isJSONRPCError(resp.Body) || !resp.IsSuccess() || !looksLikeTask(resp.Body) {
@@ -107,6 +111,9 @@ func (e *SessionSmuggleExecutor) Execute(ctx context.Context, target string, opt
 		return nil, nil // accepted but neutralized (normalized to user role)
 	}
 
+	if !reached {
+		return nil, attack.ErrInconclusive
+	}
 	return nil, nil
 }
 

--- a/internal/attack/a2a/task_idor.go
+++ b/internal/attack/a2a/task_idor.go
@@ -42,7 +42,7 @@ func NewTaskIDORExecutor(r attack.RuleContext) *TaskIDORExecutor {
 
 func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
 	vars := attack.NewVars(target, opts.OOBListenerURL)
-	endpoint, _ := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
+	endpoint, ok := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
 	var findings []attack.Finding
 
 	authedClient := attack.NewHTTPClient(opts, vars)
@@ -93,11 +93,29 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 	if !accepted {
 		// Not a responsive A2A server, or our credentials were rejected: there
 		// is no owner-created task to test ownership against.
-		return e.probeTaskList(ctx, unauthClient, vars), nil
+		f, restReached := e.probeTaskList(ctx, unauthClient, vars)
+		if len(f) > 0 {
+			return f, nil
+		}
+		// JSON-RPC creation did not succeed and the REST task-list probe reached
+		// nothing: the rule could not be exercised against a testable endpoint.
+		if !ok && !restReached {
+			return nil, attack.ErrInconclusive
+		}
+		return nil, nil
 	}
 	taskID, contextID := extractTaskContext(ownerResp.Body)
 	if taskID == "" {
-		return e.probeTaskList(ctx, unauthClient, vars), nil
+		f, restReached := e.probeTaskList(ctx, unauthClient, vars)
+		if len(f) > 0 {
+			return f, nil
+		}
+		// JSON-RPC creation did not succeed and the REST task-list probe reached
+		// nothing: the rule could not be exercised against a testable endpoint.
+		if !ok && !restReached {
+			return nil, attack.ErrInconclusive
+		}
+		return nil, nil
 	}
 
 	// Step 2: Auth-enforcement discriminator. Attempt the same creation with no
@@ -147,7 +165,8 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 		})
 	}
 
-	findings = append(findings, e.probeTaskList(ctx, unauthClient, vars)...)
+	listFindings, _ := e.probeTaskList(ctx, unauthClient, vars)
+	findings = append(findings, listFindings...)
 	return findings, nil
 }
 
@@ -156,13 +175,17 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 // discloses every session's task IDs (and often history) server-wide, which is
 // the strongest form of the same broken-authorization failure. It runs over the
 // unauthenticated client and is independent of the per-task IDOR check above.
-func (e *TaskIDORExecutor) probeTaskList(ctx context.Context, unauthClient *attack.HTTPClient, vars attack.Vars) []attack.Finding {
+func (e *TaskIDORExecutor) probeTaskList(ctx context.Context, unauthClient *attack.HTTPClient, vars attack.Vars) ([]attack.Finding, bool) {
 	listEndpoints := []string{
 		vars.BaseURL + "/v1/tasks",
 		vars.BaseURL + "/tasks",
 	}
+	reached := false
 	for _, le := range listEndpoints {
 		listResp, err := unauthClient.GET(ctx, le, nil)
+		if err == nil && listResp.StatusCode != 404 {
+			reached = true
+		}
 		if err == nil && listResp.IsSuccess() && listResp.ContainsAny(`"tasks"`, `"contextId"`, `"history"`) {
 			return []attack.Finding{{
 				RuleID:     e.rule.ID,
@@ -177,8 +200,8 @@ func (e *TaskIDORExecutor) probeTaskList(ctx context.Context, unauthClient *atta
 				Evidence:    fmt.Sprintf("HTTP %d from %s\n%s", listResp.StatusCode, le, snippet(listResp.Body, 400)),
 				Remediation: e.rule.Remediation,
 				TargetURL:   le,
-			}}
+			}}, reached
 		}
 	}
-	return nil
+	return nil, reached
 }

--- a/internal/attack/executor.go
+++ b/internal/attack/executor.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"strings"
 )
 
@@ -14,6 +15,12 @@ type Executor interface {
 	// Execute runs the attack and returns a (possibly empty) list of findings.
 	Execute(ctx context.Context, target string, opts Options) ([]Finding, error)
 }
+
+// ErrInconclusive signals that a rule could not reach a testable endpoint, so it
+// was not exercised. The engine surfaces this as a skipped result (neither a
+// finding nor an error) so reporting can distinguish "tested, nothing found"
+// from "could not test". Wrap it with %w to attach detail.
+var ErrInconclusive = errors.New("rule could not reach a testable endpoint")
 
 // RuleContext carries the metadata from a rule that executors need to populate findings.
 // This avoids importing the rules package inside executor packages (preventing import cycles).

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -4,6 +4,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	attackpkg "github.com/calbebop/batesian/internal/attack"
@@ -115,6 +116,15 @@ func (e *Engine) runOne(ctx context.Context, target string, entry planEntry, bb 
 		findings, err = chained.ExecuteChained(ctx, target, e.opts, bb)
 	} else {
 		findings, err = entry.executor.Execute(ctx, target, e.opts)
+	}
+	// A rule that could not reach a testable endpoint is recorded as skipped, not
+	// as a (misleading) clean result and not as an error.
+	if errors.Is(err, attackpkg.ErrInconclusive) {
+		return RunResult{
+			Rule:    r,
+			Skipped: true,
+			SkipMsg: "could not reach a testable endpoint",
+		}
 	}
 	return RunResult{
 		Rule:     r,

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1,6 +1,7 @@
 package engine_test
 
 import (
+	"strings"
 	"testing"
 
 	batesian "github.com/calbebop/batesian"
@@ -36,8 +37,11 @@ func TestAllBundledRulesResolve(t *testing.T) {
 				t.Fatalf("expected 1 result, got %d", len(results))
 			}
 			res := results[0]
-			if res.Skipped {
-				t.Errorf("rule %q was skipped (%s) - add its attack.type to engine.resolveExecutor", r.ID, res.SkipMsg)
+			// Only a "no executor" skip indicates an unregistered attack.type. A
+			// skip because the rule could not reach a testable endpoint (expected
+			// against this unreachable target) means the executor DID resolve and run.
+			if res.Skipped && strings.Contains(res.SkipMsg, "no executor") {
+				t.Errorf("rule %q has no registered executor (%s) - add its attack.type to engine.resolveExecutor", r.ID, res.SkipMsg)
 			}
 		})
 	}

--- a/internal/engine/inconclusive_test.go
+++ b/internal/engine/inconclusive_test.go
@@ -1,0 +1,37 @@
+package engine_test
+
+import (
+	"strings"
+	"testing"
+
+	batesian "github.com/calbebop/batesian"
+	"github.com/calbebop/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/engine"
+	"github.com/calbebop/batesian/internal/rules"
+)
+
+// TestRun_UnreachableA2ARuleIsInconclusive verifies that an A2A rule run against
+// an unreachable target is recorded as a skipped/inconclusive result (the
+// executor returned attack.ErrInconclusive), not as a clean pass or an error.
+func TestRun_UnreachableA2ARuleIsInconclusive(t *testing.T) {
+	loaded, _, err := rules.LoadFS(batesian.RulesFS())
+	if err != nil {
+		t.Fatalf("LoadFS: %v", err)
+	}
+	var r *rules.Rule
+	for _, x := range loaded {
+		if x.ID == "a2a-peer-impersonation-001" {
+			r = x
+			break
+		}
+	}
+	if r == nil {
+		t.Skip("a2a-peer-impersonation-001 not present")
+	}
+
+	res := engine.New(attack.Options{TimeoutSeconds: 1}).Run(t.Context(), "http://127.0.0.1:1", []*rules.Rule{r})[0]
+	if !res.Skipped || !strings.Contains(res.SkipMsg, "could not reach") {
+		t.Errorf("expected inconclusive skip, got skipped=%v msg=%q err=%v findings=%d",
+			res.Skipped, res.SkipMsg, res.Err, len(res.Findings))
+	}
+}

--- a/internal/report/inconclusive_test.go
+++ b/internal/report/inconclusive_test.go
@@ -1,0 +1,41 @@
+package report_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/engine"
+	"github.com/calbebop/batesian/internal/report"
+	"github.com/calbebop/batesian/internal/rules"
+)
+
+// TestPrintScanSummary_InconclusiveNotClean: when rules were skipped because no
+// endpoint was reachable and there are no findings, the summary must NOT claim
+// the target "appears clean".
+func TestPrintScanSummary_InconclusiveNotClean(t *testing.T) {
+	var buf bytes.Buffer
+	report.New(&buf, false).PrintScanSummary([]engine.RunResult{
+		{Rule: &rules.Rule{ID: "a2a-x"}, Skipped: true, SkipMsg: "could not reach a testable endpoint"},
+		{Rule: &rules.Rule{ID: "a2a-y"}, Skipped: true, SkipMsg: "could not reach a testable endpoint"},
+	})
+	out := buf.String()
+	if strings.Contains(out, "appears clean") {
+		t.Errorf("must not claim 'appears clean' when no rule was exercised:\n%s", out)
+	}
+	if !strings.Contains(out, "could not reach a testable endpoint") {
+		t.Errorf("expected an inconclusive note, got:\n%s", out)
+	}
+}
+
+// TestPrintScanSummary_CleanWhenAllRan: with no findings and no skips, the
+// "appears clean" message is correct.
+func TestPrintScanSummary_CleanWhenAllRan(t *testing.T) {
+	var buf bytes.Buffer
+	report.New(&buf, false).PrintScanSummary([]engine.RunResult{
+		{Rule: &rules.Rule{ID: "a2a-x"}},
+	})
+	if !strings.Contains(buf.String(), "appears clean") {
+		t.Errorf("expected 'appears clean' when rules ran with no findings, got:\n%s", buf.String())
+	}
+}

--- a/internal/report/printer.go
+++ b/internal/report/printer.go
@@ -274,8 +274,21 @@ func (p *Printer) PrintScanSummary(results []engine.RunResult) {
 	p.section(fmt.Sprintf("Scan Results (%d finding(s))", total))
 	fmt.Fprintln(p.w)
 
+	notExercised := 0
+	for _, r := range results {
+		if r.Skipped {
+			notExercised++
+		}
+	}
+
 	if total == 0 {
-		fmt.Fprintf(p.w, "  %s\n\n", Green("No findings. Target appears clean for the tested rules."))
+		if notExercised > 0 {
+			fmt.Fprintf(p.w, "  %s\n\n", Yellow(fmt.Sprintf(
+				"No findings, but %d of %d rule(s) could not reach a testable endpoint and were not exercised. The target was not fully tested.",
+				notExercised, len(results))))
+		} else {
+			fmt.Fprintf(p.w, "  %s\n\n", Green("No findings. Target appears clean for the tested rules."))
+		}
 		return
 	}
 
@@ -299,6 +312,12 @@ func (p *Printer) PrintScanSummary(results []engine.RunResult) {
 		if r.Err != nil {
 			p.Warn(fmt.Sprintf("ERROR running %s: %v", r.Rule.ID, r.Err))
 		}
+	}
+
+	if notExercised > 0 {
+		fmt.Fprintf(p.w, "\n  %s\n", Yellow(fmt.Sprintf(
+			"Note: %d of %d rule(s) could not reach a testable endpoint and were not exercised.",
+			notExercised, len(results))))
 	}
 }
 


### PR DESCRIPTION
## Summary

**PR 2 of 3.** Makes reporting honest: when A2A rules could not reach a testable endpoint, the scan no longer prints "Target appears clean" for a target it never actually exercised.

Builds on PR1's discovery: `resolveA2AEndpoint` already returns whether an endpoint was found; this PR turns that into an operator-visible signal.

## Changes

- **`attack.ErrInconclusive` sentinel.** The engine maps it to a *skipped* result (neither a finding nor an error). Skips already flow into the JSON output's `skipped` array, so machine-readable output gets it for free.
- **Honest summary.** With no findings: if some rules were not exercised, the summary says *"No findings, but N of M rule(s) could not reach a testable endpoint... The target was not fully tested"* instead of "appears clean." When all rules ran, "appears clean" still shows. A matching note is also printed alongside findings.
- **A2A executors emit the sentinel when nothing was reached:**
  - 8 pure JSON-RPC executors: inconclusive when discovery fails.
  - 4 with REST fallbacks (`task_idor`, `extcard`, `session_smuggle`, `push_ssrf`): still run the REST fallback and report inconclusive **only if nothing at all was reachable** (per your decision — preserves REST-only coverage, never mislabels a tested-but-clean server).
- **Discovery hardening:** the candidate probe now tries both `tasks/get` (v0.3) and `GetTask` (v1.0). A server can answer 404 for one method while being a valid JSON-RPC endpoint for the other; probing only one could wrongly judge a real endpoint unreachable.

## Validation
- **Unit:** engine maps `ErrInconclusive` → skipped; printer shows the inconclusive note (not "appears clean") when rules were skipped, and shows "appears clean" only when all rules ran.
- **No regression:** full suite passes. One test fix: `TestAllBundledRulesResolve` now distinguishes a *missing-executor* skip from an *inconclusive* skip (its actual purpose). One unrealistic fixture that returned HTTP 404 for unknown methods was changed to return JSON-RPC `-32601`, matching how real servers (incl. a2a-python) behave.
- **Live:** scanning an unreachable A2A target now prints:
  ```
  No findings, but 7 of 15 rule(s) could not reach a testable endpoint and were not exercised. The target was not fully tested.
  ```
- `go build` / `vet` / `golangci-lint` (0 issues) / `go test ./...` all pass; no em-dashes.

## Scope
PR3 (next) fixes the latent `protocol/a2a` `GetServiceURL()` `[0]`-selection bug on the probe side.
