### PR TITLE
docs: record validation results against reference implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Bundled rules: **17 A2A, 17 MCP (34 total)**. The set is deliberately narrow - e
 - [A2A rules](docs/rules-a2a.md) (17)
 - [MCP rules](docs/rules-mcp.md) (17)
 
+Rules are validated against third-party reference implementations, not only against the bundled fixtures. [Validation results](docs/validation-results.md) records what fires, what correctly stays silent on a server with no authentication at all, and the scanner defects that exercise has found.
+
 Coverage spans:
 
 - **OAuth & token validation** - OAuth 2.1 / DCR scope escalation, audience binding, token replay, version-downgrade bypass, forged-token acceptance, redirect_uri confused deputy

--- a/docs/validation-results.md
+++ b/docs/validation-results.md
@@ -1,0 +1,195 @@
+# Validation Results
+
+Every Batesian rule ships with an in-process `httptest` harness and, for most
+rules, a deliberately vulnerable Python fixture in [`testdata/`](../testdata/README.md).
+Those are necessary but not sufficient: a rule validated only against a fixture
+its own author wrote is largely a test of that author's assumptions. Fixtures
+serve JSON-RPC exactly where the executor expects it, answer with exactly the
+error codes the executor checks for, and advertise exactly the capabilities the
+rule gates on.
+
+This document records what happens when the rules are pointed at **third-party
+reference implementations** instead: servers written by the protocol maintainers,
+with no knowledge of Batesian.
+
+---
+
+## Why this matters
+
+Running against reference implementations has repeatedly found defects that the
+fixture harnesses could not, because the fixtures encoded the same assumption the
+executor did. Each of the following was a real bug in Batesian, found only by
+running against third-party code:
+
+| Defect | How it surfaced | Fix |
+|---|---|---|
+| A2A rules assumed the JSON-RPC endpoint was at the target root | The reference agent mounts it at `/a2a/jsonrpc`; every A2A rule POSTed to `/`, got 404, and the scan reported "appears clean" | Endpoint discovery from the agent card ([#79](https://github.com/calbebop/batesian/pull/79)), plus honest inconclusive reporting ([#80](https://github.com/calbebop/batesian/pull/80)) and JSON-RPC interface selection ([#81](https://github.com/calbebop/batesian/pull/81)) |
+| `completion/complete` probe used a single-character argument value | Prefix-matching servers filtered it out, so a server that *was* disclosing values returned nothing and the rule stayed silent | Probe with an empty value, which asks a prefix matcher for its whole candidate set ([#83](https://github.com/calbebop/batesian/pull/83)) |
+| `logging/setLevel` probe only accepted `-32602` as proof of dispatch | The reference server answers an invalid level with `-32603` from an internal validation path, so a genuine finding was missed | Treat any non-auth, non-method-not-found error as dispatch past the auth layer ([#86](https://github.com/calbebop/batesian/pull/86)) |
+
+Two of these three were **false negatives**: the rule silently reported nothing
+against a server that genuinely exhibited the condition. A false negative in a
+security scanner is worse than a noisy one, and none of them were reachable from
+a self-authored fixture.
+
+---
+
+## MCP: `@modelcontextprotocol/server-everything`
+
+The reference MCP server maintained by the Model Context Protocol project,
+exercising the full capability surface (tools, prompts, resources, logging,
+completions).
+
+**Target:** `@modelcontextprotocol/server-everything` 2026.7.4, Streamable HTTP
+transport, `http://127.0.0.1:3120`
+**Command:** `batesian scan --target http://127.0.0.1:3120 --timeout 20`
+
+### Result
+
+```
+Scan Results (10 finding(s))    critical 0 · high 6 · medium 4
+```
+
+| Rules | Count |
+|---|---|
+| MCP rules that fired | 6 of 17 (10 findings) |
+| MCP rules that ran and reported nothing | 11 of 17 |
+| MCP rules skipped as unreachable | 0 |
+| A2A rules that fired against an MCP server | **0** |
+
+### What fired
+
+| Rule | Severity | Finding |
+|---|---|---|
+| `mcp-dns-rebind-origin-001` | high | Origin header not validated |
+| `mcp-resources-unauth-001` | high | `resources/list` returned 7 resources; resource content readable |
+| `mcp-tools-unauth-001` | high / medium | `tools/call` dispatch reachable; `tools/list` returned 13 tools |
+| `mcp-prompt-unauth-001` | high / medium | Prompt content readable; `prompts/list` returned 4 templates |
+| `mcp-completion-unauth-001` | high / medium | Suggestion values disclosed; endpoint reachable |
+| `mcp-logging-unauth-001` | medium | `logging/setLevel` reachable |
+
+**Honest framing.** `server-everything` is a reference implementation with no
+authorization layer by design. The unauthenticated-access findings above
+accurately describe its behavior, but they are expected for a demo server and
+should not be read as defects in it. What they demonstrate is that the rules
+correctly identify real protocol conditions in code Batesian's authors did not
+write.
+
+One finding is different in kind. **Missing Origin validation is a genuine spec
+violation**, not an artifact of the server having no auth. The Streamable HTTP
+transport requires servers to validate `Origin` and reject a foreign one with
+`403`, specifically because these servers bind to localhost and a browser can be
+induced to reach them via DNS rebinding. The check is a two-step control:
+
+```
+endpoint: http://127.0.0.1:3120/mcp
+baseline initialize (no Origin): accepted
+initialize with Origin https://dns-rebind.batesian.invalid: accepted (should be HTTP 403)
+```
+
+The baseline proves the endpoint is live and responsive; the second request
+differs only in the `Origin` header. This is the class behind CVE-2025-49596
+(MCP Inspector RCE).
+
+Hand-verified findings, confirmed by probing the server directly rather than
+trusting the scanner's own report:
+
+```
+completion/complete → prompt "completable-prompt", argument "department"
+  values (4): [Engineering Sales Marketing Support]
+
+logging/setLevel with a valid level → {"result":{}}   (unauthenticated)
+logging/setLevel with an invalid level → -32603
+```
+
+### What correctly stayed silent
+
+This is the more informative half. Eleven MCP rules ran against a server with
+**no authentication whatsoever** and reported nothing, because each carries an
+explicit precondition or discriminator that a naive implementation would lack:
+
+| Rule | Why it declined to report |
+|---|---|
+| `mcp-token-replay-001` | Gates on OAuth metadata being present. The server publishes none, so there is no token-validation layer to test. A rule that simply checked "was my forged token accepted?" would have fired here, since a server with no auth accepts everything. |
+| `mcp-init-downgrade-001` | Requires the modern-version session to be *rejected* and the legacy one accepted. Both succeed here, which means no auth at all rather than a downgrade bypass. |
+| `mcp-session-fixation-001` | Control requires an un-initialized session id to be rejected. It is accepted, so the server tracks no sessions and this is not fixation. |
+| `mcp-jsonrpc-batch-bypass-001` | Requires the single-request control to be rejected while the batch succeeds. Nothing is rejected, so there is no bypass to demonstrate. |
+| `mcp-oauth-dcr-001`, `mcp-oauth-audience-002`, `mcp-oauth-metadata-ssrf-001`, `mcp-confused-deputy-001` | No OAuth registration, authorization, or metadata endpoints exist. |
+| `mcp-secret-canary-001` | The canary credential was not echoed in any response. |
+| `mcp-sse-resume-replay-001` | Requires two distinct server-minted sessions and id-bearing events to replay. |
+| `mcp-header-body-split-001` | The server does not enforce `Mcp-Method` presence, so it is not SEP-2243-aware and there is no split-brain to demonstrate. |
+
+A scanner pointed at a completely open server is under maximum pressure to
+over-report. That eleven rules declined, each for a specific documented reason,
+is the strongest available evidence that the `confirmed` tier means what it
+claims.
+
+### Cross-protocol check
+
+All 17 A2A rules produced **zero findings** against an MCP server: 8 reported
+inconclusive (no reachable A2A endpoint) and 9 skipped cleanly on unmet
+preconditions. Protocol misidentification does not generate noise.
+
+---
+
+## A2A: `a2a-python` reference sample
+
+The reference A2A agent maintained by the A2A project (`a2a-sdk`).
+
+This target drove the endpoint-discovery work described above. Before that fix,
+**every A2A JSON-RPC rule silently missed everything** on this server: the sample
+advertises its JSON-RPC interface at `/a2a/jsonrpc` in the agent card, while the
+executors POSTed to the target root, received 404, and the scan reported the
+target as clean. Because a 404 was indistinguishable from "nothing found", the
+failure was invisible.
+
+After [#79](https://github.com/calbebop/batesian/pull/79)–[#81](https://github.com/calbebop/batesian/pull/81),
+a re-run resolved the endpoint from the card, issued 16 JSON-RPC requests to
+`/a2a/jsonrpc`, and surfaced a genuine `a2a-session-smuggle-001` finding. That
+sequence is independently reviewable in the three linked pull requests.
+
+The same run also demonstrated a correct **absence** of a finding:
+`a2a-task-cancel-idor-001` reported nothing, because the sample completes tasks
+almost immediately and the probe task reached a terminal state before it could be
+cancelled. That limitation is documented in the rule catalog rather than papered
+over.
+
+> **Reproducing this one is currently awkward.** The `a2a-python` repository has
+> restructured and its `samples/` directory no longer carries a runnable agent, so
+> the A2A results above date from the pull requests that fixed them rather than
+> from a re-run. The MCP results in this document were captured fresh.
+
+---
+
+## Self-validation: fuzzing
+
+Beyond third-party servers, the response parsers are fuzzed, since a scanned host
+controls every byte reaching them. Go native fuzz targets cover agent-card
+decoding, service-URL selection, task and context id extraction, MCP capability
+detection, and the dispatch classifiers that decide whether a `confirmed` finding
+is reported ([#90](https://github.com/calbebop/batesian/pull/90)).
+
+Fuzzing found a defect that the unit harnesses could not: evidence truncation
+sliced at a byte offset, splitting multi-byte UTF-8 characters. Evidence flows
+into JSON and SARIF output, where a trailing partial rune is silently rewritten
+to `U+FFFD`, corrupting the reported evidence for any target returning non-ASCII
+text. Truncation now backs up to a rune boundary, and the input that found it is
+retained as a regression seed.
+
+---
+
+## Reproducing
+
+```sh
+# MCP reference server
+PORT=3120 npx -y @modelcontextprotocol/server-everything streamableHttp
+batesian scan --target http://127.0.0.1:3120 --timeout 20
+
+# Bundled vulnerable fixtures (see testdata/README.md for the registry)
+python testdata/mcp_logging_unauth_server.py
+batesian scan --target http://127.0.0.1:7797 --rule-ids mcp-logging-unauth-001 -v
+```
+
+Reference servers are third-party software; their behavior changes between
+versions. The version scanned is recorded above so a differing result can be
+attributed to the target rather than to Batesian.


### PR DESCRIPTION
## Summary

Adds `docs/validation-results.md`, recording what happens when the rule set is pointed at **third-party reference implementations** rather than the bundled fixtures, and links it from the README.

## Why

Every rule ships with an `httptest` harness and, for most rules, a vulnerable Python fixture. Those are necessary but not sufficient: a rule validated only against a fixture its own author wrote largely tests that author's assumptions. The fixture serves JSON-RPC exactly where the executor expects it, answers with exactly the error codes the executor checks, and advertises exactly the capabilities the rule gates on.

Nothing in the repository showed what happens against code written by someone else, even though that exercise has repeatedly found real defects.

## What the document records

**MCP, against `@modelcontextprotocol/server-everything` 2026.7.4** (captured fresh for this PR):

| | |
|---|---|
| MCP rules that fired | 6 of 17 (10 findings: 6 high, 4 medium) |
| MCP rules that ran and reported nothing | 11 of 17 |
| A2A rules that fired against an MCP server | 0 |

The silent eleven are the more informative half. On a server with **no authorization layer at all** the rules under maximum pressure to over-report declined, each for a specific documented reason. For example `mcp-token-replay-001` gates on OAuth metadata being present; a rule that merely asked "was my forged token accepted?" would have fired, because a server with no auth accepts everything.

The document is explicit that `server-everything` is a demo server and its unauthenticated-access findings are expected rather than defects in it. One finding is called out as different in kind: **missing `Origin` validation is a genuine spec violation** regardless of auth posture, and the evidence shows the two-step control (baseline without `Origin` accepted, foreign `Origin` also accepted where `403` is required).

**Scanner defects found by this exercise**, two of them false negatives that no self-authored fixture could have surfaced:
- A2A rules assumed the JSON-RPC endpoint was at the target root; the reference agent mounts it at `/a2a/jsonrpc`, so every A2A rule 404'd and the scan reported "appears clean" (#79-#81)
- the `completion/complete` probe used a single-character value that prefix-matching servers filtered away (#83)
- the `logging/setLevel` probe accepted only `-32602`, while the reference server returns `-32603` (#86)

## Honesty notes

- A2A results are attributed to the pull requests that fixed them rather than to a fresh run, because the `a2a-python` repository has restructured and its `samples/` directory no longer carries a runnable agent. This caveat is stated in the document rather than omitted.
- The scanned version of each reference server is recorded, so a differing result later can be attributed to the target rather than to Batesian.

## Test plan

Documentation only; no code changes. Cross-referenced links resolve, and the reproduction commands in the document are the ones used to produce the recorded output.
