### PR TITLE
chore(ci): replace the retired Go Report Card badge with OpenSSF Scorecard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,14 +43,10 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      # -coverprofile implies -cover, so the per-package coverage percentages are
+      # reported in the job log. The profile itself is not uploaded anywhere.
       - name: Test
         run: go test -race -coverprofile=coverage.out ./...
-
-      - name: Upload coverage
-        uses: codecov/codecov-action@v7
-        with:
-          files: coverage.out
-          fail_ci_if_error: false
 
   lint:
     name: Lint

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,59 @@
+name: Scorecard
+
+# OpenSSF Scorecard grades the repository's supply-chain security posture
+# (signed releases, SBOMs, dependency pinning, branch protection, SAST,
+# vulnerability scanning). Results are published so the README badge resolves,
+# and uploaded to the Security tab as SARIF.
+#
+# Note: with GitHub's classic Branch Protection, the Branch-Protection check
+# needs a fine-grained PAT to read the settings; without one that single check
+# is reported with reduced confidence. Every other check works with the default
+# token.
+
+on:
+  push:
+    # Only the default branch is supported.
+    branches:
+      - main
+  schedule:
+    # Weekly, Monday 05:30 UTC.
+    - cron: '30 5 * * 1'
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to the code-scanning dashboard.
+      security-events: write
+      # Needed for the GitHub OIDC token when publish_results is true.
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Required for the README badge to resolve, and it lets the Scorecard
+          # project reuse this run instead of scanning the repo separately.
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Go Version](https://img.shields.io/badge/go-1.25+-00ADD8.svg)](https://golang.org)
 [![Build](https://github.com/calbebop/batesian/actions/workflows/ci.yml/badge.svg)](https://github.com/calbebop/batesian/actions)
-[![Go Report Card](https://goreportcard.com/badge/github.com/calbebop/batesian)](https://goreportcard.com/report/github.com/calbebop/batesian)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/calbebop/batesian/badge)](https://scorecard.dev/viewer/?uri=github.com/calbebop/batesian)
 
 CLI for adversarial testing of [A2A](https://a2a-protocol.org) and [MCP](https://modelcontextprotocol.io) stacks. It drives concrete protocol traffic (OAuth audience/scope/DCR, push-notification callbacks, JWS card signatures, session and task boundaries, agent-card handling) and records outcomes as `confirmed` or `indicator`, with optional SARIF for CI.
 


### PR DESCRIPTION
## Summary

Go Report Card has been [sunset](https://goreportcard.com/), so its badge now renders **"retired"** instead of a grade. Its maintainers point to `golangci-lint` as the successor, which this repo already runs in CI, so the badge was carrying no signal.

## Changes

**1. Replace the badge with OpenSSF Scorecard.** Scorecard grades exactly the supply-chain properties this project already invests in: signed releases (cosign), SBOMs, dependency pinning, branch protection, SAST, and vulnerability scanning. That makes it a substantive badge for a security tool rather than a decorative one.

Adds `.github/workflows/scorecard.yml` (weekly + on push to `main`) with `publish_results: true`, which is required for the badge to resolve. Results are also uploaded to the Security tab as SARIF. The workflow's own actions are pinned by commit SHA.

**2. Remove the dead Codecov step.** The repository is not enabled on Codecov, so with `fail_ci_if_error: false` the upload has been failing silently on every run while the badge rendered `unknown`. Coverage is still computed by the test step (`-coverprofile` implies `-cover`, so per-package percentages appear in the job log); nothing now pretends to publish it.

## Notes

- The Scorecard badge will show `no data` until this lands on `main` and the workflow runs once.
- Expect the initial score to be docked on **Pinned-Dependencies**: `ci.yml` and `release` reference actions by tag (`@v7`, `@v5`) rather than SHA. That is honest signal. Happy to pin them in a follow-up once we see the actual report.
- With GitHub's classic Branch Protection, the Branch-Protection check needs a fine-grained PAT to read settings; without one that single check reports with reduced confidence. Every other check works with the default token.

## Test plan

- Both workflow files parse as valid YAML (`ci.yml` jobs: build, lint, vuln, release; `scorecard.yml` job: analysis).
- No remaining references to `goreportcard` or `codecov` anywhere in the repo.
- CI (build, lint, vuln scan) must stay green on this PR.
