### PR TITLE
chore(release): surface security fixes in the release notes

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -83,6 +83,16 @@ changelog:
   sort: asc
   use: git
   filters:
+    # Routine maintenance is filtered out of release notes. Two behaviours to
+    # know when reading a generated changelog:
+    #   - These excludes are applied BEFORE grouping, so a security fix
+    #     committed as `chore:` is dropped outright and never reaches the
+    #     Security group below.
+    #   - The patterns are not scope-aware: `^chore:` matches `chore: x` but NOT
+    #     `chore(ci): x`, so a scoped maintenance commit still lands under
+    #     "Other" rather than being excluded.
+    # Either way a security fix filed as a chore is mislabelled, so commit it as
+    # `fix(deps):` or `fix(security):` (see CONTRIBUTING.md, Commit Style).
     exclude:
       - '^docs:'
       - '^test:'
@@ -91,15 +101,20 @@ changelog:
       - Merge pull request
       - Merge branch
   groups:
+    # Security must precede the generic Bug fixes group: the first matching
+    # group claims the commit, and `fix(deps):` also matches `fix(...)`.
+    - title: Security
+      regexp: '^.*?fix\((deps|security)\)!?:.+$'
+      order: 0
     - title: New attack rules
       regexp: '^.*?rule(\(.+\))??!?:.+$'
-      order: 0
+      order: 1
     - title: Features
       regexp: '^.*?feat(\(.+\))??!?:.+$'
-      order: 1
+      order: 2
     - title: Bug fixes
       regexp: '^.*?fix(\(.+\))??!?:.+$'
-      order: 2
+      order: 3
     - title: Other
       order: 999
 
@@ -110,11 +125,30 @@ release:
   draft: false
   prerelease: auto
   name_template: "v{{.Version}}"
+  # The rule count and the Security section below are per-release content:
+  # review both before tagging. The Security section names the advisories fixed
+  # in this release and should be emptied or updated for the next one.
   header: |
     ## Batesian {{.Version}}
 
     Adversarial red-team CLI for AI agent protocols (A2A and MCP).
     34 bundled attack rules (17 A2A + 17 MCP). Single binary. No runtime dependencies.
+
+    ### Security
+
+    Fixes **CVE-2026-39824** ([GO-2026-5024](https://pkg.go.dev/vuln/GO-2026-5024)):
+    a string-length overflow in `NewNTUnicodeString` in `golang.org/x/sys/windows`,
+    which returned a truncated string instead of an error for over-long input.
+    Resolved by upgrading `golang.org/x/sys` to v0.44.0. Batesian never calls the
+    affected symbol, so the advisory was not reachable from this code, but it is
+    fixed in the dependency tree.
+
+    This release is also the first to carry [SLSA build provenance](https://slsa.dev)
+    alongside the existing cosign signature and CycloneDX SBOMs. Verify with:
+
+    ```bash
+    gh attestation verify batesian_<version>_<platform>.tar.gz --repo calbebop/batesian
+    ```
 
     ### Install
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,6 +227,13 @@ PR description.
 - Use conventional commit prefixes: `feat:`, `fix:`, `chore:`, `docs:`, `test:`
 - One logical change per commit.
 - Reference the rule ID in the commit message when adding or modifying a rule.
+- **Security fixes must use `fix(security):` or `fix(deps):`**, never `chore:`.
+  The release changelog excludes `chore:`, `docs:` and `test:` before grouping,
+  so a dependency bump or hardening change committed as `chore:` is silently
+  dropped from the release notes. The `fix(deps):` / `fix(security):` prefixes
+  land it in the **Security** section instead. Name the advisory (CVE and/or
+  `GO-` identifier) in the commit body so the release notes identify what was
+  fixed.
 
 ---
 


### PR DESCRIPTION
## Summary

The v1.4.0 release notes would not have named the vulnerability the release fixes. This corrects that and prevents a recurrence.

## The actual problem

I initially assumed the changelog would come out empty because all unreleased commits are `chore:`/`test:`. That was wrong, and worth stating precisely:

- `^chore:` does **not** match a scoped `chore(ci):` commit, so both hardening PRs *would* have appeared, filed under a generic **"Other"** heading.
- Only the `test:` commit is excluded.

So the changelog was not empty, but the entry read `chore(ci): harden the supply chain per the OpenSSF Scorecard report (#89)` and **never named CVE-2026-39824**. Release notes are meant to identify the vulnerabilities a release closes, so the substance of the problem stands even though my original reasoning did not.

## Changes

**1. Security changelog group.** Added ahead of the generic `Bug fixes` group, because the first matching group claims a commit and `fix(deps):` also matches `fix(...)`. Verified by classifying sample and real commit subjects against the actual regexps:

```
[Security]   fix(deps): bump golang.org/x/sys to v0.44.0 for CVE-2026-39824
[Security]   fix(security): reject unsigned agent cards
[Bug fixes]  fix(probe): select the JSON-RPC interface
[Features]   feat(mcp-logging-unauth-001): detect unauthenticated logging/setLevel
```

**2. Commit convention.** `CONTRIBUTING.md` now requires security work to use `fix(security):` or `fix(deps):` rather than `chore:`, and to name the advisory in the commit body.

**3. Documented the filter behaviour** next to the filters themselves: excludes run *before* grouping (so a `chore:` security fix is dropped outright), and the patterns are not scope-aware (so a `chore(ci):` one is merely mislabelled into "Other"). Both were surprising; neither was written down.

**4. Release header** now records **CVE-2026-39824 / GO-2026-5024** with a plain description of the flaw, notes that Batesian never calls the affected symbol so it was unreachable here, and documents that this is the first release carrying SLSA build provenance plus how to verify it. The header holds per-release content, so it is flagged for review before each tag.

## Notes

- The non-scope-aware exclude patterns are left as they are. Tightening them to `^chore(\(.+\))?:` would be more consistent, but it would also drop the two hardening PRs from v1.4.0 entirely, and erring toward more visibility is the safer default. Documented rather than changed.
- Satisfies the OpenSSF Best Practices `release_notes_vulns` criterion, which was the one outstanding gap in the badge questionnaire.

## Test plan

- `.goreleaser.yaml` parses as valid YAML.
- Changelog grouping regexps verified against both sample and real commit subjects.
