### PR TITLE
feat(a2a-task-cancel-idor-001): detect cross-principal task cancellation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -114,7 +114,7 @@ release:
     ## Batesian {{.Version}}
 
     Adversarial red-team CLI for AI agent protocols (A2A and MCP).
-    30 bundled attack rules (15 A2A + 15 MCP). Single binary. No runtime dependencies.
+    31 bundled attack rules (16 A2A + 15 MCP). Single binary. No runtime dependencies.
 
     ### Install
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ CLI for adversarial testing of [A2A](https://a2a-protocol.org) and [MCP](https:/
 
 ## What ships
 
-Bundled rules: **15 A2A, 15 MCP (30 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
+Bundled rules: **16 A2A, 15 MCP (31 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
 
-- [A2A rules](docs/rules-a2a.md) (15)
+- [A2A rules](docs/rules-a2a.md) (16)
 - [MCP rules](docs/rules-mcp.md) (15)
 
 Coverage spans:
@@ -29,7 +29,7 @@ Coverage spans:
 - **OAuth & token validation** - OAuth 2.1 / DCR scope escalation, audience binding, token replay, version-downgrade bypass, forged-token acceptance, redirect_uri confused deputy
 - **Agent-card trust (A2A)** - JWS signatures, canonicalization, cache/freshness, required-extension downgrade, host-header injection, unauthenticated extended card
 - **Request & task integrity** - task IDOR, agent-role injection, artifact tampering, SEP-2243 header/body routing, SSE resumption replay
-- **Multi-party isolation** - cross-tenant isolation, session/context fixation, delegation chain-of-custody
+- **Multi-party isolation** - cross-tenant isolation, session/context fixation, delegation chain-of-custody, cross-principal task cancellation
 - **SSRF & secret leakage** - push-notification SSRF, push control-plane binding, OAuth discovery/metadata SSRF, credential leakage into responses
 - **Unauthenticated & cross-origin access** - exposed MCP tools, resources, and prompt templates, Streamable HTTP Origin validation (DNS rebinding)
 

--- a/docs/rules-a2a.md
+++ b/docs/rules-a2a.md
@@ -1,6 +1,6 @@
 # A2A Attack Rules
 
-Batesian ships **15 rules** targeting the [Agent-to-Agent (A2A) protocol](https://a2a-protocol.org/).
+Batesian ships **16 rules** targeting the [Agent-to-Agent (A2A) protocol](https://a2a-protocol.org/).
 Every rule is an active probe: it sends crafted protocol traffic and judges the
 server's actual response. Rules are deliberately scoped to A2A-specific semantics
 (agent cards, JWS card signatures, tasks/contexts, push notifications, peer
@@ -30,6 +30,7 @@ Each finding carries a **confidence**:
 | `a2a-extension-downgrade-001` | [Required-Extension Downgrade / Fail-Open](#a2a-extension-downgrade-001) | High | confirmed | CWE-636 |
 | `a2a-push-binding-001` | [Push/Webhook Control-Plane Not Bound to Task Owner](#a2a-push-binding-001) | High | confirmed | CWE-639 |
 | `a2a-jsonrpc-batch-bypass-001` | [JSON-RPC Batch Authentication Bypass](#a2a-jsonrpc-batch-bypass-001) | High | confirmed | CWE-288 |
+| `a2a-task-cancel-idor-001` | [Cross-Principal Task Cancellation](#a2a-task-cancel-idor-001) | High | confirmed | CWE-639 / CWE-862 |
 
 ---
 
@@ -326,3 +327,30 @@ carries a result or a non-auth application error such as `TaskNotFound`). The
 probe is a read-only `GetTask` for a non-existent task id, so nothing is sent,
 created, or mutated. A2A does not define batching, so a correct server should
 reject the array rather than dispatch it unauthenticated (CWE-288).
+
+---
+
+### a2a-task-cancel-idor-001
+
+**Cross-Principal Task Cancellation** | Severity: High | CWE-639 / CWE-862
+
+Tests whether task cancellation (`CancelTask` / `tasks/cancel`) is bound to the
+task's owner. Cancellation is a distinct handler from reading a task
+(`a2a-task-idor-001`) or continuing it (`a2a-delegation-integrity-001`) and can be
+left unprotected on its own, giving an attacker a targeted way to terminate other
+principals' tasks. Needs two authenticated principals and reports two confirmed
+failures:
+
+- **Unauthenticated cancellation (CWE-862).** The rule creates a task as A, then
+  cancels it with no credentials. If that cancel is accepted (the task becomes
+  `canceled`), authentication is missing on a state-changing operation.
+- **Cross-principal cancellation (CWE-639).** If the unauthenticated cancel is
+  rejected (so auth is enforced), the rule cancels A's task as the wrong principal
+  B. A **confirmed** finding is raised only when B's cancel succeeds and a
+  read-back as owner A shows the task is now `canceled`.
+
+A server that rejects the wrong-principal cancel, or that cannot cancel the task
+(already terminal), produces no finding. The rule creates and cancels its own
+throwaway task; it never cancels a pre-existing one. Against a server that
+completes tasks almost immediately, the probe task may be terminal before it can
+be canceled, in which case the rule reports nothing.

--- a/internal/attack/a2a/task_cancel_idor.go
+++ b/internal/attack/a2a/task_cancel_idor.go
@@ -1,0 +1,265 @@
+package a2a
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// TaskCancelIDORExecutor tests whether an A2A server scopes task cancellation to
+// the task's owner (rule a2a-task-cancel-idor-001).
+//
+// CancelTask (v1.0) / tasks/cancel (v0.3) terminates a task. The spec requires
+// servers to "implement appropriate authorization scoping to ensure clients can
+// only access authorized tasks", so cancellation must be bound to the owning
+// principal. This rule covers the cancel verb specifically: it is a separate
+// handler from reading (a2a-task-idor-001) or continuing (a2a-delegation-
+// integrity-001) a task and can be left unprotected independently.
+//
+// It reports two distinct, confirmed failures:
+//   - Unauthenticated cancellation: an anonymous cancel terminates the task
+//     (CWE-862, missing authentication on a state-changing operation).
+//   - Cross-principal cancellation: a non-owning authenticated principal cancels
+//     another principal's task (CWE-639, broken object-level authorization),
+//     reported only after an unauthenticated-cancel discriminator proves the
+//     server does enforce auth, and a read-back as the owner confirms the task
+//     is now canceled.
+//
+// SAFETY: the rule creates its own throwaway task and cancels that; it never
+// cancels a pre-existing task. It is deliberately standalone (it does not consume
+// shared blackboard tasks that other rules may still need).
+type TaskCancelIDORExecutor struct {
+	rule attack.RuleContext
+}
+
+func init() {
+	attack.Register("a2a-task-cancel-idor", func(rc attack.RuleContext) attack.Executor {
+		return NewTaskCancelIDORExecutor(rc)
+	})
+}
+
+func NewTaskCancelIDORExecutor(r attack.RuleContext) *TaskCancelIDORExecutor {
+	return &TaskCancelIDORExecutor{rule: r}
+}
+
+// cancelOutcome classifies a single cancellation attempt.
+type cancelOutcome int
+
+const (
+	cancelOther        cancelOutcome = iota // application error: not found / not cancelable / unknown method
+	cancelAuthRejected                      // rejected at the auth layer (HTTP 401/403 or an auth error)
+	cancelCanceled                          // accepted: the task is now canceled
+)
+
+func (e *TaskCancelIDORExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
+	if len(opts.Principals) < 2 {
+		return nil, nil
+	}
+	a, b := opts.Principals[0], opts.Principals[1]
+	if a.Token == b.Token {
+		return nil, nil // same identity cannot demonstrate a cross-principal cancel
+	}
+
+	vars := attack.NewVars(target, opts.OOBListenerURL)
+	endpoint, ok := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
+	if !ok {
+		return nil, attack.ErrInconclusive
+	}
+
+	clientA := principalClient(opts, vars, a)
+	clientB := principalClient(opts, vars, b)
+	unauthClient := attack.NewUnauthHTTPClient(opts, attack.NewVars(target, opts.OOBListenerURL))
+
+	// Step 1: create a cancelable task owned by A.
+	taskID := e.createTask(ctx, clientA, endpoint, a, vars.RandID)
+	if taskID == "" {
+		return nil, nil // not a responsive A2A server, or no task could be created
+	}
+
+	// Step 2: discriminator. Attempt to cancel A's task with no credentials.
+	switch e.cancelTask(ctx, unauthClient, endpoint, nil, taskID, vars.RandID) {
+	case cancelCanceled:
+		// No authentication on the cancel handler at all.
+		return []attack.Finding{e.unauthFinding(endpoint, taskID)}, nil
+	case cancelAuthRejected:
+		// Auth is enforced; a successful cancel by a non-owner is now a true IDOR.
+	default:
+		// The task is not cancelable (already terminal) or the server hid it, so the
+		// cancel surface cannot be exercised cleanly. No finding.
+		return nil, nil
+	}
+
+	// Step 3: cancel A's task as the WRONG principal B.
+	if e.cancelTask(ctx, clientB, endpoint, b.Headers, taskID, vars.RandID) != cancelCanceled {
+		return nil, nil // cancellation is bound to the owner
+	}
+
+	// Step 4: read the task back as the owner A to confirm the cancel persisted.
+	if !e.taskIsCanceled(ctx, clientA, endpoint, a.Headers, taskID, vars.RandID) {
+		return nil, nil // could not confirm the task is actually canceled
+	}
+
+	return []attack.Finding{e.idorFinding(endpoint, a, b, taskID)}, nil
+}
+
+// createTask creates a task as the given principal, trying the A2A v1.0 shape
+// first and falling back to the v0.3 slash-method shape. Returns the created task
+// id, or empty if creation was not accepted.
+func (e *TaskCancelIDORExecutor) createTask(ctx context.Context, c *attack.HTTPClient, endpoint string, p attack.Principal, randID string) string {
+	v1Headers := map[string]string{"A2A-Version": "1.0"}
+	for k, v := range p.Headers {
+		v1Headers[k] = v
+	}
+	resp, err := c.POST(ctx, endpoint, v1Headers, map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      "batesian-cancel-create-" + p.Name + "-" + randID,
+		"method":  "SendMessage",
+		"params": map[string]interface{}{
+			"message": map[string]interface{}{
+				"role":      1, // USER
+				"parts":     []interface{}{map[string]string{"text": "batesian cancel probe " + randID}},
+				"messageId": "batesian-cancel-" + p.Name + "-" + randID,
+			},
+		},
+	})
+	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+		resp, err = c.POST(ctx, endpoint, p.Headers, map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      "batesian-cancel-create-" + p.Name + "-" + randID,
+			"method":  "message/send",
+			"params": map[string]interface{}{
+				"message": map[string]interface{}{
+					"role":      "user",
+					"parts":     []interface{}{map[string]string{"kind": "text", "text": "batesian cancel probe " + randID}},
+					"messageId": "batesian-cancel-" + p.Name + "-" + randID,
+				},
+			},
+		})
+	}
+	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+		return ""
+	}
+	taskID, _ := extractTaskContext(resp.Body)
+	return taskID
+}
+
+// cancelTask attempts to cancel taskID over the given client and classifies the
+// result. It tries the v1.0 CancelTask shape then the v0.3 tasks/cancel shape, so
+// a server that does not implement one (answering method-not-found) is still
+// exercised via the other.
+func (e *TaskCancelIDORExecutor) cancelTask(ctx context.Context, c *attack.HTTPClient, endpoint string, extraHeaders map[string]string, taskID, randID string) cancelOutcome {
+	v1Headers := map[string]string{"A2A-Version": "1.0"}
+	for k, v := range extraHeaders {
+		v1Headers[k] = v
+	}
+	shapes := []struct {
+		method  string
+		headers map[string]string
+	}{
+		{"CancelTask", v1Headers},
+		{"tasks/cancel", extraHeaders},
+	}
+	for _, s := range shapes {
+		resp, err := c.POST(ctx, endpoint, s.headers, map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      "batesian-cancel-" + randID,
+			"method":  s.method,
+			"params":  map[string]interface{}{"id": taskID},
+		})
+		if err != nil {
+			continue
+		}
+		if isA2AAuthRejection(resp) {
+			return cancelAuthRejected
+		}
+		if resp.IsSuccess() && !isJSONRPCError(resp.Body) && bodyShowsCanceled(resp.Body) {
+			return cancelCanceled
+		}
+		// Otherwise an application error (not cancelable / not found / unknown
+		// method): try the next shape.
+	}
+	return cancelOther
+}
+
+// taskIsCanceled reads the task back (GetTask v1.0, then tasks/get v0.3) and
+// reports whether its state is canceled.
+func (e *TaskCancelIDORExecutor) taskIsCanceled(ctx context.Context, c *attack.HTTPClient, endpoint string, extraHeaders map[string]string, taskID, randID string) bool {
+	v1Headers := map[string]string{"A2A-Version": "1.0"}
+	for k, v := range extraHeaders {
+		v1Headers[k] = v
+	}
+	resp, err := c.POST(ctx, endpoint, v1Headers, map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      "batesian-cancel-get-" + randID,
+		"method":  "GetTask",
+		"params":  map[string]interface{}{"id": taskID, "historyLength": 1},
+	})
+	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+		resp, err = c.POST(ctx, endpoint, extraHeaders, map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      "batesian-cancel-get-" + randID,
+			"method":  "tasks/get",
+			"params":  map[string]interface{}{"id": taskID, "historyLength": 1},
+		})
+	}
+	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+		return false
+	}
+	return bodyShowsCanceled(resp.Body)
+}
+
+// bodyShowsCanceled reports whether a task body's state is canceled, covering the
+// v0.3 string ("canceled") and the v1.0 proto enum ("TASK_STATE_CANCELED"). It
+// will not match "TaskNotCancelableError" (a different word, "cancelable").
+func bodyShowsCanceled(body []byte) bool {
+	s := string(body)
+	return strings.Contains(s, `"canceled"`) || strings.Contains(s, "CANCELED")
+}
+
+func (e *TaskCancelIDORExecutor) unauthFinding(endpoint, taskID string) attack.Finding {
+	return attack.Finding{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "high",
+		Confidence: attack.ConfirmedExploit,
+		Title:      "A2A task cancellation accepted without authentication",
+		Description: fmt.Sprintf(
+			"An unauthenticated cancel request terminated task %s at %s. Cancellation is a "+
+				"state-changing operation that must require authentication; an anonymous caller can "+
+				"cancel any task whose id they learn or guess, disrupting other principals' work.",
+			taskID, endpoint),
+		Evidence:    fmt.Sprintf("endpoint: %s\ntask: %s\nunauthenticated cancel: accepted (task canceled)", endpoint, taskID),
+		Remediation: e.rule.Remediation,
+		TargetURL:   endpoint,
+	}
+}
+
+func (e *TaskCancelIDORExecutor) idorFinding(endpoint string, owner, attacker attack.Principal, taskID string) attack.Finding {
+	return attack.Finding{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "high",
+		Confidence: attack.ConfirmedExploit,
+		Title:      "A2A task canceled by a non-owning principal (IDOR)",
+		Description: fmt.Sprintf(
+			"Principal %q canceled task %s owned by principal %q. The server rejected an "+
+				"unauthenticated cancel of the same task (so authentication is enforced), yet allowed a "+
+				"different authenticated principal to cancel it, and a read-back as the owner confirms "+
+				"the task is now canceled. Cancellation is not bound to the owning principal, so any "+
+				"authenticated caller can terminate another principal's tasks.",
+			attacker.Name, taskID, owner.Name),
+		Evidence: fmt.Sprintf(
+			"owner: %s (tenant %s)\nattacker: %s (tenant %s)\ntask: %s\n"+
+				"unauthenticated cancel: rejected (auth enforced)\nwrong-principal cancel: accepted\n"+
+				"owner read-back: task state is canceled",
+			owner.Name, owner.Tenant, attacker.Name, attacker.Tenant, taskID),
+		Remediation: e.rule.Remediation,
+		TargetURL:   endpoint,
+		Chain: []attack.ChainStep{
+			{Hop: 1, Principal: owner.Name, Action: "create task " + taskID, Outcome: "task owned by " + owner.Name},
+			{Hop: 2, Principal: attacker.Name, Action: "cancel task " + taskID + " as a different principal", Outcome: "GRANTED - task canceled by non-owner"},
+		},
+	}
+}

--- a/internal/attack/a2a/task_cancel_idor_test.go
+++ b/internal/attack/a2a/task_cancel_idor_test.go
@@ -1,0 +1,199 @@
+package a2a_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	a2aattack "github.com/calbebop/batesian/internal/attack/a2a"
+)
+
+// cancelServer builds a mock A2A server whose cancel behavior depends on mode:
+//   - "vuln":           unauth cancel is rejected (401) but ANY authenticated
+//     token may cancel any task (cross-principal IDOR).
+//   - "secure":         cancel is bound to the task's owner; unauth -> 401, a
+//     non-owner token -> 403.
+//   - "no-auth":        cancel is accepted with no credentials at all.
+//   - "not-cancelable": cancel always returns TaskNotCancelable (-32002).
+//   - "not-a2a":        every request 404s.
+//
+// GetTask/tasks/get returns the stored task state so the rule's owner read-back
+// can confirm a cancellation persisted.
+func cancelServer(mode string) *httptest.Server {
+	type task struct {
+		state string
+		owner string
+	}
+	var mu sync.Mutex
+	store := map[string]*task{}
+	counter := 0
+
+	bearer := func(r *http.Request) string {
+		return strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if mode == "not-a2a" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]interface{}
+		_ = json.Unmarshal(body, &req)
+		method, _ := req["method"].(string)
+		id := req["id"]
+		params, _ := req["params"].(map[string]interface{})
+		tok := bearer(r)
+		w.Header().Set("Content-Type", "application/json")
+
+		result := func(res map[string]interface{}) {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id, "result": res})
+		}
+		rpcErr := func(code int, msg string) {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": code, "message": msg}})
+		}
+		taskID, _ := params["id"].(string)
+
+		switch method {
+		case "SendMessage", "message/send":
+			mu.Lock()
+			counter++
+			tid := fmt.Sprintf("task-%d", counter)
+			store[tid] = &task{state: "submitted", owner: tok}
+			mu.Unlock()
+			result(map[string]interface{}{"id": tid, "contextId": "ctx-" + tid,
+				"status": map[string]interface{}{"state": "submitted"}})
+
+		case "CancelTask", "tasks/cancel":
+			if mode == "not-cancelable" {
+				rpcErr(-32002, "Task is not in a cancelable state")
+				return
+			}
+			if mode != "no-auth" && tok == "" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			mu.Lock()
+			t := store[taskID]
+			if mode == "secure" && (t == nil || t.owner != tok) {
+				mu.Unlock()
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+			if t != nil {
+				t.state = "canceled"
+			}
+			mu.Unlock()
+			result(map[string]interface{}{"id": taskID, "status": map[string]interface{}{"state": "canceled"}})
+
+		case "GetTask", "tasks/get":
+			mu.Lock()
+			t := store[taskID]
+			mu.Unlock()
+			if t == nil {
+				rpcErr(-32001, "Task not found")
+				return
+			}
+			result(map[string]interface{}{"id": taskID, "contextId": "ctx-" + taskID,
+				"status": map[string]interface{}{"state": t.state}})
+
+		default:
+			rpcErr(-32601, "method not found")
+		}
+	}))
+}
+
+func runTaskCancel(t *testing.T, srv *httptest.Server) ([]attack.Finding, error) {
+	t.Helper()
+	exec := a2aattack.NewTaskCancelIDORExecutor(attack.RuleContext{
+		ID:   "a2a-task-cancel-idor-001",
+		Name: "A2A Cross-Principal Task Cancellation",
+	})
+	return exec.Execute(context.Background(), srv.URL, attack.Options{
+		TimeoutSeconds: 5,
+		Principals: []attack.Principal{
+			{Name: "tenant-a", Token: "tok-a", Tenant: "A"},
+			{Name: "tenant-b", Token: "tok-b", Tenant: "B"},
+		},
+	})
+}
+
+// TestTaskCancelIDOR_CrossPrincipal: unauth cancel rejected, but a different
+// authenticated principal cancels the owner's task => confirmed IDOR.
+func TestTaskCancelIDOR_CrossPrincipal(t *testing.T) {
+	srv := cancelServer("vuln")
+	defer srv.Close()
+
+	findings, err := runTaskCancel(t, srv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Confidence != attack.ConfirmedExploit || f.Severity != "high" {
+		t.Errorf("expected high/confirmed, got %q/%v", f.Severity, f.Confidence)
+	}
+	if !strings.Contains(f.Title, "non-owning") {
+		t.Errorf("expected the cross-principal IDOR finding, got title %q", f.Title)
+	}
+}
+
+// TestTaskCancelIDOR_Unauthenticated: cancel accepted with no credentials =>
+// the unauthenticated-cancellation finding.
+func TestTaskCancelIDOR_Unauthenticated(t *testing.T) {
+	srv := cancelServer("no-auth")
+	defer srv.Close()
+
+	findings, err := runTaskCancel(t, srv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %+v", len(findings), findings)
+	}
+	if !strings.Contains(findings[0].Title, "without authentication") {
+		t.Errorf("expected the unauthenticated-cancel finding, got title %q", findings[0].Title)
+	}
+}
+
+// TestTaskCancelIDOR_Secure: cancel bound to the owner => no finding.
+func TestTaskCancelIDOR_Secure(t *testing.T) {
+	srv := cancelServer("secure")
+	defer srv.Close()
+
+	if findings, err := runTaskCancel(t, srv); err != nil || len(findings) != 0 {
+		t.Errorf("expected 0 findings / nil err for owner-bound cancel, got %d findings, err=%v", len(findings), err)
+	}
+}
+
+// TestTaskCancelIDOR_NotCancelable: task cannot be canceled => no finding.
+func TestTaskCancelIDOR_NotCancelable(t *testing.T) {
+	srv := cancelServer("not-cancelable")
+	defer srv.Close()
+
+	if findings, err := runTaskCancel(t, srv); err != nil || len(findings) != 0 {
+		t.Errorf("expected 0 findings / nil err when the task is not cancelable, got %d findings, err=%v", len(findings), err)
+	}
+}
+
+// TestTaskCancelIDOR_NotA2A: no reachable endpoint => inconclusive.
+func TestTaskCancelIDOR_NotA2A(t *testing.T) {
+	srv := cancelServer("not-a2a")
+	defer srv.Close()
+
+	_, err := runTaskCancel(t, srv)
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive for a non-A2A endpoint, got err=%v", err)
+	}
+}

--- a/rules/a2a/task-cancel-idor-001.yaml
+++ b/rules/a2a/task-cancel-idor-001.yaml
@@ -1,0 +1,63 @@
+id: a2a-task-cancel-idor-001
+info:
+  name: A2A Cross-Principal Task Cancellation
+  author: batesian
+  severity: high
+  description: |
+    Tests whether an A2A server binds task cancellation to the task's owner.
+
+    CancelTask (v1.0) / tasks/cancel (v0.3) moves a task to the terminal
+    "canceled" state. The spec requires servers to implement authorization
+    scoping so clients can only access authorized tasks, so cancellation must be
+    owner-bound. Cancellation is a distinct handler from reading a task
+    (a2a-task-idor-001) or continuing it (a2a-delegation-integrity-001) and can
+    be left unprotected on its own, giving an attacker a targeted disruption
+    primitive over other principals' tasks.
+
+    The rule needs two authenticated principals (A and B) and reports two
+    distinct confirmed failures:
+
+      1. Unauthenticated cancellation (CWE-862): the rule creates a task as A,
+         then cancels it with NO credentials. If that cancel is accepted (the
+         task becomes canceled), authentication is missing on a state-changing
+         operation.
+      2. Cross-principal cancellation (CWE-639): if the unauthenticated cancel is
+         rejected (so auth IS enforced), the rule cancels A's task as the WRONG
+         principal B. A CONFIRMED finding is raised only when B's cancel succeeds
+         and a read-back as owner A shows the task is now canceled.
+
+    A server that rejects the wrong-principal cancel, or that cannot cancel the
+    task (already terminal), produces no finding.
+
+    SAFETY: the rule creates and cancels its OWN throwaway task; it never cancels
+    a pre-existing task, and is standalone (it does not consume tasks other rules
+    created).
+
+    Note: against a server that completes tasks almost immediately the probe task
+    may reach a terminal state before it can be canceled, in which case the rule
+    cannot demonstrate the issue and reports nothing.
+
+  references:
+    - https://a2a-protocol.org/latest/specification/
+    - https://cwe.mitre.org/data/definitions/639.html
+    - https://cwe.mitre.org/data/definitions/862.html
+
+  tags:
+    - a2a
+    - authorization
+    - idor
+    - tasks
+    - cancel
+    - cwe-639
+
+attack:
+  protocol: a2a
+  type: a2a-task-cancel-idor
+
+remediation: |
+  1. Authenticate every cancel request and bind cancellation to the task's owning
+     principal; reject a cancel from any other identity with an authorization
+     error.
+  2. Never allow unauthenticated cancellation of a task.
+  3. Apply the same owner-scoping to all task-lifecycle operations (get, cancel,
+     resubscribe, push-config), not just task creation.

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -18,7 +18,7 @@ pip install starlette uvicorn httpx mcp
 
 ## Server Registry
 
-The bundled rule set is **15 A2A + 15 MCP = 30 rules**. Every rule's primary
+The bundled rule set is **16 A2A + 15 MCP = 31 rules**. Every rule's primary
 validation is an in-process `net/http/httptest` harness in its Go
 `*_test.go` (multiple server postures: vulnerable must fire / patched / open /
 benign must stay silent). The Python servers below are optional standalone
@@ -35,6 +35,7 @@ fixtures for live-validation / manual smoke testing.
 | `a2a_extension_downgrade_server.py` | 3106 | `a2a-extension-downgrade-001` |
 | `a2a_push_binding_server.py` | 3107 | `a2a-push-binding-001` (two principals; needs two `--principal`s) |
 | `a2a_batch_bypass_server.py` | 3108 | `a2a-jsonrpc-batch-bypass-001` |
+| `a2a_task_cancel_server.py` | 3109 | `a2a-task-cancel-idor-001` (two principals; needs two `--principal`s) |
 | `mcp_unauth_resources_server.py` | 7787 | `mcp-resources-unauth-001` |
 | `mcp_oauth_dcr_server.py` | 7788 | `mcp-oauth-dcr-001` |
 | `mcp_oauth_audience_server.py` | 7785 | `mcp-oauth-audience-002` |
@@ -48,7 +49,7 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_dns_rebind_origin_server.py` | 7794 | `mcp-dns-rebind-origin-001` |
 | `mcp_batch_bypass_server.py` | 7795 | `mcp-jsonrpc-batch-bypass-001` |
 
-**Coverage.** 29 of the 30 rules have a standalone Python fixture above. The
+**Coverage.** 30 of the 31 rules have a standalone Python fixture above. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
 (`internal/attack/mcp/token_replay_test.go`); the same is true of the per-rule
 edge-case harnesses for every other rule. `mockserver.go` is a Go helper used by

--- a/testdata/a2a_task_cancel_server.py
+++ b/testdata/a2a_task_cancel_server.py
@@ -1,0 +1,87 @@
+"""
+Deliberately vulnerable A2A server for validating:
+  - a2a-task-cancel-idor-001: task cancellation is NOT bound to the task owner.
+
+An unauthenticated cancel is rejected (HTTP 401), but ANY authenticated principal
+may cancel ANY task, so principal B can cancel principal A's task (CWE-639). Tasks
+stay in a cancelable state until canceled, so the cancel surface is exercisable.
+
+Run with two principals:
+  python testdata/a2a_task_cancel_server.py
+  batesian scan --target http://127.0.0.1:3109 \\
+      --rule-ids a2a-task-cancel-idor-001 \\
+      --principal name=a,token=tok-a --principal name=b,token=tok-b -v
+
+Endpoint: http://127.0.0.1:3109/
+"""
+import itertools
+import json
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route
+import uvicorn
+
+PORT = 3109
+TASKS = {}  # task id -> {"state": ..., "owner": <token>}
+_counter = itertools.count(1)
+
+
+def _bearer(request: Request) -> str:
+    auth = request.headers.get("authorization", "")
+    return auth[len("Bearer "):] if auth.startswith("Bearer ") else ""
+
+
+async def rpc(request: Request) -> Response:
+    raw = await request.body()
+    try:
+        req = json.loads(raw)
+    except Exception:
+        return JSONResponse(
+            {"jsonrpc": "2.0", "id": None, "error": {"code": -32700, "message": "parse error"}},
+            status_code=400,
+        )
+    method = req.get("method", "")
+    rid = req.get("id")
+    params = req.get("params") or {}
+    tok = _bearer(request)
+
+    def result(res):
+        return JSONResponse({"jsonrpc": "2.0", "id": rid, "result": res})
+
+    def rpc_err(code, msg):
+        return JSONResponse({"jsonrpc": "2.0", "id": rid, "error": {"code": code, "message": msg}})
+
+    if method in ("SendMessage", "message/send"):
+        if not tok:
+            return Response(status_code=401)
+        tid = f"task-{next(_counter)}"
+        TASKS[tid] = {"state": "submitted", "owner": tok}
+        return result({"id": tid, "contextId": f"ctx-{tid}", "status": {"state": "submitted"}})
+
+    if method in ("CancelTask", "tasks/cancel"):
+        if not tok:
+            return Response(status_code=401)  # unauthenticated cancel is rejected
+        tid = params.get("id", "")
+        task = TASKS.get(tid)
+        if task is None:
+            return rpc_err(-32001, "Task not found")
+        # VULNERABILITY: any authenticated principal may cancel any task; the
+        # cancel handler does not check that the caller owns the task.
+        task["state"] = "canceled"
+        return result({"id": tid, "status": {"state": "canceled"}})
+
+    if method in ("GetTask", "tasks/get"):
+        tid = params.get("id", "")
+        task = TASKS.get(tid)
+        if task is None:
+            return rpc_err(-32001, "Task not found")
+        return result({"id": tid, "contextId": f"ctx-{tid}", "status": {"state": task["state"]}})
+
+    return rpc_err(-32601, "method not found")
+
+
+app = Starlette(routes=[Route("/", rpc, methods=["POST"])])
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="127.0.0.1", port=PORT, log_level="warning")


### PR DESCRIPTION
## Summary

New A2A rule, `a2a-task-cancel-idor-001`, covering authorization on **task cancellation** (CWE-639 / CWE-862).

`CancelTask` (v1.0) / `tasks/cancel` (v0.3) moves a task to the terminal `canceled` state. The spec requires servers to scope task access to authorized clients, so cancellation must be owner-bound. It's a distinct handler from reading a task (`task-idor`) or continuing it (`delegation-integrity`) and can be left unprotected on its own, giving an attacker a targeted way to terminate other principals' tasks.

## Detection (two confirmed findings)
Needs two authenticated principals (A, B). Creates a task as A, then:
- **Unauthenticated cancellation (CWE-862):** cancel A's task with no credentials. If accepted (task becomes `canceled`), auth is missing on a state-changing operation.
- **Cross-principal cancellation (CWE-639):** if the unauthenticated cancel is rejected (auth enforced), cancel A's task as the wrong principal B. **Confirmed** only when B's cancel succeeds *and* a read-back as owner A shows the task is now `canceled` (the same read-back standard `artifact-tamper` uses).

The unauth attempt is a discriminator: it cleanly separates "no auth at all" from a true cross-principal break, so the IDOR finding is never raised on a no-auth server.

**Safety / design:** the rule creates and cancels its *own* throwaway task, never a pre-existing one, and is deliberately standalone (it doesn't consume blackboard tasks other rules still need — cancel is destructive).

## Known limitation (documented)
Against a server that completes tasks almost immediately, the probe task can reach a terminal state before the cancel (`TaskNotCancelable`), and the rule reports nothing. The fixture keeps tasks cancelable for the positive case.

## Validation
- **Unit tests**, five postures: cross-principal IDOR (fires), unauthenticated (fires), owner-bound/secure (silent), not-cancelable (silent), unreachable (inconclusive).
- **Live:** `testdata/a2a_task_cancel_server.py` (port 3109, two principals) fires the IDOR finding; the a2a-python reference sample produces **no false positive** (its tasks complete before the cancel, exactly the documented limitation) and no crash.
- `go build` / `vet` / `golangci-lint` (0 issues) / `go test ./...` (forced, all 31 rules incl. the engine zero-egress dry-run) all pass; `gofmt` clean; no em-dashes.

## Counts
Rule set is now **31 (16 A2A + 15 MCP)**. README, A2A catalog (intro + row + detail), testdata registry/coverage, and the goreleaser release header updated.
