### PR TITLE
feat(mcp-completion-unauth-001): detect unauthenticated completion/complete

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -114,7 +114,7 @@ release:
     ## Batesian {{.Version}}
 
     Adversarial red-team CLI for AI agent protocols (A2A and MCP).
-    31 bundled attack rules (16 A2A + 15 MCP). Single binary. No runtime dependencies.
+    32 bundled attack rules (16 A2A + 16 MCP). Single binary. No runtime dependencies.
 
     ### Install
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ CLI for adversarial testing of [A2A](https://a2a-protocol.org) and [MCP](https:/
 
 ## What ships
 
-Bundled rules: **16 A2A, 15 MCP (31 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
+Bundled rules: **16 A2A, 16 MCP (32 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
 
 - [A2A rules](docs/rules-a2a.md) (16)
-- [MCP rules](docs/rules-mcp.md) (15)
+- [MCP rules](docs/rules-mcp.md) (16)
 
 Coverage spans:
 
@@ -31,7 +31,7 @@ Coverage spans:
 - **Request & task integrity** - task IDOR, agent-role injection, artifact tampering, SEP-2243 header/body routing, SSE resumption replay
 - **Multi-party isolation** - cross-tenant isolation, session/context fixation, delegation chain-of-custody, cross-principal task cancellation
 - **SSRF & secret leakage** - push-notification SSRF, push control-plane binding, OAuth discovery/metadata SSRF, credential leakage into responses
-- **Unauthenticated & cross-origin access** - exposed MCP tools, resources, and prompt templates, Streamable HTTP Origin validation (DNS rebinding)
+- **Unauthenticated & cross-origin access** - exposed MCP tools, resources, prompt templates, and completion suggestions, Streamable HTTP Origin validation (DNS rebinding)
 
 ## Install
 

--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -1,6 +1,6 @@
 # MCP Attack Rules
 
-Batesian ships **15 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
+Batesian ships **16 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
 Every rule is an active probe: it sends crafted protocol traffic and judges the
 server's actual response. Rules are deliberately scoped to MCP-specific semantics
 (OAuth 2.1 authorization, DCR, audience binding, discovery-chain metadata-fetch
@@ -28,6 +28,7 @@ JSON-RPC `error` (the common MCP rejection shape) is a rejection, not a finding.
 | `mcp-resources-unauth-001` | [Unauthenticated Resource Read](#mcp-resources-unauth-001) | High / Critical | confirmed | CWE-862 |
 | `mcp-prompt-unauth-001` | [Prompt Templates Without Authentication](#mcp-prompt-unauth-001) | Medium | confirmed | CWE-862 |
 | `mcp-tools-unauth-001` | [Tools Accessible Without Authentication](#mcp-tools-unauth-001) | High / Medium | confirmed | CWE-862 |
+| `mcp-completion-unauth-001` | [completion/complete Without Authentication](#mcp-completion-unauth-001) | High / Medium | confirmed | CWE-862 |
 | `mcp-init-downgrade-001` | [Protocol Version Downgrade Auth Bypass](#mcp-init-downgrade-001) | Critical | confirmed | CWE-757 |
 | `mcp-session-fixation-001` | [Session ID Fixation](#mcp-session-fixation-001) | High | confirmed | CWE-384 |
 | `mcp-header-body-split-001` | [Header/Body Routing Split-Brain (SEP-2243)](#mcp-header-body-split-001) | High | confirmed | CWE-444 |
@@ -150,6 +151,29 @@ protocol error; reaching that error (or any result envelope) shows the call was
 dispatched without credentials. It **never invokes a real or advertised tool** -
 destructive tool-argument fuzzing is out of scope. A server that requires auth, or
 does not advertise the tools capability, produces no finding.
+
+---
+
+### mcp-completion-unauth-001
+
+**completion/complete Without Authentication** | Severity: High / Medium | CWE-862 / CWE-200
+
+`completion/complete` returns autocompletion suggestions for prompt arguments and
+resource-template URIs; servers that support it advertise the `completions`
+capability, which is confirmed structurally from the captured `initialize` result
+(`ServerSupports`). The MCP spec requires implementations to control access to
+completion suggestions and prevent completion-based information disclosure, so an
+unauthenticated completion endpoint is both an access-control failure and an
+enumeration oracle. The rule confirms two outcomes: `completion/complete`
+dispatching an unauthenticated request (**medium**), and returning real suggestion
+values for a discovered prompt argument or resource-template variable (**high**) -
+both **confirmed**. To establish reachability without depending on an open
+prompts/resources listing, the rule falls back to a synthetic prompt reference,
+which the spec answers with a `-32602` (invalid params) protocol error; reaching
+that error (or any result envelope) shows the call was dispatched without
+credentials. The probe is read-only - it never executes a tool and sends only
+benign single-character argument values. A server that requires auth, or does not
+advertise the completions capability, produces no finding.
 
 ---
 

--- a/internal/attack/mcp/completion_unauth.go
+++ b/internal/attack/mcp/completion_unauth.go
@@ -1,0 +1,363 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// CompletionUnauthExecutor probes whether the MCP completion/complete method is
+// reachable without authentication (rule mcp-completion-unauth-001).
+//
+// completion/complete returns autocompletion suggestions for prompt arguments
+// and resource-template URIs. The MCP spec requires implementations to "control
+// access to sensitive suggestions" and "prevent completion-based information
+// disclosure". An unauthenticated completion endpoint is therefore an access
+// control failure and, more concretely, an enumeration oracle: an anonymous
+// caller can fuzz argument values or URI-template segments and read back valid
+// completions (usernames, file paths, identifiers) the operator never meant to
+// expose.
+//
+// SAFETY: completion/complete is read-only; it never executes a tool or mutates
+// state. The probe sends a benign empty argument value.
+type CompletionUnauthExecutor struct {
+	rule attack.RuleContext
+}
+
+// register the executor for the mcp-completion-unauth attack type.
+func init() {
+	attack.Register("mcp-completion-unauth", func(rc attack.RuleContext) attack.Executor { return NewCompletionUnauthExecutor(rc) })
+}
+
+// NewCompletionUnauthExecutor creates an executor for mcp-completion-unauth.
+func NewCompletionUnauthExecutor(r attack.RuleContext) *CompletionUnauthExecutor {
+	return &CompletionUnauthExecutor{rule: r}
+}
+
+// maxRealRefs bounds how many discovered prompt/resource references the rule
+// probes, so a server with many prompts does not turn one rule into a flood.
+const maxRealRefs = 8
+
+// completionRef is a completion/complete reference paired with the argument name
+// to complete. real marks refs discovered from the live server (prompt or
+// resource template), which can yield an actual disclosure oracle; synthetic
+// refs only establish that the method dispatches without auth.
+type completionRef struct {
+	params  map[string]interface{}
+	argName string
+	real    bool
+	label   string
+}
+
+// completionOutcome records the result of a single reachable completion probe.
+type completionOutcome struct {
+	ref    completionRef
+	status int
+	reason string
+	values []string
+}
+
+// templateVar extracts the first RFC 6570 variable name from a URI template,
+// e.g. "file:///{path}" -> "path", "db://{+table}/{id}" -> "table". Returns no
+// match when the template declares no variable.
+var templateVar = regexp.MustCompile(`\{[+#./;?&]?([A-Za-z0-9_]+)`)
+
+func (e *CompletionUnauthExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
+	vars := attack.NewVars(target, opts.OOBListenerURL)
+	// Deliberately omit the bearer token - the rule tests whether completion is
+	// reachable WITHOUT authentication. Injecting opts.Token would mask the finding.
+	client := attack.NewUnauthHTTPClient(opts, vars)
+
+	session, err := initializeMCP(ctx, client, vars.BaseURL)
+	if err != nil {
+		return nil, nil // not an MCP server
+	}
+
+	// Skip servers that do not advertise the completions capability; probing them
+	// would produce meaningless noise. Read from the captured handshake object
+	// rather than substring-matching the body.
+	if !session.ServerSupports("completions") {
+		return nil, nil
+	}
+
+	// Probe real refs discovered from the live server first, preferring one that
+	// actually leaks suggestion values (the disclosure oracle). Track the first
+	// reachable probe so reachability is reported even when no ref discloses.
+	var firstReachable, disclosure *completionOutcome
+	for _, ref := range e.discoverRefs(ctx, client, session) {
+		out := e.probe(ctx, client, session, ref)
+		if out == nil {
+			continue
+		}
+		if firstReachable == nil {
+			firstReachable = out
+		}
+		if len(out.values) > 0 {
+			disclosure = out
+			break
+		}
+	}
+
+	// If no real ref was reachable (e.g. prompts/resources listing is itself
+	// auth-gated, or the server exposes none), fall back to a synthetic prompt
+	// reference so the rule still establishes reachability. A server that gates
+	// completion answers this with 401/403 or an auth error and stays silent.
+	if firstReachable == nil {
+		synth := completionRef{
+			params:  map[string]interface{}{"type": "ref/prompt", "name": "batesian-nonexistent-" + vars.RandID},
+			argName: "batesian_probe",
+			real:    false,
+			label:   "synthetic probe ref",
+		}
+		firstReachable = e.probe(ctx, client, session, synth)
+	}
+
+	if firstReachable == nil {
+		return nil, nil
+	}
+
+	// Base the reachability finding on the disclosure probe when one was found, so
+	// both findings describe the same reference.
+	base := firstReachable
+	if disclosure != nil {
+		base = disclosure
+	}
+
+	findings := []attack.Finding{{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "medium",
+		Confidence: attack.ConfirmedExploit,
+		Title:      "MCP completion/complete reachable without authentication",
+		Description: fmt.Sprintf(
+			"completion/complete at %s dispatched an unauthenticated request (probed via %s). The MCP "+
+				"spec requires servers to control access to completion suggestions and prevent "+
+				"completion-based information disclosure; an anonymous caller can use this endpoint as an "+
+				"enumeration oracle, fuzzing argument values or URI-template segments to recover valid "+
+				"completions.", session.Endpoint, base.ref.label),
+		Evidence:    fmt.Sprintf("HTTP %d from %s\nprobe: %s\n%s", base.status, session.Endpoint, base.ref.label, base.reason),
+		Remediation: e.rule.Remediation,
+		TargetURL:   session.Endpoint,
+	}}
+
+	// Escalate when a real ref returned actual suggestion values: the endpoint is
+	// not just reachable but is leaking valid completions to an anonymous caller.
+	if disclosure != nil {
+		findings = append(findings, attack.Finding{
+			RuleID:     e.rule.ID,
+			RuleName:   e.rule.Name,
+			Severity:   "high",
+			Confidence: attack.ConfirmedExploit,
+			Title:      fmt.Sprintf("MCP completion/complete disclosed suggestion values without authentication (%s)", disclosure.ref.label),
+			Description: fmt.Sprintf(
+				"completion/complete for %s at %s returned %d suggestion value(s) to an unauthenticated "+
+					"caller. Completions expose valid argument values and URI-template segments (identifiers, "+
+					"file paths, usernames), giving an attacker a live enumeration oracle over the server's "+
+					"internal namespace.", disclosure.ref.label, session.Endpoint, len(disclosure.values)),
+			Evidence:    fmt.Sprintf("HTTP %d from %s\n%s\nvalues (%d): %v", disclosure.status, session.Endpoint, disclosure.ref.label, len(disclosure.values), sampleValues(disclosure.values)),
+			Remediation: e.rule.Remediation,
+			TargetURL:   session.Endpoint,
+		})
+	}
+
+	return findings, nil
+}
+
+// probe sends a single unauthenticated completion/complete request for ref and
+// returns the outcome if the handler was reached, or nil on an HTTP auth gate,
+// transport error, or a non-dispatching JSON-RPC error. Suggestion values are
+// captured only for real refs (synthetic refs never disclose real data).
+func (e *CompletionUnauthExecutor) probe(ctx context.Context, client *attack.HTTPClient, session mcpSession, ref completionRef) *completionOutcome {
+	resp, err := client.POST(ctx, session.Endpoint, session.header(), map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      7,
+		"method":  "completion/complete",
+		// An empty value asks the server to enumerate all suggestions for the
+		// argument. Fuzzy/prefix matchers (the common implementation) return their
+		// full candidate set for the empty prefix, which is exactly the
+		// enumerate-everything behavior an attacker abuses; a non-empty probe value
+		// would be silently filtered out against namespaces that do not share its
+		// prefix (e.g. numeric identifiers).
+		"params": map[string]interface{}{
+			"ref":      ref.params,
+			"argument": map[string]interface{}{"name": ref.argName, "value": ""},
+		},
+	})
+	if err != nil || !resp.IsSuccess() {
+		return nil
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		return nil
+	}
+	reachable, reason := completionDispatchReachable(body)
+	if !reachable {
+		return nil
+	}
+	out := &completionOutcome{ref: ref, status: resp.StatusCode, reason: reason}
+	if ref.real {
+		out.values = completionValues(body)
+	}
+	return out
+}
+
+// discoverRefs returns real completion references built from the server's live
+// prompts and resource templates (capped at maxRealRefs). Each requires an
+// argument name to complete: a prompt argument, or a URI-template variable.
+func (e *CompletionUnauthExecutor) discoverRefs(ctx context.Context, client *attack.HTTPClient, session mcpSession) []completionRef {
+	var refs []completionRef
+
+	if session.ServerSupports("prompts") {
+		refs = append(refs, promptRefs(ctx, client, session)...)
+	}
+	if session.ServerSupports("resources") {
+		refs = append(refs, resourceTemplateRefs(ctx, client, session)...)
+	}
+
+	if len(refs) > maxRealRefs {
+		refs = refs[:maxRealRefs]
+	}
+	return refs
+}
+
+// promptRefs lists prompts and builds a completion ref for every prompt argument.
+func promptRefs(ctx context.Context, client *attack.HTTPClient, session mcpSession) []completionRef {
+	body, ok := rpcResult(ctx, client, session, "prompts/list")
+	if !ok {
+		return nil
+	}
+	prompts, _ := body["prompts"].([]interface{})
+	var refs []completionRef
+	for _, p := range prompts {
+		pm, ok := p.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := pm["name"].(string)
+		if name == "" {
+			continue
+		}
+		args, _ := pm["arguments"].([]interface{})
+		for _, a := range args {
+			am, ok := a.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			an, _ := am["name"].(string)
+			if an == "" {
+				continue
+			}
+			refs = append(refs, completionRef{
+				params:  map[string]interface{}{"type": "ref/prompt", "name": name},
+				argName: an,
+				real:    true,
+				label:   fmt.Sprintf("prompt %q argument %q", name, an),
+			})
+		}
+	}
+	return refs
+}
+
+// resourceTemplateRefs lists resource templates and builds a completion ref for
+// the first variable of every template that declares one.
+func resourceTemplateRefs(ctx context.Context, client *attack.HTTPClient, session mcpSession) []completionRef {
+	body, ok := rpcResult(ctx, client, session, "resources/templates/list")
+	if !ok {
+		return nil
+	}
+	templates, _ := body["resourceTemplates"].([]interface{})
+	var refs []completionRef
+	for _, t := range templates {
+		tm, ok := t.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		ut, _ := tm["uriTemplate"].(string)
+		m := templateVar.FindStringSubmatch(ut)
+		if m == nil {
+			continue
+		}
+		refs = append(refs, completionRef{
+			params:  map[string]interface{}{"type": "ref/resource", "uri": ut},
+			argName: m[1],
+			real:    true,
+			label:   fmt.Sprintf("resource template %q variable %q", ut, m[1]),
+		})
+	}
+	return refs
+}
+
+// rpcResult issues a paramless JSON-RPC call without auth and returns the
+// result object, or ok=false on any transport failure, non-2xx, or JSON-RPC
+// error (which means the listing itself is gated and yields no usable ref).
+func rpcResult(ctx context.Context, client *attack.HTTPClient, session mcpSession, method string) (map[string]interface{}, bool) {
+	resp, err := client.POST(ctx, session.Endpoint, session.header(), map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      6,
+		"method":  method,
+		"params":  map[string]interface{}{},
+	})
+	if err != nil || !resp.IsSuccess() {
+		return nil, false
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		return nil, false
+	}
+	if _, hasErr := body["error"]; hasErr {
+		return nil, false
+	}
+	result, ok := body["result"].(map[string]interface{})
+	return result, ok
+}
+
+// completionDispatchReachable reports whether a completion/complete response
+// shows the handler was reached without auth. A completion result, any result
+// envelope, or a -32602 (invalid params / invalid prompt name) protocol error
+// all mean the call dispatched. A -32601 (capability not supported), an
+// auth-flavored error, or any other error does not. The reason is used as
+// finding evidence.
+func completionDispatchReachable(body map[string]interface{}) (bool, string) {
+	if errObj, ok := body["error"].(map[string]interface{}); ok {
+		code, _ := errObj["code"].(float64)
+		if int(code) == -32602 {
+			return true, "JSON-RPC error -32602 (invalid params) returned for the completion probe, so completion/complete was dispatched without auth"
+		}
+		return false, ""
+	}
+	if res, ok := body["result"].(map[string]interface{}); ok {
+		if _, ok := res["completion"]; ok {
+			return true, "completion/complete returned a completion result without auth"
+		}
+		return true, "completion/complete returned a result envelope without auth"
+	}
+	return false, ""
+}
+
+// completionValues extracts the string suggestion values from a
+// completion/complete result.
+func completionValues(body map[string]interface{}) []string {
+	res, _ := body["result"].(map[string]interface{})
+	comp, _ := res["completion"].(map[string]interface{})
+	raw, _ := comp["values"].([]interface{})
+	var out []string
+	for _, v := range raw {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// sampleValues caps disclosed values for evidence so a large completion list
+// does not bloat the report.
+func sampleValues(values []string) []string {
+	const max = 10
+	if len(values) <= max {
+		return values
+	}
+	return append(values[:max:max], "...")
+}

--- a/internal/attack/mcp/completion_unauth_test.go
+++ b/internal/attack/mcp/completion_unauth_test.go
@@ -1,0 +1,241 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+// completionServer builds a mock MCP server whose completion/complete behavior
+// is driven by mode:
+//   - "oracle":          completions+prompts advertised; completion/complete
+//     returns real suggestion values => medium reachability + high disclosure.
+//   - "resource-oracle": completions+prompts+resources advertised; the prompt
+//     arg returns empty but the resource-template variable discloses values =>
+//     medium + high, with the high referencing the resource template.
+//   - "reachable-empty": completions+prompts advertised; completion/complete
+//     returns an empty completion result => medium only (no disclosure).
+//   - "reachable-synth": only completions advertised; completion/complete answers
+//     -32602 for the synthetic probe ref => medium only.
+//   - "auth-enforced":   completion/complete answers -32001 Unauthorized => silent.
+//   - "no-cap":          completions capability absent => silent.
+//   - "not-mcp":         initialize 404s => silent.
+func completionServer(mode string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if mode == "not-mcp" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		method, _ := req["method"].(string)
+		params, _ := req["params"].(map[string]interface{})
+		w.Header().Set("Content-Type", "application/json")
+		enc := func(v map[string]interface{}) { _ = json.NewEncoder(w).Encode(v) }
+		rpcErr := func(code int, msg string) {
+			enc(map[string]interface{}{"jsonrpc": "2.0", "id": req["id"],
+				"error": map[string]interface{}{"code": code, "message": msg}})
+		}
+		completion := func(values []interface{}) {
+			enc(map[string]interface{}{"jsonrpc": "2.0", "id": req["id"],
+				"result": map[string]interface{}{"completion": map[string]interface{}{
+					"values": values, "total": len(values), "hasMore": false}}})
+		}
+
+		switch method {
+		case "initialize":
+			caps := map[string]interface{}{}
+			if mode != "no-cap" {
+				caps["completions"] = map[string]interface{}{}
+			}
+			if mode == "oracle" || mode == "reachable-empty" || mode == "resource-oracle" {
+				caps["prompts"] = map[string]interface{}{}
+			}
+			if mode == "resource-oracle" {
+				caps["resources"] = map[string]interface{}{}
+			}
+			enc(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req["id"],
+				"result": map[string]interface{}{
+					"protocolVersion": "2025-03-26",
+					"serverInfo":      map[string]interface{}{"name": "completion-srv", "version": "1.0"},
+					"capabilities":    caps,
+				},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "prompts/list":
+			enc(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req["id"],
+				"result": map[string]interface{}{
+					"prompts": []interface{}{
+						map[string]interface{}{
+							"name": "code_review",
+							"arguments": []interface{}{
+								map[string]interface{}{"name": "language"},
+							},
+						},
+					},
+				},
+			})
+		case "resources/templates/list":
+			enc(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req["id"],
+				"result": map[string]interface{}{
+					"resourceTemplates": []interface{}{
+						map[string]interface{}{"uriTemplate": "file:///project/{path}", "name": "project-file"},
+					},
+				},
+			})
+		case "completion/complete":
+			ref, _ := params["ref"].(map[string]interface{})
+			refType, _ := ref["type"].(string)
+			switch mode {
+			case "auth-enforced":
+				rpcErr(-32001, "Unauthorized")
+			case "reachable-synth":
+				rpcErr(-32602, "Invalid params: unknown prompt")
+			case "reachable-empty":
+				completion([]interface{}{})
+			case "resource-oracle":
+				// The prompt argument yields nothing; the resource template leaks.
+				if refType == "ref/resource" {
+					completion([]interface{}{"accounts/admin.py", "secrets/prod.env"})
+				} else {
+					completion([]interface{}{})
+				}
+			default: // oracle
+				completion([]interface{}{"python", "pytorch", "pyside"})
+			}
+		default:
+			rpcErr(-32601, "Method not found")
+		}
+	}))
+}
+
+func runCompletionUnauth(t *testing.T, srv *httptest.Server) []attack.Finding {
+	t.Helper()
+	exec := mcpattack.NewCompletionUnauthExecutor(attack.RuleContext{ID: "mcp-completion-unauth-001"})
+	findings, err := exec.Execute(context.Background(), srv.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return findings
+}
+
+// TestCompletionUnauth_Oracle: real ref returns values => medium + high.
+func TestCompletionUnauth_Oracle(t *testing.T) {
+	srv := completionServer("oracle")
+	defer srv.Close()
+
+	findings := runCompletionUnauth(t, srv)
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings (reachability + disclosure), got %d: %+v", len(findings), findings)
+	}
+	hasMedium, hasHigh := false, false
+	for _, f := range findings {
+		if f.Confidence != attack.ConfirmedExploit {
+			t.Errorf("expected ConfirmedExploit, got %v", f.Confidence)
+		}
+		switch f.Severity {
+		case "medium":
+			hasMedium = true
+		case "high":
+			hasHigh = true
+		}
+	}
+	if !hasMedium || !hasHigh {
+		t.Errorf("expected both medium and high findings, got medium=%v high=%v", hasMedium, hasHigh)
+	}
+}
+
+// TestCompletionUnauth_ResourceOracle: the prompt arg discloses nothing but the
+// resource-template variable leaks values => medium + high, high naming the
+// resource template.
+func TestCompletionUnauth_ResourceOracle(t *testing.T) {
+	srv := completionServer("resource-oracle")
+	defer srv.Close()
+
+	findings := runCompletionUnauth(t, srv)
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings (reachability + disclosure), got %d: %+v", len(findings), findings)
+	}
+	var high *attack.Finding
+	for i := range findings {
+		if findings[i].Severity == "high" {
+			high = &findings[i]
+		}
+	}
+	if high == nil {
+		t.Fatal("expected a high disclosure finding")
+	}
+	if !strings.Contains(high.Title, "resource template") {
+		t.Errorf("expected high finding to name the resource template, got %q", high.Title)
+	}
+}
+
+// TestCompletionUnauth_ReachableEmpty: reachable but no values => medium only.
+func TestCompletionUnauth_ReachableEmpty(t *testing.T) {
+	srv := completionServer("reachable-empty")
+	defer srv.Close()
+
+	findings := runCompletionUnauth(t, srv)
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 finding (reachability only), got %d: %+v", len(findings), findings)
+	}
+	if findings[0].Severity != "medium" {
+		t.Errorf("expected medium reachability finding, got %q", findings[0].Severity)
+	}
+}
+
+// TestCompletionUnauth_ReachableSynthetic: no prompt/resource refs to discover,
+// synthetic probe dispatches (-32602) => medium only.
+func TestCompletionUnauth_ReachableSynthetic(t *testing.T) {
+	srv := completionServer("reachable-synth")
+	defer srv.Close()
+
+	findings := runCompletionUnauth(t, srv)
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 finding (synthetic reachability), got %d: %+v", len(findings), findings)
+	}
+	if findings[0].Severity != "medium" {
+		t.Errorf("expected medium reachability finding, got %q", findings[0].Severity)
+	}
+}
+
+// TestCompletionUnauth_AuthEnforced: completion/complete requires auth => silent.
+func TestCompletionUnauth_AuthEnforced(t *testing.T) {
+	srv := completionServer("auth-enforced")
+	defer srv.Close()
+
+	if findings := runCompletionUnauth(t, srv); len(findings) != 0 {
+		t.Errorf("expected 0 findings when auth is enforced, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestCompletionUnauth_NoCapability: server does not advertise completions => skip.
+func TestCompletionUnauth_NoCapability(t *testing.T) {
+	srv := completionServer("no-cap")
+	defer srv.Close()
+
+	if findings := runCompletionUnauth(t, srv); len(findings) != 0 {
+		t.Errorf("expected 0 findings without the completions capability, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestCompletionUnauth_NotMCP: initialize fails => silent.
+func TestCompletionUnauth_NotMCP(t *testing.T) {
+	srv := completionServer("not-mcp")
+	defer srv.Close()
+
+	if findings := runCompletionUnauth(t, srv); len(findings) != 0 {
+		t.Errorf("expected 0 findings for a non-MCP server, got %d: %+v", len(findings), findings)
+	}
+}

--- a/rules/mcp/completion-unauth-001.yaml
+++ b/rules/mcp/completion-unauth-001.yaml
@@ -1,0 +1,58 @@
+id: mcp-completion-unauth-001
+info:
+  name: MCP completion/complete Reachable Without Authentication
+  author: batesian
+  severity: medium
+  description: |
+    Tests whether an MCP server answers completion/complete requests without
+    requiring authentication.
+
+    completion/complete returns autocompletion suggestions for prompt arguments
+    and resource-template URIs. Servers that support it advertise the
+    "completions" capability in the initialize handshake. The MCP specification's
+    Security section requires implementations to control access to sensitive
+    suggestions and to prevent completion-based information disclosure.
+
+    When the endpoint is reachable without authentication it becomes an
+    enumeration oracle: an anonymous caller can fuzz argument values or
+    URI-template segments and read back valid completions. Those suggestions can
+    reveal internal identifiers, file paths, usernames, or other namespace
+    contents that were never meant to be exposed to an unauthenticated client.
+
+    The rule reports two outcomes:
+    - completion/complete dispatches an unauthenticated request (medium): the
+      access control gap is confirmed by probing with a reference the server
+      handles rather than rejecting at an auth layer.
+    - completion/complete returns real suggestion values for a discovered prompt
+      argument or resource template (high): the endpoint is actively leaking
+      valid completions to an anonymous caller.
+
+    completion/complete is read-only; the probe never executes a tool or mutates
+    state and sends only benign single-character argument values.
+
+  references:
+    - https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/completion
+    - https://modelcontextprotocol.io/docs/concepts/authorization
+    - https://cwe.mitre.org/data/definitions/862.html
+    - https://cwe.mitre.org/data/definitions/200.html
+
+  tags:
+    - mcp
+    - auth
+    - completion
+    - information-disclosure
+    - cwe-862
+    - cwe-200
+
+attack:
+  protocol: mcp
+  type: mcp-completion-unauth
+
+remediation: |
+  1. Require authentication (OAuth 2.1 bearer token) before responding to
+     completion/complete requests, the same as any other data-bearing method.
+  2. Return a JSON-RPC auth error (or HTTP 401/403) for unauthenticated
+     completion/complete calls instead of dispatching them.
+  3. Scope completion suggestions to what the authenticated caller is authorized
+     to see, and rate-limit the endpoint so it cannot be used to brute-force the
+     server's internal namespace.

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -18,7 +18,7 @@ pip install starlette uvicorn httpx mcp
 
 ## Server Registry
 
-The bundled rule set is **16 A2A + 15 MCP = 31 rules**. Every rule's primary
+The bundled rule set is **16 A2A + 16 MCP = 32 rules**. Every rule's primary
 validation is an in-process `net/http/httptest` harness in its Go
 `*_test.go` (multiple server postures: vulnerable must fire / patched / open /
 benign must stay silent). The Python servers below are optional standalone
@@ -48,8 +48,9 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_confused_deputy_server.py` | 7793 | `mcp-confused-deputy-001` |
 | `mcp_dns_rebind_origin_server.py` | 7794 | `mcp-dns-rebind-origin-001` |
 | `mcp_batch_bypass_server.py` | 7795 | `mcp-jsonrpc-batch-bypass-001` |
+| `mcp_completion_unauth_server.py` | 7796 | `mcp-completion-unauth-001` |
 
-**Coverage.** 30 of the 31 rules have a standalone Python fixture above. The
+**Coverage.** 31 of the 32 rules have a standalone Python fixture above. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
 (`internal/attack/mcp/token_replay_test.go`); the same is true of the per-rule
 edge-case harnesses for every other rule. `mockserver.go` is a Go helper used by

--- a/testdata/mcp_completion_unauth_server.py
+++ b/testdata/mcp_completion_unauth_server.py
@@ -1,0 +1,111 @@
+"""
+Deliberately vulnerable MCP test server for validating:
+  - mcp-completion-unauth-001: answers completion/complete without auth and
+    leaks valid suggestion values to an anonymous caller.
+
+The server advertises the completions, prompts, and resources capabilities and
+serves completion/complete for both a prompt argument (ref/prompt) and a
+resource-template variable (ref/resource) with no authentication, so the rule
+fires its medium reachability finding plus the high disclosure finding.
+
+Run: python testdata/mcp_completion_unauth_server.py
+"""
+import json
+import uuid
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.routing import Route
+import uvicorn
+
+PORT = 7796
+
+PROMPTS = [
+    {
+        "name": "code_review",
+        "description": "Review code in a given language",
+        "arguments": [{"name": "language", "description": "Programming language", "required": True}],
+    },
+]
+
+RESOURCE_TEMPLATES = [
+    {"uriTemplate": "file:///project/{path}", "name": "project-file", "mimeType": "text/plain"},
+]
+
+# Completion suggestions the server leaks. These stand in for internal namespace
+# contents an operator would not want an anonymous caller to enumerate.
+LANGUAGE_VALUES = ["python", "pytorch", "pyside"]
+PATH_VALUES = ["accounts/admin.py", "accounts/billing.py", "secrets/prod.env"]
+
+sessions = {}
+
+
+def rpc_result(req_id, result):
+    return Response(json.dumps({"jsonrpc": "2.0", "id": req_id, "result": result}),
+                    media_type="application/json")
+
+
+def rpc_error(req_id, code, message):
+    return Response(json.dumps({"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}}),
+                    media_type="application/json")
+
+
+async def mcp_endpoint(request: Request) -> Response:
+    body = await request.json()
+    method = body.get("method", "")
+    req_id = body.get("id")
+    params = body.get("params", {})
+
+    if method == "initialize":
+        sid = str(uuid.uuid4())
+        sessions[sid] = True
+        result = {
+            "protocolVersion": params.get("protocolVersion", "2025-03-26"),
+            "serverInfo": {"name": "mcp-completion-vuln-server", "version": "1.0"},
+            "capabilities": {
+                "completions": {},
+                "prompts": {"listChanged": False},
+                "resources": {"listChanged": False},
+            },
+        }
+        return Response(json.dumps({"jsonrpc": "2.0", "id": req_id, "result": result}),
+                        media_type="application/json",
+                        headers={"Content-Type": "application/json", "Mcp-Session-Id": sid})
+
+    if method == "notifications/initialized":
+        return Response(status_code=202)
+
+    # No auth check on any of the methods below (vulnerable).
+    if method == "prompts/list":
+        return rpc_result(req_id, {"prompts": PROMPTS})
+
+    if method == "resources/templates/list":
+        return rpc_result(req_id, {"resourceTemplates": RESOURCE_TEMPLATES})
+
+    if method == "completion/complete":
+        ref = params.get("ref", {})
+        ref_type = ref.get("type", "")
+        if ref_type == "ref/prompt":
+            if ref.get("name") == "code_review":
+                values = LANGUAGE_VALUES
+            else:
+                # Unknown prompt name: dispatched, but invalid params per spec.
+                return rpc_error(req_id, -32602, "Invalid params: unknown prompt")
+        elif ref_type == "ref/resource":
+            values = PATH_VALUES
+        else:
+            return rpc_error(req_id, -32602, "Invalid params: unknown reference type")
+        return rpc_result(req_id, {"completion": {"values": values, "total": len(values), "hasMore": False}})
+
+    return rpc_error(req_id, -32601, "Method not found")
+
+
+app = Starlette(routes=[
+    Route("/mcp", mcp_endpoint, methods=["POST"]),
+    Route("/", mcp_endpoint, methods=["POST"]),
+])
+
+if __name__ == "__main__":
+    print(f"[*] MCP completion-unauth vulnerable server on port {PORT}", flush=True)
+    print("[*] Vulnerability: completion/complete answers without auth and leaks suggestion values", flush=True)
+    uvicorn.run(app, host="127.0.0.1", port=PORT)


### PR DESCRIPTION
## Summary

Adds `mcp-completion-unauth-001`: a rule that tests whether an MCP server answers `completion/complete` without authentication.

`completion/complete` returns autocompletion suggestions for prompt arguments and resource-template URIs (servers that support it advertise the `completions` capability). The spec's Security section requires implementations to control access to completion suggestions and to prevent completion-based information disclosure. An unauthenticated completion endpoint is both an access-control failure and a live enumeration oracle: an anonymous caller can read back valid argument values and URI-template segments (identifiers, file paths, usernames) from the server's internal namespace.

## Detection

- Gates on the advertised `completions` capability, read structurally from the captured `initialize` result (not a substring match).
- Discovers real references from the live server: every prompt argument (`ref/prompt`) and every resource-template variable (`ref/resource`), capped at 8.
- Probes `completion/complete` with an **empty** argument value, so a prefix/fuzzy matcher returns its full candidate set rather than filtering it out against a namespace that does not share a probe prefix.
- Reports two confirmed findings:
  - **medium** reachability when the handler dispatches an unauthenticated request (a completion result, any result envelope, or a `-32602` invalid-params error all prove dispatch);
  - **high** disclosure when a real reference returns actual suggestion values.
- Falls back to a synthetic prompt reference to establish reachability when prompts/resources listing is itself auth-gated. An auth-enforcing server (HTTP 401/403 or an auth-flavored JSON-RPC error) produces no finding.

Maps to CWE-862 (missing authorization) and CWE-200 (information exposure). The probe is read-only: it never invokes a tool or mutates state.

## Validation

- Unit harness across seven server postures (disclosure oracle via prompt arg, disclosure via resource template while the prompt arg is empty, reachable-but-empty, synthetic-only reachability, auth enforced, no completions capability, non-MCP).
- Standalone deliberately-vulnerable fixture on port 7796.
- End-to-end run against the `modelcontextprotocol` server-everything sample: the rule discovered `completion/complete` reachable without auth and disclosed live prompt-argument suggestions (`Engineering, Sales, Marketing, Support`) to an unauthenticated caller.

## Rule count

Bundled rules: **32 (16 A2A + 16 MCP)**. README, `docs/rules-mcp.md`, `testdata/README.md`, and the release header updated to match.

## Test plan

- `go test ./...` passes.
- `gofmt` clean, `golangci-lint run ./...` reports 0 issues.
