### PR TITLE
fix(ci): bump every codeql-action reference together to v4.37.4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,12 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
+    # Actions published from a single repository must move together. CodeQL
+    # aborts with "Loaded a configuration file for version X, but running
+    # version Y" when init, autobuild, analyze and upload-sarif are not on the
+    # same release, so an ungrouped bump opens one PR per action and every one
+    # of them fails in isolation. Grouping makes the bump atomic.
+    groups:
+      codeql-action:
+        patterns:
+          - github/codeql-action*

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,15 +44,15 @@ jobs:
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: go
           queries: security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           category: "/language:go"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -54,6 +54,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Replaces #107, #108 and #109, which each fail CI, and fixes the root cause so it cannot recur.

## Why those three fail

Dependabot opened a separate PR for each action it found from the `github/codeql-action` repository:

| PR | Action |
|---|---|
| #109 | `codeql-action/init` |
| #107 | `codeql-action/autobuild` |
| #108 | `codeql-action/analyze` |

CodeQL requires those actions to come from the same release. On each branch only one reference moved to 4.37.4 while the others stayed at 4.37.1, so the **Autobuild** step aborted:

```
Loaded a configuration file for version '4.37.4', but running version '4.37.1'
```

Each PR is individually unmergeable but would succeed if all landed together. `Build & Test`, `Lint` and `Vulnerability Scan` pass on all three, so the Go code was never implicated.

## Changes

**1. All four references moved together.** There is a fourth reference Dependabot did not open a PR for: `codeql-action/upload-sarif` in `scorecard.yml`. Leaving it at 4.37.1 would reintroduce the same skew on the next Scorecard run, so it is included here.

- `codeql.yml`: `init`, `autobuild`, `analyze`
- `scorecard.yml`: `upload-sarif`

The 4.37.4 commit SHA (`f205ea1c3313d32999d8d6a48b4f6530d4437b38`) was resolved from the tag through the GitHub API and independently matches the SHA Dependabot proposed.

**2. Dependabot grouping.** `github/codeql-action*` updates are now grouped, so future bumps arrive as one atomic PR instead of one per action. Without this, the next codeql-action release reproduces exactly this failure.

## After merging

Close #107, #108 and #109 as superseded.

## Test plan

All three workflow files parse as valid YAML. CI on this PR exercises the real fix: `Analyze Go` must pass with all four references aligned, which is the check that fails on the split PRs.
