### PR TITLE
feat(mcp-logging-unauth-001): detect unauthenticated logging/setLevel

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -114,7 +114,7 @@ release:
     ## Batesian {{.Version}}
 
     Adversarial red-team CLI for AI agent protocols (A2A and MCP).
-    33 bundled attack rules (17 A2A + 16 MCP). Single binary. No runtime dependencies.
+    34 bundled attack rules (17 A2A + 17 MCP). Single binary. No runtime dependencies.
 
     ### Install
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ CLI for adversarial testing of [A2A](https://a2a-protocol.org) and [MCP](https:/
 
 ## What ships
 
-Bundled rules: **17 A2A, 16 MCP (33 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
+Bundled rules: **17 A2A, 17 MCP (34 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
 
 - [A2A rules](docs/rules-a2a.md) (17)
-- [MCP rules](docs/rules-mcp.md) (16)
+- [MCP rules](docs/rules-mcp.md) (17)
 
 Coverage spans:
 
@@ -31,7 +31,7 @@ Coverage spans:
 - **Request & task integrity** - task IDOR, agent-role injection, artifact tampering, SEP-2243 header/body routing, SSE resumption replay
 - **Multi-party isolation** - cross-tenant isolation, session/context fixation, delegation chain-of-custody, cross-principal task cancellation
 - **SSRF & secret leakage** - push-notification SSRF, push control-plane binding, OAuth discovery/metadata SSRF, credential leakage into responses
-- **Unauthenticated & cross-origin access** - exposed MCP tools, resources, prompt templates, and completion suggestions, Streamable HTTP Origin validation (DNS rebinding)
+- **Unauthenticated & cross-origin access** - exposed MCP tools, resources, prompt templates, completion suggestions, and log-level control, Streamable HTTP Origin validation (DNS rebinding)
 
 ## Install
 

--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -1,6 +1,6 @@
 # MCP Attack Rules
 
-Batesian ships **16 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
+Batesian ships **17 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
 Every rule is an active probe: it sends crafted protocol traffic and judges the
 server's actual response. Rules are deliberately scoped to MCP-specific semantics
 (OAuth 2.1 authorization, DCR, audience binding, discovery-chain metadata-fetch
@@ -29,6 +29,7 @@ JSON-RPC `error` (the common MCP rejection shape) is a rejection, not a finding.
 | `mcp-prompt-unauth-001` | [Prompt Templates Without Authentication](#mcp-prompt-unauth-001) | Medium | confirmed | CWE-862 |
 | `mcp-tools-unauth-001` | [Tools Accessible Without Authentication](#mcp-tools-unauth-001) | High / Medium | confirmed | CWE-862 |
 | `mcp-completion-unauth-001` | [completion/complete Without Authentication](#mcp-completion-unauth-001) | High / Medium | confirmed | CWE-862 |
+| `mcp-logging-unauth-001` | [logging/setLevel Without Authentication](#mcp-logging-unauth-001) | Medium | confirmed | CWE-862 |
 | `mcp-init-downgrade-001` | [Protocol Version Downgrade Auth Bypass](#mcp-init-downgrade-001) | Critical | confirmed | CWE-757 |
 | `mcp-session-fixation-001` | [Session ID Fixation](#mcp-session-fixation-001) | High | confirmed | CWE-384 |
 | `mcp-header-body-split-001` | [Header/Body Routing Split-Brain (SEP-2243)](#mcp-header-body-split-001) | High | confirmed | CWE-444 |
@@ -174,6 +175,26 @@ that error (or any result envelope) shows the call was dispatched without
 credentials. The probe is read-only - it never executes a tool and sends only
 benign single-character argument values. A server that requires auth, or does not
 advertise the completions capability, produces no finding.
+
+---
+
+### mcp-logging-unauth-001
+
+**logging/setLevel Without Authentication** | Severity: Medium | CWE-862
+
+`logging/setLevel` sets the server's minimum log verbosity; servers that support
+it advertise the `logging` capability, confirmed structurally from the captured
+`initialize` result (`ServerSupports`). The MCP spec's Security section requires
+implementations to control log access, so an unauthenticated `logging/setLevel` is
+an access-control failure on a state-changing method: an anonymous caller can
+flood logs at `debug` (cost/DoS and burying attack traces) or suppress them at
+`emergency` (hiding malicious activity). The rule gates on the capability, then
+sends one `logging/setLevel` with a deliberately **invalid** level string; a
+`-32602` (invalid params) error - or any result envelope - proves the handler was
+dispatched without auth, while the invalid level means the server's real verbosity
+is never changed. A server that rejects with HTTP 401/403 or an auth error, or
+does not advertise the logging capability, produces no finding. Reported
+**confirmed** at medium severity.
 
 ---
 

--- a/internal/attack/mcp/logging_unauth.go
+++ b/internal/attack/mcp/logging_unauth.go
@@ -1,0 +1,141 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// LoggingUnauthExecutor probes whether the MCP logging/setLevel method is
+// reachable without authentication (rule mcp-logging-unauth-001).
+//
+// logging/setLevel sets the server's minimum log verbosity; servers that support
+// it advertise the "logging" capability. The MCP spec's Security section requires
+// implementations to "control log access". logging/setLevel is state-changing: an
+// anonymous caller who can set the level can flood logs at debug (cost/DoS, and
+// burying attack traces in noise) or suppress them at emergency (hiding malicious
+// activity from operators), so an unauthenticated setLevel is an access-control
+// failure.
+//
+// SAFETY: the probe sends a deliberately INVALID level string, so a compliant
+// server answers -32602 (invalid params) and changes nothing. The rule never
+// alters the server's real log verbosity.
+type LoggingUnauthExecutor struct {
+	rule attack.RuleContext
+}
+
+// register the executor for the mcp-logging-unauth attack type.
+func init() {
+	attack.Register("mcp-logging-unauth", func(rc attack.RuleContext) attack.Executor { return NewLoggingUnauthExecutor(rc) })
+}
+
+// NewLoggingUnauthExecutor creates an executor for mcp-logging-unauth.
+func NewLoggingUnauthExecutor(r attack.RuleContext) *LoggingUnauthExecutor {
+	return &LoggingUnauthExecutor{rule: r}
+}
+
+func (e *LoggingUnauthExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
+	vars := attack.NewVars(target, opts.OOBListenerURL)
+	// Deliberately omit the bearer token - the rule tests whether logging/setLevel
+	// is reachable WITHOUT authentication. Injecting opts.Token would mask the finding.
+	client := attack.NewUnauthHTTPClient(opts, vars)
+
+	session, err := initializeMCP(ctx, client, vars.BaseURL)
+	if err != nil {
+		return nil, nil // not an MCP server
+	}
+
+	// Skip servers that do not advertise the logging capability; probing them would
+	// produce meaningless noise. Read from the captured handshake object rather than
+	// substring-matching the body.
+	if !session.ServerSupports("logging") {
+		return nil, nil
+	}
+
+	// Send logging/setLevel with an INVALID level so nothing is actually changed.
+	// A compliant server rejects it with -32602 (invalid params) per the spec; a
+	// server enforcing auth rejects at the auth layer first (401/403 or auth error).
+	bogusLevel := "batesian-invalid-" + vars.RandID
+	resp, err := client.POST(ctx, session.Endpoint, session.header(), map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      3,
+		"method":  "logging/setLevel",
+		"params":  map[string]interface{}{"level": bogusLevel},
+	})
+	if err != nil || !resp.IsSuccess() {
+		return nil, nil // auth gate (401/403) or unreachable
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		return nil, nil
+	}
+
+	reachable, reason := setLevelDispatchReachable(body)
+	if !reachable {
+		return nil, nil
+	}
+
+	return []attack.Finding{{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "medium",
+		Confidence: attack.ConfirmedExploit,
+		Title:      "MCP logging/setLevel reachable without authentication",
+		Description: fmt.Sprintf(
+			"logging/setLevel at %s dispatched an unauthenticated request (probed with an invalid level, "+
+				"so the server's real log verbosity was not changed). The MCP spec requires servers to "+
+				"control log access; an anonymous caller can set the minimum log level, flooding logs at "+
+				"debug (cost/DoS and burying attack traces) or suppressing them at emergency (hiding "+
+				"malicious activity from operators).", session.Endpoint),
+		Evidence:    fmt.Sprintf("HTTP %d from %s\nprobe level (invalid): %s\n%s", resp.StatusCode, session.Endpoint, bogusLevel, reason),
+		Remediation: e.rule.Remediation,
+		TargetURL:   session.Endpoint,
+	}}, nil
+}
+
+// setLevelDispatchReachable reports whether a logging/setLevel response for an
+// invalid level shows the handler was reached without auth. The caller has
+// already excluded HTTP 401/403 (returning early on a non-2xx status), and MCP
+// auth rejections are normally at the HTTP layer, so any HTTP-200 JSON-RPC error
+// here means the request was processed past the auth layer - the server validated
+// (and rejected) the level. Different servers surface an invalid level with
+// different codes (the spec says -32602, but some return -32603 from an internal
+// validation path), so the rule accepts any error except a genuine "method not
+// found" or an auth-flavored error, plus any result envelope. The returned reason
+// is used as finding evidence.
+func setLevelDispatchReachable(body map[string]interface{}) (bool, string) {
+	if errObj, ok := body["error"].(map[string]interface{}); ok {
+		code, _ := errObj["code"].(float64)
+		msg, _ := errObj["message"].(string)
+		if int(code) == -32601 {
+			return false, "" // method not found despite the advertised capability
+		}
+		if isAuthFlavoredError(msg) {
+			return false, "" // auth enforced via a JSON-RPC error
+		}
+		return true, fmt.Sprintf(
+			"JSON-RPC error %d returned for an invalid level, so logging/setLevel was dispatched past the auth layer without credentials", int(code))
+	}
+	if _, ok := body["result"]; ok {
+		return true, "logging/setLevel returned a result envelope for an unauthenticated request, so it was dispatched without auth"
+	}
+	return false, ""
+}
+
+// isAuthFlavoredError reports whether a JSON-RPC error message indicates an
+// authentication/authorization rejection rather than a request-processing error.
+// MCP auth rejections are normally HTTP 401/403, so this only guards the uncommon
+// case of a server that signals auth failure through a 200 JSON-RPC error.
+func isAuthFlavoredError(msg string) bool {
+	m := strings.ToLower(msg)
+	for _, kw := range []string{"unauthor", "forbidden", "authentic", "permission", "access denied", "not allowed", "invalid token", "missing token"} {
+		if strings.Contains(m, kw) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/attack/mcp/logging_unauth_test.go
+++ b/internal/attack/mcp/logging_unauth_test.go
@@ -1,0 +1,138 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+// loggingServer builds a mock MCP server whose logging/setLevel behavior depends
+// on mode:
+//   - "reachable":     logging advertised; setLevel answers -32602 for the invalid
+//     probe level (dispatched without auth) => finding.
+//   - "reachable-internal": setLevel answers -32603 for the invalid level (as the
+//     server-everything reference does) => finding.
+//   - "auth-enforced": setLevel answers -32001 Unauthorized => silent.
+//   - "no-cap":        the logging capability is absent => silent.
+//   - "not-mcp":       initialize 404s => silent.
+func loggingServer(mode string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if mode == "not-mcp" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		method, _ := req["method"].(string)
+		w.Header().Set("Content-Type", "application/json")
+		enc := func(v map[string]interface{}) { _ = json.NewEncoder(w).Encode(v) }
+		rpcErr := func(code int, msg string) {
+			enc(map[string]interface{}{"jsonrpc": "2.0", "id": req["id"],
+				"error": map[string]interface{}{"code": code, "message": msg}})
+		}
+
+		switch method {
+		case "initialize":
+			caps := map[string]interface{}{}
+			if mode != "no-cap" {
+				caps["logging"] = map[string]interface{}{}
+			}
+			enc(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req["id"],
+				"result": map[string]interface{}{
+					"protocolVersion": "2025-03-26",
+					"serverInfo":      map[string]interface{}{"name": "logging-srv", "version": "1.0"},
+					"capabilities":    caps,
+				},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "logging/setLevel":
+			switch mode {
+			case "auth-enforced":
+				rpcErr(-32001, "Unauthorized")
+			case "reachable-internal":
+				// server-everything surfaces an invalid level as -32603 (internal).
+				rpcErr(-32603, "invalid_value: unknown log level")
+			default:
+				// The scanner only ever sends an invalid level; a compliant server
+				// answers -32602 and changes nothing.
+				rpcErr(-32602, "Invalid params: unknown log level")
+			}
+		default:
+			rpcErr(-32601, "Method not found")
+		}
+	}))
+}
+
+func runLoggingUnauth(t *testing.T, srv *httptest.Server) []attack.Finding {
+	t.Helper()
+	exec := mcpattack.NewLoggingUnauthExecutor(attack.RuleContext{ID: "mcp-logging-unauth-001"})
+	findings, err := exec.Execute(context.Background(), srv.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return findings
+}
+
+// TestLoggingUnauth_Reachable: setLevel dispatches an unauthenticated call => finding.
+func TestLoggingUnauth_Reachable(t *testing.T) {
+	srv := loggingServer("reachable")
+	defer srv.Close()
+
+	findings := runLoggingUnauth(t, srv)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Confidence != attack.ConfirmedExploit || f.Severity != "medium" {
+		t.Errorf("expected medium/confirmed, got %q/%v", f.Severity, f.Confidence)
+	}
+}
+
+// TestLoggingUnauth_ReachableInternalError: an invalid level answered with -32603
+// (as server-everything does) still proves dispatch without auth => finding.
+func TestLoggingUnauth_ReachableInternalError(t *testing.T) {
+	srv := loggingServer("reachable-internal")
+	defer srv.Close()
+
+	findings := runLoggingUnauth(t, srv)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding for a -32603 invalid-level response, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestLoggingUnauth_AuthEnforced: setLevel requires auth => silent.
+func TestLoggingUnauth_AuthEnforced(t *testing.T) {
+	srv := loggingServer("auth-enforced")
+	defer srv.Close()
+
+	if findings := runLoggingUnauth(t, srv); len(findings) != 0 {
+		t.Errorf("expected 0 findings when auth is enforced, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestLoggingUnauth_NoCapability: server does not advertise logging => skip.
+func TestLoggingUnauth_NoCapability(t *testing.T) {
+	srv := loggingServer("no-cap")
+	defer srv.Close()
+
+	if findings := runLoggingUnauth(t, srv); len(findings) != 0 {
+		t.Errorf("expected 0 findings without the logging capability, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestLoggingUnauth_NotMCP: initialize fails => silent.
+func TestLoggingUnauth_NotMCP(t *testing.T) {
+	srv := loggingServer("not-mcp")
+	defer srv.Close()
+
+	if findings := runLoggingUnauth(t, srv); len(findings) != 0 {
+		t.Errorf("expected 0 findings for a non-MCP server, got %d: %+v", len(findings), findings)
+	}
+}

--- a/rules/mcp/logging-unauth-001.yaml
+++ b/rules/mcp/logging-unauth-001.yaml
@@ -1,0 +1,52 @@
+id: mcp-logging-unauth-001
+info:
+  name: MCP logging/setLevel Reachable Without Authentication
+  author: batesian
+  severity: medium
+  description: |
+    Tests whether an MCP server answers logging/setLevel requests without
+    requiring authentication.
+
+    logging/setLevel sets the server's minimum log verbosity. Servers that
+    support it advertise the "logging" capability in the initialize handshake.
+    The MCP specification's Security section requires implementations to control
+    log access.
+
+    logging/setLevel is a state-changing operation. When it is reachable without
+    authentication, an anonymous caller can:
+    - flood logs at the debug level (driving cost/DoS on the logging pipeline and
+      burying attack traces in noise), or
+    - suppress logging at the emergency level (hiding malicious activity from
+      operators).
+
+    The rule gates on the advertised logging capability, then sends a single
+    logging/setLevel request with a deliberately invalid level string. A -32602
+    (invalid params) protocol error, or any result envelope, proves the handler
+    was dispatched without authentication. A server that enforces authentication
+    rejects the request with HTTP 401/403 or an auth error before dispatch.
+
+    The probe never changes the server's real log verbosity: the invalid level is
+    rejected by a compliant server (nothing is set).
+
+  references:
+    - https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging
+    - https://modelcontextprotocol.io/docs/concepts/authorization
+    - https://cwe.mitre.org/data/definitions/862.html
+
+  tags:
+    - mcp
+    - auth
+    - logging
+    - cwe-862
+
+attack:
+  protocol: mcp
+  type: mcp-logging-unauth
+
+remediation: |
+  1. Require authentication (OAuth 2.1 bearer token) before responding to
+     logging/setLevel requests, the same as any other state-changing method.
+  2. Return a JSON-RPC auth error (or HTTP 401/403) for unauthenticated
+     logging/setLevel calls instead of dispatching them.
+  3. Rate-limit and scope log-level control so a caller cannot use it to flood or
+     silence the server's logging pipeline.

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -18,7 +18,7 @@ pip install starlette uvicorn httpx mcp
 
 ## Server Registry
 
-The bundled rule set is **17 A2A + 16 MCP = 33 rules**. Every rule's primary
+The bundled rule set is **17 A2A + 17 MCP = 34 rules**. Every rule's primary
 validation is an in-process `net/http/httptest` harness in its Go
 `*_test.go` (multiple server postures: vulnerable must fire / patched / open /
 benign must stay silent). The Python servers below are optional standalone
@@ -50,8 +50,9 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_dns_rebind_origin_server.py` | 7794 | `mcp-dns-rebind-origin-001` |
 | `mcp_batch_bypass_server.py` | 7795 | `mcp-jsonrpc-batch-bypass-001` |
 | `mcp_completion_unauth_server.py` | 7796 | `mcp-completion-unauth-001` |
+| `mcp_logging_unauth_server.py` | 7797 | `mcp-logging-unauth-001` |
 
-**Coverage.** 32 of the 33 rules have a standalone Python fixture above. The
+**Coverage.** 33 of the 34 rules have a standalone Python fixture above. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
 (`internal/attack/mcp/token_replay_test.go`); the same is true of the per-rule
 edge-case harnesses for every other rule. `mockserver.go` is a Go helper used by

--- a/testdata/mcp_logging_unauth_server.py
+++ b/testdata/mcp_logging_unauth_server.py
@@ -1,0 +1,77 @@
+"""
+Deliberately vulnerable MCP test server for validating:
+  - mcp-logging-unauth-001: answers logging/setLevel without authentication.
+
+The server advertises the logging capability and dispatches logging/setLevel with
+no auth check, so the rule fires its medium/confirmed finding. The probe sends an
+invalid level, which this server rejects with -32602 (nothing is changed).
+
+Run: python testdata/mcp_logging_unauth_server.py
+"""
+import json
+import uuid
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.routing import Route
+import uvicorn
+
+PORT = 7797
+
+VALID_LEVELS = {
+    "debug", "info", "notice", "warning",
+    "error", "critical", "alert", "emergency",
+}
+
+sessions = {}
+
+
+async def mcp_endpoint(request: Request) -> Response:
+    body = await request.json()
+    method = body.get("method", "")
+    req_id = body.get("id")
+    params = body.get("params", {})
+
+    def result(res):
+        return Response(json.dumps({"jsonrpc": "2.0", "id": req_id, "result": res}),
+                        media_type="application/json")
+
+    def error(code, msg):
+        return Response(json.dumps({"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": msg}}),
+                        media_type="application/json")
+
+    if method == "initialize":
+        sid = str(uuid.uuid4())
+        sessions[sid] = True
+        res = {
+            "protocolVersion": params.get("protocolVersion", "2025-03-26"),
+            "serverInfo": {"name": "mcp-logging-vuln-server", "version": "1.0"},
+            "capabilities": {"logging": {}},
+        }
+        return Response(json.dumps({"jsonrpc": "2.0", "id": req_id, "result": res}),
+                        media_type="application/json",
+                        headers={"Content-Type": "application/json", "Mcp-Session-Id": sid})
+
+    if method == "notifications/initialized":
+        return Response(status_code=202)
+
+    # No auth check on logging/setLevel (vulnerable). An invalid level is rejected
+    # with -32602 per the spec; a valid level would be accepted with an empty result.
+    if method == "logging/setLevel":
+        level = params.get("level", "")
+        if level not in VALID_LEVELS:
+            return error(-32602, f"Invalid params: unknown log level {level!r}")
+        return result({})
+
+    return error(-32601, "Method not found")
+
+
+app = Starlette(routes=[
+    Route("/mcp", mcp_endpoint, methods=["POST"]),
+    Route("/", mcp_endpoint, methods=["POST"]),
+])
+
+if __name__ == "__main__":
+    print(f"[*] MCP logging-unauth vulnerable server on port {PORT}", flush=True)
+    print("[*] Vulnerability: logging/setLevel answers without authentication", flush=True)
+    uvicorn.run(app, host="127.0.0.1", port=PORT)


### PR DESCRIPTION
## Summary

Adds `mcp-logging-unauth-001`: a rule that tests whether an MCP server answers `logging/setLevel` without authentication.

`logging/setLevel` sets the server's minimum log verbosity (servers that support it advertise the `logging` capability). The MCP spec's Security section requires implementations to control log access. `logging/setLevel` is state-changing, so when it is reachable without authentication an anonymous caller can flood logs at `debug` (cost/DoS, and burying attack traces in noise) or suppress them at `emergency` (hiding malicious activity from operators).

## Detection

- Gate on the advertised `logging` capability, read structurally from the captured `initialize` result (not a substring match).
- Send one `logging/setLevel` with a deliberately **invalid** level string, so the server's real verbosity is never changed.
- HTTP 401/403 is excluded up front, and MCP auth rejections are normally at the HTTP layer, so any HTTP-200 JSON-RPC error means the request was processed past the auth layer. The rule treats any such error as dispatch (the spec says `-32602` for an invalid level, but the `server-everything` reference returns `-32603` from an internal validation path), plus any result envelope; a `-32601` (method not found) or an auth-flavored error is not reachable.
- Reported **confirmed** at medium severity (CWE-862).

## Safety

The probe sends an invalid level, which a compliant server rejects without setting anything. The rule never alters the server's real log verbosity.

## Validation

- Five-posture unit harness: fires on the `-32602` and `-32603` invalid-level responses; silent on auth-enforced (`-32001 Unauthorized`), no `logging` capability, and non-MCP.
- Standalone deliberately-vulnerable fixture on port 7797.
- End-to-end run against the `modelcontextprotocol` server-everything reference server, which advertises the `logging` capability and serves `logging/setLevel` unauthenticated (a valid level returns `{"result":{}}`; the invalid probe returns `-32603`). This surfaced and drove a discriminator fix: relying only on `-32602` was a false negative against the reference server.

## Rule count

Bundled rules: **34 (17 A2A + 17 MCP)**. README, `docs/rules-mcp.md`, `testdata/README.md`, and the release header updated to match.

## Test plan

- `go test ./...` passes; `gofmt` clean; `golangci-lint run ./...` reports 0 issues.
