### PR TITLE
chore(build): bump go directive to 1.25.12 for GO-2026-5856

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/calbebop/batesian
 
-go 1.25.11
+go 1.25.12
 
 retract (
 	// Pre-release development versions, retained only for history.


### PR DESCRIPTION
## Summary

Bumps the `go` directive in `go.mod` from `1.25.11` to `1.25.12` to clear the CI vulnerability scan.

## Why

CI's `setup-go` step uses `go-version-file: go.mod`, so the govulncheck job ran under **go1.25.11** and flagged **[GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856)** in the `crypto/tls` standard library. That package is reached through the shared HTTP client every rule uses, so govulncheck reports it as called and the job exits non-zero.

The advisory is fixed in **go1.25.12** (released). This is a standard-library toolchain issue, independent of any rule code; it began failing once the advisory was published to the govulncheck database, so `main` and every open PR fail the scan until the toolchain is bumped.

## Test plan

- `go build ./...` passes on the bumped directive.
- CI vulnerability scan will run under go1.25.12 and no longer report GO-2026-5856.