### PR TITLE
feat(a2a-card-security-unenforced-001): flag unenforced card-declared auth

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -114,7 +114,7 @@ release:
     ## Batesian {{.Version}}
 
     Adversarial red-team CLI for AI agent protocols (A2A and MCP).
-    32 bundled attack rules (16 A2A + 16 MCP). Single binary. No runtime dependencies.
+    33 bundled attack rules (17 A2A + 16 MCP). Single binary. No runtime dependencies.
 
     ### Install
 

--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ CLI for adversarial testing of [A2A](https://a2a-protocol.org) and [MCP](https:/
 
 ## What ships
 
-Bundled rules: **16 A2A, 16 MCP (32 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
+Bundled rules: **17 A2A, 16 MCP (33 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
 
-- [A2A rules](docs/rules-a2a.md) (16)
+- [A2A rules](docs/rules-a2a.md) (17)
 - [MCP rules](docs/rules-mcp.md) (16)
 
 Coverage spans:
 
 - **OAuth & token validation** - OAuth 2.1 / DCR scope escalation, audience binding, token replay, version-downgrade bypass, forged-token acceptance, redirect_uri confused deputy
-- **Agent-card trust (A2A)** - JWS signatures, canonicalization, cache/freshness, required-extension downgrade, host-header injection, unauthenticated extended card
+- **Agent-card trust (A2A)** - JWS signatures, canonicalization, cache/freshness, required-extension downgrade, host-header injection, unauthenticated extended card, declared-but-unenforced auth
 - **Request & task integrity** - task IDOR, agent-role injection, artifact tampering, SEP-2243 header/body routing, SSE resumption replay
 - **Multi-party isolation** - cross-tenant isolation, session/context fixation, delegation chain-of-custody, cross-principal task cancellation
 - **SSRF & secret leakage** - push-notification SSRF, push control-plane binding, OAuth discovery/metadata SSRF, credential leakage into responses

--- a/docs/rules-a2a.md
+++ b/docs/rules-a2a.md
@@ -1,6 +1,6 @@
 # A2A Attack Rules
 
-Batesian ships **16 rules** targeting the [Agent-to-Agent (A2A) protocol](https://a2a-protocol.org/).
+Batesian ships **17 rules** targeting the [Agent-to-Agent (A2A) protocol](https://a2a-protocol.org/).
 Every rule is an active probe: it sends crafted protocol traffic and judges the
 server's actual response. Rules are deliberately scoped to A2A-specific semantics
 (agent cards, JWS card signatures, tasks/contexts, push notifications, peer
@@ -31,6 +31,7 @@ Each finding carries a **confidence**:
 | `a2a-push-binding-001` | [Push/Webhook Control-Plane Not Bound to Task Owner](#a2a-push-binding-001) | High | confirmed | CWE-639 |
 | `a2a-jsonrpc-batch-bypass-001` | [JSON-RPC Batch Authentication Bypass](#a2a-jsonrpc-batch-bypass-001) | High | confirmed | CWE-288 |
 | `a2a-task-cancel-idor-001` | [Cross-Principal Task Cancellation](#a2a-task-cancel-idor-001) | High | confirmed | CWE-639 / CWE-862 |
+| `a2a-card-security-unenforced-001` | [Agent Card Declares Unenforced Authentication](#a2a-card-security-unenforced-001) | High | confirmed | CWE-287 / CWE-306 |
 
 ---
 
@@ -354,3 +355,31 @@ A server that rejects the wrong-principal cancel, or that cannot cancel the task
 throwaway task; it never cancels a pre-existing one. Against a server that
 completes tasks almost immediately, the probe task may be terminal before it can
 be canceled, in which case the rule reports nothing.
+
+---
+
+### a2a-card-security-unenforced-001
+
+**Agent Card Declares Unenforced Authentication** | Severity: High | CWE-287 / CWE-306
+
+The AgentCard is a machine-readable contract: its `securitySchemes` plus a
+requirements list (named `security` in v0.3 cards, `securityRequirements` in v1.0
+proto-JSON cards - both are read) declare which authentication a caller MUST
+present. This rule fires only when the card declares a **non-empty** requirement
+with **no anonymous alternative** (an empty `{}` requirement object, per OpenAPI
+convention, explicitly permits anonymous access and is not flagged), then sends an
+unauthenticated core request. A first, non-mutating `tasks/get` for a random
+non-existent id records whether the read path is reachable anonymously; the
+definitive confirmation is an unauthenticated `message/send` that returns a task
+result (the created task is then read back unauthenticated to corroborate). A
+**confirmed** finding is raised only on a positive result envelope - never on an
+ambiguous application error - so a server that answers the unauthenticated request
+with HTTP 401/403 produces no finding.
+
+This complements `a2a-task-idor-001`, which keys off whether anonymous creation is
+rejected and **suppresses** its finding when the server enforces no authentication
+at all - so a wide-open agent goes unflagged there. This rule flags exactly that
+case, but only when the card promised authentication, making it an attributable
+contract violation (CWE-287 / CWE-306). It is distinct from `a2a-extcard-unauth-001`
+(the extended-card endpoint) and `a2a-card-trust-001` / `a2a-jws-algconf-001` (card
+signatures).

--- a/internal/attack/a2a/card_security_unenforced.go
+++ b/internal/attack/a2a/card_security_unenforced.go
@@ -1,0 +1,275 @@
+package a2a
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// CardSecurityUnenforcedExecutor tests whether an A2A server enforces the
+// authentication its own AgentCard advertises (rule a2a-card-security-unenforced-001).
+//
+// The AgentCard is a machine-readable contract. Its securitySchemes plus a
+// requirements list (named "security" in v0.3 cards, "securityRequirements" in
+// v1.0 proto-JSON cards) declare which authentication a caller MUST present. When
+// the card declares a non-empty requirement with no anonymous alternative, yet
+// the server answers an unauthenticated core request with a result, the agent
+// violates its own published security contract - broad unauthenticated access to
+// an agent that told clients it was protected.
+//
+// This is the case nothing else covers: a2a-task-idor-001 keys off whether
+// anonymous creation is rejected and suppresses its finding when the server has
+// no auth at all, so a wide-open agent goes unflagged today. This rule flags it
+// precisely when the card promised auth (an attributable regression). It is
+// distinct from a2a-extcard-unauth-001 (the extended-card endpoint) and
+// a2a-card-trust-001 / a2a-jws-algconf-001 (card signatures).
+//
+// SAFETY: the read probe is non-mutating (tasks/get on a random non-existent id).
+// The confirmation write creates a single throwaway probe task, the same footprint
+// a2a-task-idor-001 already has.
+type CardSecurityUnenforcedExecutor struct {
+	rule attack.RuleContext
+}
+
+func init() {
+	attack.Register("a2a-card-security-unenforced", func(rc attack.RuleContext) attack.Executor {
+		return NewCardSecurityUnenforcedExecutor(rc)
+	})
+}
+
+func NewCardSecurityUnenforcedExecutor(r attack.RuleContext) *CardSecurityUnenforcedExecutor {
+	return &CardSecurityUnenforcedExecutor{rule: r}
+}
+
+// probeOutcome classifies an unauthenticated core request.
+type probeOutcome int
+
+const (
+	probeAuthRejected    probeOutcome = iota // HTTP 401/403 or an auth-flavored error: auth enforced
+	probeProcessedError                      // reached the handler, returned a non-auth application error
+	probeProcessedResult                     // reached the handler, returned a success result envelope
+)
+
+func (e *CardSecurityUnenforcedExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
+	vars := attack.NewVars(target, opts.OOBListenerURL)
+	client := attack.NewHTTPClient(opts, vars)
+
+	// Fetch the card. Without it there is no declared contract to test against.
+	cardBody, ok := fetchAgentCardBody(ctx, client, vars.BaseURL)
+	if !ok {
+		return nil, attack.ErrInconclusive
+	}
+	card, ok := parseCard(cardBody)
+	if !ok {
+		return nil, attack.ErrInconclusive
+	}
+
+	// Only proceed when the card declares required auth with no anonymous option.
+	schemes, required := declaredAuthRequirement(card)
+	if !required {
+		return nil, nil
+	}
+
+	// Resolve the JSON-RPC endpoint to probe. The card requires auth but we cannot
+	// reach a testable endpoint, so the contract cannot be exercised here.
+	endpoint, ok := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
+	if !ok {
+		return nil, attack.ErrInconclusive
+	}
+
+	unauthClient := attack.NewUnauthHTTPClient(opts, attack.NewVars(target, opts.OOBListenerURL))
+
+	// Step 1 (non-mutating): can an unauthenticated read even reach the handler?
+	// A read of a random non-existent id cannot return a task, so this only tells
+	// us whether the read path rejects at the auth layer (evidence, not verdict).
+	readReachable := e.readTask(ctx, unauthClient, endpoint, "batesian-missing-"+vars.RandID, vars.RandID) != probeAuthRejected
+
+	// Step 2 (definitive): unauthenticated create. A returned task proves a core
+	// write executed with no credentials despite the card requiring them.
+	createOutcome, createdTaskID := e.createProbe(ctx, unauthClient, endpoint, vars.RandID)
+	if createOutcome != probeProcessedResult {
+		// No unauthenticated request was processed into a success result: either the
+		// server enforces auth (rejected) or only returned application errors. Do not
+		// claim a violation without a positive, unambiguous result envelope.
+		return nil, nil
+	}
+
+	// Strengthen: read the just-created task back with no credentials. If that also
+	// returns the task, both the write and the read paths ignore the declared auth.
+	readBack := createdTaskID != "" && e.readTask(ctx, unauthClient, endpoint, createdTaskID, vars.RandID) == probeProcessedResult
+
+	return []attack.Finding{e.finding(endpoint, schemes, createdTaskID, readReachable, readBack)}, nil
+}
+
+// readTask issues an unauthenticated tasks/get for taskID (v1.0 GetTask then v0.3
+// tasks/get) and classifies the strongest outcome seen.
+func (e *CardSecurityUnenforcedExecutor) readTask(ctx context.Context, c *attack.HTTPClient, endpoint, taskID, randID string) probeOutcome {
+	shapes := []struct {
+		method  string
+		headers map[string]string
+	}{
+		{"GetTask", map[string]string{"A2A-Version": "1.0"}},
+		{"tasks/get", nil},
+	}
+	outcome := probeAuthRejected
+	for _, s := range shapes {
+		resp, err := c.POST(ctx, endpoint, s.headers, map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      "batesian-cardsec-get-" + randID,
+			"method":  s.method,
+			"params":  map[string]interface{}{"id": taskID, "historyLength": 1},
+		})
+		if err != nil {
+			continue
+		}
+		if o := classifyProbe(resp); o > outcome {
+			outcome = o
+		}
+	}
+	return outcome
+}
+
+// createProbe issues an unauthenticated message/send (v1.0 SendMessage then v0.3
+// message/send) and reports whether a task was created without credentials.
+func (e *CardSecurityUnenforcedExecutor) createProbe(ctx context.Context, c *attack.HTTPClient, endpoint, randID string) (probeOutcome, string) {
+	shapes := []struct {
+		method  string
+		headers map[string]string
+		message map[string]interface{}
+	}{
+		{"SendMessage", map[string]string{"A2A-Version": "1.0"}, map[string]interface{}{
+			"role":      1,
+			"parts":     []interface{}{map[string]string{"text": "batesian card-security probe " + randID}},
+			"messageId": "batesian-cardsec-" + randID,
+		}},
+		{"message/send", nil, map[string]interface{}{
+			"role":      "user",
+			"parts":     []interface{}{map[string]string{"kind": "text", "text": "batesian card-security probe " + randID}},
+			"messageId": "batesian-cardsec-" + randID,
+		}},
+	}
+	outcome := probeAuthRejected
+	for _, s := range shapes {
+		resp, err := c.POST(ctx, endpoint, s.headers, map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      "batesian-cardsec-send-" + randID,
+			"method":  s.method,
+			"params":  map[string]interface{}{"message": s.message},
+		})
+		if err != nil {
+			continue
+		}
+		o := classifyProbe(resp)
+		if o == probeProcessedResult {
+			taskID, _ := extractTaskContext(resp.Body)
+			return probeProcessedResult, taskID
+		}
+		if o > outcome {
+			outcome = o
+		}
+	}
+	return outcome, ""
+}
+
+// classifyProbe maps an unauthenticated response to a probeOutcome. An auth
+// rejection (HTTP 401/403 or auth-flavored error) means auth is enforced; an
+// HTTP 200 with a JSON-RPC result envelope means the handler processed the
+// anonymous request and returned data; anything else in between (HTTP 200 with a
+// non-auth application error) means the handler was reached but errored.
+func classifyProbe(resp *attack.Response) probeOutcome {
+	if isA2AAuthRejection(resp) {
+		return probeAuthRejected
+	}
+	if resp.IsSuccess() && !isJSONRPCError(resp.Body) && resp.ContainsAny(`"result"`) {
+		return probeProcessedResult
+	}
+	if resp.IsSuccess() {
+		return probeProcessedError
+	}
+	return probeAuthRejected
+}
+
+func (e *CardSecurityUnenforcedExecutor) finding(endpoint string, schemes []string, taskID string, readReachable, readBack bool) attack.Finding {
+	schemeList := strings.Join(schemes, ", ")
+	readLine := "unauthenticated read (tasks/get) of the created task: not confirmed"
+	if readBack {
+		readLine = "unauthenticated read (tasks/get) of the created task: task returned"
+	} else if readReachable {
+		readLine = "unauthenticated read (tasks/get) path: reachable (not rejected at the auth layer)"
+	}
+	return attack.Finding{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "high",
+		Confidence: attack.ConfirmedExploit,
+		Title:      "A2A agent card declares required authentication but the endpoint serves unauthenticated requests",
+		Description: fmt.Sprintf(
+			"The agent card declares a security requirement (scheme(s): %s) that a caller MUST satisfy, "+
+				"yet an unauthenticated message/send at %s created task %s and returned its result with no "+
+				"credentials presented. The card is the agent's published security contract; the server does "+
+				"not enforce it, so any anonymous caller has the access the card says requires "+
+				"authentication.", schemeList, endpoint, taskID),
+		Evidence: fmt.Sprintf(
+			"endpoint: %s\ncard-declared security scheme(s): %s\nunauthenticated message/send: accepted (created task %s)\n%s",
+			endpoint, schemeList, taskID, readLine),
+		Remediation: e.rule.Remediation,
+		TargetURL:   endpoint,
+	}
+}
+
+// fetchAgentCardBody returns the raw card body from the primary (v1.0) path,
+// falling back to the legacy (v0.3) path.
+func fetchAgentCardBody(ctx context.Context, client *attack.HTTPClient, baseURL string) ([]byte, bool) {
+	if body, _, ok := fetchCard(ctx, client, baseURL+cardPathPrimary); ok {
+		return body, true
+	}
+	if body, _, ok := fetchCard(ctx, client, baseURL+cardPathLegacy); ok {
+		return body, true
+	}
+	return nil, false
+}
+
+// declaredAuthRequirement reports the distinct scheme names a card requires, and
+// whether authentication is required with no anonymous alternative. It reads the
+// v1.0 securityRequirements list first, then the v0.3 security list. Per OpenAPI
+// semantics an empty requirement object ({}) in the list explicitly permits
+// anonymous access, so its presence means auth is NOT required.
+func declaredAuthRequirement(card map[string]interface{}) (schemes []string, required bool) {
+	list := cardSecurityList(card)
+	if len(list) == 0 {
+		return nil, false
+	}
+	seen := map[string]bool{}
+	for _, item := range list {
+		obj, ok := item.(map[string]interface{})
+		if !ok {
+			return nil, false // malformed requirement entry: do not assert a violation
+		}
+		if len(obj) == 0 {
+			return nil, false // empty requirement object: anonymous access is allowed
+		}
+		for name := range obj {
+			if !seen[name] {
+				seen[name] = true
+				schemes = append(schemes, name)
+			}
+		}
+	}
+	sort.Strings(schemes)
+	return schemes, true
+}
+
+// cardSecurityList returns the requirements list, preferring the v1.0
+// securityRequirements field and falling back to the v0.3 security field.
+func cardSecurityList(card map[string]interface{}) []interface{} {
+	if v, ok := card["securityRequirements"].([]interface{}); ok && len(v) > 0 {
+		return v
+	}
+	if v, ok := card["security"].([]interface{}); ok {
+		return v
+	}
+	return nil
+}

--- a/internal/attack/a2a/card_security_unenforced_test.go
+++ b/internal/attack/a2a/card_security_unenforced_test.go
@@ -1,0 +1,213 @@
+package a2a_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	a2aattack "github.com/calbebop/batesian/internal/attack/a2a"
+)
+
+// cardSecServer builds a mock A2A server whose AgentCard security declaration and
+// JSON-RPC auth behavior depend on mode:
+//   - "vuln-v1":      card declares securityRequirements (v1.0 field) requiring a
+//     scheme, but message/send is served unauthenticated => finding.
+//   - "vuln-v03":     same, but the card uses the v0.3 "security" field => finding
+//     (proves both field spellings are read).
+//   - "secure":       card declares required auth and the server enforces it
+//     (401 without a token) => silent.
+//   - "anon-allowed": card requirement list includes an empty {} object, so
+//     anonymous access is explicitly permitted; even though the endpoint is open,
+//     it must not be flagged => silent.
+//   - "no-security":  card declares no security requirement; the open endpoint is
+//     not a broken promise => silent.
+//   - "not-a2a":      no card, everything 404 => inconclusive.
+func cardSecServer(mode string) *httptest.Server {
+	var mu sync.Mutex
+	store := map[string]bool{}
+	counter := 0
+
+	card := func() string {
+		var sec string
+		switch mode {
+		case "vuln-v03":
+			sec = `"security":[{"bearerAuth":[]}],`
+		case "anon-allowed":
+			sec = `"securityRequirements":[{},{"bearerAuth":[]}],`
+		case "no-security":
+			sec = ``
+		default: // vuln-v1, secure
+			sec = `"securityRequirements":[{"bearerAuth":[]}],`
+		}
+		return `{
+			"name": "Card Security Test Agent",
+			"description": "test",
+			"version": "1.0.0",
+			"capabilities": {},
+			"skills": [],
+			"securitySchemes": {"bearerAuth": {"httpAuthSecurityScheme": {"scheme": "Bearer"}}},
+			` + sec + `
+			"defaultInputModes": ["text/plain"],
+			"defaultOutputModes": ["text/plain"]
+		}`
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if mode == "not-a2a" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if r.Method == http.MethodGet && r.URL.Path == "/.well-known/agent-card.json" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, card())
+			return
+		}
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]interface{}
+		_ = json.Unmarshal(body, &req)
+		method, _ := req["method"].(string)
+		id := req["id"]
+		params, _ := req["params"].(map[string]interface{})
+		hasToken := strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ")
+		w.Header().Set("Content-Type", "application/json")
+
+		result := func(res map[string]interface{}) {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id, "result": res})
+		}
+		rpcErr := func(code int, msg string) {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": code, "message": msg}})
+		}
+
+		// In secure mode every method requires a bearer token.
+		if mode == "secure" && !hasToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		switch method {
+		case "SendMessage", "message/send":
+			mu.Lock()
+			counter++
+			tid := fmt.Sprintf("task-%d", counter)
+			store[tid] = true
+			mu.Unlock()
+			result(map[string]interface{}{"id": tid, "contextId": "ctx-" + tid,
+				"status": map[string]interface{}{"state": "submitted"}})
+		case "GetTask", "tasks/get":
+			taskID, _ := params["id"].(string)
+			mu.Lock()
+			exists := store[taskID]
+			mu.Unlock()
+			if !exists {
+				rpcErr(-32001, "Task not found")
+				return
+			}
+			result(map[string]interface{}{"id": taskID, "contextId": "ctx-" + taskID,
+				"status": map[string]interface{}{"state": "submitted"}})
+		default:
+			rpcErr(-32601, "method not found")
+		}
+	}))
+}
+
+func runCardSec(t *testing.T, srv *httptest.Server) ([]attack.Finding, error) {
+	t.Helper()
+	exec := a2aattack.NewCardSecurityUnenforcedExecutor(attack.RuleContext{
+		ID:   "a2a-card-security-unenforced-001",
+		Name: "A2A Agent Card Declares Authentication That Is Not Enforced",
+	})
+	return exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+}
+
+// TestCardSecurity_VulnV1: v1.0 card requires auth but message/send is open => finding.
+func TestCardSecurity_VulnV1(t *testing.T) {
+	srv := cardSecServer("vuln-v1")
+	defer srv.Close()
+
+	findings, err := runCardSec(t, srv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Confidence != attack.ConfirmedExploit || f.Severity != "high" {
+		t.Errorf("expected high/confirmed, got %q/%v", f.Severity, f.Confidence)
+	}
+	if !strings.Contains(f.Title, "declares required authentication") {
+		t.Errorf("unexpected title %q", f.Title)
+	}
+}
+
+// TestCardSecurity_VulnV03: the v0.3 "security" field must be read, not only the
+// v1.0 "securityRequirements".
+func TestCardSecurity_VulnV03(t *testing.T) {
+	srv := cardSecServer("vuln-v03")
+	defer srv.Close()
+
+	findings, err := runCardSec(t, srv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding for a v0.3 secured-but-open card, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestCardSecurity_Secure: card requires auth and the server enforces it => silent.
+func TestCardSecurity_Secure(t *testing.T) {
+	srv := cardSecServer("secure")
+	defer srv.Close()
+
+	if findings, err := runCardSec(t, srv); err != nil || len(findings) != 0 {
+		t.Errorf("expected 0 findings / nil err when auth is enforced, got %d findings, err=%v", len(findings), err)
+	}
+}
+
+// TestCardSecurity_AnonymousAllowed: an empty {} requirement object permits
+// anonymous access, so an open endpoint must not be flagged.
+func TestCardSecurity_AnonymousAllowed(t *testing.T) {
+	srv := cardSecServer("anon-allowed")
+	defer srv.Close()
+
+	if findings, err := runCardSec(t, srv); err != nil || len(findings) != 0 {
+		t.Errorf("expected 0 findings / nil err when the card permits anonymous access, got %d findings, err=%v", len(findings), err)
+	}
+}
+
+// TestCardSecurity_NoSecurity: card declares no requirement, so an open endpoint
+// is not a broken promise.
+func TestCardSecurity_NoSecurity(t *testing.T) {
+	srv := cardSecServer("no-security")
+	defer srv.Close()
+
+	if findings, err := runCardSec(t, srv); err != nil || len(findings) != 0 {
+		t.Errorf("expected 0 findings / nil err when the card declares no security, got %d findings, err=%v", len(findings), err)
+	}
+}
+
+// TestCardSecurity_NotA2A: no card / no endpoint => inconclusive.
+func TestCardSecurity_NotA2A(t *testing.T) {
+	srv := cardSecServer("not-a2a")
+	defer srv.Close()
+
+	_, err := runCardSec(t, srv)
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive for a non-A2A endpoint, got err=%v", err)
+	}
+}

--- a/internal/protocol/a2a/card.go
+++ b/internal/protocol/a2a/card.go
@@ -43,9 +43,12 @@ type AgentCard struct {
 	Provider         *AgentProvider `json:"provider,omitempty"`
 	IconURL          string         `json:"iconUrl,omitempty"`
 
-	// Authentication (OpenAPI-style security schemes)
+	// Authentication (OpenAPI-style security schemes). The requirements list is
+	// named securityRequirements in v1.0 (proto JSON) but security in v0.3 cards;
+	// both are captured so either version's declared auth can be read.
 	SecuritySchemes      map[string]SecurityScheme `json:"securitySchemes,omitempty"`
 	SecurityRequirements []SecurityRequirement     `json:"securityRequirements,omitempty"`
+	Security             []SecurityRequirement     `json:"security,omitempty"`
 
 	// Signatures holds JWS signatures over the Agent Card (RFC 7515).
 	Signatures []AgentCardSignature `json:"signatures,omitempty"`

--- a/internal/protocol/a2a/card_test.go
+++ b/internal/protocol/a2a/card_test.go
@@ -245,6 +245,33 @@ func TestAgentCard_FullV1(t *testing.T) {
 	}
 }
 
+// TestAgentCard_V03SecurityField verifies the v0.3 spelling of the requirements
+// list (`security`) parses, not only the v1.0 `securityRequirements`.
+func TestAgentCard_V03SecurityField(t *testing.T) {
+	const v03SecuredCard = `{
+		"name": "Secured Legacy Agent",
+		"url": "https://legacy.example.com",
+		"version": "0.3.0",
+		"capabilities": {},
+		"skills": [],
+		"securitySchemes": {"apiKey": {"apiKeySecurityScheme": {"location": "header", "name": "X-API-Key"}}},
+		"security": [{"apiKey": []}]
+	}`
+	var card AgentCard
+	if err := json.Unmarshal([]byte(v03SecuredCard), &card); err != nil {
+		t.Fatalf("failed to parse v0.3 secured card: %v", err)
+	}
+	if len(card.Security) != 1 {
+		t.Fatalf("Security (v0.3) len = %d, want 1", len(card.Security))
+	}
+	if _, ok := card.Security[0]["apiKey"]; !ok {
+		t.Errorf("Security[0] should reference the apiKey scheme, got %v", card.Security[0])
+	}
+	if len(card.SecurityRequirements) != 0 {
+		t.Errorf("SecurityRequirements should be empty for a v0.3 card, got %d", len(card.SecurityRequirements))
+	}
+}
+
 func TestAgentCard_RoundTrip(t *testing.T) {
 	var card AgentCard
 	if err := json.Unmarshal([]byte(fullV1CardJSON), &card); err != nil {

--- a/rules/a2a/card-security-unenforced-001.yaml
+++ b/rules/a2a/card-security-unenforced-001.yaml
@@ -1,0 +1,62 @@
+id: a2a-card-security-unenforced-001
+info:
+  name: A2A Agent Card Declares Authentication That Is Not Enforced
+  author: batesian
+  severity: high
+  description: |
+    Tests whether an A2A server actually enforces the authentication its own
+    AgentCard advertises.
+
+    The AgentCard is a machine-readable contract. Its securitySchemes plus a
+    requirements list declare which authentication a caller must present. The
+    list is named "security" in v0.3 cards and "securityRequirements" in v1.0
+    (proto-JSON) cards; both are read.
+
+    When the card declares a non-empty requirement with no anonymous alternative
+    (an empty requirement object, per OpenAPI convention, would explicitly permit
+    anonymous access and is not flagged), the rule sends an unauthenticated core
+    request. If the server processes it and returns a result instead of rejecting
+    it at the auth layer (HTTP 401/403), the agent is not enforcing the security
+    contract it published, so any anonymous caller has the access the card says
+    requires authentication.
+
+    Detection:
+    - Fetch and parse the card; require a non-empty declared security requirement
+      with no anonymous ({}) alternative, else no finding.
+    - Read probe (non-mutating): an unauthenticated tasks/get for a random,
+      non-existent task id, used to record whether the read path is reachable
+      anonymously.
+    - Confirmation (definitive): an unauthenticated message/send. A returned task
+      result proves a core write executed with no credentials. The created task is
+      then read back unauthenticated to corroborate. The finding is raised only on
+      a positive result envelope, never on an ambiguous application error.
+
+    This complements a2a-task-idor-001, which suppresses its finding when a server
+    enforces no authentication at all: a wide-open agent is flagged here precisely
+    because its card promised authentication.
+
+  references:
+    - https://a2a-protocol.org/latest/specification/
+    - https://cwe.mitre.org/data/definitions/287.html
+    - https://cwe.mitre.org/data/definitions/306.html
+
+  tags:
+    - a2a
+    - auth
+    - agent-card
+    - cwe-287
+    - cwe-306
+
+attack:
+  protocol: a2a
+  type: a2a-card-security-unenforced
+
+remediation: |
+  1. Enforce, at the transport layer, the authentication your AgentCard declares
+     in securitySchemes / security (securityRequirements): reject requests that
+     omit valid credentials with HTTP 401 (and a WWW-Authenticate header) before
+     dispatching any JSON-RPC method.
+  2. If some endpoints are intentionally public, reflect that in the card - do not
+     declare a required security scheme the server does not enforce.
+  3. Keep the published card and the server's actual enforcement in sync; treat
+     the card as the authoritative contract clients rely on.

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -18,7 +18,7 @@ pip install starlette uvicorn httpx mcp
 
 ## Server Registry
 
-The bundled rule set is **16 A2A + 16 MCP = 32 rules**. Every rule's primary
+The bundled rule set is **17 A2A + 16 MCP = 33 rules**. Every rule's primary
 validation is an in-process `net/http/httptest` harness in its Go
 `*_test.go` (multiple server postures: vulnerable must fire / patched / open /
 benign must stay silent). The Python servers below are optional standalone
@@ -35,6 +35,7 @@ fixtures for live-validation / manual smoke testing.
 | `a2a_extension_downgrade_server.py` | 3106 | `a2a-extension-downgrade-001` |
 | `a2a_push_binding_server.py` | 3107 | `a2a-push-binding-001` (two principals; needs two `--principal`s) |
 | `a2a_batch_bypass_server.py` | 3108 | `a2a-jsonrpc-batch-bypass-001` |
+| `a2a_card_security_unenforced_server.py` | 3110 | `a2a-card-security-unenforced-001` |
 | `a2a_task_cancel_server.py` | 3109 | `a2a-task-cancel-idor-001` (two principals; needs two `--principal`s) |
 | `mcp_unauth_resources_server.py` | 7787 | `mcp-resources-unauth-001` |
 | `mcp_oauth_dcr_server.py` | 7788 | `mcp-oauth-dcr-001` |
@@ -50,7 +51,7 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_batch_bypass_server.py` | 7795 | `mcp-jsonrpc-batch-bypass-001` |
 | `mcp_completion_unauth_server.py` | 7796 | `mcp-completion-unauth-001` |
 
-**Coverage.** 31 of the 32 rules have a standalone Python fixture above. The
+**Coverage.** 32 of the 33 rules have a standalone Python fixture above. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
 (`internal/attack/mcp/token_replay_test.go`); the same is true of the per-rule
 edge-case harnesses for every other rule. `mockserver.go` is a Go helper used by

--- a/testdata/a2a_card_security_unenforced_server.py
+++ b/testdata/a2a_card_security_unenforced_server.py
@@ -1,0 +1,86 @@
+"""
+Deliberately vulnerable A2A test server for validating:
+  - a2a-card-security-unenforced-001: the AgentCard declares that a Bearer token
+    is required (securitySchemes + securityRequirements), but the JSON-RPC
+    endpoint serves message/send and tasks/get with no authentication.
+
+The card promises auth; the server does not enforce it, so the rule fires its
+high/confirmed finding after an unauthenticated message/send returns a task.
+
+Run: python testdata/a2a_card_security_unenforced_server.py
+"""
+import json
+import uuid
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route
+import uvicorn
+
+PORT = 3110
+BASE = f"http://127.0.0.1:{PORT}"
+
+AGENT_CARD = {
+    "name": "Insecure Research Agent",
+    "description": "Declares Bearer auth but does not enforce it",
+    "version": "1.0.0",
+    "supportedInterfaces": [
+        {"url": BASE + "/", "protocolBinding": "JSONRPC", "protocolVersion": "1.0"},
+    ],
+    "capabilities": {"streaming": False},
+    "defaultInputModes": ["text/plain"],
+    "defaultOutputModes": ["text/plain"],
+    "skills": [
+        {"id": "research", "name": "Research", "description": "Answers questions", "tags": ["research"]},
+    ],
+    # The card advertises that callers MUST present a Bearer token...
+    "securitySchemes": {
+        "bearerAuth": {"httpAuthSecurityScheme": {"scheme": "Bearer", "bearerFormat": "JWT"}},
+    },
+    "securityRequirements": [{"bearerAuth": []}],
+}
+
+tasks = {}
+
+
+async def agent_card(request: Request) -> Response:
+    return JSONResponse(AGENT_CARD)
+
+
+async def jsonrpc(request: Request) -> Response:
+    body = await request.json()
+    method = body.get("method", "")
+    req_id = body.get("id")
+    params = body.get("params", {})
+
+    def result(res):
+        return JSONResponse({"jsonrpc": "2.0", "id": req_id, "result": res})
+
+    def error(code, msg):
+        return JSONResponse({"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": msg}})
+
+    # ...but no method below checks the Authorization header (vulnerable).
+    if method in ("SendMessage", "message/send"):
+        tid = "task-" + uuid.uuid4().hex[:8]
+        tasks[tid] = {"id": tid, "contextId": "ctx-" + tid, "status": {"state": "submitted"}}
+        return result(tasks[tid])
+
+    if method in ("GetTask", "tasks/get"):
+        tid = params.get("id", "")
+        task = tasks.get(tid)
+        if task is None:
+            return error(-32001, "Task not found")
+        return result(task)
+
+    return error(-32601, "Method not found")
+
+
+app = Starlette(routes=[
+    Route("/.well-known/agent-card.json", agent_card, methods=["GET"]),
+    Route("/", jsonrpc, methods=["POST"]),
+])
+
+if __name__ == "__main__":
+    print(f"[*] A2A card-security-unenforced vulnerable server on port {PORT}", flush=True)
+    print("[*] Vulnerability: card declares Bearer auth but message/send is served unauthenticated", flush=True)
+    uvicorn.run(app, host="127.0.0.1", port=PORT)


### PR DESCRIPTION
## Summary

Adds `a2a-card-security-unenforced-001`: a rule that tests whether an A2A server actually enforces the authentication its own AgentCard advertises.

The AgentCard is a machine-readable contract. Its `securitySchemes` plus a requirements list declare which authentication a caller MUST present. The list is named `security` in v0.3 cards and `securityRequirements` in v1.0 (proto-JSON) cards; **both are read**. When the card declares a non-empty requirement with **no anonymous alternative**, yet the server answers an unauthenticated core request with a result, the agent violates its own published security contract, giving anonymous callers the access the card says requires authentication.

## Detection

- Fetch and parse the card from both well-known paths; require a non-empty declared security requirement.
- **False-positive guard (OpenAPI semantics):** an empty `{}` requirement object explicitly permits anonymous access, so its presence means auth is not required and nothing is flagged. An empty/absent requirements list is likewise not flagged.
- Read probe (non-mutating): an unauthenticated `tasks/get` for a random non-existent id, recording whether the read path is reachable anonymously.
- Confirmation (definitive): an unauthenticated `message/send`. A returned task result proves a core write executed with no credentials; the created task is then read back unauthenticated to corroborate.
- A **high / confirmed** finding is raised only on a positive result envelope, never on an ambiguous application error. HTTP 401/403 (or an auth-flavored error) means auth is enforced and produces no finding.

Maps to CWE-287 (improper authentication) and CWE-306 (missing auth for a critical function). Both v1.0 (`SendMessage`/`GetTask`) and v0.3 (`message/send`/`tasks/get`) method shapes are probed.

## Why it is distinct

`a2a-task-idor-001` keys off whether anonymous creation is rejected and **suppresses** its finding when a server enforces no authentication at all, so a wide-open agent goes unflagged there. This rule flags exactly that case, but only when the card promised authentication, making it an attributable contract violation. It is separate from `a2a-extcard-unauth-001` (the extended-card endpoint) and `a2a-card-trust-001` / `a2a-jws-algconf-001` (card signatures).

## Model fix

The typed `AgentCard` only modelled `securityRequirements` (v1.0); a `Security` field (`json:"security"`) is added so v0.3 cards parse their declared requirements. Confirmed against the `a2a-python` SDK that v1.0 emits `securityRequirements` and the v0.3 compat model emits `security`.

## Validation

- Six-posture unit harness: fires on open v1.0 and v0.3 cards; silent on enforced auth, anonymous-allowed (`{}`), and no-declared-security; inconclusive on a non-A2A endpoint. Plus a card-model parse test for the v0.3 `security` field.
- Standalone deliberately-vulnerable fixture on port 3110 (card declares Bearer, endpoint serves `message/send` open): live run fires the high finding, with the created task read back unauthenticated.

## Rule count

Bundled rules: **33 (17 A2A + 16 MCP)**. README, `docs/rules-a2a.md`, `testdata/README.md`, and the release header updated to match.

## Test plan

- `go test ./...` passes; `gofmt` clean; `golangci-lint run ./...` reports 0 issues.
