### PR TITLE
fix(security): detect MCP dispatch without auth for non-(-32602) errors

### DIFF
--- a/internal/attack/mcp/completion_unauth.go
+++ b/internal/attack/mcp/completion_unauth.go
@@ -316,23 +316,20 @@ func rpcResult(ctx context.Context, client *attack.HTTPClient, session mcpSessio
 
 // completionDispatchReachable reports whether a completion/complete response
 // shows the handler was reached without auth. A completion result, any result
-// envelope, or a -32602 (invalid params / invalid prompt name) protocol error
-// all mean the call dispatched. A -32601 (capability not supported), an
-// auth-flavored error, or any other error does not. The reason is used as
-// finding evidence.
+// envelope, or any JSON-RPC error that is not "method not found" and not
+// auth-flavored means the call dispatched. The reason is used as finding evidence.
 func completionDispatchReachable(body map[string]interface{}) (bool, string) {
-	if errObj, ok := body["error"].(map[string]interface{}); ok {
-		code, _ := errObj["code"].(float64)
-		if int(code) == -32602 {
-			return true, "JSON-RPC error -32602 (invalid params) returned for the completion probe, so completion/complete was dispatched without auth"
-		}
-		return false, ""
-	}
-	if res, ok := body["result"].(map[string]interface{}); ok {
-		if _, ok := res["completion"]; ok {
-			return true, "completion/complete returned a completion result without auth"
+	sig, code := classifyDispatch(body)
+	switch sig {
+	case dispatchResult:
+		if res, ok := body["result"].(map[string]interface{}); ok {
+			if _, ok := res["completion"]; ok {
+				return true, "completion/complete returned a completion result without auth"
+			}
 		}
 		return true, "completion/complete returned a result envelope without auth"
+	case dispatchError:
+		return true, fmt.Sprintf("JSON-RPC error %d returned for the completion probe, so completion/complete was dispatched without auth", code)
 	}
 	return false, ""
 }

--- a/internal/attack/mcp/completion_unauth_test.go
+++ b/internal/attack/mcp/completion_unauth_test.go
@@ -23,6 +23,8 @@ import (
 //     returns an empty completion result => medium only (no disclosure).
 //   - "reachable-synth": only completions advertised; completion/complete answers
 //     -32602 for the synthetic probe ref => medium only.
+//   - "reachable-internal": only completions advertised; completion/complete
+//     answers -32603 for the synthetic probe ref => medium only.
 //   - "auth-enforced":   completion/complete answers -32001 Unauthorized => silent.
 //   - "no-cap":          completions capability absent => silent.
 //   - "not-mcp":         initialize 404s => silent.
@@ -102,6 +104,9 @@ func completionServer(mode string) *httptest.Server {
 				rpcErr(-32001, "Unauthorized")
 			case "reachable-synth":
 				rpcErr(-32602, "Invalid params: unknown prompt")
+			case "reachable-internal":
+				// A non-(-32602) validation path: still proves dispatch without auth.
+				rpcErr(-32603, "internal: unknown completion ref")
 			case "reachable-empty":
 				completion([]interface{}{})
 			case "resource-oracle":
@@ -204,6 +209,22 @@ func TestCompletionUnauth_ReachableSynthetic(t *testing.T) {
 	findings := runCompletionUnauth(t, srv)
 	if len(findings) != 1 {
 		t.Fatalf("expected exactly 1 finding (synthetic reachability), got %d: %+v", len(findings), findings)
+	}
+	if findings[0].Severity != "medium" {
+		t.Errorf("expected medium reachability finding, got %q", findings[0].Severity)
+	}
+}
+
+// TestCompletionUnauth_ReachableViaInternalError: a synthetic probe answered with
+// -32603 still proves completion/complete was dispatched without auth. The old
+// dispatch helper accepted only -32602 and stayed silent here (false negative).
+func TestCompletionUnauth_ReachableViaInternalError(t *testing.T) {
+	srv := completionServer("reachable-internal")
+	defer srv.Close()
+
+	findings := runCompletionUnauth(t, srv)
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 reachability finding for the -32603 response, got %d: %+v", len(findings), findings)
 	}
 	if findings[0].Severity != "medium" {
 		t.Errorf("expected medium reachability finding, got %q", findings[0].Severity)

--- a/internal/attack/mcp/dispatch.go
+++ b/internal/attack/mcp/dispatch.go
@@ -1,0 +1,87 @@
+package mcp
+
+import "strings"
+
+// authFlavoredError reports whether a JSON-RPC error signals an authentication
+// or authorization rejection rather than a request-processing or validation
+// error. MCP auth rejections are normally delivered as HTTP 401/403; this guards
+// the uncommon case of a server that signals auth failure through a 200 response
+// carrying a JSON-RPC error.
+//
+// The match is deliberately precise. This predicate is used to suppress an
+// unauth-reachability finding, and for a scanner a false negative (missing a
+// method reachable without auth) is worse than a false positive, so only
+// unambiguous auth signals count. Bare substrings that occur in unrelated error
+// messages are avoided: in particular "token" alone is not matched, since a
+// validation message such as "unexpected token" would otherwise hide a real
+// finding.
+func authFlavoredError(code int, msg string) bool {
+	switch code {
+	case -32001, -32002: // unauthenticated / forbidden (project convention)
+		return true
+	}
+	m := strings.ToLower(msg)
+	for _, kw := range authErrorKeywords {
+		if strings.Contains(m, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// authErrorKeywords are message substrings that unambiguously indicate an auth
+// rejection. Kept specific to avoid suppressing real findings.
+var authErrorKeywords = []string{
+	"unauth",
+	"authentic",
+	"authoriz",
+	"forbidden",
+	"credential",
+	"permission",
+	"access denied",
+	"not allowed",
+	"invalid token",
+	"missing token",
+	"log in",
+	"login",
+}
+
+// dispatchSignal classifies how an unauthenticated probe response proves the
+// handler was reached past the auth layer.
+type dispatchSignal int
+
+const (
+	// dispatchNone means the handler was not reached: the method is unsupported
+	// (-32601) or auth was enforced via a JSON-RPC error.
+	dispatchNone dispatchSignal = iota
+	// dispatchResult means the response carried a JSON-RPC result envelope.
+	dispatchResult
+	// dispatchError means the response carried a non-auth, non-not-found
+	// JSON-RPC error, so the handler ran and validated/rejected the request.
+	dispatchError
+)
+
+// classifyDispatch inspects an unauthenticated probe response body (already
+// known to be HTTP 2xx, since the caller returns early on a non-2xx auth gate).
+// At HTTP 2xx a result envelope, or any JSON-RPC error that is not "method not
+// found" (-32601) and not auth-flavored, means the request was processed past
+// the auth layer. It returns the signal and, for dispatchError, the JSON-RPC
+// error code.
+func classifyDispatch(body map[string]interface{}) (dispatchSignal, int) {
+	if errObj, ok := body["error"].(map[string]interface{}); ok {
+		c, _ := errObj["code"].(float64)
+		msg, _ := errObj["message"].(string)
+		code := int(c)
+		if code == -32601 {
+			return dispatchNone, 0 // method not found despite the advertised capability
+		}
+		if authFlavoredError(code, msg) {
+			return dispatchNone, 0 // auth enforced via a JSON-RPC error
+		}
+		return dispatchError, code // dispatched: the handler validated and rejected
+	}
+	if _, ok := body["result"]; ok {
+		return dispatchResult, 0
+	}
+	return dispatchNone, 0
+}

--- a/internal/attack/mcp/dispatch_test.go
+++ b/internal/attack/mcp/dispatch_test.go
@@ -1,0 +1,86 @@
+package mcp
+
+import "testing"
+
+func errBody(code int, msg string) map[string]interface{} {
+	// json.Unmarshal decodes numbers as float64, so the fixture must too.
+	return map[string]interface{}{"error": map[string]interface{}{"code": float64(code), "message": msg}}
+}
+
+func TestClassifyDispatch_ResultEnvelope(t *testing.T) {
+	for _, tc := range []map[string]interface{}{
+		{"result": map[string]interface{}{}},
+		{"result": map[string]interface{}{"completion": map[string]interface{}{}}},
+	} {
+		sig, code := classifyDispatch(tc)
+		if sig != dispatchResult || code != 0 {
+			t.Errorf("classifyDispatch(%v) = %d/%d, want result/0", tc, sig, code)
+		}
+	}
+}
+
+func TestClassifyDispatch_ErrorDispatched(t *testing.T) {
+	// Any non-auth, non-not-found JSON-RPC error proves the handler ran. This is
+	// the convergence fix: tools/completion previously accepted only -32602.
+	for _, code := range []int{-32602, -32603, -32600, -32700} {
+		sig, got := classifyDispatch(errBody(code, "some validation failure"))
+		if sig != dispatchError || got != code {
+			t.Errorf("code %d: got %d/%d, want error/%d", code, sig, got, code)
+		}
+	}
+}
+
+func TestClassifyDispatch_MethodNotFound(t *testing.T) {
+	sig, _ := classifyDispatch(errBody(-32601, "Method not found"))
+	if sig != dispatchNone {
+		t.Errorf("got %d, want none (method not found excludes dispatch)", sig)
+	}
+}
+
+func TestClassifyDispatch_AuthCodes(t *testing.T) {
+	for _, code := range []int{-32001, -32002} {
+		sig, _ := classifyDispatch(errBody(code, ""))
+		if sig != dispatchNone {
+			t.Errorf("auth code %d: got %d, want none", code, sig)
+		}
+	}
+}
+
+func TestClassifyDispatch_AuthKeywords(t *testing.T) {
+	for _, msg := range []string{
+		"Unauthorized", "Authentication required", "authorization denied",
+		"Forbidden", "permission denied", "access denied", "not allowed",
+		"invalid token", "missing token", "please log in",
+	} {
+		sig, _ := classifyDispatch(errBody(-32603, msg))
+		if sig != dispatchNone {
+			t.Errorf("auth message %q: got %d, want none", msg, sig)
+		}
+	}
+}
+
+// TestClassifyDispatch_BareTokenNotSuppressed locks in the precise keyword set:
+// a validation message containing bare "token" must NOT be treated as auth and
+// must still count as a dispatch, so a real unauth-reachable method is reported.
+func TestClassifyDispatch_BareTokenNotSuppressed(t *testing.T) {
+	sig, code := classifyDispatch(errBody(-32603, "unexpected token in argument"))
+	if sig != dispatchError || code != -32603 {
+		t.Errorf("bare-token message: got %d/%d, want error/-32603 (not suppressed)", sig, code)
+	}
+}
+
+func TestClassifyDispatch_NoResultNoError(t *testing.T) {
+	sig, _ := classifyDispatch(map[string]interface{}{"jsonrpc": "2.0"})
+	if sig != dispatchNone {
+		t.Errorf("got %d, want none", sig)
+	}
+}
+
+func TestAuthFlavoredError_Code(t *testing.T) {
+	if !authFlavoredError(-32001, "") || !authFlavoredError(-32002, "") {
+		t.Error("expected -32001/-32002 to be auth-flavored")
+	}
+	if authFlavoredError(-32602, "Unknown tool") {
+		t.Error("-32602 must not be auth-flavored")
+	}
+}

--- a/internal/attack/mcp/logging_unauth.go
+++ b/internal/attack/mcp/logging_unauth.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/calbebop/batesian/internal/attack"
 )
@@ -99,43 +98,18 @@ func (e *LoggingUnauthExecutor) Execute(ctx context.Context, target string, opts
 
 // setLevelDispatchReachable reports whether a logging/setLevel response for an
 // invalid level shows the handler was reached without auth. The caller has
-// already excluded HTTP 401/403 (returning early on a non-2xx status), and MCP
-// auth rejections are normally at the HTTP layer, so any HTTP-200 JSON-RPC error
-// here means the request was processed past the auth layer - the server validated
-// (and rejected) the level. Different servers surface an invalid level with
-// different codes (the spec says -32602, but some return -32603 from an internal
-// validation path), so the rule accepts any error except a genuine "method not
-// found" or an auth-flavored error, plus any result envelope. The returned reason
-// is used as finding evidence.
+// already excluded HTTP 401/403 (returning early on a non-2xx status), so any
+// HTTP-2xx result, or any JSON-RPC error that is not "method not found" and not
+// auth-flavored, means the request was processed past the auth layer. The shared
+// classifier handles the auth-flavored and not-found exclusions; the reason is
+// used as finding evidence.
 func setLevelDispatchReachable(body map[string]interface{}) (bool, string) {
-	if errObj, ok := body["error"].(map[string]interface{}); ok {
-		code, _ := errObj["code"].(float64)
-		msg, _ := errObj["message"].(string)
-		if int(code) == -32601 {
-			return false, "" // method not found despite the advertised capability
-		}
-		if isAuthFlavoredError(msg) {
-			return false, "" // auth enforced via a JSON-RPC error
-		}
-		return true, fmt.Sprintf(
-			"JSON-RPC error %d returned for an invalid level, so logging/setLevel was dispatched past the auth layer without credentials", int(code))
-	}
-	if _, ok := body["result"]; ok {
+	switch sig, code := classifyDispatch(body); sig {
+	case dispatchResult:
 		return true, "logging/setLevel returned a result envelope for an unauthenticated request, so it was dispatched without auth"
+	case dispatchError:
+		return true, fmt.Sprintf(
+			"JSON-RPC error %d returned for an invalid level, so logging/setLevel was dispatched past the auth layer without credentials", code)
 	}
 	return false, ""
-}
-
-// isAuthFlavoredError reports whether a JSON-RPC error message indicates an
-// authentication/authorization rejection rather than a request-processing error.
-// MCP auth rejections are normally HTTP 401/403, so this only guards the uncommon
-// case of a server that signals auth failure through a 200 JSON-RPC error.
-func isAuthFlavoredError(msg string) bool {
-	m := strings.ToLower(msg)
-	for _, kw := range []string{"unauthor", "forbidden", "authentic", "permission", "access denied", "not allowed", "invalid token", "missing token"} {
-		if strings.Contains(m, kw) {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/attack/mcp/tools_unauth.go
+++ b/internal/attack/mcp/tools_unauth.go
@@ -152,20 +152,16 @@ func (e *ToolsUnauthExecutor) Execute(ctx context.Context, target string, opts a
 }
 
 // callDispatchReachable reports whether a tools/call response for a non-existent
-// tool shows the invocation path was reached without auth. A -32602 ("unknown
-// tool" / invalid params) protocol error or any result envelope means the server
-// dispatched the call; a -32601 (method not found) or auth-flavored error does
-// not. The returned reason is used as finding evidence.
+// tool shows the invocation path was reached without auth. A result envelope, or
+// any JSON-RPC error that is not "method not found" and not auth-flavored, means
+// the server dispatched the call. The returned reason is used as finding evidence.
 func callDispatchReachable(body map[string]interface{}) (bool, string) {
-	if errObj, ok := body["error"].(map[string]interface{}); ok {
-		code, _ := errObj["code"].(float64)
-		if int(code) == -32602 {
-			return true, "JSON-RPC error -32602 (unknown tool) returned for a non-existent tool, so the call was dispatched without auth"
-		}
-		return false, ""
-	}
-	if _, ok := body["result"]; ok {
+	sig, code := classifyDispatch(body)
+	switch sig {
+	case dispatchResult:
 		return true, "tools/call returned a result envelope for a non-existent tool, so the call was dispatched without auth"
+	case dispatchError:
+		return true, fmt.Sprintf("JSON-RPC error %d returned for a non-existent tool, so tools/call was dispatched without auth", code)
 	}
 	return false, ""
 }

--- a/internal/attack/mcp/tools_unauth_test.go
+++ b/internal/attack/mcp/tools_unauth_test.go
@@ -14,6 +14,7 @@ import (
 // toolsUnauthServer builds a mock MCP server. callBehavior controls how
 // tools/call answers an unknown tool name:
 //   - "unknown": JSON-RPC -32602 "Unknown tool" (dispatch reached, no auth)
+//   - "internal": JSON-RPC -32603 internal error (dispatch reached, no auth)
 //   - "authgate": JSON-RPC -32001 "Unauthorized" (call gated behind auth)
 //
 // When advertiseTools is false the server omits the tools capability. When
@@ -61,6 +62,12 @@ func toolsUnauthServer(advertiseTools, listAuth bool, callBehavior string) *http
 			if callBehavior == "authgate" {
 				enc(map[string]interface{}{"jsonrpc": "2.0", "id": req["id"],
 					"error": map[string]interface{}{"code": -32001, "message": "Unauthorized"}})
+				return
+			}
+			if callBehavior == "internal" {
+				// A non-(-32602) validation path: still proves dispatch without auth.
+				enc(map[string]interface{}{"jsonrpc": "2.0", "id": req["id"],
+					"error": map[string]interface{}{"code": -32603, "message": "internal error: unknown tool " + paramName(req)}})
 				return
 			}
 			// "unknown": the scanner only ever calls a non-existent tool name.
@@ -150,6 +157,29 @@ func TestToolsUnauth_NoToolsCapability(t *testing.T) {
 
 	if findings := runToolsUnauth(t, srv); len(findings) != 0 {
 		t.Errorf("expected 0 findings for a server without the tools capability, got %d", len(findings))
+	}
+}
+
+// TestToolsUnauth_CallReachableViaInternalError: tools/call surfacing a -32603
+// for the non-existent tool still proves the invocation path was reached without
+// auth. The old dispatch helper accepted only -32602 and reported just the list
+// finding here (false negative).
+func TestToolsUnauth_CallReachableViaInternalError(t *testing.T) {
+	srv := toolsUnauthServer(true, false, "internal")
+	defer srv.Close()
+
+	findings := runToolsUnauth(t, srv)
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings (list + call via -32603), got %d: %+v", len(findings), findings)
+	}
+	hasHigh := false
+	for _, f := range findings {
+		if f.Severity == "high" {
+			hasHigh = true
+		}
+	}
+	if !hasHigh {
+		t.Error("expected a high tools/call reachability finding for the -32603 response")
 	}
 }
 


### PR DESCRIPTION
## Summary

Three unauth rules each answer the same question, *did this unauthenticated probe reach the handler past the auth layer?*, with three drifted helpers. `logging` already accepted any non-(-32601), non-auth JSON-RPC error as proof of dispatch; `tools` and `completion` accepted **only** `-32602`. A server that surfaced an invalid probe any other way (`-32603` internal, `-32600` invalid request) was treated as "not reached" and the rule stayed silent. That is a false negative, inverted from the scanner's stated bias.

This is the same family as the prior waves: a too-narrow predicate silently turns a real finding into a clean result.

## Changes

- **New `internal/attack/mcp/dispatch.go`** with two shared primitives:
  - `authFlavoredError(code, msg)` matches only unambiguous auth signals (`-32001`/`-32002` plus precise keywords). It deliberately avoids bare `token`, so a validation message like "unexpected token" cannot suppress a real finding.
  - `classifyDispatch(body)` returns `result` / `error` / `none`: at HTTP 2xx a result envelope, or any error that is not `-32601` (method not found) and not auth-flavored, means the handler ran.
- **Converge the three helpers** (`setLevelDispatchReachable`, `callDispatchReachable`, `completionDispatchReachable`) onto `classifyDispatch`. Each keeps its own evidence wording and its `(bool, reason)` signature, so call sites are unchanged. logging's local `isAuthFlavoredError` is removed.

## Notes

`jsonrpc_batch_bypass.isAuthRejection` is a distinct control-path predicate ("was this auth-rejected at all", includes HTTP 401/403) with a different risk profile, so it is left untouched.

## Test plan

- New `dispatch_test.go` (internal `package mcp`): `classifyDispatch` over result, dispatched errors (`-32602`/`-32603`/`-32600`/`-32700`), `-32601` and auth codes/keywords → none, empty body → none, and a bare-`token` message → `error` (locks in the precise keyword set).
- New `TestToolsUnauth_CallReachableViaInternalError` and `TestCompletionUnauth_ReachableViaInternalError`: a `-32603` on the bogus probe now fires the reachability finding (both were silent before).
- `gofmt` clean, `go vet` clean, `go build` clean, `go test -race ./...` green. `golangci-lint` reports only the pre-existing SA5011 in `completion_unauth_test.go` (untouched). Existing logging `-32603` test and the tools/completion `-32602`/`-32001` tests pass unchanged.
