### PR TITLE
fix(security): stop following redirects; accept only JSON-RPC results

### DIFF
--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -83,8 +83,10 @@ matching. The negative control disambiguates: if the control is accepted, the
 server accepts any forged token regardless of audience, so the result is reported
 as **blanket forged-token acceptance** (point at `mcp-token-replay-001`) rather
 than misattributed to a specific matching bug. A trap acceptance is a
-**confirmed** isolated matching bug only when the control was rejected; an
-ambiguous control downgrades trap acceptances to an **indicator**. Catching a
+**confirmed** isolated matching bug only when the control was rejected; a
+control that carried no JSON-RPC result envelope (so it could not be clearly
+rejected) downgrades trap acceptances to an **indicator**, and a 2xx body with
+no result envelope is never itself treated as acceptance. Catching a
 server that validates signatures correctly but still mishandles `aud` (the
 CVE-2026-30863 / RFC 7523-bis class) requires a real validly-signed cross-resource
 token and is tracked as a follow-up.

--- a/internal/attack/a2a/artifact_tamper.go
+++ b/internal/attack/a2a/artifact_tamper.go
@@ -114,7 +114,7 @@ func (e *ArtifactTamperExecutor) Execute(ctx context.Context, target string, opt
 	// A re-submission is "accepted" only on HTTP success WITHOUT a JSON-RPC error
 	// envelope. A 4xx, or a 200 carrying {"error": {...}} such as "task already
 	// exists", is a rejection => immutability enforced => no finding.
-	tamperAccepted := tamperResp.IsSuccess() && !isJSONRPCError(tamperResp.Body)
+	tamperAccepted := tamperResp.IsAccepted()
 	if !tamperAccepted {
 		return nil, nil
 	}
@@ -131,7 +131,7 @@ func (e *ArtifactTamperExecutor) Execute(ctx context.Context, target string, opt
 
 	// Could not read the task back: report the accepted re-submission as an
 	// indicator (suspicious, but the overwrite is unproven).
-	if getErr != nil || getResp == nil || !getResp.IsSuccess() || isJSONRPCError(getResp.Body) {
+	if getErr != nil || getResp == nil || !getResp.IsAccepted() {
 		return []attack.Finding{e.indicator(endpoint, assignedID, tamperResp.StatusCode, tamperResp.BodyString())}, nil
 	}
 

--- a/internal/attack/a2a/card_security_unenforced.go
+++ b/internal/attack/a2a/card_security_unenforced.go
@@ -167,7 +167,13 @@ func (e *CardSecurityUnenforcedExecutor) createProbe(ctx context.Context, c *att
 		o := classifyProbe(resp)
 		if o == probeProcessedResult {
 			taskID, _ := extractTaskContext(resp.Body)
-			return probeProcessedResult, taskID
+			if taskID == "" {
+				// A result envelope with no task id does not confirm a task was
+				// actually created; do not promote to a confirmed processed result.
+				o = probeProcessedError
+			} else {
+				return probeProcessedResult, taskID
+			}
 		}
 		if o > outcome {
 			outcome = o
@@ -185,7 +191,7 @@ func classifyProbe(resp *attack.Response) probeOutcome {
 	if isA2AAuthRejection(resp) {
 		return probeAuthRejected
 	}
-	if resp.IsSuccess() && !isJSONRPCError(resp.Body) && resp.ContainsAny(`"result"`) {
+	if resp.IsAccepted() {
 		return probeProcessedResult
 	}
 	if resp.IsSuccess() {

--- a/internal/attack/a2a/card_security_unenforced_test.go
+++ b/internal/attack/a2a/card_security_unenforced_test.go
@@ -100,6 +100,12 @@ func cardSecServer(mode string) *httptest.Server {
 
 		switch method {
 		case "SendMessage", "message/send":
+			if mode == "result-no-taskid" {
+				// A result envelope that carries no task id: not a confirmable
+				// task creation, so the rule must not fire.
+				result(map[string]interface{}{"status": map[string]interface{}{"state": "submitted"}})
+				return
+			}
 			mu.Lock()
 			counter++
 			tid := fmt.Sprintf("task-%d", counter)
@@ -209,5 +215,22 @@ func TestCardSecurity_NotA2A(t *testing.T) {
 	_, err := runCardSec(t, srv)
 	if !errors.Is(err, attack.ErrInconclusive) {
 		t.Fatalf("expected ErrInconclusive for a non-A2A endpoint, got err=%v", err)
+	}
+}
+
+// TestCardSecurity_ResultWithoutTaskID: an unauthenticated message/send that
+// returns a result envelope carrying no task id is not a confirmable task
+// creation, so the rule must not fire. Previously a bare "result" substring
+// promoted this to a confirmed finding with an empty task id.
+func TestCardSecurity_ResultWithoutTaskID(t *testing.T) {
+	srv := cardSecServer("result-no-taskid")
+	defer srv.Close()
+
+	findings, err := runCardSec(t, srv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings for a result with no task id, got %d: %+v", len(findings), findings)
 	}
 }

--- a/internal/attack/a2a/context_fixation.go
+++ b/internal/attack/a2a/context_fixation.go
@@ -121,7 +121,7 @@ func (e *ContextFixationExecutor) sendUnderContext(ctx context.Context, c *attac
 			},
 		},
 	})
-	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+	if err != nil || !resp.IsAccepted() {
 		resp, err = c.POST(ctx, endpoint, extraHeaders, map[string]interface{}{
 			"jsonrpc": "2.0",
 			"id":      "batesian-ctxfix-send-" + randID,
@@ -136,7 +136,7 @@ func (e *ContextFixationExecutor) sendUnderContext(ctx context.Context, c *attac
 			},
 		})
 	}
-	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+	if err != nil || !resp.IsAccepted() {
 		return "", ""
 	}
 	taskID, returnedCtx = extractTaskContext(resp.Body)
@@ -157,7 +157,7 @@ func (e *ContextFixationExecutor) taskHistoryContains(ctx context.Context, c *at
 		"method":  "GetTask",
 		"params":  map[string]interface{}{"id": taskID, "historyLength": 50},
 	})
-	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+	if err != nil || !resp.IsAccepted() {
 		resp, err = c.POST(ctx, endpoint, extraHeaders, map[string]interface{}{
 			"jsonrpc": "2.0",
 			"id":      "batesian-ctxfix-get-" + randID,
@@ -165,7 +165,7 @@ func (e *ContextFixationExecutor) taskHistoryContains(ctx context.Context, c *at
 			"params":  map[string]interface{}{"id": taskID, "historyLength": 50},
 		})
 	}
-	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+	if err != nil || !resp.IsAccepted() {
 		return false
 	}
 	return resp.ContainsAny(marker)

--- a/internal/attack/a2a/delegation_integrity.go
+++ b/internal/attack/a2a/delegation_integrity.go
@@ -124,7 +124,7 @@ func (e *DelegationIntegrityExecutor) createTask(ctx context.Context, c *attack.
 			},
 		},
 	})
-	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+	if err != nil || !resp.IsAccepted() {
 		resp, err = c.POST(ctx, endpoint, p.Headers, map[string]interface{}{
 			"jsonrpc": "2.0",
 			"id":      "batesian-deleg-create-" + p.Name + "-" + randID,
@@ -138,7 +138,7 @@ func (e *DelegationIntegrityExecutor) createTask(ctx context.Context, c *attack.
 			},
 		})
 	}
-	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+	if err != nil || !resp.IsAccepted() {
 		return "", "", false
 	}
 	taskID, contextID = extractTaskContext(resp.Body)
@@ -168,7 +168,7 @@ func (e *DelegationIntegrityExecutor) continueTask(ctx context.Context, c *attac
 			},
 		},
 	})
-	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+	if err != nil || !resp.IsAccepted() {
 		resp, err = c.POST(ctx, endpoint, extraHeaders, map[string]interface{}{
 			"jsonrpc": "2.0",
 			"id":      "batesian-deleg-cont-" + randID,
@@ -184,7 +184,7 @@ func (e *DelegationIntegrityExecutor) continueTask(ctx context.Context, c *attac
 			},
 		})
 	}
-	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+	if err != nil || !resp.IsAccepted() {
 		return false
 	}
 	// The continuation landed on A's task only if the result still references it.

--- a/internal/attack/a2a/extcard.go
+++ b/internal/attack/a2a/extcard.go
@@ -82,9 +82,9 @@ func (e *ExtCardExecutor) Execute(ctx context.Context, target string, opts attac
 	if errA == nil && respA.StatusCode != 404 {
 		reached = true
 	}
-	if errA == nil && respA.IsSuccess() && !isJSONRPCError(respA.Body) {
+	if errA == nil && extCardDisclosed(respA) {
 		findings = append(findings, e.finding("HTTP GET", extURL, invalidToken, respA))
-	} else if respB, errB := unauthClient.GET(ctx, extURL, nil); errB == nil && respB.IsSuccess() && !isJSONRPCError(respB.Body) {
+	} else if respB, errB := unauthClient.GET(ctx, extURL, nil); errB == nil && extCardDisclosed(respB) {
 		findings = append(findings, e.finding("HTTP GET", extURL, "", respB))
 	} else if errB == nil && respB.StatusCode != 404 {
 		reached = true
@@ -153,8 +153,8 @@ func (e *ExtCardExecutor) probeJSONRPC(ctx context.Context, client *attack.HTTPC
 	if err != nil {
 		return nil, false
 	}
-	if !resp.IsSuccess() || isJSONRPCError(resp.Body) {
-		return resp, false // reached the endpoint, but not a disclosure
+	if !resp.IsAccepted() {
+		return resp, false // reached the endpoint, but no result envelope = not a disclosure
 	}
 	return resp, true
 }
@@ -167,6 +167,19 @@ func isJSONRPCError(body []byte) bool {
 	}
 	_, hasError := m["error"]
 	return hasError
+}
+
+// extCardDisclosed reports whether resp is a 2xx whose body parses as an agent
+// card. The extended card is served as a raw JSON object over HTTP GET, so a
+// disclosure is confirmed by validating the card shape (parseCard requires a
+// name or url) rather than treating any 2xx non-error body - including an HTML
+// login page or "{}" - as a card.
+func extCardDisclosed(resp *attack.Response) bool {
+	if !resp.IsSuccess() {
+		return false
+	}
+	_, ok := parseCard(resp.Body)
+	return ok
 }
 
 // snippet returns at most the first n bytes of body as a string, appending an

--- a/internal/attack/a2a/extcard_test.go
+++ b/internal/attack/a2a/extcard_test.go
@@ -155,3 +155,35 @@ func TestExtCardExecutor_HTMLLoginNotFinding(t *testing.T) {
 		t.Errorf("expected zero findings for a 200 HTML login page, got %d: %+v", len(findings), findings)
 	}
 }
+
+// TestExtCardExecutor_HTTPGetRawCard is the positive control for the legacy
+// HTTP-GET transport: a server that serves a raw agent card (top-level name/url)
+// at the extended-card path. This exercises the parseCard-based extCardDisclosed
+// gate, which the other tests (which serve a JSON-RPC result envelope) do not.
+func TestExtCardExecutor_HTTPGetRawCard(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/extendedAgentCard" {
+			writeJSON(w, map[string]interface{}{
+				"name":        "Raw Card Agent",
+				"url":         "https://agent.example.com",
+				"description": "extended capabilities",
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer ts.Close()
+
+	findings, err := a2a.NewExtCardExecutor(testRuleCtx()).Execute(context.Background(), ts.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding from the HTTP-GET raw-card path, got %d: %+v", len(findings), findings)
+	}
+	// The first GET carries a fabricated invalid token; a card returned to it is
+	// a critical auth bypass.
+	if findings[0].Severity != "critical" {
+		t.Errorf("expected critical (fabricated token accepted), got %q", findings[0].Severity)
+	}
+}

--- a/internal/attack/a2a/extcard_test.go
+++ b/internal/attack/a2a/extcard_test.go
@@ -133,3 +133,25 @@ func TestExtCardExecutor_Clean(t *testing.T) {
 		t.Errorf("expected zero findings, got %d: %+v", len(findings), findings)
 	}
 }
+
+// TestExtCardExecutor_HTMLLoginNotFinding verifies that a server answering the
+// extended-card probe with a 200 HTML login page produces no finding. Previously
+// the rule treated any 2xx non-error body as a card and raised a CRITICAL
+// finding, which false-positived any target that redirects/answers probes with a
+// login page.
+func TestExtCardExecutor_HTMLLoginNotFinding(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<html><body><h1>Please log in</h1></body></html>"))
+	}))
+	defer ts.Close()
+
+	findings, err := a2a.NewExtCardExecutor(testRuleCtx()).Execute(context.Background(), ts.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings for a 200 HTML login page, got %d: %+v", len(findings), findings)
+	}
+}

--- a/internal/attack/a2a/extension_downgrade.go
+++ b/internal/attack/a2a/extension_downgrade.go
@@ -148,7 +148,7 @@ func (e *ExtensionDowngradeExecutor) sendMessage(ctx context.Context, c *attack.
 				},
 			},
 		})
-		if err == nil && resp.IsSuccess() && !isJSONRPCError(resp.Body) {
+		if err == nil && resp.IsAccepted() {
 			return true, v.name
 		}
 	}

--- a/internal/attack/a2a/multitenant_isolation.go
+++ b/internal/attack/a2a/multitenant_isolation.go
@@ -116,7 +116,7 @@ func (e *MultiTenantIsolationExecutor) createTask(ctx context.Context, c *attack
 			},
 		},
 	})
-	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+	if err != nil || !resp.IsAccepted() {
 		slashHeaders := map[string]string{}
 		for k, v := range p.Headers {
 			slashHeaders[k] = v
@@ -134,7 +134,7 @@ func (e *MultiTenantIsolationExecutor) createTask(ctx context.Context, c *attack
 			},
 		})
 	}
-	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+	if err != nil || !resp.IsAccepted() {
 		return "", "", false
 	}
 	taskID, contextID = extractTaskContext(resp.Body)
@@ -156,7 +156,7 @@ func (e *MultiTenantIsolationExecutor) readTask(ctx context.Context, c *attack.H
 		"method":  "GetTask",
 		"params":  map[string]interface{}{"id": taskID, "historyLength": 10},
 	})
-	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+	if err != nil || !resp.IsAccepted() {
 		// Fall back to the v0.3 slash-method shape.
 		resp, err = c.POST(ctx, endpoint, extraHeaders, map[string]interface{}{
 			"jsonrpc": "2.0",
@@ -165,7 +165,7 @@ func (e *MultiTenantIsolationExecutor) readTask(ctx context.Context, c *attack.H
 			"params":  map[string]interface{}{"id": taskID, "historyLength": 10},
 		})
 	}
-	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+	if err != nil || !resp.IsAccepted() {
 		return false
 	}
 	return resp.ContainsAny(`"history"`, `"contextId"`, taskID, contextID)

--- a/internal/attack/a2a/peer_impersonation.go
+++ b/internal/attack/a2a/peer_impersonation.go
@@ -105,8 +105,8 @@ func (e *PeerImpersonationExecutor) Execute(ctx context.Context, target string, 
 	// only difference between the two probes is the Authorization header, so the
 	// forged-vs-baseline comparison isolates credential handling regardless of
 	// how the server signals rejection.
-	forgedOK := forgedResp.IsSuccess() && !isJSONRPCError(forgedResp.Body)
-	baselineOK := baselineResp.IsSuccess() && !isJSONRPCError(baselineResp.Body)
+	forgedOK := forgedResp.IsAccepted()
+	baselineOK := baselineResp.IsAccepted()
 
 	var findings []attack.Finding
 

--- a/internal/attack/a2a/peer_impersonation.go
+++ b/internal/attack/a2a/peer_impersonation.go
@@ -100,8 +100,9 @@ func (e *PeerImpersonationExecutor) Execute(ctx context.Context, target string, 
 		return nil, nil
 	}
 
-	// Acceptance = HTTP success with no JSON-RPC error. Rejection is anything
-	// else: a 401/403, a 4xx, OR a 200 carrying a JSON-RPC error envelope. The
+	// Acceptance = a 2xx carrying a JSON-RPC result envelope (IsAccepted).
+	// Rejection is anything else: a 401/403, a 4xx, OR a 200 carrying a
+	// JSON-RPC error envelope (no result). The
 	// only difference between the two probes is the Authorization header, so the
 	// forged-vs-baseline comparison isolates credential handling regardless of
 	// how the server signals rejection.

--- a/internal/attack/a2a/push_binding.go
+++ b/internal/attack/a2a/push_binding.go
@@ -120,7 +120,7 @@ func (e *PushBindingExecutor) createTask(ctx context.Context, c *attack.HTTPClie
 			},
 		},
 	})
-	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+	if err != nil || !resp.IsAccepted() {
 		resp, err = c.POST(ctx, endpoint, p.Headers, map[string]interface{}{
 			"jsonrpc": "2.0",
 			"id":      "batesian-pb-create-" + p.Name + "-" + randID,
@@ -134,7 +134,7 @@ func (e *PushBindingExecutor) createTask(ctx context.Context, c *attack.HTTPClie
 			},
 		})
 	}
-	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+	if err != nil || !resp.IsAccepted() {
 		return ""
 	}
 	taskID, _ := extractTaskContext(resp.Body)
@@ -164,7 +164,7 @@ func (e *PushBindingExecutor) setPush(ctx context.Context, c *attack.HTTPClient,
 			"method":  at.method,
 			"params":  at.params,
 		})
-		if err == nil && resp.IsSuccess() && !isJSONRPCError(resp.Body) {
+		if err == nil && resp.IsAccepted() {
 			return true
 		}
 	}
@@ -185,7 +185,7 @@ func (e *PushBindingExecutor) getPush(ctx context.Context, c *attack.HTTPClient,
 			"method":  method,
 			"params":  map[string]interface{}{"taskId": taskID, "id": taskID},
 		})
-		if err == nil && resp.IsSuccess() && !isJSONRPCError(resp.Body) {
+		if err == nil && resp.IsAccepted() {
 			return resp.BodyString(), true
 		}
 	}

--- a/internal/attack/a2a/push_ssrf.go
+++ b/internal/attack/a2a/push_ssrf.go
@@ -68,8 +68,9 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 	token := "batesian-" + vars.RandID
 
 	// Try multiple transport bindings and SDK versions.
-	// Note: A JSON-RPC error response also contains "id" - we must check !isJSONRPCError
-	// to avoid false positives from -32601 Method Not Found responses.
+	// Note: A JSON-RPC error response (e.g. -32601 Method Not Found) is not a
+	// task acceptance. IsAccepted requires a real result envelope, which excludes
+	// both error envelopes and non-JSON 2xx bodies (login pages, empty acks).
 	var taskAccepted bool
 	var acceptedBinding string
 
@@ -91,7 +92,7 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 	if err == nil && sendResp.StatusCode != 404 {
 		reached = true
 	}
-	if err == nil && sendResp.IsSuccess() && !isJSONRPCError(sendResp.Body) {
+	if err == nil && sendResp.IsAccepted() {
 		// Got a task - try to register push notification config for it
 		taskID, _ := extractTaskContext(sendResp.Body)
 		if taskID != "" {
@@ -105,7 +106,7 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 					"token":               token,
 				},
 			})
-			if pushErr == nil && pushResp.IsSuccess() && !isJSONRPCError(pushResp.Body) {
+			if pushErr == nil && pushResp.IsAccepted() {
 				taskAccepted = true
 				acceptedBinding = "JSONRPC/v1.0-CreateTaskPushNotificationConfig"
 			}
@@ -118,8 +119,7 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 		if err2 == nil && jsonrpcResp.StatusCode != 404 {
 			reached = true
 		}
-		if err2 == nil && jsonrpcResp.IsSuccess() && !isJSONRPCError(jsonrpcResp.Body) &&
-			jsonrpcResp.ContainsAny(`"result"`) {
+		if err2 == nil && jsonrpcResp.IsAccepted() {
 			taskAccepted = true
 			acceptedBinding = "JSONRPC/v0.3-tasks-send"
 		}
@@ -131,7 +131,7 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 		if err3 == nil && httpResp.StatusCode != 404 {
 			reached = true
 		}
-		if err3 == nil && httpResp.IsSuccess() {
+		if err3 == nil && httpResp.IsSuccess() && httpResp.IsJSON() {
 			taskAccepted = true
 			acceptedBinding = "HTTP+JSON"
 		}

--- a/internal/attack/a2a/session_smuggle.go
+++ b/internal/attack/a2a/session_smuggle.go
@@ -77,7 +77,7 @@ func (e *SessionSmuggleExecutor) Execute(ctx context.Context, target string, opt
 				},
 			},
 		})
-		if err != nil || (!resp.IsSuccess() && !isJSONRPCError(resp.Body)) {
+		if err != nil || !resp.IsAccepted() {
 			resp, err = client.POST(ctx, ep, nil, map[string]interface{}{
 				"jsonrpc": "2.0",
 				"id":      "batesian-" + vars.RandID,
@@ -99,7 +99,7 @@ func (e *SessionSmuggleExecutor) Execute(ctx context.Context, target string, opt
 		}
 
 		// Server rejected the agent-role message (per spec). Not vulnerable here.
-		if isJSONRPCError(resp.Body) || !resp.IsSuccess() || !looksLikeTask(resp.Body) {
+		if !resp.IsAccepted() || !looksLikeTask(resp.Body) {
 			continue
 		}
 
@@ -185,7 +185,7 @@ func readTaskHistory(ctx context.Context, client *attack.HTTPClient, ep string, 
 		"method":  "GetTask",
 		"params":  map[string]interface{}{"id": taskID, "historyLength": 20},
 	})
-	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+	if err != nil || !resp.IsAccepted() {
 		resp, err = client.POST(ctx, ep, nil, map[string]interface{}{
 			"jsonrpc": "2.0",
 			"id":      "batesian-get-" + vars.RandID,
@@ -193,7 +193,7 @@ func readTaskHistory(ctx context.Context, client *attack.HTTPClient, ep string, 
 			"params":  map[string]interface{}{"id": taskID, "historyLength": 20},
 		})
 	}
-	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+	if err != nil || !resp.IsAccepted() {
 		return nil, false
 	}
 	return resp.Body, true

--- a/internal/attack/a2a/session_smuggle_test.go
+++ b/internal/attack/a2a/session_smuggle_test.go
@@ -82,6 +82,55 @@ func TestSessionSmuggle_VulnerableHonored(t *testing.T) {
 	}
 }
 
+// TestSessionSmuggle_V03OnlyFallback: a server that implements only the legacy
+// v0.3 message/send method, answering the v1.0 SendMessage with -32601. Before
+// the fallback-trigger fix the rule never tried message/send here (the v1.0
+// -32601 response did not trigger the fallback) and silently reported clean;
+// after the fix the rule falls back to message/send, the agent-role message is
+// honored, and the confirmed finding fires.
+func TestSessionSmuggle_V03OnlyFallback(t *testing.T) {
+	var stored map[string]interface{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		body := readBody(r)
+		method, _ := body["method"].(string)
+		id := body["id"]
+		switch method {
+		case "SendMessage":
+			rpcErr(w, id, -32601, "Method not found") // v1.0 method not implemented
+		case "message/send":
+			params, _ := body["params"].(map[string]interface{})
+			stored, _ = params["message"].(map[string]interface{})
+			taskResult(w, id, "task-smuggle-v03", "ctx-smuggle-v03")
+		case "GetTask", "tasks/get":
+			writeJSON(w, map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{
+					"id": "task-smuggle-v03", "contextId": "ctx-smuggle-v03",
+					"history": []interface{}{stored},
+				},
+			})
+		default:
+			rpcErr(w, id, -32601, "Method not found")
+		}
+	}))
+	defer ts.Close()
+
+	findings, err := a2a.NewSessionSmuggleExecutor(testRuleCtx()).Execute(context.Background(), ts.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding via the v0.3 fallback, got %d: %+v", len(findings), findings)
+	}
+	if findings[0].Confidence != attack.ConfirmedExploit {
+		t.Errorf("want ConfirmedExploit, got %q", findings[0].Confidence)
+	}
+}
+
 // TestSessionSmuggle_PatchedRejects: the server rejects any non-user role with
 // JSON-RPC -32602. The rule MUST stay silent.
 func TestSessionSmuggle_PatchedRejects(t *testing.T) {

--- a/internal/attack/a2a/task_cancel_idor.go
+++ b/internal/attack/a2a/task_cancel_idor.go
@@ -124,7 +124,7 @@ func (e *TaskCancelIDORExecutor) createTask(ctx context.Context, c *attack.HTTPC
 			},
 		},
 	})
-	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+	if err != nil || !resp.IsAccepted() {
 		resp, err = c.POST(ctx, endpoint, p.Headers, map[string]interface{}{
 			"jsonrpc": "2.0",
 			"id":      "batesian-cancel-create-" + p.Name + "-" + randID,
@@ -138,7 +138,7 @@ func (e *TaskCancelIDORExecutor) createTask(ctx context.Context, c *attack.HTTPC
 			},
 		})
 	}
-	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+	if err != nil || !resp.IsAccepted() {
 		return ""
 	}
 	taskID, _ := extractTaskContext(resp.Body)
@@ -174,7 +174,7 @@ func (e *TaskCancelIDORExecutor) cancelTask(ctx context.Context, c *attack.HTTPC
 		if isA2AAuthRejection(resp) {
 			return cancelAuthRejected
 		}
-		if resp.IsSuccess() && !isJSONRPCError(resp.Body) && bodyShowsCanceled(resp.Body) {
+		if resp.IsAccepted() && bodyShowsCanceled(resp.Body) {
 			return cancelCanceled
 		}
 		// Otherwise an application error (not cancelable / not found / unknown
@@ -196,7 +196,7 @@ func (e *TaskCancelIDORExecutor) taskIsCanceled(ctx context.Context, c *attack.H
 		"method":  "GetTask",
 		"params":  map[string]interface{}{"id": taskID, "historyLength": 1},
 	})
-	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+	if err != nil || !resp.IsAccepted() {
 		resp, err = c.POST(ctx, endpoint, extraHeaders, map[string]interface{}{
 			"jsonrpc": "2.0",
 			"id":      "batesian-cancel-get-" + randID,
@@ -204,7 +204,7 @@ func (e *TaskCancelIDORExecutor) taskIsCanceled(ctx context.Context, c *attack.H
 			"params":  map[string]interface{}{"id": taskID, "historyLength": 1},
 		})
 	}
-	if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+	if err != nil || !resp.IsAccepted() {
 		return false
 	}
 	return bodyShowsCanceled(resp.Body)

--- a/internal/attack/a2a/task_idor.go
+++ b/internal/attack/a2a/task_idor.go
@@ -68,7 +68,7 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 				},
 			},
 		})
-		if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+		if err != nil || !resp.IsAccepted() {
 			resp, err = c.POST(ctx, endpoint, nil, map[string]interface{}{
 				"jsonrpc": "2.0",
 				"id":      "batesian-create-" + vars.RandID,
@@ -82,7 +82,7 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 				},
 			})
 		}
-		if err != nil || !resp.IsSuccess() || isJSONRPCError(resp.Body) {
+		if err != nil || !resp.IsAccepted() {
 			return resp, false
 		}
 		return resp, true
@@ -135,7 +135,7 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 		"method":  "GetTask",
 		"params":  getParams,
 	})
-	if err != nil || !getResp.IsSuccess() || isJSONRPCError(getResp.Body) {
+	if err != nil || !getResp.IsAccepted() {
 		getResp, err = unauthClient.POST(ctx, endpoint, nil, map[string]interface{}{
 			"jsonrpc": "2.0",
 			"id":      "batesian-get-" + vars.RandID,
@@ -143,8 +143,8 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 			"params":  getParams,
 		})
 	}
-	unauthReadSucceeded := err == nil && getResp.IsSuccess() && !isJSONRPCError(getResp.Body) &&
-		getResp.ContainsAny(`"history"`, `"contextId"`, taskID, contextID)
+	unauthReadSucceeded := err == nil && getResp.IsAccepted() &&
+		getResp.ContainsAny(taskID, contextID)
 
 	if authEnforcedOnCreate && unauthReadSucceeded {
 		findings = append(findings, attack.Finding{

--- a/internal/attack/a2a/task_idor.go
+++ b/internal/attack/a2a/task_idor.go
@@ -144,7 +144,7 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 		})
 	}
 	unauthReadSucceeded := err == nil && getResp.IsAccepted() &&
-		getResp.ContainsAny(taskID, contextID)
+		getResp.ContainsAny(`"history"`, `"contextId"`, taskID, contextID)
 
 	if authEnforcedOnCreate && unauthReadSucceeded {
 		findings = append(findings, attack.Finding{

--- a/internal/attack/http.go
+++ b/internal/attack/http.go
@@ -47,6 +47,16 @@ func NewHTTPClient(opts Options, vars Vars) *HTTPClient {
 		inner: &http.Client{
 			Timeout:   timeout,
 			Transport: Transport(opts),
+			// Do not follow redirects. A scanner must see exactly what the
+			// probed endpoint returns: following a 3xx to a login page masks an
+			// auth rejection (and would then be misjudged as a 2xx success), and
+			// silently bouncing a request that may carry the operator's bearer
+			// token to a third-party host is a redirect-leak risk. Rules that
+			// need the raw redirect response (e.g. confused-deputy) keep their
+			// own client. OAuth token acquisition is unaffected: it uses the
+			// separate client in internal/auth, which legitimately follows
+			// redirects during the authorization-code flow.
+			CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
 		},
 		vars:  vars,
 		token: opts.Token,
@@ -70,6 +80,50 @@ func (r *Response) BodyString() string {
 // IsSuccess returns true for 2xx status codes.
 func (r *Response) IsSuccess() bool {
 	return r.StatusCode >= 200 && r.StatusCode < 300
+}
+
+// IsAccepted reports whether the response represents a successful JSON-RPC
+// result: an HTTP 2xx whose body is valid JSON carrying a "result" envelope and
+// no "error" envelope. This is the canonical "the JSON-RPC call succeeded"
+// oracle.
+//
+// It exists because the older idiom IsSuccess() && !isJSONRPCError(body) treats
+// any 2xx that is not a JSON-RPC error envelope as success - including an HTML
+// login page, an empty body, "{}", or a bare object. Those are not results, and
+// judging them as "accepted" produces false positives whenever a target answers
+// an unauthenticated probe with a 2xx non-JSON body (common: redirects to a
+// login page, generic 200 acks, HTML error interstitials).
+//
+// A JSON-null or empty-object result ({"result":null}, {"result":{}}) still
+// counts as accepted: both are valid JSON-RPC success shapes, and rejecting
+// them would risk false negatives on methods that legitimately return an empty
+// result (e.g. logging/setLevel).
+func (r *Response) IsAccepted() bool {
+	if !r.IsSuccess() {
+		return false
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(r.Body, &m); err != nil {
+		return false
+	}
+	_, hasResult := m["result"]
+	_, hasError := m["error"]
+	return hasResult && !hasError
+}
+
+// IsJSON reports whether the response body is a JSON object. Use it for raw HTTP
+// responses that are not JSON-RPC result envelopes (for example an A2A extended
+// agent card fetched over HTTP GET) to reject HTML, empty, or non-JSON bodies
+// before applying a structural shape check. Prefer IsAccepted for JSON-RPC
+// method calls, which additionally requires a result envelope.
+func (r *Response) IsJSON() bool {
+	var m map[string]interface{}
+	if err := json.Unmarshal(r.Body, &m); err != nil {
+		return false
+	}
+	// A JSON "null" unmarshals to a nil map without error, but it is not a JSON
+	// object, so it must not qualify as one.
+	return m != nil
 }
 
 // NormalizeHeaders returns a lowercase-keyed map of the response headers.

--- a/internal/attack/http_test.go
+++ b/internal/attack/http_test.go
@@ -174,3 +174,39 @@ func TestHTTPClient_DoesNotFollowRedirects(t *testing.T) {
 	default:
 	}
 }
+
+// TestHTTPClient_RedirectDoesNotForwardToken guards the security property behind
+// S1: because the client does not follow redirects, a request carrying the
+// operator's bearer token is never forwarded to the redirect target (which may
+// be a third-party host). A redirecting endpoint must not become a token leak.
+func TestHTTPClient_RedirectDoesNotForwardToken(t *testing.T) {
+	gotAuthz := make(chan string, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/start", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/sink", http.StatusFound) // 302
+	})
+	mux.HandleFunc("/sink", func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case gotAuthz <- r.Header.Get("Authorization"):
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := attack.NewHTTPClient(attack.Options{TimeoutSeconds: 5, Token: "operator-bearer-secret"}, attack.NewVars(srv.URL, ""))
+	resp, err := c.GET(context.Background(), srv.URL+"/start", nil)
+	if err != nil {
+		t.Fatalf("GET failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302 (redirect not followed), got %d", resp.StatusCode)
+	}
+	select {
+	case authz := <-gotAuthz:
+		t.Fatalf("bearer token was forwarded to the redirect target (Authorization=%q); the client must not follow redirects", authz)
+	default:
+		// good: /sink was never reached, so the token stayed put
+	}
+}

--- a/internal/attack/http_test.go
+++ b/internal/attack/http_test.go
@@ -78,3 +78,99 @@ func TestResponseContainsAny_SkipsEmptySubstring(t *testing.T) {
 		t.Error(`ContainsAny("", "result") did not match a present non-empty needle`)
 	}
 }
+
+// TestResponse_IsAccepted guards the canonical JSON-RPC success oracle. The
+// older IsSuccess() && !isJSONRPCError(body) idiom treated any 2xx that was not a
+// JSON-RPC error envelope as success - including HTML, empty bodies, and "{}" -
+// which false-positived targets that answer an unauthenticated probe with a 2xx
+// non-JSON body. IsAccepted must require a real result envelope.
+func TestResponse_IsAccepted(t *testing.T) {
+	cases := []struct {
+		name string
+		code int
+		body string
+		want bool
+	}{
+		{"valid result object", 200, `{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}`, true},
+		{"null result is a valid success", 200, `{"result":null}`, true},
+		{"empty-object result is a valid success", 200, `{"result":{}}`, true},
+		{"error envelope is rejection", 200, `{"jsonrpc":"2.0","error":{"code":-32600}}`, false},
+		{"html body is rejection", 200, `<html><body>please log in</body></html>`, false},
+		{"empty body is rejection", 200, ``, false},
+		{"bare object with no result is rejection", 200, `{"jsonrpc":"2.0"}`, false},
+		{"non-2xx is rejection", 401, `{"result":{}}`, false},
+		{"both result and error is rejection", 200, `{"result":{},"error":{"code":-1}}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &attack.Response{StatusCode: tc.code, Body: []byte(tc.body)}
+			if got := r.IsAccepted(); got != tc.want {
+				t.Errorf("IsAccepted() = %v, want %v (body=%q)", got, tc.want, tc.body)
+			}
+		})
+	}
+}
+
+// TestResponse_IsJSON guards the raw-HTTP body gate used where a response is a
+// bare JSON object (not a JSON-RPC result envelope), e.g. an A2A extended card
+// fetched over HTTP GET.
+func TestResponse_IsJSON(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"object", `{"name":"agent","url":"https://x"}`, true},
+		{"empty object", `{}`, true},
+		{"html", `<html>`, false},
+		{"empty", ``, false},
+		{"array is not an object", `[1,2,3]`, false},
+		{"null is not an object", `null`, false},
+		{"bare scalar", `"hello"`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &attack.Response{StatusCode: 200, Body: []byte(tc.body)}
+			if got := r.IsJSON(); got != tc.want {
+				t.Errorf("IsJSON() = %v, want %v (body=%q)", got, tc.want, tc.body)
+			}
+		})
+	}
+}
+
+// TestHTTPClient_DoesNotFollowRedirects guards S1: the scan client must return
+// the 3xx itself rather than follow it. Following would both mask an auth
+// rejection (302 -> 200 login page read as success) and risk bouncing a request
+// carrying the operator's bearer token to a third-party host.
+func TestHTTPClient_DoesNotFollowRedirects(t *testing.T) {
+	loginHit := make(chan struct{}, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/start", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/login", http.StatusFound) // 302
+	})
+	mux.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case loginHit <- struct{}{}:
+		default:
+		}
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<html><body>login</body></html>"))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := attack.NewHTTPClient(attack.Options{TimeoutSeconds: 5}, attack.NewVars(srv.URL, ""))
+	resp, err := c.GET(context.Background(), srv.URL+"/start", nil)
+	if err != nil {
+		t.Fatalf("GET failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302 (redirect not followed), got %d", resp.StatusCode)
+	}
+	select {
+	case <-loginHit:
+		t.Fatal("client followed the redirect to /login; it must return the 3xx")
+	default:
+	}
+}

--- a/internal/attack/mcp/dns_rebind_origin.go
+++ b/internal/attack/mcp/dns_rebind_origin.go
@@ -89,9 +89,8 @@ func (e *DNSRebindOriginExecutor) initAccepted(ctx context.Context, client *atta
 		headers["Origin"] = origin
 	}
 	resp, err := client.POST(ctx, ep, headers, json.RawMessage(mcpInitBody))
-	if err != nil || resp.StatusCode != 200 {
+	if err != nil || !resp.IsAccepted() {
 		return false
 	}
-	body := resp.BodyString()
-	return isJSONRPCResult(body) && !isJSONRPCError(body)
+	return true
 }

--- a/internal/attack/mcp/oauth_audience.go
+++ b/internal/attack/mcp/oauth_audience.go
@@ -62,7 +62,6 @@ type audVerdict int
 const (
 	verdictRejected audVerdict = iota
 	verdictAcceptedVulnerable
-	verdictAcceptedAmbiguous
 	verdictInconclusive
 )
 
@@ -351,7 +350,10 @@ func runProbesAgainstEndpoint(ctx context.Context, client *attack.HTTPClient, ba
 // HTTP 200 + a JSON-RPC `result` envelope is the cleanest acceptance signal.
 // HTTP 200 + a JSON-RPC `error` envelope is treated as rejection because the
 // server is explicitly refusing the call. HTTP 200 with neither shape (empty
-// body, raw HTML, etc.) is ambiguous and downgrades the rule-level verdict.
+// body, raw HTML, "{}", etc.) is inconclusive: it is not evidence that the call
+// was accepted, so it produces no finding. (Previously this was treated as a
+// downgraded "ambiguous" acceptance, which false-positived non-MCP targets whose
+// /mcp request fell through to a 200 HTML page.)
 func classifyResponse(resp *attack.Response) audVerdict {
 	switch {
 	case resp.StatusCode == 200:
@@ -364,7 +366,7 @@ func classifyResponse(resp *attack.Response) audVerdict {
 		if isJSONRPCResult(body) {
 			return verdictAcceptedVulnerable
 		}
-		return verdictAcceptedAmbiguous
+		return verdictInconclusive
 	case resp.StatusCode == 401, resp.StatusCode == 403:
 		return verdictRejected
 	case resp.StatusCode >= 400 && resp.StatusCode < 500:
@@ -415,13 +417,12 @@ func isJSONRPCError(body string) bool {
 // fact instead of a misattributed matching bug. A specific matching-bug finding
 // is reported as ConfirmedExploit only when the control was clearly REJECTED
 // (so the audience value is the decisive factor); if the control response was
-// ambiguous, accepted traps are downgraded to RiskIndicator because the bug
-// cannot be cleanly isolated.
+// inconclusive (not clearly rejected), accepted traps are downgraded to
+// RiskIndicator because the bug cannot be cleanly isolated.
 func coalesceOutcomes(rc attack.RuleContext, endpoint, expected string, outcomes []probeOutcome) *attack.Finding {
 	var (
 		control    *probeOutcome
 		vulnerable []probeOutcome
-		ambiguous  []probeOutcome
 	)
 	for i := range outcomes {
 		o := outcomes[i]
@@ -429,11 +430,8 @@ func coalesceOutcomes(rc attack.RuleContext, endpoint, expected string, outcomes
 			control = &outcomes[i]
 			continue
 		}
-		switch o.verdict {
-		case verdictAcceptedVulnerable:
+		if o.verdict == verdictAcceptedVulnerable {
 			vulnerable = append(vulnerable, o)
-		case verdictAcceptedAmbiguous:
-			ambiguous = append(ambiguous, o)
 		}
 	}
 
@@ -447,36 +445,26 @@ func coalesceOutcomes(rc attack.RuleContext, endpoint, expected string, outcomes
 			Confidence:  attack.ConfirmedExploit,
 			Title:       fmt.Sprintf("MCP server %s", control.probe.titleSuffix),
 			Description: control.probe.descSuffix,
-			Evidence:    formatEvidence(endpoint, expected, []probeOutcome{*control}, nil),
+			Evidence:    formatEvidence(endpoint, expected, []probeOutcome{*control}),
 			Remediation: rc.Remediation,
 			TargetURL:   endpoint,
 		}
 	}
 
-	if len(vulnerable) == 0 && len(ambiguous) == 0 {
+	if len(vulnerable) == 0 {
 		return nil
 	}
 
 	controlRejected := control != nil && control.verdict == verdictRejected
 
-	var (
-		confidence attack.Confidence
-		primary    probeOutcome
-	)
-	switch {
-	case len(vulnerable) > 0 && controlRejected:
-		// Control rejected but a trap accepted: the audience value is decisive,
-		// so the matching bug is cleanly isolated.
+	// A trap that returned a clear result envelope is a real acceptance. If the
+	// negative control was clearly rejected, the audience value is the decisive
+	// factor and the matching bug is cleanly isolated (confirmed). Otherwise the
+	// control was inconclusive and the bug cannot be fully isolated (indicator).
+	primary := vulnerable[0]
+	confidence := attack.RiskIndicator
+	if controlRejected {
 		confidence = attack.ConfirmedExploit
-		primary = vulnerable[0]
-	case len(vulnerable) > 0:
-		// Trap accepted but the control response was ambiguous/inconclusive:
-		// cannot fully isolate the matching logic. Report as an indicator.
-		confidence = attack.RiskIndicator
-		primary = vulnerable[0]
-	default:
-		confidence = attack.RiskIndicator
-		primary = ambiguous[0]
 	}
 
 	return &attack.Finding{
@@ -486,7 +474,7 @@ func coalesceOutcomes(rc attack.RuleContext, endpoint, expected string, outcomes
 		Confidence:  confidence,
 		Title:       fmt.Sprintf("MCP server %s", primary.probe.titleSuffix),
 		Description: primary.probe.descSuffix,
-		Evidence:    formatEvidence(endpoint, expected, vulnerable, ambiguous),
+		Evidence:    formatEvidence(endpoint, expected, vulnerable),
 		Remediation: rc.Remediation,
 		TargetURL:   endpoint,
 	}
@@ -495,7 +483,7 @@ func coalesceOutcomes(rc attack.RuleContext, endpoint, expected string, outcomes
 // formatEvidence renders the per-probe evidence block. The operator-supplied
 // audience is summarized rather than echoed verbatim to avoid leaking
 // production identifiers into shared scan reports.
-func formatEvidence(endpoint, expected string, vulnerable, ambiguous []probeOutcome) string {
+func formatEvidence(endpoint, expected string, vulnerable []probeOutcome) string {
 	var sb strings.Builder
 	sb.WriteString("endpoint: ")
 	sb.WriteString(endpoint)
@@ -506,12 +494,6 @@ func formatEvidence(endpoint, expected string, vulnerable, ambiguous []probeOutc
 	if len(vulnerable) > 0 {
 		sb.WriteString("\nAccepted probes (clear vulnerability signal):\n")
 		for _, o := range vulnerable {
-			writeOutcomeLine(&sb, o)
-		}
-	}
-	if len(ambiguous) > 0 {
-		sb.WriteString("\nAccepted probes (ambiguous response shape):\n")
-		for _, o := range ambiguous {
 			writeOutcomeLine(&sb, o)
 		}
 	}

--- a/internal/attack/mcp/oauth_audience_test.go
+++ b/internal/attack/mcp/oauth_audience_test.go
@@ -297,6 +297,41 @@ func TestOAuthAudience_Ambiguous200(t *testing.T) {
 	}
 }
 
+// TestOAuthAudience_TrapAcceptedControlNonResult covers the rewritten
+// coalesceOutcomes path where a trap probe returns a clear result envelope
+// (accepted) but the negative control returns a 200 body with no result
+// envelope (inconclusive, not a clear rejection). The trap must still be
+// reported, downgraded to RiskIndicator (not confirmed, and not dropped).
+func TestOAuthAudience_TrapAcceptedControlNonResult(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		aud := decodeJWTAud(t, r.Header.Get("Authorization"))
+		if s, ok := aud.(string); ok && strings.HasPrefix(s, "https://batesian-control") {
+			// negative control: 200 with no JSON-RPC result envelope
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+			return
+		}
+		// every trap probe is accepted with a clean result envelope
+		initializeOK(w)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC())
+	findings, err := exec.Execute(context.Background(), srv.URL, optsWithAudience(testExpectedAud))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 downgraded finding (trap accepted, control inconclusive), got %d: %+v", len(findings), findings)
+	}
+	if findings[0].Confidence != attack.RiskIndicator {
+		t.Errorf("expected RiskIndicator (control not clearly rejected), got %q", findings[0].Confidence)
+	}
+}
+
 func TestOAuthAudience_EvidenceRedaction(t *testing.T) {
 	// The operator-supplied audience must not appear verbatim in finding
 	// evidence: only a length-tagged summary is allowed. This protects

--- a/internal/attack/mcp/oauth_audience_test.go
+++ b/internal/attack/mcp/oauth_audience_test.go
@@ -272,9 +272,12 @@ func TestOAuthAudience_AutoDiscovery_FromResourceMetadata(t *testing.T) {
 }
 
 func TestOAuthAudience_Ambiguous200(t *testing.T) {
-	// Server returns 200 with no JSON-RPC envelope to every probe. This is
-	// signal-poor: cannot conclude exploit, but also cannot dismiss. The
-	// rule must downgrade to RiskIndicator.
+	// Server returns 200 with no JSON-RPC envelope to every probe (e.g. a
+	// non-MCP endpoint or a generic 2xx ack). That is not evidence that any
+	// forged token was accepted, so the rule must produce no finding rather
+	// than a downgraded indicator. (Previously a 200 non-result was treated as
+	// "ambiguous acceptance" and emitted a RiskIndicator, which false-positived
+	// non-MCP targets whose /mcp fell through to a 200 page.)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
@@ -289,11 +292,8 @@ func TestOAuthAudience_Ambiguous200(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(findings) != 1 {
-		t.Fatalf("expected 1 coalesced finding for ambiguous 200, got %d", len(findings))
-	}
-	if findings[0].Confidence != attack.RiskIndicator {
-		t.Errorf("expected RiskIndicator for ambiguous 200, got %q", findings[0].Confidence)
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings for a 200 non-result target, got %d: %+v", len(findings), findings)
 	}
 }
 

--- a/internal/attack/mcp/sse_resume_replay.go
+++ b/internal/attack/mcp/sse_resume_replay.go
@@ -195,7 +195,13 @@ func (e *SSEResumeReplayExecutor) sseCollect(ctx context.Context, client *http.C
 }
 
 func rawSSEClient(opts attack.Options) *http.Client {
-	return &http.Client{Transport: attack.Transport(opts)}
+	return &http.Client{
+		Transport: attack.Transport(opts),
+		// Match the shared scan client: do not follow redirects. The SSE GET
+		// must hit the stream endpoint the rule selected, not whatever a 3xx
+		// would bounce it to.
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
 }
 
 // resumeCheckpoint selects the first id-bearing event as the resume cursor and

--- a/internal/attack/mcp/token_replay.go
+++ b/internal/attack/mcp/token_replay.go
@@ -159,7 +159,7 @@ func (e *TokenReplayExecutor) Execute(ctx context.Context, target string, opts a
 			// Acceptance = HTTP 200 with a JSON-RPC result envelope. A 200 that
 			// carries a JSON-RPC error is a protocol-layer rejection of the
 			// forged token and must not be reported.
-			if resp.StatusCode == 200 && isJSONRPCResult(resp.BodyString()) && !isJSONRPCError(resp.BodyString()) {
+			if resp.IsAccepted() {
 				findings = append(findings, attack.Finding{
 					RuleID:      e.rule.ID,
 					RuleName:    e.rule.Name,

--- a/rules/mcp/oauth-audience-002.yaml
+++ b/rules/mcp/oauth-audience-002.yaml
@@ -22,8 +22,10 @@ info:
       (no signature/audience validation) and the rule reports that blanket
       acceptance rather than misattributing it to a specific matching bug. A
       trap acceptance is only reported as a specific, confirmed matching bug when
-      the control was REJECTED; if the control response is ambiguous, trap
-      acceptances are downgraded to an indicator.
+      the control was REJECTED; if the control response carried no JSON-RPC
+      result envelope (so it could not be clearly rejected), trap acceptances
+      are downgraded to an indicator. A 2xx body with no result envelope is
+      never itself treated as acceptance.
     - `aud-substring-trap`   - wraps the expected value in a clearly-different
       string (e.g., `<expected>.canary-batesian-mismatch.invalid`). Catches
       validators that use `strings.Contains` / `HasPrefix` / `HasSuffix`.


### PR DESCRIPTION
## Summary

Fixes two shared-helper defects in the HTTP/oracle layer that produced false positives and false negatives against realistic (non-fixture) targets. One pass, many rules.

## Background

- **Redirects:** `NewHTTPClient` had no `CheckRedirect`, so Go followed up to 10 redirects. That masked auth rejection (a 302 to a login page was read as a 2xx success) and risked bouncing a request carrying the operator bearer token to a third-party host.
- **Success oracle:** `isJSONRPCError` / `isJSONRPCResult` return `false` on any non-JSON body, so `IsSuccess() && !isJSONRPCError(body)` treated a 2xx HTML page, empty body, or `{}` as a successful JSON-RPC call. This was the acceptance idiom in ~9 places.

## Changes

**S1 - no-follow redirect policy**
- `NewHTTPClient` and `sse_resume_replay`'s raw client now return `http.ErrUseLastResponse`.
- OAuth (`internal/auth`) deliberately untouched; the authorization-code flow legitimately follows redirects.

**S2 - canonical success oracle**
- Added `Response.IsAccepted()` (2xx + valid JSON + a `result` envelope, no `error`) and `Response.IsJSON()` on the shared client. FN-safe: `{"result":null}` and `{"result":{}}` still count.
- Migrated ~9 acceptance sites (Phase A) and ~15 rejection guards (Phase B) off `IsSuccess() && !isJSONRPCError` across `a2a` and `mcp`.

**Behavioral fixes folded in**
- `oauth_audience`: a 200 non-result/non-error is now inconclusive, not a downgraded finding (the main FP vs non-MCP targets whose `/mcp` falls through to a 200 page). The now-unreachable `verdictAcceptedAmbiguous` constant and its `coalesceOutcomes` / `formatEvidence` handling were removed.
- `extcard`: the HTTP-GET branch validates an actual agent card via `parseCard` instead of treating any 2xx non-error body as a card (previously a critical finding on any 2xx).
- `card_security_unenforced`: a result envelope with no task id no longer promotes to a confirmed finding.
- `session_smuggle`: the `v1.0 -> v0.3` fallback trigger was inverted (`&&` vs `||`), so v0.3-only servers that answered `SendMessage` with a `-32601` error were never probed with `message/send`. It now falls back unless a result was returned.

## Validation

- `go vet`, `go build`, `go test -race ./...`, and `golangci-lint run` are all clean.
- `TestOAuthAudience_Ambiguous200` now expects 0 findings (it had encoded the FP as a `RiskIndicator`).
- New tests: `IsAccepted`/`IsJSON` table tests, `TestHTTPClient_DoesNotFollowRedirects`, `TestExtCardExecutor_HTMLLoginNotFinding`, `TestCardSecurity_ResultWithoutTaskID`.
- Positive paths (real results still fire) verified by the existing vulnerable-case tests.

## Notes

- Recon clients (`internal/protocol/*`) have the same two bugs in a parallel surface and are intentionally out of scope here (Wave 4: consolidate onto the shared client).