### PR TITLE
fix(security): send Mcp-Protocol-Version and offer current MCP versions

### DIFF
--- a/internal/attack/mcp/header_body_split.go
+++ b/internal/attack/mcp/header_body_split.go
@@ -114,7 +114,7 @@ func (e *HeaderBodySplitExecutor) initialize(ctx context.Context, client *attack
 	if !resp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
 		return mcpSession{}, false
 	}
-	session := mcpSession{Endpoint: ep, SessionID: resp.Headers.Get("Mcp-Session-Id"), RawInit: resp.Body}
+	session := mcpSession{Endpoint: ep, SessionID: resp.Headers.Get("Mcp-Session-Id"), ProtocolVersion: negotiatedVersion(resp.Body), RawInit: resp.Body}
 	initedHeaders := session.header()
 	if initedHeaders == nil {
 		initedHeaders = map[string]string{}

--- a/internal/attack/mcp/init_downgrade.go
+++ b/internal/attack/mcp/init_downgrade.go
@@ -45,7 +45,7 @@ func NewInitDowngradeExecutor(r attack.RuleContext) *InitDowngradeExecutor {
 // spec, used as the auth-enforcing baseline.
 const (
 	legacyVersion = "2024-11-05"
-	modernVersion = "2025-03-26"
+	modernVersion = latestStable
 )
 
 func (e *InitDowngradeExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
@@ -173,7 +173,7 @@ func (e *InitDowngradeExecutor) initAndList(ctx context.Context, client *attack.
 		return false, false, 0
 	}
 
-	session := mcpSession{Endpoint: ep, SessionID: initResp.Headers.Get("Mcp-Session-Id")}
+	session := mcpSession{Endpoint: ep, SessionID: initResp.Headers.Get("Mcp-Session-Id"), ProtocolVersion: negotiatedVersion(initResp.Body)}
 	_, _ = client.POST(ctx, ep, session.header(), map[string]interface{}{
 		"jsonrpc": "2.0",
 		"method":  "notifications/initialized",

--- a/internal/attack/mcp/init_downgrade_test.go
+++ b/internal/attack/mcp/init_downgrade_test.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	legacyVer = "2024-11-05"
-	modernVer = "2025-03-26"
+	modernVer = "2025-06-18"
 )
 
 // versionAwareServer models a server that tracks each session's negotiated

--- a/internal/attack/mcp/jsonrpc_batch_bypass.go
+++ b/internal/attack/mcp/jsonrpc_batch_bypass.go
@@ -105,7 +105,7 @@ func (e *BatchBypassExecutor) probeEndpoint(ctx context.Context, client *attack.
 
 	case isMCPInitialize(ctrl):
 		// initialize is open; look for a per-method gate that the batch bypasses.
-		session := mcpSession{Endpoint: ep, SessionID: ctrl.Headers.Get("Mcp-Session-Id"), RawInit: ctrl.Body}
+		session := mcpSession{Endpoint: ep, SessionID: ctrl.Headers.Get("Mcp-Session-Id"), ProtocolVersion: negotiatedVersion(ctrl.Body), RawInit: ctrl.Body}
 		_, _ = client.POST(ctx, ep, session.header(), map[string]interface{}{
 			"jsonrpc": "2.0",
 			"method":  "notifications/initialized",

--- a/internal/attack/mcp/resources_unauth.go
+++ b/internal/attack/mcp/resources_unauth.go
@@ -184,7 +184,7 @@ func initializeMCP(ctx context.Context, client *attack.HTTPClient, baseURL strin
 			"id":      1,
 			"method":  "initialize",
 			"params": map[string]interface{}{
-				"protocolVersion": "2025-03-26",
+				"protocolVersion": latestStable,
 				"capabilities":    map[string]interface{}{"resources": map[string]interface{}{}},
 				"clientInfo":      map[string]interface{}{"name": "batesian", "version": "1.0"},
 			},
@@ -197,9 +197,10 @@ func initializeMCP(ctx context.Context, client *attack.HTTPClient, baseURL strin
 		}
 
 		session := mcpSession{
-			Endpoint:  ep,
-			SessionID: initResp.Headers.Get("Mcp-Session-Id"),
-			RawInit:   initResp.Body,
+			Endpoint:        ep,
+			SessionID:       initResp.Headers.Get("Mcp-Session-Id"),
+			ProtocolVersion: negotiatedVersion(initResp.Body),
+			RawInit:         initResp.Body,
 		}
 
 		// notifications/initialized - fire and forget

--- a/internal/attack/mcp/secret_canary.go
+++ b/internal/attack/mcp/secret_canary.go
@@ -82,7 +82,7 @@ func (e *SecretCanaryExecutor) probe(ctx context.Context, client *attack.HTTPCli
 	var session mcpSession
 	if err == nil {
 		record(initResp.BodyString())
-		session = mcpSession{Endpoint: ep, SessionID: initResp.Headers.Get("Mcp-Session-Id")}
+		session = mcpSession{Endpoint: ep, SessionID: initResp.Headers.Get("Mcp-Session-Id"), ProtocolVersion: negotiatedVersion(initResp.Body)}
 	}
 
 	// A handful of further calls, including a malformed one to elicit verbose

--- a/internal/attack/mcp/session.go
+++ b/internal/attack/mcp/session.go
@@ -24,6 +24,11 @@ func endpointCandidates(baseURL string) []string {
 type mcpSession struct {
 	Endpoint  string
 	SessionID string
+	// ProtocolVersion is the MCP version in effect for this session: the
+	// protocolVersion the server returned in its initialize result, or the
+	// offered version if the server did not echo one. Sent on subsequent
+	// requests via the Mcp-Protocol-Version header.
+	ProtocolVersion string
 	// RawInit is the raw JSON body of the server's initialize response, captured
 	// once during the handshake so executors can inspect advertised server
 	// capabilities without issuing a second initialize.
@@ -51,11 +56,43 @@ func (s mcpSession) ServerSupports(capability string) bool {
 	return ok
 }
 
-// header returns the Mcp-Session-Id header map if a session ID is present,
-// or nil if the server did not issue one (older servers, test servers).
+// header returns the headers that must accompany subsequent MCP requests on this
+// session: Mcp-Protocol-Version (Streamable HTTP servers validate it to route
+// and may reject requests that omit it) and, when the server issued one,
+// Mcp-Session-Id. Returns nil if neither applies (older servers, test servers).
 func (s mcpSession) header() map[string]string {
-	if s.SessionID == "" {
+	h := map[string]string{}
+	if s.ProtocolVersion != "" {
+		h["Mcp-Protocol-Version"] = s.ProtocolVersion
+	}
+	if s.SessionID != "" {
+		h["Mcp-Session-Id"] = s.SessionID
+	}
+	if len(h) == 0 {
 		return nil
 	}
-	return map[string]string{"Mcp-Session-Id": s.SessionID}
+	return h
+}
+
+// latestStable is the MCP protocol version offered in initialize requests. The
+// spec says clients should offer the latest version they support; the server
+// negotiates by responding with its own version. Offering a stale version risks
+// an "Unsupported protocol version" rejection on current servers (a silent
+// false negative), so this stays current.
+const latestStable = "2025-06-18"
+
+// negotiatedVersion reads the protocolVersion the server chose from its
+// initialize result body, falling back to latestStable if the server did not
+// echo one. The negotiated value is sent in the Mcp-Protocol-Version header on
+// subsequent requests.
+func negotiatedVersion(initBody []byte) string {
+	var body struct {
+		Result struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		} `json:"result"`
+	}
+	if json.Unmarshal(initBody, &body) == nil && body.Result.ProtocolVersion != "" {
+		return body.Result.ProtocolVersion
+	}
+	return latestStable
 }

--- a/internal/attack/mcp/session_fixation.go
+++ b/internal/attack/mcp/session_fixation.go
@@ -74,7 +74,7 @@ func (e *SessionFixationExecutor) ExecuteChained(ctx context.Context, target str
 	}
 
 	// Best-effort: complete the handshake for the pre-seeded session.
-	_, _ = client.POST(ctx, ep, map[string]string{"Mcp-Session-Id": fixed}, map[string]interface{}{
+	_, _ = client.POST(ctx, ep, map[string]string{"Mcp-Session-Id": fixed, "Mcp-Protocol-Version": latestStable}, map[string]interface{}{
 		"jsonrpc": "2.0",
 		"method":  "notifications/initialized",
 	})
@@ -131,7 +131,7 @@ func (e *SessionFixationExecutor) initWithSession(ctx context.Context, client *a
 			"id":      1,
 			"method":  "initialize",
 			"params": map[string]interface{}{
-				"protocolVersion": "2025-03-26",
+				"protocolVersion": latestStable,
 				"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
 				"clientInfo":      map[string]interface{}{"name": "batesian", "version": "1.0"},
 			},
@@ -154,7 +154,7 @@ func (e *SessionFixationExecutor) initWithSession(ctx context.Context, client *a
 // not found"); a method-not-found error still means the session passed
 // validation and reached method dispatch.
 func (e *SessionFixationExecutor) sessionAccepted(ctx context.Context, client *attack.HTTPClient, ep, sessionID string, extraHeaders map[string]string) bool {
-	headers := map[string]string{"Mcp-Session-Id": sessionID}
+	headers := map[string]string{"Mcp-Session-Id": sessionID, "Mcp-Protocol-Version": latestStable}
 	for k, v := range extraHeaders {
 		headers[k] = v
 	}

--- a/internal/attack/mcp/sse_resume_replay.go
+++ b/internal/attack/mcp/sse_resume_replay.go
@@ -141,7 +141,7 @@ func (e *SSEResumeReplayExecutor) initialize(ctx context.Context, client *attack
 		return "", false
 	}
 	sid := resp.Headers.Get("Mcp-Session-Id")
-	inited := map[string]string{}
+	inited := map[string]string{"Mcp-Protocol-Version": latestStable}
 	if token != "" {
 		inited["Authorization"] = "Bearer " + token
 	}

--- a/internal/attack/mcp/task_idor.go
+++ b/internal/attack/mcp/task_idor.go
@@ -165,9 +165,10 @@ func (e *TaskIDORExecutor) initSession(ctx context.Context, client *attack.HTTPC
 			continue
 		}
 		session := mcpSession{
-			Endpoint:  ep,
-			SessionID: resp.Headers.Get("Mcp-Session-Id"),
-			RawInit:   resp.Body,
+			Endpoint:        ep,
+			SessionID:       resp.Headers.Get("Mcp-Session-Id"),
+			ProtocolVersion: negotiatedVersion(resp.Body),
+			RawInit:         resp.Body,
 		}
 		_, _ = client.POST(ctx, ep, e.headers(session, token), map[string]interface{}{
 			"jsonrpc": "2.0",
@@ -181,6 +182,9 @@ func (e *TaskIDORExecutor) initSession(ctx context.Context, client *attack.HTTPC
 // headers builds the per-request headers for a session and principal.
 func (e *TaskIDORExecutor) headers(s mcpSession, token string) map[string]string {
 	h := map[string]string{}
+	if s.ProtocolVersion != "" {
+		h["Mcp-Protocol-Version"] = s.ProtocolVersion
+	}
 	if s.SessionID != "" {
 		h["Mcp-Session-Id"] = s.SessionID
 	}

--- a/internal/attack/mcp/token_replay.go
+++ b/internal/attack/mcp/token_replay.go
@@ -47,8 +47,11 @@ func NewTokenReplayExecutor(r attack.RuleContext) *TokenReplayExecutor {
 	return &TokenReplayExecutor{rule: r}
 }
 
-// mcpInitBody is the standard MCP initialize request used as the probe body.
-const mcpInitBody = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"batesian","version":"dev"}}}`
+// mcpInitBody is the standard MCP initialize request used as the probe body. The
+// offered protocolVersion mirrors latestStable: a stale offered version here is
+// rejected as "Unsupported protocol version" by current servers (a silent false
+// negative). Shared by token_replay, dns_rebind_origin, and oauth_audience.
+const mcpInitBody = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"batesian","version":"dev"}}}`
 
 // Execute runs the token replay / audience validation test.
 func (e *TokenReplayExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {

--- a/internal/attack/mcp/token_replay_test.go
+++ b/internal/attack/mcp/token_replay_test.go
@@ -255,3 +255,73 @@ func TestTokenReplay_NoOAuthMetadata(t *testing.T) {
 		t.Errorf("expected zero findings when no OAuth metadata present, got %d", len(findings))
 	}
 }
+
+// versionRejectingTokenServer advertises OAuth metadata and rejects an
+// initialize offered with the stale 2024-11-05 protocol version (returning the
+// JSON-RPC error a strict current server sends for an unsupported version),
+// while accepting the current version. Proves the mcpInitBody version bump
+// closes a false negative: before the bump, every forged-token initialize was
+// rejected on version grounds and the rule reported clean.
+func versionRejectingTokenServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		base := "http://" + srv.Listener.Addr().String()
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"issuer":         base,
+				"token_endpoint": base + "/token",
+			})
+		case "/mcp":
+			var req map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			params, _ := req["params"].(map[string]interface{})
+			version, _ := params["protocolVersion"].(string)
+			if version == "2024-11-05" {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"jsonrpc": "2.0",
+					"id":      req["id"],
+					"error":   map[string]interface{}{"code": -32600, "message": "Unsupported protocol version"},
+				})
+				return
+			}
+			if strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"jsonrpc": "2.0",
+					"id":      req["id"],
+					"result": map[string]interface{}{
+						"protocolVersion": version,
+						"serverInfo":      map[string]interface{}{"name": "test-server", "version": "1.0"},
+					},
+				})
+				return
+			}
+			w.WriteHeader(http.StatusUnauthorized)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return srv
+}
+
+// TestTokenReplay_CurrentVersionNotRejected: a strict current server rejects an
+// initialize offered as 2024-11-05. The rule must offer a current version so the
+// forged-token initialize is accepted (and the finding fires), not rejected on
+// version grounds.
+func TestTokenReplay_CurrentVersionNotRejected(t *testing.T) {
+	srv := versionRejectingTokenServer(t)
+	defer srv.Close()
+
+	findings, err := mcpattack.NewTokenReplayExecutor(tokenReplayRC()).Execute(context.Background(), srv.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) == 0 {
+		t.Fatal("expected a finding (current-version initialize accepted, forged token accepted); got 0 - the offered protocolVersion may have been rejected as stale")
+	}
+}


### PR DESCRIPTION
## Summary

Two MCP false negatives against current/strict servers. The rules offered stale protocol versions in initialize (token_replay, dns_rebind, and oauth_audience shared a `2024-11-05` body; session_fixation offered `2025-03-26`; init_downgrade's modern baseline was `2025-03-26`), and a current server rejects an unsupported offered version with an "Unsupported protocol version" error, so the rule never reached its auth test. Separately, no rule sent the `Mcp-Protocol-Version` header that Streamable HTTP servers route post-handshake requests on, so a strict server could reject every follow-up.

## Changes

- `mcpSession` carries a `ProtocolVersion`; `session.header()` now emits `Mcp-Protocol-Version` alongside `Mcp-Session-Id`, so every follow-up from the session-based rules carries it.
- A `latestStable` constant (`2025-06-18`) and a `negotiatedVersion` helper that reads the version the server chose from its initialize result.
- **Stale offered versions bumped**: `mcpInitBody` `2024-11-05` -> `2025-06-18` (shared by token_replay, dns_rebind, oauth_audience), session_fixation and init_downgrade's modern baseline -> `latestStable`. Intentional versions stay: init_downgrade's legacy `2024-11-05` (the attack itself) and jsonrpc_batch's `2025-03-26` (last batch-supporting revision).
- Rules that build headers by hand rather than via `session.header()` (task_idor's `headers`, session_fixation, sse_resume_replay) send `Mcp-Protocol-Version` on their follow-ups.

The initialize request still offers the version in its body, where negotiation happens; the header rides on post-handshake requests, which is where routing on it matters. Adding it to every initialize POST too is a follow-up, not needed for any known target.

## Test plan

A version-rejecting server (rejects `2024-11-05`, accepts the current version) proves the token_replay bump closes the false negative. Existing vulnerable and secure tests are untouched and green. `go test ./...`, `gofmt`, `go vet` clean.