### PR TITLE
docs(mcp): record 2026-07-28 currency for the affected rules

### DIFF
--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -20,6 +20,27 @@ Acceptance is judged at the **protocol layer** throughout: a probe counts as
 accepted only on HTTP 200 carrying a JSON-RPC `result` envelope. A 200 with a
 JSON-RPC `error` (the common MCP rejection shape) is a rejection, not a finding.
 
+## Protocol currency
+
+These rules target the **handshake-based** MCP revisions (`2024-11-05` through
+`2025-11-25`), which establish a session with `initialize` and carry
+`Mcp-Session-Id`. That is what the reference implementations still speak: as of
+this writing `@modelcontextprotocol/server-everything` negotiates `2025-11-25`
+and does not implement `server/discover`.
+
+The **`2026-07-28`** revision makes MCP stateless. It removes the
+`initialize`/`notifications/initialized` handshake in favour of per-request
+`_meta`, removes protocol-level sessions and the `Mcp-Session-Id` header,
+removes the HTTP GET stream and `Last-Event-ID` resumability, removes
+`logging/setLevel`, and moves tasks into an extension. Support for it is
+tracked separately; individual rules whose surface changed carry a **Currency**
+note below.
+
+Rules gate on advertised capabilities and on reaching a live endpoint, so
+against a server this rule set cannot handshake with they report **inconclusive
+or skip**, never a clean pass. A target that could not be exercised is reported
+as not tested rather than as secure.
+
 | Rule ID | Attack | Severity | Confidence | CWE |
 |---|---|:---:|:---:|---|
 | `mcp-oauth-dcr-001` | [OAuth DCR Scope Escalation](#mcp-oauth-dcr-001) | High | indicator | CWE-284 |
@@ -199,6 +220,13 @@ is never changed. A server that rejects with HTTP 401/403 or an auth error, or
 does not advertise the logging capability, produces no finding. Reported
 **confirmed** at medium severity.
 
+**Currency.** `logging/setLevel` is normative in revisions 2024-11-05 through
+2025-11-25. The **2026-07-28** revision **removes the method outright** (log
+level is now set per-request via `io.modelcontextprotocol/logLevel` in `_meta`)
+and deprecates the Logging feature as a whole. This rule therefore applies to
+servers on the earlier revisions. Because it gates on the advertised `logging`
+capability, a 2026-07-28 server is skipped rather than producing a false result.
+
 ---
 
 ### mcp-task-idor-001
@@ -244,8 +272,13 @@ tool as potentially destructive by default. Because `tasks/result` blocks until 
 task is terminal, the rule polls `tasks/get` within a bounded budget and requests
 the result only once the task has finished.
 
-**Currency.** Tasks are marked experimental in 2025-11-25 and their design may
-evolve, so this rule is version-scoped.
+**Currency.** Tasks were introduced as experimental in 2025-11-25, and the
+**2026-07-28** revision moved them out of the core protocol into the
+`io.modelcontextprotocol/tasks` extension: the blocking `tasks/result` is
+replaced by polling `tasks/get`, `tasks/update` is added, and **`tasks/list` is
+removed**. This rule targets the 2025-11-25 core shape and gates on the core
+`tasks` capability, so a 2026-07-28 server advertising the extension instead is
+skipped rather than mis-tested. Covering the extension is separate work.
 
 ---
 

--- a/rules/mcp/logging-unauth-001.yaml
+++ b/rules/mcp/logging-unauth-001.yaml
@@ -28,6 +28,13 @@ info:
     The probe never changes the server's real log verbosity: the invalid level is
     rejected by a compliant server (nothing is set).
 
+    Currency: logging/setLevel is normative in revisions 2024-11-05 through
+    2025-11-25. The 2026-07-28 revision removes the method outright (log level is
+    set per-request via io.modelcontextprotocol/logLevel in _meta) and deprecates
+    the Logging feature as a whole, so this rule applies to servers on the earlier
+    revisions. A 2026-07-28 server does not advertise the logging capability, so
+    the rule's capability gate skips it rather than reporting a false result.
+
   references:
     - https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging
     - https://modelcontextprotocol.io/docs/concepts/authorization

--- a/rules/mcp/task-idor-001.yaml
+++ b/rules/mcp/task-idor-001.yaml
@@ -39,8 +39,13 @@ info:
     blocks until a task is terminal, the rule polls tasks/get within a bounded
     budget and only requests the result once the task has finished.
 
-    Currency: tasks are marked experimental in the 2025-11-25 specification and
-    their design may evolve, so this rule is version-scoped.
+    Currency: tasks were introduced as experimental in 2025-11-25, and the
+    2026-07-28 revision moved them out of the core protocol into the
+    io.modelcontextprotocol/tasks extension. The redesign replaces the blocking
+    tasks/result method with polling via tasks/get, adds tasks/update, and removes
+    tasks/list. This rule targets the 2025-11-25 core shape: it gates on the core
+    tasks capability, so a 2026-07-28 server that advertises the extension instead
+    is skipped rather than mis-tested. Covering the extension is separate work.
 
   references:
     - https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks


### PR DESCRIPTION
## Summary

Phase 0 of the MCP 2026-07-28 response: record what changed and which revisions the rules target. Documentation only, no detection behaviour changes.

## Context

The **2026-07-28** revision is now the *current* MCP protocol version, and it makes MCP stateless. It removes:

- the `initialize` / `notifications/initialized` handshake (replaced by per-request `_meta`)
- protocol-level sessions and the `Mcp-Session-Id` header
- the HTTP GET stream and `Last-Event-ID` resumability
- `logging/setLevel` (log level moves to `io.modelcontextprotocol/logLevel` in `_meta`)
- `tasks/list`, with tasks moving into the `io.modelcontextprotocol/tasks` extension

It adds a mandatory `server/discover` RPC, per-request `MCP-Protocol-Version` / `Mcp-Method` / `Mcp-Name` headers, and renumbered error codes.

**The ecosystem has not followed yet.** Probing the current reference server directly:

| Probe | Result |
|---|---|
| `server/discover` (MUST-implement in 2026-07-28) | HTTP 400, `-32000 "Server not initialized"` |
| `initialize` offering `2026-07-28` | HTTP 200, negotiated **`2025-11-25`**, minted a session ID |

So `@modelcontextprotocol/server-everything` (2026.7.4, SDK 1.30.0) is still handshake-based. That is what these rules target, and it is worth stating plainly rather than leaving readers to infer it.

## Changes

**1. A `Protocol currency` section** in the MCP catalog preamble: which revisions the rules target, what 2026-07-28 changed, and that support for it is tracked separately.

It also records a property worth being explicit about: rules gate on advertised capabilities and on reaching a live endpoint, so against a server this rule set cannot handshake with they report **inconclusive or skip, never a clean pass**. Verified rather than asserted: 14 MCP executors return `ErrInconclusive` (the #101 work).

**2. Two rules that lacked accurate notes:**

- **`mcp-logging-unauth-001`** had *no* currency note at all, despite targeting a method 2026-07-28 removes outright.
- **`mcp-task-idor-001`** said only that tasks were "experimental", omitting that they moved to an extension, that `tasks/result` is now polled via `tasks/get`, and that **`tasks/list` was removed**.

Both now state which revisions they apply to, and that their capability gate skips a 2026-07-28 server rather than producing a false result. That gate claim was verified in code (`logging_unauth.go:53`), not assumed.

Rules that already carried accurate 2026-07-28 notes (`session-fixation`, `sse-resume-replay`, `jsonrpc-batch-bypass`) are untouched.

## What this deliberately does not do

No era detection, no `server/discover`, no per-request `_meta`. Building unvalidatable protocol support against a spec no reachable server implements is how the false negatives in #100-#104 got in. That work is gated on a real 2026-07-28 server existing to test against.

## Test plan

Both YAML files parse; the bundled-rule resolver test passes; full `go test ./...` green. No em-dashes.
