### PR TITLE
feat(mcp-task-idor-001): detect cross-context tasks/list enumeration

### DIFF
--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -211,10 +211,19 @@ and `tasks/cancel` requests for tasks that do not belong to the same
 authorization context as the requestor".
 
 The rule creates a task as one principal and reads it from a separate session as
-another, reporting two failures. An accepted cross-context `tasks/get` discloses
-another context's task metadata: status, timing, and status messages (**high**).
-An accepted cross-context `tasks/result` discloses the **actual tool output** the
-task produced, not metadata (**critical**). Both are **confirmed**.
+another, reporting three failures, all **confirmed**:
+
+- An accepted cross-context `tasks/get` discloses another context's task
+  metadata: status, timing, and status messages (**high**).
+- An accepted cross-context `tasks/result` discloses the **actual tool output**
+  the task produced, not metadata (**critical**).
+- An accepted cross-context `tasks/list` **enumerates** another context's tasks
+  (**critical**). This is the strongest of the three because it needs no prior
+  knowledge of any task id at all, so every task on the server can be listed and
+  then read. It is gated on the `tasks.list` capability being advertised, and is
+  checked independently of the by-id failures: the spec requires anything
+  gettable to also be listable, but not the converse, so a server can scope
+  `tasks/get` and still leak the list.
 
 A finding is raised only after anonymous task creation is *rejected*, proving the
 server does enforce authentication. A server with no authentication at all is a

--- a/internal/attack/mcp/task_idor.go
+++ b/internal/attack/mcp/task_idor.go
@@ -107,18 +107,29 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 		return nil, nil // need a distinct session to demonstrate the boundary
 	}
 
-	meta, ok := e.getTask(ctx, client, sessB, tokenB, taskID)
-	if !ok {
-		return nil, nil // correctly scoped: B cannot see A's task
+	var findings []attack.Finding
+
+	// Step 4: can B read A's task by id? A correctly-scoped server answers -32602.
+	if meta, ok := e.getTask(ctx, client, sessB, tokenB, taskID); ok {
+		findings = append(findings, e.metadataFinding(sessA.Endpoint, taskID, meta, crossPrincipal))
+
+		// Escalate if B can also read the result. tasks/result blocks until the
+		// task is terminal, so poll tasks/get first and stay inside the budget.
+		if e.pollTerminal(ctx, client, sessB, tokenB, taskID) {
+			if content, ok := e.getResult(ctx, client, sessB, tokenB, taskID); ok {
+				findings = append(findings, e.resultFinding(sessA.Endpoint, taskID, tool.name, content, crossPrincipal))
+			}
+		}
 	}
 
-	findings := []attack.Finding{e.metadataFinding(sessA.Endpoint, taskID, meta, crossPrincipal)}
-
-	// Step 4: escalate if B can also read the result. tasks/result blocks until
-	// the task is terminal, so poll tasks/get first and stay inside the budget.
-	if e.pollTerminal(ctx, client, sessB, tokenB, taskID) {
-		if content, ok := e.getResult(ctx, client, sessB, tokenB, taskID); ok {
-			findings = append(findings, e.resultFinding(sessA.Endpoint, taskID, tool.name, content, crossPrincipal))
+	// Step 5: can B enumerate A's task without knowing its id? This is checked
+	// independently of step 4: the spec requires anything gettable to also be
+	// listable, but not the converse, so a server can scope tasks/get and still
+	// leak the list. Enumeration is the stronger failure because it needs no
+	// prior knowledge of the task id at all.
+	if tasksSupportsList(sessA.RawInit) {
+		if ids, ok := e.listTasks(ctx, client, sessB, tokenB); ok && containsTaskID(ids, taskID) {
+			findings = append(findings, e.enumerationFinding(sessA.Endpoint, taskID, len(ids), crossPrincipal))
 		}
 	}
 
@@ -199,6 +210,70 @@ func tasksSupportsToolCall(rawInit []byte) bool {
 	}
 	_, ok := body.Result.Capabilities.Tasks.Requests.Tools["call"]
 	return ok
+}
+
+// tasksSupportsList reports whether the handshake declared capabilities.tasks.list,
+// which is what permits tasks/list at all. The spec tells receivers that cannot
+// identify requestors not to declare it, precisely because listing exposes task
+// metadata regardless of how much entropy the task ids carry.
+func tasksSupportsList(rawInit []byte) bool {
+	var body struct {
+		Result struct {
+			Capabilities struct {
+				Tasks map[string]json.RawMessage `json:"tasks"`
+			} `json:"capabilities"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(rawInit, &body); err != nil {
+		return false
+	}
+	_, ok := body.Result.Capabilities.Tasks["list"]
+	return ok
+}
+
+// listTasks enumerates the tasks visible to the given principal, returning the
+// task ids from the first page. ok is false when the server refuses the call.
+func (e *TaskIDORExecutor) listTasks(ctx context.Context, client *attack.HTTPClient, s mcpSession, token string) ([]string, bool) {
+	resp, err := client.POST(ctx, s.Endpoint, e.headers(s, token), map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      6,
+		"method":  "tasks/list",
+		"params":  map[string]interface{}{},
+	})
+	if err != nil || !resp.IsSuccess() {
+		return nil, false
+	}
+	var body struct {
+		Result *struct {
+			Tasks []struct {
+				TaskID string `json:"taskId"`
+			} `json:"tasks"`
+		} `json:"result"`
+		Error map[string]interface{} `json:"error"`
+	}
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		return nil, false
+	}
+	if body.Error != nil || body.Result == nil {
+		return nil, false
+	}
+	ids := make([]string, 0, len(body.Result.Tasks))
+	for _, t := range body.Result.Tasks {
+		if t.TaskID != "" {
+			ids = append(ids, t.TaskID)
+		}
+	}
+	return ids, true
+}
+
+// containsTaskID reports whether the enumerated list includes the target task.
+func containsTaskID(ids []string, taskID string) bool {
+	for _, id := range ids {
+		if id == taskID {
+			return true
+		}
+	}
+	return false
 }
 
 // findSafeTaskTool picks a task-capable tool the rule is willing to invoke, and
@@ -410,6 +485,29 @@ func (e *TaskIDORExecutor) metadataFinding(endpoint, taskID string, st taskState
 			"endpoint: %s\ntask: %s\nanonymous task creation: rejected (auth enforced)\n"+
 				"cross-context tasks/get: accepted\ndisclosed status: %s\nstatusMessage: %s\ncreatedAt: %s",
 			endpoint, taskID, st.Status, st.StatusMessage, st.CreatedAt),
+		Remediation: e.rule.Remediation,
+		TargetURL:   endpoint,
+	}
+}
+
+func (e *TaskIDORExecutor) enumerationFinding(endpoint, taskID string, total int, crossPrincipal bool) attack.Finding {
+	return attack.Finding{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "critical",
+		Confidence: attack.ConfirmedExploit,
+		Title:      "MCP tasks/list enumerates another authorization context's tasks",
+		Description: fmt.Sprintf(
+			"tasks/list at %s returned task %s to %s that did not create it, in a list of %d task(s). "+
+				"This is a stronger failure than reading a task by id: the caller needs no prior knowledge "+
+				"of any task id, so every task on the server can be enumerated and then read. The MCP spec "+
+				"requires receivers to return only tasks associated with the requestor's authorization "+
+				"context, and to not advertise the tasks.list capability at all when requestors cannot be "+
+				"identified.", endpoint, taskID, requestorLabel(crossPrincipal), total),
+		Evidence: fmt.Sprintf(
+			"endpoint: %s\nanonymous task creation: rejected (auth enforced)\n"+
+				"cross-context tasks/list: accepted\ntasks returned: %d\nincludes another context's task: %s",
+			endpoint, total, taskID),
 		Remediation: e.rule.Remediation,
 		TargetURL:   endpoint,
 	}

--- a/internal/attack/mcp/task_idor_test.go
+++ b/internal/attack/mcp/task_idor_test.go
@@ -65,11 +65,14 @@ func taskIDORServer(mode string) *httptest.Server {
 			mu.Unlock()
 			caps := map[string]interface{}{"tools": map[string]interface{}{}}
 			if mode != "no-tasks-cap" {
-				caps["tasks"] = map[string]interface{}{
-					"list":     map[string]interface{}{},
+				tasksCap := map[string]interface{}{
 					"cancel":   map[string]interface{}{},
 					"requests": map[string]interface{}{"tools": map[string]interface{}{"call": map[string]interface{}{}}},
 				}
+				if mode != "no-list-cap" {
+					tasksCap["list"] = map[string]interface{}{}
+				}
+				caps["tasks"] = tasksCap
 			}
 			w.Header().Set("Mcp-Session-Id", newSID)
 			result(map[string]interface{}{
@@ -122,7 +125,7 @@ func taskIDORServer(mode string) *httptest.Server {
 			mu.Lock()
 			own, exists := owner[tid]
 			mu.Unlock()
-			if !exists || (mode == "secure" && own != sid) {
+			if !exists || ((mode == "secure" || mode == "list-only") && own != sid) {
 				rpcErr(-32602, "Task not found")
 				return
 			}
@@ -138,7 +141,7 @@ func taskIDORServer(mode string) *httptest.Server {
 			mu.Lock()
 			own, exists := owner[tid]
 			mu.Unlock()
-			if !exists || mode == "metadata-only" || (mode == "secure" && own != sid) {
+			if !exists || mode == "metadata-only" || mode == "list-only" || (mode == "secure" && own != sid) {
 				rpcErr(-32602, "Task not found")
 				return
 			}
@@ -146,6 +149,19 @@ func taskIDORServer(mode string) *httptest.Server {
 				"content": []interface{}{map[string]interface{}{"type": "text", "text": "CONFIDENTIAL research output"}},
 				"isError": false,
 			})
+
+		case "tasks/list":
+			mu.Lock()
+			var listed []interface{}
+			for tid, own := range owner {
+				// A correctly-scoped server returns only the caller's own tasks.
+				if (mode == "secure" || mode == "metadata-only") && own != sid {
+					continue
+				}
+				listed = append(listed, map[string]interface{}{"taskId": tid, "status": "completed"})
+			}
+			mu.Unlock()
+			result(map[string]interface{}{"tasks": listed})
 
 		default:
 			rpcErr(-32601, "Method not found")
@@ -175,26 +191,41 @@ func TestTaskIDOR_CrossContext(t *testing.T) {
 	defer srv.Close()
 
 	findings := runTaskIDOR(t, srv)
-	if len(findings) != 2 {
-		t.Fatalf("expected 2 findings (tasks/get + tasks/result), got %d: %+v", len(findings), findings)
+	if len(findings) != 3 {
+		t.Fatalf("expected 3 findings (tasks/get + tasks/result + tasks/list), got %d: %+v", len(findings), findings)
 	}
-	var high, critical bool
+	// Identify each failure by the method it names: severity alone is ambiguous
+	// now that both the result leak and the enumeration are critical.
+	var sawGet, sawResult, sawList bool
 	for _, f := range findings {
 		if f.Confidence != attack.ConfirmedExploit {
 			t.Errorf("expected ConfirmedExploit, got %v", f.Confidence)
 		}
-		switch f.Severity {
-		case "high":
-			high = true
-		case "critical":
-			critical = true
+		switch {
+		case strings.Contains(f.Title, "tasks/get"):
+			sawGet = true
+			if f.Severity != "high" {
+				t.Errorf("tasks/get finding should be high, got %q", f.Severity)
+			}
+		case strings.Contains(f.Title, "tasks/result"):
+			sawResult = true
+			if f.Severity != "critical" {
+				t.Errorf("tasks/result finding should be critical, got %q", f.Severity)
+			}
 			if !strings.Contains(f.Evidence, "CONFIDENTIAL research output") {
 				t.Errorf("result finding should cite the disclosed output, got evidence %q", f.Evidence)
 			}
+		case strings.Contains(f.Title, "tasks/list"):
+			sawList = true
+			if f.Severity != "critical" {
+				t.Errorf("tasks/list finding should be critical, got %q", f.Severity)
+			}
+		default:
+			t.Errorf("unexpected finding title %q", f.Title)
 		}
 	}
-	if !high || !critical {
-		t.Errorf("expected both high and critical findings, got high=%v critical=%v", high, critical)
+	if !sawGet || !sawResult || !sawList {
+		t.Errorf("expected all three failures, got get=%v result=%v list=%v", sawGet, sawResult, sawList)
 	}
 }
 
@@ -209,6 +240,43 @@ func TestTaskIDOR_MetadataOnly(t *testing.T) {
 	}
 	if findings[0].Severity != "high" {
 		t.Errorf("expected the high tasks/get finding, got %q", findings[0].Severity)
+	}
+}
+
+// TestTaskIDOR_ListOnly: tasks/get and tasks/result are correctly scoped, but
+// tasks/list still enumerates another session's tasks. The enumeration check
+// must therefore run independently of the by-id checks.
+func TestTaskIDOR_ListOnly(t *testing.T) {
+	srv := taskIDORServer("list-only")
+	defer srv.Close()
+
+	findings := runTaskIDOR(t, srv)
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 finding (enumeration only), got %d: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Severity != "critical" {
+		t.Errorf("expected the critical enumeration finding, got %q", f.Severity)
+	}
+	if !strings.Contains(f.Title, "tasks/list") {
+		t.Errorf("expected the tasks/list enumeration finding, got title %q", f.Title)
+	}
+}
+
+// TestTaskIDOR_NoListCapability: the server does not advertise tasks.list, so
+// only the by-id failure is reported and no enumeration is attempted.
+func TestTaskIDOR_NoListCapability(t *testing.T) {
+	srv := taskIDORServer("no-list-cap")
+	defer srv.Close()
+
+	findings := runTaskIDOR(t, srv)
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings (tasks/get + tasks/result, no enumeration), got %d: %+v", len(findings), findings)
+	}
+	for _, f := range findings {
+		if strings.Contains(f.Title, "tasks/list") {
+			t.Errorf("must not report enumeration when tasks.list is not advertised: %q", f.Title)
+		}
 	}
 }
 

--- a/testdata/mcp_task_idor_server.py
+++ b/testdata/mcp_task_idor_server.py
@@ -110,8 +110,13 @@ async def mcp_endpoint(request: Request) -> Response:
             "_meta": {"io.modelcontextprotocol/related-task": {"taskId": tid}},
         })
 
+    # Vulnerable: the list is not filtered to the requesting session either, so a
+    # caller can enumerate every task on the server without knowing any task id.
     if method == "tasks/list":
-        return result({"tasks": [{"taskId": t, "status": "completed"} for t in TASKS]})
+        return result({"tasks": [
+            {"taskId": t, "status": "completed", "createdAt": "2026-07-20T07:00:00Z"}
+            for t in TASKS
+        ]})
 
     return error(-32601, "Method not found")
 


### PR DESCRIPTION
## Summary

Extends `mcp-task-idor-001` with a third failure: cross-context enumeration via `tasks/list`.

Reading another context's task by id requires *knowing that id*. Enumerating `tasks/list` requires **nothing at all** — every task on the server can be listed and then read. That makes it the strongest of the three failures the rule now covers.

> "For `tasks/list` requests, receivers **MUST** ensure the returned task list includes only tasks associated with the requestor's authorization context."
>
> "receivers that cannot identify requestors **SHOULD NOT** declare the `tasks.list` capability, as listing tasks would expose task metadata to any requestor regardless of task ID entropy."

## Why extend rather than add a rule

`a2a-task-idor-001` already folds list enumeration into itself via `probeTaskList` (`task_idor.go:178`) rather than carrying a separate rule for the same root cause. Following that keeps the two protocols symmetric, reuses the existing scaffolding and discriminator, and leaves the rule count at **35**.

## Design

- Gated on the `tasks.list` capability being advertised, which is declared separately from `tasks.requests.tools.call`.
- **Checked independently of the by-id failures.** The spec requires anything gettable to also be listable, but *not* the converse, so a server can correctly scope `tasks/get` and still leak the list. The previous control flow returned early when `tasks/get` was scoped; that would have missed this case entirely.
- The existing anonymous-creation discriminator still guards all three findings, so a server with no authentication is suppressed rather than mislabelled as an authorization failure.

## Tests

Nine postures now. Two new ones pin the independence claim:

| Posture | Expected |
|---|---|
| `list-only` — `tasks/get` and `tasks/result` scoped, `tasks/list` leaks | exactly 1 finding, the critical enumeration |
| `no-list-cap` — `tasks.list` not advertised | 2 findings, and **no** enumeration attempted |

The cross-context test now identifies findings by the method they name rather than by severity. That was a real bug in the test I had to fix: the result leak and the enumeration are *both* critical, so the old severity-based assertion matched the wrong finding and failed.

## Validation

- **Fixture (port 7798)**: fires all three — `tasks/get` (high), `tasks/result` (critical), `tasks/list` enumeration (critical).
- **`server-everything` reference**: silent. Same caveat as the parent rule, stated plainly: that server enforces no authentication, so the discriminator suppresses before the cross-context reads are attempted. Its `tasks/list` *is* correctly session-scoped (verified directly during the spike: session B's list came back empty while session A held a live task), but that scoping is not what produced the silence in this run.

## Test plan

`go test ./...` passes; `gofmt` and `go vet` clean; no rule-count change.
