### PR TITLE
fix(probe): select the JSON-RPC interface in AgentCard.GetServiceURL

### DIFF
--- a/internal/protocol/a2a/card.go
+++ b/internal/protocol/a2a/card.go
@@ -2,6 +2,11 @@
 // Spec reference: https://a2a-protocol.org/latest/specification/
 package a2a
 
+import (
+	"net/url"
+	"strings"
+)
+
 // AgentCard is the agent's public identity document.
 // Served at GET /.well-known/agent-card.json (v1.0) or /.well-known/agent.json (v0.3 legacy).
 type AgentCard struct {
@@ -13,11 +18,20 @@ type AgentCard struct {
 	Skills       []AgentSkill      `json:"skills"`
 
 	// SupportedInterfaces lists the A2A service endpoints for this agent (v1.0).
-	// The first entry is the preferred endpoint.
+	// Order is not significant: the JSON-RPC interface is selected by binding, not
+	// by position (the first entry is frequently gRPC).
 	SupportedInterfaces []AgentInterface `json:"supportedInterfaces,omitempty"`
 
-	// URL is the v0.3 top-level service URL field. Still present in many deployed agents.
-	// Prefer SupportedInterfaces[0].URL when present.
+	// AdditionalInterfaces lists alternate-transport endpoints in v0.3 cards, each
+	// tagged with a transport rather than a protocolBinding.
+	AdditionalInterfaces []AgentInterface `json:"additionalInterfaces,omitempty"`
+
+	// PreferredTransport names the transport for the top-level URL in v0.3 cards
+	// (e.g. "JSONRPC", "GRPC").
+	PreferredTransport string `json:"preferredTransport,omitempty"`
+
+	// URL is the v0.3 top-level service URL field. Still present in many deployed
+	// agents; usable as the JSON-RPC endpoint only when PreferredTransport is JSONRPC.
 	URL string `json:"url,omitempty"`
 
 	// Required content-type defaults
@@ -37,19 +51,49 @@ type AgentCard struct {
 	Signatures []AgentCardSignature `json:"signatures,omitempty"`
 }
 
-// GetServiceURL returns the primary service URL, handling both v1.0 and v0.3 cards.
+// GetServiceURL returns the agent's JSON-RPC service URL, the transport batesian
+// speaks. It selects by binding rather than by position, because the first
+// supportedInterfaces entry is frequently gRPC (whose URL is often scheme-less).
+// Preference order: a v1.0 JSON-RPC interface, then a v0.3 additionalInterfaces
+// JSON-RPC entry, then the top-level url when preferredTransport is JSONRPC.
+// Failing that it returns the first http(s) interface, then the legacy url.
 func (c *AgentCard) GetServiceURL() string {
-	if len(c.SupportedInterfaces) > 0 {
-		return c.SupportedInterfaces[0].URL
+	for _, i := range c.SupportedInterfaces {
+		if strings.EqualFold(i.ProtocolBinding, "JSONRPC") && hasHTTPScheme(i.URL) {
+			return i.URL
+		}
+	}
+	for _, i := range c.AdditionalInterfaces {
+		if strings.EqualFold(i.Transport, "JSONRPC") && hasHTTPScheme(i.URL) {
+			return i.URL
+		}
+	}
+	if strings.EqualFold(c.PreferredTransport, "JSONRPC") && c.URL != "" {
+		return c.URL
+	}
+	// No JSON-RPC interface advertised; fall back to a usable URL for display.
+	for _, i := range c.SupportedInterfaces {
+		if hasHTTPScheme(i.URL) {
+			return i.URL
+		}
 	}
 	return c.URL
 }
 
-// AgentInterface describes a single A2A service endpoint (v1.0).
+// hasHTTPScheme reports whether rawURL is an absolute http(s) URL. gRPC interface
+// URLs are typically scheme-less "host:port" and are not usable for JSON-RPC.
+func hasHTTPScheme(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	return err == nil && (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""
+}
+
+// AgentInterface describes a single A2A service endpoint. v1.0 cards tag the
+// transport with protocolBinding; v0.3 additionalInterfaces use transport.
 type AgentInterface struct {
-	URL             string `json:"url"`             // required; absolute HTTPS URL
-	ProtocolBinding string `json:"protocolBinding"` // required; "JSONRPC" | "GRPC" | "HTTP+JSON"
-	ProtocolVersion string `json:"protocolVersion"` // required; e.g. "1.0"
+	URL             string `json:"url"`                       // required; absolute URL (http(s) for JSON-RPC)
+	ProtocolBinding string `json:"protocolBinding,omitempty"` // v1.0; "JSONRPC" | "GRPC" | "HTTP+JSON"
+	Transport       string `json:"transport,omitempty"`       // v0.3; same vocabulary as protocolBinding
+	ProtocolVersion string `json:"protocolVersion,omitempty"`
 	Tenant          string `json:"tenant,omitempty"`
 }
 

--- a/internal/protocol/a2a/card_test.go
+++ b/internal/protocol/a2a/card_test.go
@@ -151,6 +151,52 @@ func TestAgentCard_LegacyV03URL(t *testing.T) {
 	}
 }
 
+// TestGetServiceURL_SelectsJSONRPCNotFirstGRPC mirrors the official a2a-python
+// reference card: gRPC is listed first (scheme-less) and is the preferred/top-level
+// transport, but GetServiceURL must return the JSON-RPC interface, not the gRPC one.
+func TestGetServiceURL_SelectsJSONRPCNotFirstGRPC(t *testing.T) {
+	const cardJSON = `{
+		"name": "Sample Agent",
+		"supportedInterfaces": [
+			{"url": "127.0.0.1:50051", "protocolBinding": "GRPC", "protocolVersion": "1.0"},
+			{"url": "http://127.0.0.1:41241/a2a/jsonrpc", "protocolBinding": "JSONRPC", "protocolVersion": "1.0"}
+		],
+		"additionalInterfaces": [
+			{"transport": "JSONRPC", "url": "http://127.0.0.1:41241/a2a/jsonrpc"}
+		],
+		"preferredTransport": "GRPC",
+		"url": "127.0.0.1:50052"
+	}`
+	var card AgentCard
+	if err := json.Unmarshal([]byte(cardJSON), &card); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := card.GetServiceURL(); got != "http://127.0.0.1:41241/a2a/jsonrpc" {
+		t.Errorf("GetServiceURL() = %q, want the JSON-RPC interface (not the first/gRPC one)", got)
+	}
+}
+
+// TestGetServiceURL_V03AdditionalInterfaces selects the JSON-RPC entry from a v0.3
+// card's additionalInterfaces when no v1.0 supportedInterfaces JSON-RPC exists.
+func TestGetServiceURL_V03AdditionalInterfaces(t *testing.T) {
+	const cardJSON = `{
+		"name": "Legacy",
+		"additionalInterfaces": [
+			{"transport": "HTTP+JSON", "url": "http://h/rest"},
+			{"transport": "JSONRPC", "url": "http://h/jr"}
+		],
+		"preferredTransport": "GRPC",
+		"url": "h:50052"
+	}`
+	var card AgentCard
+	if err := json.Unmarshal([]byte(cardJSON), &card); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := card.GetServiceURL(); got != "http://h/jr" {
+		t.Errorf("GetServiceURL() = %q, want http://h/jr", got)
+	}
+}
+
 func TestAgentCard_FullV1(t *testing.T) {
 	var card AgentCard
 	if err := json.Unmarshal([]byte(fullV1CardJSON), &card); err != nil {


### PR DESCRIPTION
## Summary

**PR 3 of 3** (final), the probe-side counterpart to the endpoint-discovery fix.

`AgentCard.GetServiceURL()` returned `SupportedInterfaces[0].URL` — the *first* declared interface. On a real card (the a2a-python reference) the first interface is **gRPC**, whose URL is a scheme-less `host:port`, so `batesian probe` displayed the gRPC endpoint (`127.0.0.1:50052`) as the agent's service URL instead of the JSON-RPC one it actually speaks.

## Fix

Select by transport, not position (mirrors the attack-side selection from PR1):
- v1.0 `supportedInterfaces` with `protocolBinding == JSONRPC` (http scheme) →
- v0.3 `additionalInterfaces` with `transport == JSONRPC` →
- top-level `url` when `preferredTransport == JSONRPC` →
- fallback: first http(s) interface, then the legacy `url`.

Also added the `AdditionalInterfaces` and `PreferredTransport` fields and the v0.3 `transport` tag to the card model (so v0.3 cards parse), and a `hasHTTPScheme` guard so scheme-less gRPC URLs are skipped.

## Validation
- New tests: a gRPC-first reference-shaped card resolves to its JSON-RPC interface (not gRPC); a v0.3 card resolves via `additionalInterfaces`. The existing `GetServiceURL` tests are unchanged (they resolve via the fallback/legacy path).
- `go build` / `go test ./...` / `golangci-lint` (0 issues) / `gofmt` all pass; no em-dashes.
- **Live:** `probe` against the a2a-python sample now reports `URL  http://127.0.0.1:41241/a2a/jsonrpc` instead of the gRPC `:50052`.

This completes the 3-PR A2A series (endpoint discovery → reporting honesty → probe service URL).
