### PR TITLE
chore: fetch the agent card anonymously and fix fixture row order

### DIFF
--- a/internal/attack/a2a/card_security_unenforced.go
+++ b/internal/attack/a2a/card_security_unenforced.go
@@ -55,7 +55,11 @@ const (
 
 func (e *CardSecurityUnenforcedExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
 	vars := attack.NewVars(target, opts.OOBListenerURL)
-	client := attack.NewHTTPClient(opts, vars)
+	// Every request this rule makes is anonymous. The agent card is the PUBLIC
+	// contract an unauthenticated caller reads, and the probes must present no
+	// credentials, so injecting opts.Token anywhere would misrepresent what an
+	// anonymous client actually sees.
+	client := attack.NewUnauthHTTPClient(opts, vars)
 
 	// Fetch the card. Without it there is no declared contract to test against.
 	cardBody, ok := fetchAgentCardBody(ctx, client, vars.BaseURL)
@@ -75,21 +79,19 @@ func (e *CardSecurityUnenforcedExecutor) Execute(ctx context.Context, target str
 
 	// Resolve the JSON-RPC endpoint to probe. The card requires auth but we cannot
 	// reach a testable endpoint, so the contract cannot be exercised here.
-	endpoint, ok := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
+	endpoint, ok := resolveA2AEndpoint(ctx, client, vars.BaseURL)
 	if !ok {
 		return nil, attack.ErrInconclusive
 	}
 
-	unauthClient := attack.NewUnauthHTTPClient(opts, attack.NewVars(target, opts.OOBListenerURL))
-
 	// Step 1 (non-mutating): can an unauthenticated read even reach the handler?
 	// A read of a random non-existent id cannot return a task, so this only tells
 	// us whether the read path rejects at the auth layer (evidence, not verdict).
-	readReachable := e.readTask(ctx, unauthClient, endpoint, "batesian-missing-"+vars.RandID, vars.RandID) != probeAuthRejected
+	readReachable := e.readTask(ctx, client, endpoint, "batesian-missing-"+vars.RandID, vars.RandID) != probeAuthRejected
 
 	// Step 2 (definitive): unauthenticated create. A returned task proves a core
 	// write executed with no credentials despite the card requiring them.
-	createOutcome, createdTaskID := e.createProbe(ctx, unauthClient, endpoint, vars.RandID)
+	createOutcome, createdTaskID := e.createProbe(ctx, client, endpoint, vars.RandID)
 	if createOutcome != probeProcessedResult {
 		// No unauthenticated request was processed into a success result: either the
 		// server enforces auth (rejected) or only returned application errors. Do not
@@ -99,7 +101,7 @@ func (e *CardSecurityUnenforcedExecutor) Execute(ctx context.Context, target str
 
 	// Strengthen: read the just-created task back with no credentials. If that also
 	// returns the task, both the write and the read paths ignore the declared auth.
-	readBack := createdTaskID != "" && e.readTask(ctx, unauthClient, endpoint, createdTaskID, vars.RandID) == probeProcessedResult
+	readBack := createdTaskID != "" && e.readTask(ctx, client, endpoint, createdTaskID, vars.RandID) == probeProcessedResult
 
 	return []attack.Finding{e.finding(endpoint, schemes, createdTaskID, readReachable, readBack)}, nil
 }

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -35,8 +35,8 @@ fixtures for live-validation / manual smoke testing.
 | `a2a_extension_downgrade_server.py` | 3106 | `a2a-extension-downgrade-001` |
 | `a2a_push_binding_server.py` | 3107 | `a2a-push-binding-001` (two principals; needs two `--principal`s) |
 | `a2a_batch_bypass_server.py` | 3108 | `a2a-jsonrpc-batch-bypass-001` |
-| `a2a_card_security_unenforced_server.py` | 3110 | `a2a-card-security-unenforced-001` |
 | `a2a_task_cancel_server.py` | 3109 | `a2a-task-cancel-idor-001` (two principals; needs two `--principal`s) |
+| `a2a_card_security_unenforced_server.py` | 3110 | `a2a-card-security-unenforced-001` |
 | `mcp_unauth_resources_server.py` | 7787 | `mcp-resources-unauth-001` |
 | `mcp_oauth_dcr_server.py` | 7788 | `mcp-oauth-dcr-001` |
 | `mcp_oauth_audience_server.py` | 7785 | `mcp-oauth-audience-002` |


### PR DESCRIPTION
## Summary

Pre-release tidy-up found during a review pass over `main`. No functional bug, two small consistency fixes.

## 1. Anonymous card fetch (`a2a-card-security-unenforced-001`)

The rule's finding asserts that the **public** agent card declares authentication the endpoint does not enforce, so every request it makes should be anonymous. The card fetch and endpoint resolution were using the credentialed client (`attack.NewHTTPClient`), which is not what an unauthenticated caller sees.

Now a single unauthenticated client is used throughout (card fetch, endpoint resolution, and both probes), which also removes a redundant second client instance. The probes were already unauthenticated, so the reported finding is unchanged.

## 2. Fixture registry row order

`testdata/README.md` listed `a2a_card_security_unenforced_server.py` (3110) above `a2a_task_cancel_server.py` (3109). Reordered to match the port ordering the rest of the table follows.

## Test plan

- All six `TestCardSecurity_*` postures pass (fires on open v1.0 and v0.3 cards; silent on enforced-auth, anonymous-allowed, and no-declared-security; inconclusive on non-A2A).
- `go test ./...` passes uncached; `gofmt` and `go vet` clean.
- Live re-validation against the port 3110 fixture still fires the high/confirmed finding.

## Context

The wider review pass found the repo otherwise clean: rule counts match every published figure (34 = 17 A2A + 17 MCP), no duplicate rule IDs, every rule type resolves to a registered executor, full catalog coverage with no severity drift, and a complete fixture registry with no duplicate ports.