### PR TITLE
fix(security): join multi-line SSE events so chunked responses are not dropped

### DIFF
--- a/internal/attack/http.go
+++ b/internal/attack/http.go
@@ -1,7 +1,6 @@
 package attack
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -10,6 +9,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/calbebop/batesian/internal/sse"
 )
 
 const maxBody = 1 << 20 // 1 MB
@@ -254,27 +255,15 @@ func (c *HTTPClient) do(ctx context.Context, method, url string, body io.Reader,
 	}, nil
 }
 
-// readFirstSSEEvent reads a Server-Sent Events stream and returns the JSON payload
-// from the first "data:" line. The connection is not drained; the caller's defer
-// closes the body once we return. This avoids hanging indefinitely on a stream
-// that the server never closes (standard for MCP streamable HTTP transport).
-//
-// The scanner buffer is set to maxBody (1 MB) because MCP servers can emit
-// data lines with large embedded payloads (e.g., server instructions).
+// readFirstSSEEvent returns the joined payload of the first SSE event. The
+// stream is not drained: the parser stops after the first event so a stream the
+// server never closes (standard for MCP streamable HTTP) cannot block the scan.
+// A payload split across several "data:" lines is rejoined per spec. Errors
+// (an over-long line, a read failure) map to a nil body, which callers treat as
+// "no result".
 func readFirstSSEEvent(r io.Reader) []byte {
-	scanner := bufio.NewScanner(io.LimitReader(r, maxBody))
-	scanner.Buffer(make([]byte, maxBody), maxBody)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, "data:") {
-			payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
-			return []byte(payload)
-		}
-	}
-	// scanner.Err() is nil on clean EOF; non-nil means a read or buffer error.
-	// Returning nil here is safe: callers treat empty body as "no result".
-	_ = scanner.Err()
-	return nil
+	payload, _ := sse.FirstData(r, maxBody)
+	return payload
 }
 
 // marshalBody encodes body as JSON with template variable expansion applied to string values.

--- a/internal/attack/mcp/sse_resume_replay.go
+++ b/internal/attack/mcp/sse_resume_replay.go
@@ -1,7 +1,6 @@
 package mcp
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"net/http"
@@ -9,6 +8,7 @@ import (
 	"time"
 
 	"github.com/calbebop/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/sse"
 )
 
 // SSEResumeReplayExecutor tests whether an MCP Streamable HTTP server replays one
@@ -183,26 +183,18 @@ func (e *SSEResumeReplayExecutor) sseCollect(ctx context.Context, client *http.C
 	if !strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
 		return nil
 	}
+	// Read events for the window via the shared parser, which joins a payload
+	// split across several "data:" lines so a marker or checkpoint id is not
+	// reduced to its last fragment. The stream is bounded by the request
+	// context: when the window expires the body read errors and the loop stops.
+	rd := sse.NewReader(resp.Body)
 	var events []sseEvent
-	var cur sseEvent
-	sc := bufio.NewScanner(resp.Body)
-	sc.Buffer(make([]byte, 1<<20), 1<<20)
-	for sc.Scan() {
-		line := sc.Text()
-		switch {
-		case line == "":
-			if cur.data != "" {
-				events = append(events, cur)
-			}
-			cur = sseEvent{}
-		case strings.HasPrefix(line, "id:"):
-			cur.id = strings.TrimSpace(line[len("id:"):])
-		case strings.HasPrefix(line, "data:"):
-			cur.data = strings.TrimSpace(line[len("data:"):])
+	for {
+		ev, err := rd.Next()
+		if err != nil {
+			break
 		}
-	}
-	if cur.data != "" {
-		events = append(events, cur)
+		events = append(events, sseEvent{id: ev.ID, data: ev.Data})
 	}
 	return events
 }

--- a/internal/attack/mcp/sse_resume_replay_test.go
+++ b/internal/attack/mcp/sse_resume_replay_test.go
@@ -197,3 +197,111 @@ func TestResume_NotMCP(t *testing.T) {
 
 	assertInconclusive(t, mcpattack.NewSSEResumeReplayExecutor(sseRuleCtx()), ts.URL, attack.Options{TimeoutSeconds: 5})
 }
+
+// resumeServerMultiline is a vulnerable replay server whose SSE events carry a
+// trailing empty "data:" line, as a chunked stream whose payload ends in a
+// newline can emit:
+//
+//	id: <eid>
+//	data: <payload>
+//	data:
+//
+// The previous reader kept only the last "data:" line, so the empty trailing
+// line overwrote the payload, the event was recorded empty, and it was skipped.
+// Session A then captured no marker and the rule stayed silent (false negative).
+// The joined parser reassembles <payload> and the finding fires.
+func resumeServerMultiline() *httptest.Server {
+	var mu sync.Mutex
+	var sessionCounter, eventCounter int
+	var log []sseLogEntry
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			var req map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			method, _ := req["method"].(string)
+			id := req["id"]
+			w.Header().Set("Content-Type", "application/json")
+			switch method {
+			case "initialize":
+				mu.Lock()
+				sessionCounter++
+				sid := fmt.Sprintf("sess-%d", sessionCounter)
+				mu.Unlock()
+				w.Header().Set("Mcp-Session-Id", sid)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"jsonrpc": "2.0", "id": id,
+					"result": map[string]interface{}{
+						"protocolVersion": "2025-06-18",
+						"serverInfo":      map[string]interface{}{"name": "resume-ml", "version": "1.0"},
+						"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+					},
+				})
+			default:
+				w.WriteHeader(http.StatusAccepted)
+			}
+			return
+		}
+
+		sid := r.Header.Get("Mcp-Session-Id")
+		leid := r.Header.Get("Last-Event-ID")
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, _ := w.(http.Flusher)
+		writeMultiline := func(eid, data string) {
+			// Payload on the first data: line, then an empty trailing data: line.
+			fmt.Fprintf(w, "id: %s\ndata: %s\ndata:\n\n", eid, data)
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+
+		if leid == "" {
+			mu.Lock()
+			var fresh []sseLogEntry
+			for i := 0; i < 2; i++ {
+				eventCounter++
+				eid := fmt.Sprintf("evt-%s-%d", sid, eventCounter)
+				data := fmt.Sprintf(`{"sid":%q,"secret":"S-%s-%d"}`, sid, sid, eventCounter)
+				entry := sseLogEntry{eid: eid, sid: sid, data: data}
+				log = append(log, entry)
+				fresh = append(fresh, entry)
+			}
+			mu.Unlock()
+			for _, ev := range fresh {
+				writeMultiline(ev.eid, ev.data)
+			}
+			return
+		}
+		mu.Lock()
+		snapshot := append([]sseLogEntry(nil), log...)
+		mu.Unlock()
+		start := -1
+		for i, ev := range snapshot {
+			if ev.eid == leid {
+				start = i
+				break
+			}
+		}
+		if start == -1 {
+			return
+		}
+		for _, ev := range snapshot[start+1:] {
+			writeMultiline(ev.eid, ev.data)
+		}
+	}))
+}
+
+func TestResume_MultilineDataEvent(t *testing.T) {
+	ts := resumeServerMultiline()
+	defer ts.Close()
+
+	findings := runResume(t, ts)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding when events span multiple data: lines, got %d: %+v", len(findings), findings)
+	}
+	// The full marker must survive reassembly; the trailing empty data: line
+	// must not have reduced it to a fragment.
+	if !strings.Contains(findings[0].Evidence, "S-sess-1-2") {
+		t.Errorf("expected the joined marker in evidence, got:\n%s", findings[0].Evidence)
+	}
+}

--- a/internal/protocol/mcp/client.go
+++ b/internal/protocol/mcp/client.go
@@ -4,7 +4,6 @@
 package mcp
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"crypto/tls"
@@ -15,6 +14,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/calbebop/batesian/internal/sse"
 )
 
 const (
@@ -380,19 +381,12 @@ func readBody(resp *http.Response) []byte {
 	return b
 }
 
-// readFirstSSEData scans an SSE stream and returns the payload from the first
-// "data:" line. The scanner buffer is maxBodyBytes to handle large payloads
-// such as MCP server instructions embedded in initialize responses.
+// readFirstSSEData returns the joined payload of the first SSE event from r,
+// rejoining a payload split across several "data:" lines. The stream is not
+// drained. A read error maps to a nil body.
 func readFirstSSEData(r io.Reader) []byte {
-	scanner := bufio.NewScanner(io.LimitReader(r, maxBodyBytes))
-	scanner.Buffer(make([]byte, maxBodyBytes), maxBodyBytes)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, "data:") {
-			return []byte(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
-		}
-	}
-	return nil
+	payload, _ := sse.FirstData(r, maxBodyBytes)
+	return payload
 }
 
 // HasCapability returns true if the session's capability map includes the key.

--- a/internal/sse/sse.go
+++ b/internal/sse/sse.go
@@ -1,0 +1,155 @@
+// Package sse parses Server-Sent Events streams.
+//
+// MCP Streamable HTTP carries JSON-RPC responses over SSE. An SSE event's
+// payload may span several "data:" lines, which the client joins with a newline
+// (HTML "Interpreting an event stream"). Returning only the first "data:" line
+// (as a naive reader does) captures a fragment when a server chunks a response
+// that way, so the payload fails to parse and a rule silently reports clean.
+// This package implements the spec-correct join so the first complete event is
+// returned intact.
+package sse
+
+import (
+	"bufio"
+	"io"
+	"strings"
+)
+
+// MaxBytes is the default cap on how many bytes a reader will consume from a
+// stream, matching the 1 MB body cap used by the scan and recon clients.
+const MaxBytes int64 = 1 << 20
+
+const defaultLineBytes = 1 << 20
+
+// Event is one dispatched SSE event.
+type Event struct {
+	// ID is the value of the event's "id:" field, if any. It is scoped to the
+	// event: a later block with no "id:" field yields an empty ID.
+	ID string
+	// Data is the event's payload: every "data:" line within the block joined
+	// with U+000A, with the single trailing newline removed.
+	Data string
+}
+
+// Reader parses SSE events from a stream. It is safe for single-goroutine use.
+type Reader struct {
+	sc      *bufio.Scanner
+	id      string
+	data    strings.Builder
+	hasData bool
+}
+
+// NewReader returns a Reader over r with the default 1 MB per-line buffer.
+func NewReader(r io.Reader) *Reader {
+	return NewReaderSize(r, defaultLineBytes)
+}
+
+// NewReaderSize returns a Reader over r whose per-line buffer grows to maxLine
+// bytes; a longer line ends the stream with bufio.ErrTooLong. The total stream
+// length is unbounded, so callers that read to completion should bound the
+// reader themselves (a context deadline, or io.LimitReader via FirstData).
+func NewReaderSize(r io.Reader, maxLine int) *Reader {
+	if maxLine <= 0 {
+		maxLine = defaultLineBytes
+	}
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, maxLine), maxLine)
+	return &Reader{sc: sc}
+}
+
+// Next returns the next event that carries a non-empty data payload.
+//
+// It returns io.EOF when the stream is exhausted and another error (for example
+// bufio.ErrTooLong) when a line could not be read. A trailing block with no
+// terminating blank line is still dispatched at EOF, so servers that omit the
+// final blank line are handled.
+func (r *Reader) Next() (Event, error) {
+	for {
+		if !r.sc.Scan() {
+			if ev, ok := r.flush(); ok {
+				return ev, nil
+			}
+			if err := r.sc.Err(); err != nil {
+				return Event{}, err
+			}
+			return Event{}, io.EOF
+		}
+		line := r.sc.Text()
+		switch {
+		case line == "":
+			if ev, ok := r.flush(); ok {
+				return ev, nil
+			}
+		case strings.HasPrefix(line, ":"):
+			// Comment line.
+		default:
+			name, value := parseField(line)
+			switch name {
+			case "data":
+				r.data.WriteString(value)
+				r.data.WriteByte('\n')
+				r.hasData = true
+			case "id":
+				// Per spec, an "id:" line containing NUL is ignored.
+				if !strings.ContainsRune(value, '\x00') {
+					r.id = value
+				}
+			}
+		}
+	}
+}
+
+// flush materializes and clears the buffered event. It returns the event and
+// true only when the block carried a non-empty joined payload; otherwise it
+// resets the buffer and returns false.
+func (r *Reader) flush() (Event, bool) {
+	defer r.reset()
+	if !r.hasData {
+		return Event{}, false
+	}
+	s := strings.TrimSuffix(r.data.String(), "\n")
+	if s == "" {
+		return Event{}, false
+	}
+	return Event{ID: r.id, Data: s}, true
+}
+
+func (r *Reader) reset() {
+	r.id = ""
+	r.data.Reset()
+	r.hasData = false
+}
+
+// parseField splits an SSE line into its field name and value. A line with no
+// colon is the field name with an empty value. When a colon is present, exactly
+// one leading U+0020 is stripped from the value (per spec, not all whitespace).
+func parseField(line string) (name, value string) {
+	if i := strings.IndexByte(line, ':'); i >= 0 {
+		name = line[:i]
+		// Strip exactly one leading U+0020 (per spec), not all whitespace.
+		value = strings.TrimPrefix(line[i+1:], " ")
+		return name, value
+	}
+	return line, ""
+}
+
+// FirstData returns the joined payload of the first event that carries data, or
+// nil when the stream ends with no such event. It reads at most max bytes and
+// stops at the first event without draining the rest of the stream, which keeps
+// a long-lived SSE connection from blocking. A non-nil error means the stream
+// could not be read (for example a single line overrunning max); callers that
+// treat "no payload" as a clean result should ignore it.
+func FirstData(r io.Reader, max int64) ([]byte, error) {
+	if max <= 0 {
+		max = MaxBytes
+	}
+	rd := NewReaderSize(io.LimitReader(r, max), int(max))
+	ev, err := rd.Next()
+	if err == io.EOF {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return []byte(ev.Data), nil
+}

--- a/internal/sse/sse_test.go
+++ b/internal/sse/sse_test.go
@@ -1,0 +1,242 @@
+package sse
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func collect(t *testing.T, input string) []Event {
+	t.Helper()
+	rd := NewReader(strings.NewReader(input))
+	var got []Event
+	for {
+		ev, err := rd.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got = append(got, ev)
+	}
+	return got
+}
+
+func eventsEqual(a, b []Event) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestReader_SingleLine(t *testing.T) {
+	got := collect(t, "data: hello\n\n")
+	want := []Event{{Data: "hello"}}
+	if !eventsEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestReader_MultiLineJoined is the core fix: a payload split across several
+// data: lines is rejoined with newlines, so a chunked JSON-RPC message still
+// parses. A first-line-only reader would return a fragment here.
+func TestReader_MultiLineJoined(t *testing.T) {
+	input := "data: {\"jsonrpc\":\"2.0\",\"result\":{\"x\":\ndata: 1}}\n\n"
+	got := collect(t, input)
+	if len(got) != 1 {
+		t.Fatalf("got %d events, want 1: %v", len(got), got)
+	}
+	want := "{\"jsonrpc\":\"2.0\",\"result\":{\"x\":\n1}}"
+	if got[0].Data != want {
+		t.Errorf("data %q, want %q", got[0].Data, want)
+	}
+	var v map[string]any
+	if err := json.Unmarshal([]byte(got[0].Data), &v); err != nil {
+		t.Errorf("joined data did not parse as JSON: %v", err)
+	}
+}
+
+func TestReader_LeadingSpace(t *testing.T) {
+	// Exactly one leading space is stripped (per spec), the rest is preserved.
+	got := collect(t, "data:  two spaces\n\n")
+	if len(got) != 1 || got[0].Data != " two spaces" {
+		t.Errorf("got %v, want one event with data %q", got, " two spaces")
+	}
+}
+
+func TestReader_NoSpaceAfterColon(t *testing.T) {
+	got := collect(t, "data:nospace\n\n")
+	if len(got) != 1 || got[0].Data != "nospace" {
+		t.Errorf("got %v, want %q", got, "nospace")
+	}
+}
+
+func TestReader_CommentLines(t *testing.T) {
+	got := collect(t, ": keepalive\ndata: x\n\n")
+	if len(got) != 1 || got[0].Data != "x" {
+		t.Errorf("got %v, want one event with data %q (comment ignored)", got, "x")
+	}
+}
+
+func TestReader_EventFieldIgnored(t *testing.T) {
+	got := collect(t, "event: message\ndata: x\n\n")
+	if len(got) != 1 || got[0].Data != "x" {
+		t.Errorf("got %v, want one event with data %q (event field ignored)", got, "x")
+	}
+}
+
+func TestReader_BareDataNoValue(t *testing.T) {
+	// A block whose only data line has no value yields no event.
+	got := collect(t, "data\n\n")
+	if len(got) != 0 {
+		t.Errorf("got %v, want no events for a bare data line", got)
+	}
+}
+
+func TestReader_IDTracking(t *testing.T) {
+	got := collect(t, "id:5\ndata:x\n\nid:6\ndata:y\n\n")
+	want := []Event{{ID: "5", Data: "x"}, {ID: "6", Data: "y"}}
+	if !eventsEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestReader_IDResetsPerEvent(t *testing.T) {
+	// The id field is scoped to its block: an event with no id: line has empty ID.
+	got := collect(t, "id:5\ndata:x\n\ndata:y\n\n")
+	want := []Event{{ID: "5", Data: "x"}, {ID: "", Data: "y"}}
+	if !eventsEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestReader_IDWithNULIgnored(t *testing.T) {
+	got := collect(t, "id:bad\x00id\ndata:x\n\n")
+	if len(got) != 1 || got[0].ID != "" || got[0].Data != "x" {
+		t.Errorf("got %v, want empty ID (NUL id line ignored) with data x", got)
+	}
+}
+
+func TestReader_CRLFLineEndings(t *testing.T) {
+	got := collect(t, "data:x\r\n\r\n")
+	if len(got) != 1 || got[0].Data != "x" {
+		t.Errorf("got %v, want one event with data %q", got, "x")
+	}
+}
+
+func TestReader_PartialAtEOF(t *testing.T) {
+	// No terminating blank line: the trailing block is still dispatched.
+	got := collect(t, "data: x\n")
+	if len(got) != 1 || got[0].Data != "x" {
+		t.Errorf("got %v, want one event with data %q", got, "x")
+	}
+}
+
+func TestReader_IDOnlyEventNotEmitted(t *testing.T) {
+	// An id: line with no data does not produce an event on its own.
+	got := collect(t, "id:1\n\ndata:x\n\n")
+	want := []Event{{ID: "", Data: "x"}}
+	if !eventsEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestReader_OversizedLineErrors(t *testing.T) {
+	huge := "data: " + strings.Repeat("x", 200) + "\n\n"
+	rd := NewReaderSize(strings.NewReader(huge), 64)
+	_, err := rd.Next()
+	if !errors.Is(err, bufio.ErrTooLong) {
+		t.Errorf("got err %v, want bufio.ErrTooLong", err)
+	}
+}
+
+func TestFirstData_MultiLine(t *testing.T) {
+	input := "data: {\"a\":\ndata: 1}\n\n"
+	got, err := FirstData(strings.NewReader(input), MaxBytes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "{\"a\":\n1}"
+	if string(got) != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFirstData_NoDataEvent(t *testing.T) {
+	// Only comments: no payload, no error.
+	got, err := FirstData(strings.NewReader(": ping\n\n"), MaxBytes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("got %q, want nil", got)
+	}
+}
+
+func TestFirstData_OversizedLine(t *testing.T) {
+	huge := "data: " + strings.Repeat("x", 200) + "\n\n"
+	_, err := FirstData(strings.NewReader(huge), 64)
+	if !errors.Is(err, bufio.ErrTooLong) {
+		t.Errorf("got err %v, want bufio.ErrTooLong", err)
+	}
+}
+
+// TestFirstData_DoesNotDrain verifies FirstData returns after the first event
+// without blocking on the rest of an open stream (the original reason the scan
+// client reads only one event). The second Read would block forever, so a
+// draining implementation would hang this test until the timeout fires.
+func TestFirstData_DoesNotDrain(t *testing.T) {
+	r := newBlockingAfterFirst()
+	done := make(chan struct{})
+	var got []byte
+	var err error
+	go func() {
+		got, err = FirstData(r, MaxBytes)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		r.unblock()
+		t.Fatal("FirstData did not return after the first event (drained a blocking stream)")
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != "first" {
+		t.Errorf("got %q, want %q", got, "first")
+	}
+}
+
+// blockingAfterFirst serves one event, then blocks on the second Read as a live
+// SSE stream with no further event would.
+type blockingAfterFirst struct {
+	served bool
+	ch     chan struct{}
+}
+
+func newBlockingAfterFirst() *blockingAfterFirst {
+	return &blockingAfterFirst{ch: make(chan struct{})}
+}
+
+func (r *blockingAfterFirst) Read(p []byte) (int, error) {
+	if !r.served {
+		r.served = true
+		n := copy(p, []byte("data: first\n\n"))
+		return n, nil
+	}
+	<-r.ch
+	return 0, io.EOF
+}
+
+func (r *blockingAfterFirst) unblock() { close(r.ch) }


### PR DESCRIPTION
## Summary

MCP Streamable HTTP carries JSON-RPC over SSE. Per the SSE spec an event's payload may span several `data:` lines that the client rejoins with newlines. Three readers in this repo each returned only the first (or last) `data:` line:

- `readFirstSSEEvent` in the scan client (`internal/attack/http.go`)
- `readFirstSSEData` in the recon client (`internal/protocol/mcp/client.go`)
- `sseCollect` in `mcp-sse-resume-replay-001` (`internal/attack/mcp/sse_resume_replay.go`)

When a server chunked a response across lines we captured a fragment, the JSON failed to unmarshal, and the rule treated it as "no result" and reported clean. Same shape of false negative as the redirect, success-oracle, and inconclusive waves: a silent nil. The first-event readers also discarded `scanner.Err()`, so a single line over 1 MB quietly became nil.

## Changes

- **New `internal/sse` package**: a spec-correct event reader. `Reader.Next()` joins `data:` lines within an event with `\n`, ignores comment (`:`) and `event:` lines, strips exactly one leading space per spec, tracks `id:` per event (reset each block), surfaces `bufio.ErrTooLong` instead of swallowing it, and dispatches a trailing partial block at EOF. `FirstData(r, max)` returns the first event's joined payload and stops there, so an open stream cannot block.
- **Three sites rewired** onto `sse.FirstData` / `sse.NewReader`. `bufio` drops out of all three files.
- **First-event readers keep their FN-safe contract**: a read error or an event-less stream still maps to a nil body (callers treat empty as "no result"). `sse_resume_replay` now collects every event in its time window through the shared reader instead of keeping only the last `data:` line.

## Test plan

- New `internal/sse/sse_test.go`: multi-line join (chunked JSON still unmarshals), one-leading-space spec rule, comment and event-field handling, bare-`data` no-op, per-event id tracking and reset, NUL id ignored, CRLF, partial-at-EOF dispatch, oversized-line error, and a blocking-reader test proving `FirstData` does not drain past the first event.
- New `TestResume_MultilineDataEvent` in `sse_resume_replay_test.go`: a vulnerable server that emits a trailing empty `data:` line per event. The old last-line reader recorded an empty marker and skipped session A's event, so the rule stayed silent; the joined reader reassembles it and the finding fires.
- `gofmt` clean, `go vet` clean, `go build` clean, `go test -race ./...` green. `golangci-lint` reports only the pre-existing SA5011 in `completion_unauth_test.go` (untouched here).
