### PR TITLE
fix(security): MCP rules report inconclusive when no endpoint is reachable

### DIFF
--- a/internal/attack/mcp/completion_unauth.go
+++ b/internal/attack/mcp/completion_unauth.go
@@ -73,7 +73,7 @@ func (e *CompletionUnauthExecutor) Execute(ctx context.Context, target string, o
 
 	session, err := initializeMCP(ctx, client, vars.BaseURL)
 	if err != nil {
-		return nil, nil // not an MCP server
+		return nil, attack.ErrInconclusive // not an MCP server
 	}
 
 	// Skip servers that do not advertise the completions capability; probing them

--- a/internal/attack/mcp/completion_unauth_test.go
+++ b/internal/attack/mcp/completion_unauth_test.go
@@ -235,7 +235,5 @@ func TestCompletionUnauth_NotMCP(t *testing.T) {
 	srv := completionServer("not-mcp")
 	defer srv.Close()
 
-	if findings := runCompletionUnauth(t, srv); len(findings) != 0 {
-		t.Errorf("expected 0 findings for a non-MCP server, got %d: %+v", len(findings), findings)
-	}
+	assertInconclusive(t, mcpattack.NewCompletionUnauthExecutor(attack.RuleContext{ID: "mcp-completion-unauth-001"}), srv.URL, testOpts())
 }

--- a/internal/attack/mcp/dns_rebind_origin.go
+++ b/internal/attack/mcp/dns_rebind_origin.go
@@ -77,7 +77,8 @@ func (e *DNSRebindOriginExecutor) Execute(ctx context.Context, target string, op
 		// validated. No finding, and no need to try other endpoints.
 		return nil, nil
 	}
-	return nil, nil
+	// No candidate accepted a baseline initialize: not a testable MCP endpoint.
+	return nil, attack.ErrInconclusive
 }
 
 // initAccepted sends an MCP initialize to ep (optionally with an Origin header)

--- a/internal/attack/mcp/dns_rebind_origin_test.go
+++ b/internal/attack/mcp/dns_rebind_origin_test.go
@@ -92,7 +92,5 @@ func TestDNSRebind_NotMCP(t *testing.T) {
 	ts := dnsRebindServer("not-mcp")
 	defer ts.Close()
 
-	if findings := runDNSRebind(t, ts); len(findings) != 0 {
-		t.Errorf("expected zero findings against a non-MCP server, got %d", len(findings))
-	}
+	assertInconclusive(t, mcpattack.NewDNSRebindOriginExecutor(dnsRebindRC()), ts.URL, testOpts())
 }

--- a/internal/attack/mcp/header_body_split.go
+++ b/internal/attack/mcp/header_body_split.go
@@ -30,31 +30,39 @@ func (e *HeaderBodySplitExecutor) Execute(ctx context.Context, target string, op
 	vars := attack.NewVars(target, opts.OOBListenerURL)
 	client := attack.NewHTTPClient(opts, vars)
 
+	var reached bool
 	for _, ep := range endpointCandidates(vars.BaseURL) {
-		if f := e.probe(ctx, client, ep); f != nil {
+		f, epReached := e.probe(ctx, client, ep)
+		if epReached {
+			reached = true
+		}
+		if f != nil {
 			return f, nil
 		}
+	}
+	if !reached {
+		return nil, attack.ErrInconclusive
 	}
 	return nil, nil
 }
 
-func (e *HeaderBodySplitExecutor) probe(ctx context.Context, client *attack.HTTPClient, ep string) []attack.Finding {
+func (e *HeaderBodySplitExecutor) probe(ctx context.Context, client *attack.HTTPClient, ep string) ([]attack.Finding, bool) {
 	session, ok := e.initialize(ctx, client, ep)
 	if !ok {
-		return nil // not an MCP endpoint here
+		return nil, false // not an MCP endpoint here
 	}
 
 	// Probe 1: omit Mcp-Method. If the server still executes tools/list, it does
 	// not enforce header presence (not SEP-2243-aware) - nothing to confirm.
 	if e.toolsList(ctx, client, ep, session, nil) {
-		return nil
+		return nil, true
 	}
 
 	// Probe 2: matching Mcp-Method. Must be accepted, otherwise we cannot drive
 	// the mismatch test (the endpoint may require headers we are not sending).
 	matched := "tools/list"
 	if !e.toolsList(ctx, client, ep, session, &matched) {
-		return nil
+		return nil, true
 	}
 
 	// Probe 3: mismatched Mcp-Method. A compliant server MUST reject; if it
@@ -82,9 +90,9 @@ func (e *HeaderBodySplitExecutor) probe(ctx context.Context, client *attack.HTTP
 				ep),
 			Remediation: e.rule.Remediation,
 			TargetURL:   ep,
-		}}
+		}}, true
 	}
-	return nil
+	return nil, true
 }
 
 // initialize performs an MCP initialize (sending a matching Mcp-Method so a

--- a/internal/attack/mcp/header_body_split_test.go
+++ b/internal/attack/mcp/header_body_split_test.go
@@ -130,7 +130,5 @@ func TestSplit_NotMCP(t *testing.T) {
 	ts := httptest.NewServer(http.NotFoundHandler())
 	defer ts.Close()
 
-	if findings := runSplit(t, ts); len(findings) != 0 {
-		t.Errorf("expected zero findings against a non-MCP server, got %d", len(findings))
-	}
+	assertInconclusive(t, mcpattack.NewHeaderBodySplitExecutor(hbsRuleCtx()), ts.URL, attack.Options{TimeoutSeconds: 5})
 }

--- a/internal/attack/mcp/helpers_test.go
+++ b/internal/attack/mcp/helpers_test.go
@@ -1,9 +1,27 @@
 package mcp_test
 
-import "github.com/calbebop/batesian/internal/attack"
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
 
 // testOpts returns the default execution options used across MCP executor tests:
 // a short per-request timeout and no auth/OOB configuration.
 func testOpts() attack.Options {
 	return attack.Options{TimeoutSeconds: 5}
+}
+
+// assertInconclusive runs an executor against target and fails the test unless it
+// returned attack.ErrInconclusive. Used for the "not a testable MCP endpoint"
+// case: the rule must signal that it could not test (skipped), not report a
+// clean pass that is indistinguishable from "tested, nothing found".
+func assertInconclusive(t *testing.T, exec attack.Executor, target string, opts attack.Options) {
+	t.Helper()
+	_, err := exec.Execute(context.Background(), target, opts)
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive (not a testable MCP endpoint), got err=%v", err)
+	}
 }

--- a/internal/attack/mcp/init_downgrade.go
+++ b/internal/attack/mcp/init_downgrade.go
@@ -59,23 +59,35 @@ func (e *InitDowngradeExecutor) Execute(ctx context.Context, target string, opts
 	// WITHOUT proper credentials, so the probe must run with no bearer token.
 	client := attack.NewUnauthHTTPClient(opts, vars)
 
+	var reached bool
 	for _, ep := range endpointCandidates(vars.BaseURL) {
-		findings := e.probeEndpoint(ctx, client, ep)
-		if findings == nil {
-			continue
+		findings, epReached := e.probeEndpoint(ctx, client, ep)
+		if epReached {
+			reached = true
 		}
-		return findings, nil
+		if findings != nil {
+			return findings, nil
+		}
+	}
+	if !reached {
+		return nil, attack.ErrInconclusive
 	}
 	return nil, nil
 }
 
-func (e *InitDowngradeExecutor) probeEndpoint(ctx context.Context, client *attack.HTTPClient, ep string) []attack.Finding {
+func (e *InitDowngradeExecutor) probeEndpoint(ctx context.Context, client *attack.HTTPClient, ep string) ([]attack.Finding, bool) {
 	// Legacy path: initialize with the pre-auth version, then probe resources/list.
 	legacyInitOK, legacyAccess, legacyCount := e.initAndList(ctx, client, ep, legacyVersion)
 	if !legacyInitOK {
-		// Either not an MCP server here, or it rejected the legacy version
-		// outright (a secure posture). Nothing to confirm.
-		return nil
+		// The legacy initialize did not succeed. Distinguish "not an MCP
+		// endpoint" from "a server that speaks MCP but rejects this version" by
+		// probing whether the endpoint answers initialize with a JSON-RPC
+		// response at all. A version-rejection error still counts as reached:
+		// the endpoint is testable, it just declined the offered version.
+		if !e.responsiveMCP(ctx, client, ep) {
+			return nil, false // not a responsive MCP endpoint
+		}
+		return nil, true // reached, but the offered version was rejected - nothing to confirm
 	}
 
 	// Modern baseline: does the server enforce auth under the post-auth version?
@@ -105,10 +117,31 @@ func (e *InitDowngradeExecutor) probeEndpoint(ctx context.Context, client *attac
 				ep, modernVersion, legacyVersion, legacyCount),
 			Remediation: e.rule.Remediation,
 			TargetURL:   ep,
-		}}
+		}}, true
 	}
 
-	return nil
+	return nil, true
+}
+
+// responsiveMCP reports whether ep answered an MCP initialize with a JSON-RPC
+// response (a result OR an error envelope). A version-rejection error still
+// counts: the endpoint speaks MCP, it just declined the offered version, so the
+// rule reached a testable endpoint (clean) rather than being unable to test.
+func (e *InitDowngradeExecutor) responsiveMCP(ctx context.Context, client *attack.HTTPClient, ep string) bool {
+	resp, err := client.POST(ctx, ep, nil, map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]interface{}{
+			"protocolVersion": modernVersion,
+			"capabilities":    map[string]interface{}{},
+			"clientInfo":      map[string]interface{}{"name": "batesian", "version": "1.0"},
+		},
+	})
+	if err != nil || !resp.IsSuccess() {
+		return false
+	}
+	return looksJSONRPC(resp.BodyString())
 }
 
 // initAndList performs an MCP initialize with the given protocol version, sends

--- a/internal/attack/mcp/init_downgrade_test.go
+++ b/internal/attack/mcp/init_downgrade_test.go
@@ -251,11 +251,5 @@ func TestInitDowngrade_NotMCPServer(t *testing.T) {
 	defer srv.Close()
 
 	exec := mcpattack.NewInitDowngradeExecutor(attack.RuleContext{ID: "mcp-init-downgrade-001"})
-	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(findings) != 0 {
-		t.Errorf("expected 0 findings on non-MCP server, got %d", len(findings))
-	}
+	assertInconclusive(t, exec, srv.URL, attack.Options{TimeoutSeconds: 5})
 }

--- a/internal/attack/mcp/jsonrpc_batch_bypass.go
+++ b/internal/attack/mcp/jsonrpc_batch_bypass.go
@@ -51,16 +51,24 @@ func (e *BatchBypassExecutor) Execute(ctx context.Context, target string, opts a
 	// server's auth gate. Injecting opts.Token would mask the bypass.
 	client := attack.NewUnauthHTTPClient(opts, vars)
 
+	var reached bool
 	for _, ep := range endpointCandidates(vars.BaseURL) {
-		if f := e.probeEndpoint(ctx, client, ep); f != nil {
+		f, epReached := e.probeEndpoint(ctx, client, ep)
+		if epReached {
+			reached = true
+		}
+		if f != nil {
 			return f, nil
 		}
+	}
+	if !reached {
+		return nil, attack.ErrInconclusive
 	}
 	return nil, nil
 }
 
 // probeEndpoint runs the bypass check against a single candidate endpoint.
-func (e *BatchBypassExecutor) probeEndpoint(ctx context.Context, client *attack.HTTPClient, ep string) []attack.Finding {
+func (e *BatchBypassExecutor) probeEndpoint(ctx context.Context, client *attack.HTTPClient, ep string) ([]attack.Finding, bool) {
 	initObj := map[string]interface{}{
 		"jsonrpc": "2.0",
 		"id":      1,
@@ -76,7 +84,7 @@ func (e *BatchBypassExecutor) probeEndpoint(ctx context.Context, client *attack.
 
 	ctrl, err := client.POST(ctx, ep, nil, initObj)
 	if err != nil {
-		return nil // endpoint unreachable
+		return nil, false // endpoint unreachable
 	}
 
 	switch {
@@ -84,16 +92,16 @@ func (e *BatchBypassExecutor) probeEndpoint(ctx context.Context, client *attack.
 		// The server gates initialize itself. Does a one-element batch slip past?
 		test, err := client.POST(ctx, ep, nil, []interface{}{initObj})
 		if err != nil {
-			return nil
+			return nil, true
 		}
 		if test.IsSuccess() && batchHasResult(test.Body) && bodyLooksMCP(test.Body) {
 			detail := fmt.Sprintf(
 				"single initialize: HTTP %d (rejected, unauthenticated)\n"+
 					"batch [initialize]: HTTP %d (processed, returned an MCP initialize result)",
 				ctrl.StatusCode, test.StatusCode)
-			return e.finding(ep, "initialize", detail)
+			return e.finding(ep, "initialize", detail), true
 		}
-		return nil
+		return nil, true
 
 	case isMCPInitialize(ctrl):
 		// initialize is open; look for a per-method gate that the batch bypasses.
@@ -102,10 +110,10 @@ func (e *BatchBypassExecutor) probeEndpoint(ctx context.Context, client *attack.
 			"jsonrpc": "2.0",
 			"method":  "notifications/initialized",
 		})
-		return e.probeMethodGate(ctx, client, session)
+		return e.probeMethodGate(ctx, client, session), true
 
 	default:
-		return nil // not an MCP endpoint
+		return nil, false // not an MCP endpoint
 	}
 }
 

--- a/internal/attack/mcp/jsonrpc_batch_bypass_test.go
+++ b/internal/attack/mcp/jsonrpc_batch_bypass_test.go
@@ -189,7 +189,5 @@ func TestBatchBypass_NotMCP(t *testing.T) {
 	srv := batchServer("not-mcp")
 	defer srv.Close()
 
-	if findings := runBatchBypass(t, srv); len(findings) != 0 {
-		t.Errorf("expected 0 findings for a non-MCP endpoint, got %d", len(findings))
-	}
+	assertInconclusive(t, mcpattack.NewBatchBypassExecutor(attack.RuleContext{ID: "mcp-jsonrpc-batch-bypass-001"}), srv.URL, testOpts())
 }

--- a/internal/attack/mcp/logging_unauth.go
+++ b/internal/attack/mcp/logging_unauth.go
@@ -45,7 +45,7 @@ func (e *LoggingUnauthExecutor) Execute(ctx context.Context, target string, opts
 
 	session, err := initializeMCP(ctx, client, vars.BaseURL)
 	if err != nil {
-		return nil, nil // not an MCP server
+		return nil, attack.ErrInconclusive // not an MCP server
 	}
 
 	// Skip servers that do not advertise the logging capability; probing them would

--- a/internal/attack/mcp/logging_unauth_test.go
+++ b/internal/attack/mcp/logging_unauth_test.go
@@ -132,7 +132,5 @@ func TestLoggingUnauth_NotMCP(t *testing.T) {
 	srv := loggingServer("not-mcp")
 	defer srv.Close()
 
-	if findings := runLoggingUnauth(t, srv); len(findings) != 0 {
-		t.Errorf("expected 0 findings for a non-MCP server, got %d: %+v", len(findings), findings)
-	}
+	assertInconclusive(t, mcpattack.NewLoggingUnauthExecutor(attack.RuleContext{ID: "mcp-logging-unauth-001"}), srv.URL, testOpts())
 }

--- a/internal/attack/mcp/oauth_audience.go
+++ b/internal/attack/mcp/oauth_audience.go
@@ -100,7 +100,7 @@ func (e *OAuthAudienceExecutor) Execute(ctx context.Context, target string, opts
 	}
 	if endpoint == "" {
 		// No candidate endpoint produced a usable response for any probe.
-		return nil, nil
+		return nil, attack.ErrInconclusive
 	}
 
 	finding := coalesceOutcomes(e.rule, endpoint, expected, outcomes)

--- a/internal/attack/mcp/oauth_audience_test.go
+++ b/internal/attack/mcp/oauth_audience_test.go
@@ -361,3 +361,17 @@ func TestOAuthAudience_EvidenceRedaction(t *testing.T) {
 		t.Errorf("evidence missing length-tagged audience summary %q: %s", wantLenTag, findings[0].Evidence)
 	}
 }
+
+// TestOAuthAudience_UnreachableHost: when no candidate endpoint can be reached
+// (every probe transport-errors - no endpoint produced any response),
+// runProbesAgainstEndpoint returns an empty endpoint and the rule reports
+// ErrInconclusive rather than a clean pass. (A server that merely 404s the
+// probes is "reached, all rejected" = clean; this is the distinct unreachable
+// case, exercised by tearing the server down so the port refuses connections.)
+func TestOAuthAudience_UnreachableHost(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	addr := srv.URL
+	srv.Close() // refuse all further connections to this address
+
+	assertInconclusive(t, mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC()), addr, optsWithAudience(testExpectedAud))
+}

--- a/internal/attack/mcp/prompt_unauth.go
+++ b/internal/attack/mcp/prompt_unauth.go
@@ -31,7 +31,7 @@ func (e *PromptUnauthExecutor) Execute(ctx context.Context, target string, opts 
 
 	session, err := initializeMCP(ctx, client, vars.BaseURL)
 	if err != nil {
-		return nil, nil // not an MCP server
+		return nil, attack.ErrInconclusive // not an MCP server
 	}
 
 	// Skip servers that do not advertise the prompts capability - probing them

--- a/internal/attack/mcp/prompt_unauth_test.go
+++ b/internal/attack/mcp/prompt_unauth_test.go
@@ -205,3 +205,12 @@ func TestPromptUnauth_NoPromptsCapability(t *testing.T) {
 		t.Errorf("expected 0 findings for server without prompts capability, got %d", len(findings))
 	}
 }
+
+// TestPromptUnauth_NotMCP: a non-MCP server (no reachable endpoint) must report
+// ErrInconclusive, not a clean pass.
+func TestPromptUnauth_NotMCP(t *testing.T) {
+	ts := httptest.NewServer(http.NotFoundHandler())
+	defer ts.Close()
+
+	assertInconclusive(t, mcpattack.NewPromptUnauthExecutor(attack.RuleContext{ID: "mcp-prompt-unauth-001"}), ts.URL, testOpts())
+}

--- a/internal/attack/mcp/resources_unauth.go
+++ b/internal/attack/mcp/resources_unauth.go
@@ -50,7 +50,7 @@ func (e *ResourcesUnauthExecutor) Execute(ctx context.Context, target string, op
 	// MCP requires an initialize handshake before any method calls.
 	session, err := initializeMCP(ctx, client, vars.BaseURL)
 	if err != nil {
-		return nil, nil // not an MCP server
+		return nil, attack.ErrInconclusive // not an MCP server
 	}
 
 	var findings []attack.Finding

--- a/internal/attack/mcp/resources_unauth_test.go
+++ b/internal/attack/mcp/resources_unauth_test.go
@@ -216,11 +216,5 @@ func TestResourcesUnauth_NotMCPServer(t *testing.T) {
 	defer ts.Close()
 
 	exec := mcpattack.NewResourcesUnauthExecutor(resourcesRC())
-	findings, err := exec.Execute(context.Background(), ts.URL, testOpts())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(findings) != 0 {
-		t.Errorf("expected zero findings on non-MCP server, got %d", len(findings))
-	}
+	assertInconclusive(t, exec, ts.URL, testOpts())
 }

--- a/internal/attack/mcp/secret_canary.go
+++ b/internal/attack/mcp/secret_canary.go
@@ -36,15 +36,23 @@ func (e *SecretCanaryExecutor) Execute(ctx context.Context, target string, opts 
 	canaryOpts.Token = canary
 	client := attack.NewHTTPClient(canaryOpts, vars)
 
+	var reached bool
 	for _, ep := range endpointCandidates(vars.BaseURL) {
-		if f := e.probe(ctx, client, ep, canary); f != nil {
+		f, epReached := e.probe(ctx, client, ep, canary)
+		if epReached {
+			reached = true
+		}
+		if f != nil {
 			return f, nil
 		}
+	}
+	if !reached {
+		return nil, attack.ErrInconclusive
 	}
 	return nil, nil
 }
 
-func (e *SecretCanaryExecutor) probe(ctx context.Context, client *attack.HTTPClient, ep, canary string) []attack.Finding {
+func (e *SecretCanaryExecutor) probe(ctx context.Context, client *attack.HTTPClient, ep, canary string) ([]attack.Finding, bool) {
 	applicable := false
 	reflectedIn := ""
 
@@ -92,7 +100,9 @@ func (e *SecretCanaryExecutor) probe(ctx context.Context, client *attack.HTTPCli
 	}
 
 	if !applicable || reflectedIn == "" {
-		return nil
+		// applicable == false means no JSON-RPC/MCP-shaped response was seen
+		// (not an MCP endpoint); applicable == true with no reflection is secure.
+		return nil, applicable
 	}
 
 	return []attack.Finding{{
@@ -110,7 +120,7 @@ func (e *SecretCanaryExecutor) probe(ctx context.Context, client *attack.HTTPCli
 			ep, canary, snippetAround(reflectedIn, canary)),
 		Remediation: e.rule.Remediation,
 		TargetURL:   ep,
-	}}
+	}}, true
 }
 
 // looksJSONRPC reports whether a response body resembles a JSON-RPC / MCP reply,

--- a/internal/attack/mcp/secret_canary_test.go
+++ b/internal/attack/mcp/secret_canary_test.go
@@ -100,7 +100,5 @@ func TestCanary_NonMCP(t *testing.T) {
 	ts := canaryServer("nonmcp")
 	defer ts.Close()
 
-	if findings := runCanary(t, ts); len(findings) != 0 {
-		t.Errorf("expected zero findings against a non-MCP server, got %d", len(findings))
-	}
+	assertInconclusive(t, mcpattack.NewSecretCanaryExecutor(canaryRuleCtx()), ts.URL, attack.Options{TimeoutSeconds: 5})
 }

--- a/internal/attack/mcp/session_fixation.go
+++ b/internal/attack/mcp/session_fixation.go
@@ -65,7 +65,7 @@ func (e *SessionFixationExecutor) ExecuteChained(ctx context.Context, target str
 	// Step 1: initialize while presenting a client-chosen session id.
 	ep, assigned, ok := e.initWithSession(ctx, client, vars.BaseURL, fixed)
 	if !ok {
-		return nil, nil // not a responsive MCP server
+		return nil, attack.ErrInconclusive // not a responsive MCP server
 	}
 	// Discriminator: the server returned its OWN session id, ignoring the
 	// supplied one. That is the correct, secure behavior - no finding.

--- a/internal/attack/mcp/session_fixation_test.go
+++ b/internal/attack/mcp/session_fixation_test.go
@@ -161,14 +161,7 @@ func TestSessionFixation_NotMCPServer(t *testing.T) {
 	srv := httptest.NewServer(http.NotFoundHandler())
 	defer srv.Close()
 
-	findings, err := mcpattack.NewSessionFixationExecutor(sfRuleCtx()).
-		Execute(context.Background(), srv.URL, testOpts())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(findings) != 0 {
-		t.Errorf("expected zero findings against a non-MCP server, got %d", len(findings))
-	}
+	assertInconclusive(t, mcpattack.NewSessionFixationExecutor(sfRuleCtx()), srv.URL, testOpts())
 }
 
 // TestSessionFixation_CrossPrincipal: with a second principal configured the

--- a/internal/attack/mcp/sse_resume_replay.go
+++ b/internal/attack/mcp/sse_resume_replay.go
@@ -44,18 +44,31 @@ func (e *SSEResumeReplayExecutor) Execute(ctx context.Context, target string, op
 		tokenA, tokenB = opts.Principals[0].Token, opts.Principals[1].Token
 	}
 
+	var reached bool
 	for _, ep := range endpointCandidates(vars.BaseURL) {
-		if f := e.probe(ctx, client, raw, ep, tokenA, tokenB); f != nil {
+		f, epReached := e.probe(ctx, client, raw, ep, tokenA, tokenB)
+		if epReached {
+			reached = true
+		}
+		if f != nil {
 			return f, nil
 		}
+	}
+	if !reached {
+		return nil, attack.ErrInconclusive
 	}
 	return nil, nil
 }
 
-func (e *SSEResumeReplayExecutor) probe(ctx context.Context, client *attack.HTTPClient, raw *http.Client, ep, tokenA, tokenB string) []attack.Finding {
+func (e *SSEResumeReplayExecutor) probe(ctx context.Context, client *attack.HTTPClient, raw *http.Client, ep, tokenA, tokenB string) ([]attack.Finding, bool) {
 	sessionA, ok := e.initialize(ctx, client, ep, tokenA)
-	if !ok || sessionA == "" {
-		return nil // not MCP here, or server mints no session ids (can't prove cross-session)
+	if !ok {
+		return nil, false // not a responsive MCP endpoint
+	}
+	if sessionA == "" {
+		// Responsive MCP server that mints no session ids: no resumable surface
+		// to test, but the endpoint was reached.
+		return nil, true
 	}
 
 	// A's checkpoint: open A's stream and capture an id-bearing event plus the
@@ -64,12 +77,12 @@ func (e *SSEResumeReplayExecutor) probe(ctx context.Context, client *attack.HTTP
 	aEvents := e.sseCollect(ctx, raw, ep, tokenA, sessionA, "", 3*time.Second)
 	checkpointID, markers := resumeCheckpoint(aEvents)
 	if checkpointID == "" || len(markers) == 0 {
-		return nil // no resumable event surface to test
+		return nil, true // no resumable event surface to test
 	}
 
 	sessionB, ok := e.initialize(ctx, client, ep, tokenB)
 	if !ok || sessionB == "" || sessionB == sessionA {
-		return nil // need a second, distinct server-minted session
+		return nil, true // need a second, distinct server-minted session
 	}
 
 	// As B, resume from A's checkpoint id and see whether A's later events are
@@ -98,10 +111,10 @@ func (e *SSEResumeReplayExecutor) probe(ctx context.Context, client *attack.HTTP
 					ep, sessionA, checkpointID, sessionB, checkpointID, marker),
 				Remediation: e.rule.Remediation,
 				TargetURL:   ep,
-			}}
+			}}, true
 		}
 	}
-	return nil
+	return nil, true
 }
 
 // initialize performs an MCP initialize as the given token and returns the

--- a/internal/attack/mcp/sse_resume_replay_test.go
+++ b/internal/attack/mcp/sse_resume_replay_test.go
@@ -195,7 +195,5 @@ func TestResume_NotMCP(t *testing.T) {
 	ts := httptest.NewServer(http.NotFoundHandler())
 	defer ts.Close()
 
-	if findings := runResume(t, ts); len(findings) != 0 {
-		t.Errorf("expected zero findings against a non-MCP server, got %d", len(findings))
-	}
+	assertInconclusive(t, mcpattack.NewSSEResumeReplayExecutor(sseRuleCtx()), ts.URL, attack.Options{TimeoutSeconds: 5})
 }

--- a/internal/attack/mcp/task_idor.go
+++ b/internal/attack/mcp/task_idor.go
@@ -72,7 +72,7 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 	// Session A, which also discovers the endpoint.
 	sessA, ok := e.initSession(ctx, client, vars.BaseURL, tokenA)
 	if !ok {
-		return nil, nil // not an MCP server
+		return nil, attack.ErrInconclusive // not an MCP server
 	}
 
 	// Gate on the tasks capability and on task-augmented tools/call specifically.

--- a/internal/attack/mcp/task_idor_test.go
+++ b/internal/attack/mcp/task_idor_test.go
@@ -327,7 +327,5 @@ func TestTaskIDOR_NotMCP(t *testing.T) {
 	srv := taskIDORServer("not-mcp")
 	defer srv.Close()
 
-	if findings := runTaskIDOR(t, srv); len(findings) != 0 {
-		t.Errorf("expected 0 findings for a non-MCP server, got %d: %+v", len(findings), findings)
-	}
+	assertInconclusive(t, mcpattack.NewTaskIDORExecutor(attack.RuleContext{ID: "mcp-task-idor-001"}), srv.URL, testOpts())
 }

--- a/internal/attack/mcp/tools_unauth.go
+++ b/internal/attack/mcp/tools_unauth.go
@@ -43,7 +43,7 @@ func (e *ToolsUnauthExecutor) Execute(ctx context.Context, target string, opts a
 
 	session, err := initializeMCP(ctx, client, vars.BaseURL)
 	if err != nil {
-		return nil, nil // not an MCP server
+		return nil, attack.ErrInconclusive // not an MCP server
 	}
 
 	// Skip servers that do not advertise the tools capability; probing them would

--- a/internal/attack/mcp/tools_unauth_test.go
+++ b/internal/attack/mcp/tools_unauth_test.go
@@ -152,3 +152,12 @@ func TestToolsUnauth_NoToolsCapability(t *testing.T) {
 		t.Errorf("expected 0 findings for a server without the tools capability, got %d", len(findings))
 	}
 }
+
+// TestToolsUnauth_NotMCP: a non-MCP server (no reachable endpoint) must report
+// ErrInconclusive, not a clean pass.
+func TestToolsUnauth_NotMCP(t *testing.T) {
+	ts := httptest.NewServer(http.NotFoundHandler())
+	defer ts.Close()
+
+	assertInconclusive(t, mcpattack.NewToolsUnauthExecutor(attack.RuleContext{ID: "mcp-tools-unauth-001"}), ts.URL, testOpts())
+}


### PR DESCRIPTION
## Summary

MCP rules were reporting a clean pass even when they couldn't reach a testable endpoint. The engine records `ErrInconclusive` as "skipped: could not reach a testable endpoint", which is separate from clean, so a dead host or non-MCP target now shows up as not-tested instead of a green check. The A2A side already does this (#80); the MCP side never did.

`ErrInconclusive` only fires when no candidate path answered an MCP initialize. A clean result still means the rule reached a real endpoint that was secure, or that the capability/OAuth surface the rule targets simply isn't there.

## Changes

14 files.

- **9 direct swaps** where a reachability gate fell through to `return nil, nil`: resources, prompt, tools, logging, completion, session_fixation, task_idor, dns_rebind_origin, oauth_audience.
- **5 loop refactors** where one return covered both "not MCP" and "tested, secure". A "did any candidate answer like a live MCP endpoint?" signal is threaded back up, and the rule returns inconclusive only when none did: init_downgrade, header_body_split, jsonrpc_batch_bypass, secret_canary, sse_resume_replay.

`init_downgrade` also gets a `responsiveMCP` probe, because a server can reject the offered protocol version with a JSON-RPC error and still be live; that case stays clean instead of being misread as unreachable.

The four OAuth-gated rules (confused_deputy, oauth_dcr, oauth_metadata_ssrf, token_replay) treat "no OAuth metadata" as a clean N/A and are unchanged.

## Test plan

Each changed rule asserts `ErrInconclusive` against an unreachable target. The existing vulnerable and secure tests are untouched and still pass, so no real finding stops firing and no safe server gets flagged. `go test ./...`, `gofmt`, `go vet` clean.