### PR TITLE
chore(release): update the release header for v1.5.0

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -125,30 +125,35 @@ release:
   draft: false
   prerelease: auto
   name_template: "v{{.Version}}"
-  # The rule count and the Security section below are per-release content:
-  # review both before tagging. The Security section names the advisories fixed
-  # in this release and should be emptied or updated for the next one.
+  # The rule count and any per-release sections in the header below are reviewed
+  # before each tag. Keep them current; the auto-generated changelog lists the
+  # commits.
   header: |
     ## Batesian {{.Version}}
 
     Adversarial red-team CLI for AI agent protocols (A2A and MCP).
     35 bundled attack rules (17 A2A + 18 MCP). Single binary. No runtime dependencies.
 
-    ### Security
+    ### Detection accuracy
 
-    Fixes **CVE-2026-39824** ([GO-2026-5024](https://pkg.go.dev/vuln/GO-2026-5024)):
-    a string-length overflow in `NewNTUnicodeString` in `golang.org/x/sys/windows`,
-    which returned a truncated string instead of an error for over-long input.
-    Resolved by upgrading `golang.org/x/sys` to v0.44.0. Batesian never calls the
-    affected symbol, so the advisory was not reachable from this code, but it is
-    fixed in the dependency tree.
+    This release fixes several false negatives and false positives in the core
+    detection logic, surfaced by validating against third-party reference servers
+    rather than self-authored fixtures. The HTTP client no longer follows
+    redirects: a 302 to a login page was being read as a successful call, and a
+    redirect could carry the operator's bearer token to a third-party host. A 2xx
+    response that is not valid JSON with a `result` envelope is no longer treated
+    as a successful JSON-RPC call. MCP rules now report inconclusive instead of
+    clean when no endpoint is reachable, offer current protocol versions so
+    current servers no longer reject the handshake, send the `Mcp-Protocol-Version`
+    header on follow-ups, rejoin multi-line SSE events so chunked responses are
+    not dropped, and treat any non-auth JSON-RPC error (not only `-32602`) as proof
+    an unauthenticated probe reached the handler.
 
-    This release is also the first to carry [SLSA build provenance](https://slsa.dev)
-    alongside the existing cosign signature and CycloneDX SBOMs. Verify with:
+    ### New rule
 
-    ```bash
-    gh attestation verify batesian_<version>_<platform>.tar.gz --repo calbebop/batesian
-    ```
+    `mcp-task-idor-001` covers the MCP 2025-11-25 tasks surface: cross-context
+    reads of task state (`tasks/get`) and the underlying tool output
+    (`tasks/result`), plus enumeration of another context's tasks via `tasks/list`.
 
     ### Install
 


### PR DESCRIPTION
## Summary

Refreshes the hand-maintained release header for v1.5.0. The v1.4.0 header carried per-release content that is now stale: the CVE-2026-39824 block (that shipped in v1.4.0) and the "first release to carry SLSA build provenance" line (no longer the first).

The v1.5.0 header reflects the release's actual substance: a detection-accuracy wave plus the new `mcp-task-idor-001` rule. The detailed commit list still comes from the auto-generated changelog (the `fix(security):` commits route to the **Security** group).

Also trims the now-redundant header comment.

## Test plan

`.goreleaser.yaml` parses as valid YAML. No rule-count change (still 35 = 17 A2A + 18 MCP).
