### PR TITLE
feat(mcp-task-idor-001): detect cross-context MCP task and result access

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -132,7 +132,7 @@ release:
     ## Batesian {{.Version}}
 
     Adversarial red-team CLI for AI agent protocols (A2A and MCP).
-    34 bundled attack rules (17 A2A + 17 MCP). Single binary. No runtime dependencies.
+    35 bundled attack rules (17 A2A + 18 MCP). Single binary. No runtime dependencies.
 
     ### Security
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ CLI for adversarial testing of [A2A](https://a2a-protocol.org) and [MCP](https:/
 
 ## What ships
 
-Bundled rules: **17 A2A, 17 MCP (34 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
+Bundled rules: **17 A2A, 18 MCP (35 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
 
 - [A2A rules](docs/rules-a2a.md) (17)
-- [MCP rules](docs/rules-mcp.md) (17)
+- [MCP rules](docs/rules-mcp.md) (18)
 
 Rules are validated against third-party reference implementations, not only against the bundled fixtures. [Validation results](docs/validation-results.md) records what fires, what correctly stays silent on a server with no authentication at all, and the scanner defects that exercise has found.
 
@@ -31,7 +31,7 @@ Coverage spans:
 - **OAuth & token validation** - OAuth 2.1 / DCR scope escalation, audience binding, token replay, version-downgrade bypass, forged-token acceptance, redirect_uri confused deputy
 - **Agent-card trust (A2A)** - JWS signatures, canonicalization, cache/freshness, required-extension downgrade, host-header injection, unauthenticated extended card, declared-but-unenforced auth
 - **Request & task integrity** - task IDOR, agent-role injection, artifact tampering, SEP-2243 header/body routing, SSE resumption replay
-- **Multi-party isolation** - cross-tenant isolation, session/context fixation, delegation chain-of-custody, cross-principal task cancellation
+- **Multi-party isolation** - cross-tenant isolation, session/context fixation, delegation chain-of-custody, cross-principal task cancellation, cross-context MCP task and result access
 - **SSRF & secret leakage** - push-notification SSRF, push control-plane binding, OAuth discovery/metadata SSRF, credential leakage into responses
 - **Unauthenticated & cross-origin access** - exposed MCP tools, resources, prompt templates, completion suggestions, and log-level control, Streamable HTTP Origin validation (DNS rebinding)
 

--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -1,6 +1,6 @@
 # MCP Attack Rules
 
-Batesian ships **17 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
+Batesian ships **18 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
 Every rule is an active probe: it sends crafted protocol traffic and judges the
 server's actual response. Rules are deliberately scoped to MCP-specific semantics
 (OAuth 2.1 authorization, DCR, audience binding, discovery-chain metadata-fetch
@@ -30,6 +30,7 @@ JSON-RPC `error` (the common MCP rejection shape) is a rejection, not a finding.
 | `mcp-tools-unauth-001` | [Tools Accessible Without Authentication](#mcp-tools-unauth-001) | High / Medium | confirmed | CWE-862 |
 | `mcp-completion-unauth-001` | [completion/complete Without Authentication](#mcp-completion-unauth-001) | High / Medium | confirmed | CWE-862 |
 | `mcp-logging-unauth-001` | [logging/setLevel Without Authentication](#mcp-logging-unauth-001) | Medium | confirmed | CWE-862 |
+| `mcp-task-idor-001` | [Task Readable Across Authorization Contexts](#mcp-task-idor-001) | Critical / High | confirmed | CWE-639 / CWE-200 |
 | `mcp-init-downgrade-001` | [Protocol Version Downgrade Auth Bypass](#mcp-init-downgrade-001) | Critical | confirmed | CWE-757 |
 | `mcp-session-fixation-001` | [Session ID Fixation](#mcp-session-fixation-001) | High | confirmed | CWE-384 |
 | `mcp-header-body-split-001` | [Header/Body Routing Split-Brain (SEP-2243)](#mcp-header-body-split-001) | High | confirmed | CWE-444 |
@@ -195,6 +196,45 @@ dispatched without auth, while the invalid level means the server's real verbosi
 is never changed. A server that rejects with HTTP 401/403 or an auth error, or
 does not advertise the logging capability, produces no finding. Reported
 **confirmed** at medium severity.
+
+---
+
+### mcp-task-idor-001
+
+**Task Readable Across Authorization Contexts** | Severity: Critical / High | CWE-639 / CWE-200
+
+MCP 2025-11-25 added durable **tasks**: a task-augmented `tools/call` returns a
+`taskId` immediately, and the caller later reads execution state with `tasks/get`
+and the underlying tool output with `tasks/result`. The spec's Security
+Considerations require that "receivers MUST reject `tasks/get`, `tasks/result`,
+and `tasks/cancel` requests for tasks that do not belong to the same
+authorization context as the requestor".
+
+The rule creates a task as one principal and reads it from a separate session as
+another, reporting two failures. An accepted cross-context `tasks/get` discloses
+another context's task metadata: status, timing, and status messages (**high**).
+An accepted cross-context `tasks/result` discloses the **actual tool output** the
+task produced, not metadata (**critical**). Both are **confirmed**.
+
+A finding is raised only after anonymous task creation is *rejected*, proving the
+server does enforce authentication. A server with no authentication at all is a
+different and more obvious failure owned by `mcp-tools-unauth-001`, and is
+suppressed here rather than mislabelled as broken object-level authorization. A
+server that scopes tasks to their creating context answers the cross-context read
+with `-32602` and produces no finding.
+
+**Safety.** Creating a task requires invoking a real tool, which is unique among
+the rules in this package (`mcp-tools-unauth-001` deliberately calls a
+non-existent tool so nothing executes). The rule therefore only invokes a
+task-capable tool whose annotations declare it `readOnlyHint: true` or
+explicitly `destructiveHint: false`, and skips entirely when no such tool is
+advertised; an unannotated tool is never invoked, since MCP treats a non-read-only
+tool as potentially destructive by default. Because `tasks/result` blocks until a
+task is terminal, the rule polls `tasks/get` within a bounded budget and requests
+the result only once the task has finished.
+
+**Currency.** Tasks are marked experimental in 2025-11-25 and their design may
+evolve, so this rule is version-scoped.
 
 ---
 

--- a/internal/attack/mcp/oauth_dcr.go
+++ b/internal/attack/mcp/oauth_dcr.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/calbebop/batesian/internal/attack"
 )
@@ -147,10 +148,22 @@ func privilegedScopesIn(grantedScope string) []string {
 	return found
 }
 
+// snippetMCP returns at most maxLen bytes of body, appending an ellipsis when it
+// truncates.
+//
+// Truncation backs up to a UTF-8 rune boundary so a multi-byte character is
+// never split. Snippets are taken from the scanned target's raw response and end
+// up in Finding.Evidence, which is marshalled into JSON and SARIF; a trailing
+// partial rune would be silently rewritten to U+FFFD there, corrupting the
+// evidence for any target that returns non-ASCII text.
 func snippetMCP(body []byte) string {
 	const maxLen = 300
-	if len(body) > maxLen {
-		return string(body[:maxLen]) + "..."
+	if len(body) <= maxLen {
+		return string(body)
 	}
-	return string(body)
+	cut := maxLen
+	for cut > 0 && !utf8.RuneStart(body[cut]) {
+		cut--
+	}
+	return string(body[:cut]) + "..."
 }

--- a/internal/attack/mcp/parse_fuzz_test.go
+++ b/internal/attack/mcp/parse_fuzz_test.go
@@ -3,7 +3,32 @@ package mcp
 import (
 	"encoding/json"
 	"testing"
+	"unicode/utf8"
 )
+
+// FuzzSnippetMCP covers the evidence truncation shared by the OAuth and token
+// rules. Its input is the scanned target's raw response body, and its output
+// lands in Finding.Evidence, which is marshalled into JSON and SARIF, so
+// truncating valid UTF-8 must not yield invalid UTF-8: a split rune would be
+// silently rewritten to U+FFFD in the report.
+func FuzzSnippetMCP(f *testing.F) {
+	f.Add([]byte(`{"error":"invalid_client"}`))
+	f.Add([]byte(""))
+	// 300 bytes is the truncation point; multi-byte runes straddle it.
+	f.Add([]byte(`{"m":"` + string(make([]byte, 0)) + "ééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééé" + `"}`))
+	f.Add([]byte("\xff\xfe invalid utf8 prefix"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		got := snippetMCP(data)
+		const limit = 300
+		if len(got) > limit+len("...") {
+			t.Fatalf("snippetMCP exceeded its limit: got %d bytes for %q", len(got), data)
+		}
+		if utf8.Valid(data) && !utf8.ValidString(got) {
+			t.Fatalf("snippetMCP split a rune: %q produced invalid UTF-8 %q", data, got)
+		}
+	})
+}
 
 // These helpers all read JSON-RPC bodies returned by the server under test, so a
 // hostile or broken target controls their input. Each target asserts the parsers

--- a/internal/attack/mcp/task_idor.go
+++ b/internal/attack/mcp/task_idor.go
@@ -1,0 +1,438 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// TaskIDORExecutor tests whether MCP tasks are bound to the authorization
+// context that created them (rule mcp-task-idor-001).
+//
+// MCP 2025-11-25 added durable tasks: a task-augmented tools/call returns a
+// taskId, and the caller later reads state with tasks/get and the underlying
+// tool output with tasks/result. The spec is explicit that these are scoped:
+// "receivers MUST reject tasks/get, tasks/result, and tasks/cancel requests for
+// tasks that do not belong to the same authorization context as the requestor."
+//
+// Two failures are reported. Reading another context's task metadata discloses
+// status, timing and status messages. Reading its result discloses the actual
+// tool output, which is the payload the task existed to produce.
+//
+// SAFETY: creating a task requires invoking a real tool, which no other rule in
+// this package does (mcp-tools-unauth-001 deliberately calls a non-existent tool
+// so nothing executes). To bound that, the rule only invokes a task-capable tool
+// whose annotations declare it read-only or explicitly non-destructive, and
+// skips entirely when no such tool exists.
+//
+// Tasks are marked experimental in 2025-11-25, so this rule is version-scoped.
+type TaskIDORExecutor struct {
+	rule attack.RuleContext
+}
+
+func init() {
+	attack.Register("mcp-task-idor", func(rc attack.RuleContext) attack.Executor { return NewTaskIDORExecutor(rc) })
+}
+
+func NewTaskIDORExecutor(r attack.RuleContext) *TaskIDORExecutor {
+	return &TaskIDORExecutor{rule: r}
+}
+
+// taskPollBudget bounds how long the rule waits for a task to reach a terminal
+// status. tasks/result blocks until terminal by spec, so the rule polls
+// tasks/get instead and only calls tasks/result once the task has finished.
+const (
+	taskPollBudget   = 12 * time.Second
+	taskPollInterval = 750 * time.Millisecond
+	taskPollMaxTries = 16
+)
+
+// safeTool is a task-capable tool the rule is willing to invoke.
+type safeTool struct {
+	name string
+	args map[string]interface{}
+}
+
+func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
+	vars := attack.NewVars(target, opts.OOBListenerURL)
+	// One transport, with credentials attached per request, so each session can
+	// present a different principal.
+	client := attack.NewUnauthHTTPClient(opts, vars)
+
+	tokenA, tokenB := opts.Token, opts.Token
+	crossPrincipal := false
+	if len(opts.Principals) >= 2 && opts.Principals[0].Token != opts.Principals[1].Token {
+		tokenA, tokenB = opts.Principals[0].Token, opts.Principals[1].Token
+		crossPrincipal = true
+	}
+
+	// Session A, which also discovers the endpoint.
+	sessA, ok := e.initSession(ctx, client, vars.BaseURL, tokenA)
+	if !ok {
+		return nil, nil // not an MCP server
+	}
+
+	// Gate on the tasks capability and on task-augmented tools/call specifically.
+	if !sessA.ServerSupports("tasks") || !tasksSupportsToolCall(sessA.RawInit) {
+		return nil, nil
+	}
+
+	// Gate on finding a tool this rule is willing to invoke.
+	tool, ok := e.findSafeTaskTool(ctx, client, sessA, tokenA, vars.RandID)
+	if !ok {
+		return nil, nil
+	}
+
+	// Step 1: create a task as principal A.
+	taskID := e.createTask(ctx, client, sessA, tokenA, tool)
+	if taskID == "" {
+		return nil, nil
+	}
+
+	// Step 2: discriminator. If an anonymous caller can create a task too, the
+	// server enforces no authentication at all, which is a different (and more
+	// obvious) failure owned by mcp-tools-unauth-001. Do not call that an IDOR.
+	if anonSess, anonOK := e.initSession(ctx, client, vars.BaseURL, ""); anonOK {
+		if e.createTask(ctx, client, anonSess, "", tool) != "" {
+			return nil, nil
+		}
+	}
+
+	// Step 3: a second session, as principal B, tries to read A's task.
+	sessB, ok := e.initSession(ctx, client, vars.BaseURL, tokenB)
+	if !ok || sessB.SessionID == sessA.SessionID {
+		return nil, nil // need a distinct session to demonstrate the boundary
+	}
+
+	meta, ok := e.getTask(ctx, client, sessB, tokenB, taskID)
+	if !ok {
+		return nil, nil // correctly scoped: B cannot see A's task
+	}
+
+	findings := []attack.Finding{e.metadataFinding(sessA.Endpoint, taskID, meta, crossPrincipal)}
+
+	// Step 4: escalate if B can also read the result. tasks/result blocks until
+	// the task is terminal, so poll tasks/get first and stay inside the budget.
+	if e.pollTerminal(ctx, client, sessB, tokenB, taskID) {
+		if content, ok := e.getResult(ctx, client, sessB, tokenB, taskID); ok {
+			findings = append(findings, e.resultFinding(sessA.Endpoint, taskID, tool.name, content, crossPrincipal))
+		}
+	}
+
+	return findings, nil
+}
+
+// initSession performs an initialize handshake as the given token, discovering
+// the endpoint across the candidate paths, and returns the resulting session.
+func (e *TaskIDORExecutor) initSession(ctx context.Context, client *attack.HTTPClient, baseURL, token string) (mcpSession, bool) {
+	for _, ep := range endpointCandidates(baseURL) {
+		headers := map[string]string{}
+		if token != "" {
+			headers["Authorization"] = "Bearer " + token
+		}
+		resp, err := client.POST(ctx, ep, headers, map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"method":  "initialize",
+			"params": map[string]interface{}{
+				"protocolVersion": "2025-11-25",
+				// Declaring the tasks client capability keeps the handshake
+				// honest: this client really does poll and cancel tasks.
+				"capabilities": map[string]interface{}{
+					"tasks": map[string]interface{}{"list": map[string]interface{}{}, "cancel": map[string]interface{}{}},
+				},
+				"clientInfo": map[string]interface{}{"name": "batesian", "version": "1.0"},
+			},
+		})
+		if err != nil || !resp.IsSuccess() {
+			continue
+		}
+		if !resp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
+			continue
+		}
+		session := mcpSession{
+			Endpoint:  ep,
+			SessionID: resp.Headers.Get("Mcp-Session-Id"),
+			RawInit:   resp.Body,
+		}
+		_, _ = client.POST(ctx, ep, e.headers(session, token), map[string]interface{}{
+			"jsonrpc": "2.0",
+			"method":  "notifications/initialized",
+		})
+		return session, true
+	}
+	return mcpSession{}, false
+}
+
+// headers builds the per-request headers for a session and principal.
+func (e *TaskIDORExecutor) headers(s mcpSession, token string) map[string]string {
+	h := map[string]string{}
+	if s.SessionID != "" {
+		h["Mcp-Session-Id"] = s.SessionID
+	}
+	if token != "" {
+		h["Authorization"] = "Bearer " + token
+	}
+	return h
+}
+
+// tasksSupportsToolCall reports whether the handshake declared
+// capabilities.tasks.requests.tools.call, which is what permits augmenting a
+// tools/call with a task.
+func tasksSupportsToolCall(rawInit []byte) bool {
+	var body struct {
+		Result struct {
+			Capabilities struct {
+				Tasks struct {
+					Requests struct {
+						Tools map[string]json.RawMessage `json:"tools"`
+					} `json:"requests"`
+				} `json:"tasks"`
+			} `json:"capabilities"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(rawInit, &body); err != nil {
+		return false
+	}
+	_, ok := body.Result.Capabilities.Tasks.Requests.Tools["call"]
+	return ok
+}
+
+// findSafeTaskTool picks a task-capable tool the rule is willing to invoke, and
+// synthesizes arguments for it from its input schema.
+//
+// Task creation is the one place this package executes real server-side
+// functionality, so the tool must declare itself read-only or explicitly
+// non-destructive. A tool with no annotations is not invoked: MCP treats
+// destructiveHint as true by default when a tool is not read-only.
+func (e *TaskIDORExecutor) findSafeTaskTool(ctx context.Context, client *attack.HTTPClient, s mcpSession, token, randID string) (safeTool, bool) {
+	resp, err := client.POST(ctx, s.Endpoint, e.headers(s, token), map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/list",
+		"params":  map[string]interface{}{},
+	})
+	if err != nil || !resp.IsSuccess() {
+		return safeTool{}, false
+	}
+	var body struct {
+		Result struct {
+			Tools []struct {
+				Name      string `json:"name"`
+				Execution struct {
+					TaskSupport string `json:"taskSupport"`
+				} `json:"execution"`
+				Annotations *struct {
+					ReadOnlyHint    *bool `json:"readOnlyHint"`
+					DestructiveHint *bool `json:"destructiveHint"`
+				} `json:"annotations"`
+				InputSchema map[string]interface{} `json:"inputSchema"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		return safeTool{}, false
+	}
+	for _, t := range body.Result.Tools {
+		if t.Execution.TaskSupport != "optional" && t.Execution.TaskSupport != "required" {
+			continue
+		}
+		if t.Annotations == nil {
+			continue // unannotated: assume it may be destructive
+		}
+		readOnly := t.Annotations.ReadOnlyHint != nil && *t.Annotations.ReadOnlyHint
+		nonDestructive := t.Annotations.DestructiveHint != nil && !*t.Annotations.DestructiveHint
+		if !readOnly && !nonDestructive {
+			continue
+		}
+		return safeTool{name: t.Name, args: synthesizeArgs(t.InputSchema, randID)}, true
+	}
+	return safeTool{}, false
+}
+
+// synthesizeArgs builds a minimal argument object from a tool's JSON Schema,
+// filling each declared property with an inert value of the right type.
+func synthesizeArgs(schema map[string]interface{}, randID string) map[string]interface{} {
+	args := map[string]interface{}{}
+	props, _ := schema["properties"].(map[string]interface{})
+	for name, raw := range props {
+		spec, _ := raw.(map[string]interface{})
+		switch spec["type"] {
+		case "string":
+			args[name] = "batesian task probe " + randID
+		case "number", "integer":
+			args[name] = 1
+		case "boolean":
+			args[name] = false
+		case "array":
+			args[name] = []interface{}{}
+		case "object":
+			args[name] = map[string]interface{}{}
+		}
+	}
+	return args
+}
+
+// createTask issues a task-augmented tools/call and returns the created task id,
+// or empty when the request was refused.
+func (e *TaskIDORExecutor) createTask(ctx context.Context, client *attack.HTTPClient, s mcpSession, token string, tool safeTool) string {
+	resp, err := client.POST(ctx, s.Endpoint, e.headers(s, token), map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      3,
+		"method":  "tools/call",
+		"params": map[string]interface{}{
+			"name":      tool.name,
+			"arguments": tool.args,
+			"task":      map[string]interface{}{"ttl": 60000},
+		},
+	})
+	if err != nil || !resp.IsSuccess() {
+		return ""
+	}
+	var body struct {
+		Result struct {
+			Task struct {
+				TaskID string `json:"taskId"`
+			} `json:"task"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		return ""
+	}
+	return body.Result.Task.TaskID
+}
+
+// taskState is the subset of a Task object the rule reports on.
+type taskState struct {
+	Status        string `json:"status"`
+	StatusMessage string `json:"statusMessage"`
+	CreatedAt     string `json:"createdAt"`
+}
+
+// getTask reads a task as the given principal. ok is false when the server
+// refuses (the correctly-scoped outcome, a -32602 per spec).
+func (e *TaskIDORExecutor) getTask(ctx context.Context, client *attack.HTTPClient, s mcpSession, token, taskID string) (taskState, bool) {
+	resp, err := client.POST(ctx, s.Endpoint, e.headers(s, token), map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      4,
+		"method":  "tasks/get",
+		"params":  map[string]interface{}{"taskId": taskID},
+	})
+	if err != nil || !resp.IsSuccess() {
+		return taskState{}, false
+	}
+	var body struct {
+		Result *taskState             `json:"result"`
+		Error  map[string]interface{} `json:"error"`
+	}
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		return taskState{}, false
+	}
+	if body.Error != nil || body.Result == nil || body.Result.Status == "" {
+		return taskState{}, false
+	}
+	return *body.Result, true
+}
+
+// pollTerminal waits for the task to reach a terminal status, within budget.
+// tasks/result blocks until terminal, so polling first keeps the scan bounded.
+func (e *TaskIDORExecutor) pollTerminal(ctx context.Context, client *attack.HTTPClient, s mcpSession, token, taskID string) bool {
+	deadline := time.Now().Add(taskPollBudget)
+	for i := 0; i < taskPollMaxTries && time.Now().Before(deadline); i++ {
+		st, ok := e.getTask(ctx, client, s, token, taskID)
+		if !ok {
+			return false
+		}
+		switch st.Status {
+		case "completed", "failed", "cancelled":
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(taskPollInterval):
+		}
+	}
+	return false
+}
+
+// getResult reads the underlying tool output for a terminal task, returning the
+// raw result payload when the server disclosed it.
+func (e *TaskIDORExecutor) getResult(ctx context.Context, client *attack.HTTPClient, s mcpSession, token, taskID string) (string, bool) {
+	resp, err := client.POST(ctx, s.Endpoint, e.headers(s, token), map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      5,
+		"method":  "tasks/result",
+		"params":  map[string]interface{}{"taskId": taskID},
+	})
+	if err != nil || !resp.IsSuccess() {
+		return "", false
+	}
+	var body struct {
+		Result json.RawMessage        `json:"result"`
+		Error  map[string]interface{} `json:"error"`
+	}
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		return "", false
+	}
+	if body.Error != nil || len(body.Result) == 0 {
+		return "", false
+	}
+	return string(body.Result), true
+}
+
+// requestorLabel describes what boundary was actually crossed, so the finding
+// never claims a cross-principal read when only two sessions were available.
+func requestorLabel(crossPrincipal bool) string {
+	if crossPrincipal {
+		return "a different authenticated principal"
+	}
+	return "a separate authenticated session"
+}
+
+func (e *TaskIDORExecutor) metadataFinding(endpoint, taskID string, st taskState, crossPrincipal bool) attack.Finding {
+	return attack.Finding{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "high",
+		Confidence: attack.ConfirmedExploit,
+		Title:      "MCP task readable by another authorization context (tasks/get IDOR)",
+		Description: fmt.Sprintf(
+			"tasks/get at %s returned task %s to %s that did not create it. The server rejected "+
+				"anonymous task creation, so authentication is enforced, yet task lookup is not bound to "+
+				"the creating context. The MCP spec requires receivers to reject tasks/get for tasks "+
+				"outside the requestor's authorization context, so any caller who learns or guesses a "+
+				"task id can track another context's work.", endpoint, taskID, requestorLabel(crossPrincipal)),
+		Evidence: fmt.Sprintf(
+			"endpoint: %s\ntask: %s\nanonymous task creation: rejected (auth enforced)\n"+
+				"cross-context tasks/get: accepted\ndisclosed status: %s\nstatusMessage: %s\ncreatedAt: %s",
+			endpoint, taskID, st.Status, st.StatusMessage, st.CreatedAt),
+		Remediation: e.rule.Remediation,
+		TargetURL:   endpoint,
+	}
+}
+
+func (e *TaskIDORExecutor) resultFinding(endpoint, taskID, toolName, content string, crossPrincipal bool) attack.Finding {
+	return attack.Finding{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "critical",
+		Confidence: attack.ConfirmedExploit,
+		Title:      "MCP task result readable by another authorization context (tasks/result IDOR)",
+		Description: fmt.Sprintf(
+			"tasks/result at %s returned the completed output of task %s to %s that did not create it. "+
+				"This is the actual result of the %q tool invocation, not task metadata, so whatever that "+
+				"tool returned is disclosed across the authorization boundary. The MCP spec requires "+
+				"receivers to reject tasks/result for tasks outside the requestor's authorization context.",
+			endpoint, taskID, requestorLabel(crossPrincipal), toolName),
+		Evidence: fmt.Sprintf(
+			"endpoint: %s\ntask: %s\ntool: %s\nanonymous task creation: rejected (auth enforced)\n"+
+				"cross-context tasks/result: accepted\ndisclosed result: %s",
+			endpoint, taskID, toolName, snippetMCP([]byte(content))),
+		Remediation: e.rule.Remediation,
+		TargetURL:   endpoint,
+	}
+}

--- a/internal/attack/mcp/task_idor_test.go
+++ b/internal/attack/mcp/task_idor_test.go
@@ -1,0 +1,265 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+// taskIDORServer builds a mock MCP 2025-11-25 server with the tasks capability.
+// Behaviour depends on mode:
+//
+//   - "vuln":          tasks are not scoped, so any session reads any task =>
+//     both the tasks/get and tasks/result findings.
+//   - "metadata-only": tasks/get leaks across sessions but tasks/result is
+//     scoped => only the tasks/get finding.
+//   - "secure":        tasks are bound to the creating session => silent.
+//   - "no-auth":       task creation succeeds with no credentials, so the
+//     discriminator suppresses the finding => silent.
+//   - "no-tasks-cap":  the tasks capability is absent => skip.
+//   - "unsafe-tool":   the only task-capable tool carries no safety annotations,
+//     so the rule refuses to invoke it => skip.
+//   - "not-mcp":       everything 404s => silent.
+func taskIDORServer(mode string) *httptest.Server {
+	var mu sync.Mutex
+	sessions := 0
+	// taskID -> owning session id
+	owner := map[string]string{}
+	tasks := 0
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if mode == "not-mcp" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		method, _ := req["method"].(string)
+		params, _ := req["params"].(map[string]interface{})
+		id := req["id"]
+		sid := r.Header.Get("Mcp-Session-Id")
+		authed := strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ")
+		w.Header().Set("Content-Type", "application/json")
+
+		result := func(v interface{}) {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id, "result": v})
+		}
+		rpcErr := func(code int, msg string) {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": code, "message": msg}})
+		}
+
+		switch method {
+		case "initialize":
+			mu.Lock()
+			sessions++
+			newSID := fmt.Sprintf("sess-%d", sessions)
+			mu.Unlock()
+			caps := map[string]interface{}{"tools": map[string]interface{}{}}
+			if mode != "no-tasks-cap" {
+				caps["tasks"] = map[string]interface{}{
+					"list":     map[string]interface{}{},
+					"cancel":   map[string]interface{}{},
+					"requests": map[string]interface{}{"tools": map[string]interface{}{"call": map[string]interface{}{}}},
+				}
+			}
+			w.Header().Set("Mcp-Session-Id", newSID)
+			result(map[string]interface{}{
+				"protocolVersion": "2025-11-25",
+				"serverInfo":      map[string]interface{}{"name": "task-srv", "version": "1.0"},
+				"capabilities":    caps,
+			})
+
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+
+		case "tools/list":
+			tool := map[string]interface{}{
+				"name":        "research",
+				"description": "long running research",
+				"execution":   map[string]interface{}{"taskSupport": "required"},
+				"inputSchema": map[string]interface{}{
+					"type":       "object",
+					"properties": map[string]interface{}{"topic": map[string]interface{}{"type": "string"}},
+				},
+			}
+			// The rule refuses to invoke a tool that does not declare itself safe.
+			if mode != "unsafe-tool" {
+				tool["annotations"] = map[string]interface{}{"readOnlyHint": false, "destructiveHint": false}
+			}
+			result(map[string]interface{}{"tools": []interface{}{tool}})
+
+		case "tools/call":
+			if _, isTask := params["task"]; !isTask {
+				rpcErr(-32600, "task augmentation required")
+				return
+			}
+			// Every mode except no-auth requires credentials to create a task.
+			if mode != "no-auth" && !authed {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			mu.Lock()
+			tasks++
+			tid := fmt.Sprintf("task-%d", tasks)
+			owner[tid] = sid
+			mu.Unlock()
+			result(map[string]interface{}{"task": map[string]interface{}{
+				"taskId": tid, "status": "working", "createdAt": "2026-07-20T07:00:00Z",
+				"lastUpdatedAt": "2026-07-20T07:00:00Z", "ttl": 60000, "pollInterval": 10,
+			}})
+
+		case "tasks/get":
+			tid, _ := params["taskId"].(string)
+			mu.Lock()
+			own, exists := owner[tid]
+			mu.Unlock()
+			if !exists || (mode == "secure" && own != sid) {
+				rpcErr(-32602, "Task not found")
+				return
+			}
+			// Terminal immediately so the rule can proceed to tasks/result without
+			// burning its polling budget.
+			result(map[string]interface{}{
+				"taskId": tid, "status": "completed", "statusMessage": "done",
+				"createdAt": "2026-07-20T07:00:00Z", "lastUpdatedAt": "2026-07-20T07:00:05Z", "ttl": 60000,
+			})
+
+		case "tasks/result":
+			tid, _ := params["taskId"].(string)
+			mu.Lock()
+			own, exists := owner[tid]
+			mu.Unlock()
+			if !exists || mode == "metadata-only" || (mode == "secure" && own != sid) {
+				rpcErr(-32602, "Task not found")
+				return
+			}
+			result(map[string]interface{}{
+				"content": []interface{}{map[string]interface{}{"type": "text", "text": "CONFIDENTIAL research output"}},
+				"isError": false,
+			})
+
+		default:
+			rpcErr(-32601, "Method not found")
+		}
+	}))
+}
+
+func runTaskIDOR(t *testing.T, srv *httptest.Server) []attack.Finding {
+	t.Helper()
+	exec := mcpattack.NewTaskIDORExecutor(attack.RuleContext{ID: "mcp-task-idor-001"})
+	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{
+		TimeoutSeconds: 5,
+		Principals: []attack.Principal{
+			{Name: "tenant-a", Token: "tok-a"},
+			{Name: "tenant-b", Token: "tok-b"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return findings
+}
+
+// TestTaskIDOR_CrossContext: B reads A's task and its result => both findings.
+func TestTaskIDOR_CrossContext(t *testing.T) {
+	srv := taskIDORServer("vuln")
+	defer srv.Close()
+
+	findings := runTaskIDOR(t, srv)
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings (tasks/get + tasks/result), got %d: %+v", len(findings), findings)
+	}
+	var high, critical bool
+	for _, f := range findings {
+		if f.Confidence != attack.ConfirmedExploit {
+			t.Errorf("expected ConfirmedExploit, got %v", f.Confidence)
+		}
+		switch f.Severity {
+		case "high":
+			high = true
+		case "critical":
+			critical = true
+			if !strings.Contains(f.Evidence, "CONFIDENTIAL research output") {
+				t.Errorf("result finding should cite the disclosed output, got evidence %q", f.Evidence)
+			}
+		}
+	}
+	if !high || !critical {
+		t.Errorf("expected both high and critical findings, got high=%v critical=%v", high, critical)
+	}
+}
+
+// TestTaskIDOR_MetadataOnly: tasks/get leaks but tasks/result is scoped.
+func TestTaskIDOR_MetadataOnly(t *testing.T) {
+	srv := taskIDORServer("metadata-only")
+	defer srv.Close()
+
+	findings := runTaskIDOR(t, srv)
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 finding (metadata only), got %d: %+v", len(findings), findings)
+	}
+	if findings[0].Severity != "high" {
+		t.Errorf("expected the high tasks/get finding, got %q", findings[0].Severity)
+	}
+}
+
+// TestTaskIDOR_Secure: tasks bound to the creating session => silent.
+func TestTaskIDOR_Secure(t *testing.T) {
+	srv := taskIDORServer("secure")
+	defer srv.Close()
+
+	if findings := runTaskIDOR(t, srv); len(findings) != 0 {
+		t.Errorf("expected 0 findings for session-scoped tasks, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestTaskIDOR_NoAuthSuppressed: anonymous task creation succeeds, so this is a
+// missing-authentication failure rather than an IDOR and must be suppressed.
+func TestTaskIDOR_NoAuthSuppressed(t *testing.T) {
+	srv := taskIDORServer("no-auth")
+	defer srv.Close()
+
+	if findings := runTaskIDOR(t, srv); len(findings) != 0 {
+		t.Errorf("expected 0 findings when the server enforces no auth at all, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestTaskIDOR_NoTasksCapability: server does not advertise tasks => skip.
+func TestTaskIDOR_NoTasksCapability(t *testing.T) {
+	srv := taskIDORServer("no-tasks-cap")
+	defer srv.Close()
+
+	if findings := runTaskIDOR(t, srv); len(findings) != 0 {
+		t.Errorf("expected 0 findings without the tasks capability, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestTaskIDOR_UnsafeToolSkipped: the only task-capable tool carries no safety
+// annotations, so the rule must refuse to invoke it.
+func TestTaskIDOR_UnsafeToolSkipped(t *testing.T) {
+	srv := taskIDORServer("unsafe-tool")
+	defer srv.Close()
+
+	if findings := runTaskIDOR(t, srv); len(findings) != 0 {
+		t.Errorf("expected 0 findings when no safely-annotated task tool exists, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestTaskIDOR_NotMCP: initialize fails => silent.
+func TestTaskIDOR_NotMCP(t *testing.T) {
+	srv := taskIDORServer("not-mcp")
+	defer srv.Close()
+
+	if findings := runTaskIDOR(t, srv); len(findings) != 0 {
+		t.Errorf("expected 0 findings for a non-MCP server, got %d: %+v", len(findings), findings)
+	}
+}

--- a/rules/mcp/task-idor-001.yaml
+++ b/rules/mcp/task-idor-001.yaml
@@ -1,0 +1,71 @@
+id: mcp-task-idor-001
+info:
+  name: MCP Task Readable Across Authorization Contexts
+  author: batesian
+  severity: high
+  description: |
+    Tests whether MCP tasks are bound to the authorization context that created
+    them.
+
+    MCP 2025-11-25 introduced durable tasks. A task-augmented tools/call returns
+    a taskId immediately, and the caller later reads execution state with
+    tasks/get and the underlying tool output with tasks/result. The
+    specification's Security Considerations are explicit:
+
+      "receivers MUST reject tasks/get, tasks/result, and tasks/cancel requests
+       for tasks that do not belong to the same authorization context as the
+       requestor."
+
+    The rule creates a task as one principal and attempts to read it from a
+    separate session as another, reporting two distinct failures:
+
+    - tasks/get returns another context's task (high). Task metadata discloses
+      execution status, timing, and status messages for work the caller did not
+      initiate.
+    - tasks/result returns another context's result (critical). This is the
+      actual output of the tool invocation, not metadata, so whatever that tool
+      produced crosses the authorization boundary.
+
+    A finding is raised only after an anonymous task creation is rejected, which
+    proves the server does enforce authentication. A server with no
+    authentication at all is a different and more obvious failure, owned by
+    mcp-tools-unauth-001, and is suppressed here rather than mislabelled as a
+    broken object-level authorization check.
+
+    Safety: creating a task requires invoking a real tool, which is unique among
+    the rules in this package. The rule therefore only invokes a task-capable
+    tool whose annotations declare it read-only or explicitly non-destructive,
+    and skips entirely when no such tool is advertised. Because tasks/result
+    blocks until a task is terminal, the rule polls tasks/get within a bounded
+    budget and only requests the result once the task has finished.
+
+    Currency: tasks are marked experimental in the 2025-11-25 specification and
+    their design may evolve, so this rule is version-scoped.
+
+  references:
+    - https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks
+    - https://cwe.mitre.org/data/definitions/639.html
+    - https://cwe.mitre.org/data/definitions/200.html
+
+  tags:
+    - mcp
+    - auth
+    - tasks
+    - idor
+    - cwe-639
+    - cwe-200
+
+attack:
+  protocol: mcp
+  type: mcp-task-idor
+
+remediation: |
+  1. Bind every task to the authorization context that created it, and reject
+     tasks/get, tasks/result, and tasks/cancel for tasks belonging to any other
+     context. Return a JSON-RPC -32602 rather than the task.
+  2. Scope tasks/list to the requestor's own tasks. If the deployment cannot
+     identify requestors, do not advertise the tasks.list capability at all.
+  3. Where context binding is genuinely unavailable, generate task IDs with
+     enough entropy that they cannot be guessed, keep TTLs short, and document
+     the limitation so operators know task results are reachable by ID alone.
+  4. Rate-limit task operations so task IDs cannot be enumerated.

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -18,7 +18,7 @@ pip install starlette uvicorn httpx mcp
 
 ## Server Registry
 
-The bundled rule set is **17 A2A + 17 MCP = 34 rules**. Every rule's primary
+The bundled rule set is **17 A2A + 18 MCP = 35 rules**. Every rule's primary
 validation is an in-process `net/http/httptest` harness in its Go
 `*_test.go` (multiple server postures: vulnerable must fire / patched / open /
 benign must stay silent). The Python servers below are optional standalone
@@ -51,8 +51,9 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_batch_bypass_server.py` | 7795 | `mcp-jsonrpc-batch-bypass-001` |
 | `mcp_completion_unauth_server.py` | 7796 | `mcp-completion-unauth-001` |
 | `mcp_logging_unauth_server.py` | 7797 | `mcp-logging-unauth-001` |
+| `mcp_task_idor_server.py` | 7798 | `mcp-task-idor-001` (two principals; needs two `--principal`s) |
 
-**Coverage.** 33 of the 34 rules have a standalone Python fixture above. The
+**Coverage.** 34 of the 35 rules have a standalone Python fixture above. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
 (`internal/attack/mcp/token_replay_test.go`); the same is true of the per-rule
 edge-case harnesses for every other rule. `mockserver.go` is a Go helper used by

--- a/testdata/mcp_task_idor_server.py
+++ b/testdata/mcp_task_idor_server.py
@@ -1,0 +1,127 @@
+"""
+Deliberately vulnerable MCP test server for validating:
+  - mcp-task-idor-001: MCP 2025-11-25 tasks are not bound to the authorization
+    context that created them.
+
+The server enforces authentication on task creation (so the rule's
+discriminator passes) but applies no scoping to tasks/get or tasks/result, so
+any authenticated session can read another session's task and its result.
+
+Run: python testdata/mcp_task_idor_server.py
+"""
+import json
+import uuid
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.routing import Route
+import uvicorn
+
+PORT = 7798
+
+# taskId -> {"owner": session_id, "topic": str}
+TASKS = {}
+
+TOOL = {
+    "name": "research",
+    "description": "Long running research query",
+    # Task augmentation is required for this tool.
+    "execution": {"taskSupport": "required"},
+    # Declared non-destructive, so the scanner is willing to invoke it.
+    "annotations": {"readOnlyHint": False, "destructiveHint": False},
+    "inputSchema": {
+        "type": "object",
+        "properties": {"topic": {"type": "string", "description": "Research topic"}},
+    },
+}
+
+
+async def mcp_endpoint(request: Request) -> Response:
+    body = await request.json()
+    method = body.get("method", "")
+    req_id = body.get("id")
+    params = body.get("params", {})
+    sid = request.headers.get("mcp-session-id", "")
+    authed = request.headers.get("authorization", "").startswith("Bearer ")
+
+    def result(res, headers=None):
+        return Response(json.dumps({"jsonrpc": "2.0", "id": req_id, "result": res}),
+                        media_type="application/json", headers=headers or {})
+
+    def error(code, msg):
+        return Response(json.dumps({"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": msg}}),
+                        media_type="application/json")
+
+    if method == "initialize":
+        new_sid = str(uuid.uuid4())
+        return result({
+            "protocolVersion": "2025-11-25",
+            "serverInfo": {"name": "mcp-task-idor-vuln-server", "version": "1.0"},
+            "capabilities": {
+                "tools": {},
+                "tasks": {
+                    "list": {},
+                    "cancel": {},
+                    "requests": {"tools": {"call": {}}},
+                },
+            },
+        }, headers={"Content-Type": "application/json", "Mcp-Session-Id": new_sid})
+
+    if method == "notifications/initialized":
+        return Response(status_code=202)
+
+    if method == "tools/list":
+        return result({"tools": [TOOL]})
+
+    if method == "tools/call":
+        if "task" not in params:
+            return error(-32600, "Task augmentation required for this tool")
+        # Authentication IS enforced here, so this is an authorization failure
+        # rather than a missing-authentication one.
+        if not authed:
+            return Response(status_code=401)
+        tid = uuid.uuid4().hex
+        TASKS[tid] = {"owner": sid, "topic": params.get("arguments", {}).get("topic", "")}
+        return result({"task": {
+            "taskId": tid, "status": "working", "statusMessage": "Gathering sources...",
+            "createdAt": "2026-07-20T07:00:00Z", "lastUpdatedAt": "2026-07-20T07:00:00Z",
+            "ttl": 60000, "pollInterval": 500,
+        }})
+
+    # Vulnerable: neither of the following checks the requesting session against
+    # the task's owner, so any caller holding a task id can read it.
+    if method == "tasks/get":
+        tid = params.get("taskId", "")
+        if tid not in TASKS:
+            return error(-32602, "Failed to retrieve task: Task not found")
+        return result({
+            "taskId": tid, "status": "completed", "statusMessage": "Research complete",
+            "createdAt": "2026-07-20T07:00:00Z", "lastUpdatedAt": "2026-07-20T07:00:04Z", "ttl": 60000,
+        })
+
+    if method == "tasks/result":
+        tid = params.get("taskId", "")
+        if tid not in TASKS:
+            return error(-32602, "Task not found: " + tid)
+        topic = TASKS[tid]["topic"]
+        return result({
+            "content": [{"type": "text", "text": f"CONFIDENTIAL research report on {topic!r}: internal findings."}],
+            "isError": False,
+            "_meta": {"io.modelcontextprotocol/related-task": {"taskId": tid}},
+        })
+
+    if method == "tasks/list":
+        return result({"tasks": [{"taskId": t, "status": "completed"} for t in TASKS]})
+
+    return error(-32601, "Method not found")
+
+
+app = Starlette(routes=[
+    Route("/mcp", mcp_endpoint, methods=["POST"]),
+    Route("/", mcp_endpoint, methods=["POST"]),
+])
+
+if __name__ == "__main__":
+    print(f"[*] MCP task-IDOR vulnerable server on port {PORT}", flush=True)
+    print("[*] Vulnerability: tasks/get and tasks/result are not scoped to the creating session", flush=True)
+    uvicorn.run(app, host="127.0.0.1", port=PORT)


### PR DESCRIPTION
## Summary

Adds `mcp-task-idor-001`, covering the MCP **tasks** surface introduced in 2025-11-25. Nothing in the rule set touched it (grep-confirmed), despite the spec carrying explicit MUST-level authorization requirements.

> "receivers **MUST** reject `tasks/get`, `tasks/result`, and `tasks/cancel` requests for tasks that do not belong to the same authorization context as the requestor."

A task-augmented `tools/call` returns a `taskId` immediately; the caller later reads state via `tasks/get` and the underlying tool output via `tasks/result`.

## Detection

Creates a task as principal A, then reads it from a separate session as principal B:

| Finding | Severity | What is disclosed |
|---|---|---|
| cross-context `tasks/get` | high | Another context's task metadata: status, timing, status messages |
| cross-context `tasks/result` | **critical** | The **actual tool output** the task produced, not metadata |

Both are raised only after **anonymous task creation is rejected**, proving the server enforces authentication. A server with no auth at all is a different, more obvious failure owned by `mcp-tools-unauth-001`, and is suppressed rather than mislabelled as broken object-level authorization. A correctly-scoped server answers the cross-context read with `-32602` and produces nothing.

## Safety: this rule invokes a real tool

Creating a task requires it, which makes this unique in the package: `mcp-tools-unauth-001` deliberately calls a *non-existent* tool so nothing executes. To bound the exposure the rule only invokes a task-capable tool whose annotations declare it `readOnlyHint: true` or explicitly `destructiveHint: false`, and skips entirely when none is advertised. An **unannotated tool is never invoked**, since MCP treats a non-read-only tool as potentially destructive by default.

`tasks/result` blocks until the task is terminal (measured 4.0s against the reference server), so the rule polls `tasks/get` within a bounded budget and requests the result only once the task has finished, rather than hanging the scan.

## Drive-by fix: rune-splitting in `snippetMCP`

While wiring evidence output I found `snippetMCP` truncating at a **byte** offset, so a multi-byte UTF-8 character landing on the boundary was split. That output goes into `Finding.Evidence` and then JSON/SARIF, where a partial rune is silently rewritten to `U+FFFD`.

This is the identical defect fuzzing found in the A2A helper (#90); the MCP one was never covered. It is shared by `mcp-oauth-dcr-001`, `mcp-oauth-audience-002`, and `mcp-token-replay-001`. Fixed, and now fuzzed alongside the other parsers (5.6M executions clean).

## Validation

- **Seven unit postures**: cross-context leak (both findings) · metadata-only leak · session-scoped/secure · no-auth-at-all (suppressed) · no `tasks` capability · task-capable-but-unannotated tool (skipped) · non-MCP.
- **Fixture on port 7798** live-fires both findings, with the critical one citing the disclosed content.
- **`server-everything` reference**: silent, as expected. Worth stating precisely which guard produced that. The reference server enforces no authentication, so anonymous task creation succeeds and the **discriminator** suppresses before the cross-context read is attempted. What that run *did* exercise live against third-party code is capability parsing, the tool annotation gate, argument synthesis from `inputSchema`, and task creation. The session-scoping path itself is covered by the `secure` unit posture and the fixture, not by that run.

## Currency caveat

Tasks are marked **experimental** in 2025-11-25 ("design and behavior may evolve"), so this rule is version-scoped, in the same way the 2026-07-28 revision will affect `session-fixation` and `sse-resume-replay`.

## Rule count

**35 (17 A2A + 18 MCP)**. README, `docs/rules-mcp.md`, `testdata/README.md`, and the release header updated.

## Test plan

`go test ./...` passes; `gofmt` and `go vet` clean.
