### PR TITLE
feat(mcp): detect the 2026-07-28 protocol era and report it as unsupported

### DIFF
--- a/internal/attack/mcp/completion_unauth.go
+++ b/internal/attack/mcp/completion_unauth.go
@@ -73,7 +73,9 @@ func (e *CompletionUnauthExecutor) Execute(ctx context.Context, target string, o
 
 	session, err := initializeMCP(ctx, client, vars.BaseURL)
 	if err != nil {
-		return nil, attack.ErrInconclusive // not an MCP server
+		// Not reachable as a legacy MCP server; inconclusive carries the reason
+		// when the target turned out to be a modern-era server.
+		return nil, inconclusive(err)
 	}
 
 	// Skip servers that do not advertise the completions capability; probing them

--- a/internal/attack/mcp/era.go
+++ b/internal/attack/mcp/era.go
@@ -95,14 +95,17 @@ const (
 	modernErrCodeMax = -32020
 )
 
-// Named codes the specification defines in the reserved range. Detection uses
-// the range rather than this list, so a future spec-defined code is still
-// recognized, but the names make the intent legible.
-const (
-	errHeaderMismatch                  = -32020
-	errMissingRequiredClientCapability = -32021
-	errUnsupportedProtocolVersion      = -32022
-)
+// The codes the specification currently defines in the reserved range.
+// Detection deliberately keys on the range rather than this list, so a code the
+// specification adds later is still recognized as modern. The list exists so a
+// test can assert every named code really does fall inside the range that
+// isModernError accepts: if the two ever disagree, detection would miss a
+// server that identified itself with a code the specification defines.
+var specDefinedModernErrors = map[string]int{
+	"HeaderMismatch":                  -32020,
+	"MissingRequiredClientCapability": -32021,
+	"UnsupportedProtocolVersion":      -32022,
+}
 
 // isModernError reports whether a response body carries a JSON-RPC error whose
 // code falls in the range the MCP specification reserves for itself.

--- a/internal/attack/mcp/era.go
+++ b/internal/attack/mcp/era.go
@@ -1,0 +1,189 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// errModernEra marks a target that answered as a modern-era MCP server. It is
+// returned by initializeMCP instead of a generic "not found", so a rule can
+// report the target as speaking an unsupported protocol version rather than as
+// unreachable. Callers match it with errors.Is.
+var errModernEra = errors.New("server implements a protocol era these rules do not support")
+
+// IsModernEraErr reports whether err indicates the target is a modern-era MCP
+// server rather than an unreachable one.
+func IsModernEraErr(err error) bool { return errors.Is(err, errModernEra) }
+
+// inconclusive converts an initializeMCP failure into the error a rule should
+// return. Either way the rule was not exercised and the engine records it as
+// skipped rather than clean, but a modern-era target carries its reason forward
+// so the operator learns the protocol version is unsupported instead of being
+// told only that nothing was reachable.
+func inconclusive(err error) error {
+	if IsModernEraErr(err) {
+		return fmt.Errorf("%w: %s", attack.ErrInconclusive, err)
+	}
+	return attack.ErrInconclusive
+}
+
+// MCP split into two incompatible eras. Revisions up to 2025-11-25 ("legacy")
+// open with an initialize handshake and carry an Mcp-Session-Id. Revision
+// 2026-07-28 ("modern") is stateless: it removes initialize, sessions, the GET
+// stream and Last-Event-ID, and instead carries the protocol version and client
+// capabilities in each request's _meta.
+//
+// This rule set targets the legacy era. Era detection exists so a modern server
+// is reported as unsupported rather than as unreachable, which is the difference
+// between an operator seeing "this scanner does not speak your protocol version"
+// and a bare "could not connect".
+
+// Era identifies which protocol era a server implements.
+type Era int
+
+const (
+	// EraUnknown means nothing answered, so no era could be determined.
+	EraUnknown Era = iota
+	// EraLegacy is the handshake-based revisions, 2025-11-25 and earlier.
+	EraLegacy
+	// EraModern is the stateless revisions, 2026-07-28 and later.
+	EraModern
+)
+
+func (e Era) String() string {
+	switch e {
+	case EraLegacy:
+		return "legacy"
+	case EraModern:
+		return "modern"
+	default:
+		return "unknown"
+	}
+}
+
+// modernEraVersion is the protocol version offered when probing for a modern
+// server. It is deliberately separate from latestStable (the version offered in
+// legacy initialize handshakes) and from init_downgrade's modernVersion, which
+// means the revision that first mandated authorization.
+const modernEraVersion = "2026-07-28"
+
+// _meta keys the modern era requires on every request. protocolVersion and
+// clientCapabilities are both mandatory; a request missing either is malformed
+// and a compliant server rejects it with -32602.
+const (
+	metaProtocolVersion    = "io.modelcontextprotocol/protocolVersion"
+	metaClientInfo         = "io.modelcontextprotocol/clientInfo"
+	metaClientCapabilities = "io.modelcontextprotocol/clientCapabilities"
+)
+
+// The MCP specification reserves JSON-RPC error codes -32020 to -32099 for
+// itself, and states that implementations MUST NOT emit a code from that range
+// unless the specification defines it. Codes -32000 to -32019 are explicitly
+// legacy and implementation-defined, carrying no agreed meaning.
+//
+// That split is what makes era detection reliable: a code inside the reserved
+// range can only have come from a server implementing a modern revision, while
+// an implementation-defined code says nothing about era. The reference server
+// answers a modern probe with -32000 "Server not initialized", so keying on
+// "did I get a JSON-RPC error?" alone would misclassify it as modern.
+const (
+	modernErrCodeMin = -32099
+	modernErrCodeMax = -32020
+)
+
+// Named codes the specification defines in the reserved range. Detection uses
+// the range rather than this list, so a future spec-defined code is still
+// recognized, but the names make the intent legible.
+const (
+	errHeaderMismatch                  = -32020
+	errMissingRequiredClientCapability = -32021
+	errUnsupportedProtocolVersion      = -32022
+)
+
+// isModernError reports whether a response body carries a JSON-RPC error whose
+// code falls in the range the MCP specification reserves for itself.
+func isModernError(body []byte) bool {
+	code, ok := jsonRPCErrorCode(body)
+	if !ok {
+		return false
+	}
+	return code >= modernErrCodeMin && code <= modernErrCodeMax
+}
+
+// jsonRPCErrorCode extracts the numeric code from a JSON-RPC error envelope.
+// ok is false when the body is not JSON, carries no error object, or the error
+// has no numeric code.
+func jsonRPCErrorCode(body []byte) (int, bool) {
+	var envelope struct {
+		Error *struct {
+			Code *float64 `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return 0, false
+	}
+	if envelope.Error == nil || envelope.Error.Code == nil {
+		return 0, false
+	}
+	return int(*envelope.Error.Code), true
+}
+
+// detectEra determines which protocol era the server at endpoint implements by
+// sending a modern server/discover request and classifying the reply.
+//
+// server/discover is the right probe because a modern server MUST implement it,
+// so its absence is itself diagnostic. The classification follows the rule the
+// Streamable HTTP binding gives for backward compatibility: attempt a modern
+// request, and on a rejection inspect the body before concluding anything. A
+// recognized modern error means the server speaks a modern revision (the client
+// should correct its request rather than fall back); anything else means legacy.
+//
+// Only a transport failure yields EraUnknown. Any HTTP reply, including 404 or
+// 405, tells us something answered, and absent a modern error that answer is
+// legacy.
+func detectEra(ctx context.Context, client *attack.HTTPClient, endpoint string) Era {
+	headers := map[string]string{
+		// Both are REQUIRED on every modern POST. Omitting them would earn a
+		// -32020 HeaderMismatch, which is itself a modern signal, but sending
+		// them correctly keeps the probe a fair test of the server rather than
+		// of our own request.
+		"MCP-Protocol-Version": modernEraVersion,
+		"Mcp-Method":           "server/discover",
+	}
+	resp, err := client.POST(ctx, endpoint, headers, map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      "batesian-era-probe",
+		"method":  "server/discover",
+		"params": map[string]interface{}{
+			"_meta": map[string]interface{}{
+				metaProtocolVersion: modernEraVersion,
+				metaClientInfo: map[string]interface{}{
+					"name":    "batesian",
+					"version": attack.Version,
+				},
+				// Required, and deliberately empty: this probe asks only what
+				// the server is, so it needs no client capability.
+				metaClientCapabilities: map[string]interface{}{},
+			},
+		},
+	})
+	if err != nil {
+		return EraUnknown
+	}
+
+	// A DiscoverResult means the server implements the modern discovery RPC.
+	if resp.IsAccepted() {
+		return EraModern
+	}
+	// A spec-reserved error code can only come from a modern server, whatever
+	// the HTTP status carrying it.
+	if isModernError(resp.Body) {
+		return EraModern
+	}
+	// Something answered, but not as a modern server would.
+	return EraLegacy
+}

--- a/internal/attack/mcp/era_test.go
+++ b/internal/attack/mcp/era_test.go
@@ -1,0 +1,251 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// eraServer returns a server that answers every request with the given status
+// and body, which is all era detection needs to classify it.
+func eraServer(status int, body string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+func detect(t *testing.T, srv *httptest.Server) Era {
+	t.Helper()
+	opts := attack.Options{TimeoutSeconds: 5}
+	client := attack.NewUnauthHTTPClient(opts, attack.NewVars(srv.URL, ""))
+	return detectEra(context.Background(), client, srv.URL)
+}
+
+func TestDetectEra(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   Era
+		why    string
+	}{
+		{
+			name:   "discover result",
+			status: 200,
+			body:   `{"jsonrpc":"2.0","id":"x","result":{"resultType":"complete","supportedVersions":["2026-07-28"],"capabilities":{}}}`,
+			want:   EraModern,
+			why:    "a DiscoverResult can only come from a server implementing the modern discovery RPC",
+		},
+		{
+			name:   "unsupported protocol version",
+			status: 400,
+			body:   `{"jsonrpc":"2.0","id":1,"error":{"code":-32022,"message":"Unsupported protocol version","data":{"supported":["2026-07-28"]}}}`,
+			want:   EraModern,
+			why:    "-32022 is spec-reserved, so only a modern server emits it",
+		},
+		{
+			name:   "header mismatch",
+			status: 400,
+			body:   `{"jsonrpc":"2.0","id":1,"error":{"code":-32020,"message":"Header mismatch"}}`,
+			want:   EraModern,
+			why:    "-32020 is spec-reserved",
+		},
+		{
+			name:   "missing required client capability",
+			status: 400,
+			body:   `{"jsonrpc":"2.0","id":1,"error":{"code":-32021,"message":"Missing capability"}}`,
+			want:   EraModern,
+			why:    "-32021 is spec-reserved",
+		},
+		{
+			name:   "unallocated code inside the reserved range",
+			status: 400,
+			body:   `{"jsonrpc":"2.0","id":1,"error":{"code":-32050,"message":"Some future spec error"}}`,
+			want:   EraModern,
+			why:    "detection keys on the reserved range, so a future spec-defined code still reads as modern",
+		},
+		{
+			// The case that matters most. The reference server answers a modern
+			// probe with exactly this. A naive "400 plus a JSON-RPC error means
+			// modern" check would misclassify every legacy server in the wild.
+			name:   "legacy implementation-defined error",
+			status: 400,
+			body:   `{"jsonrpc":"2.0","error":{"code":-32000,"message":"Bad Request: Server not initialized"},"id":null}`,
+			want:   EraLegacy,
+			why:    "-32000 is implementation-defined and carries no era meaning",
+		},
+		{
+			name:   "method not found",
+			status: 404,
+			body:   `{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}`,
+			want:   EraLegacy,
+			why:    "-32601 is a standard JSON-RPC code, not a modern signal",
+		},
+		{
+			name:   "method not allowed with no body",
+			status: 405,
+			body:   ``,
+			want:   EraLegacy,
+			why:    "something answered but said nothing modern",
+		},
+		{
+			name:   "empty 400 body",
+			status: 400,
+			body:   ``,
+			want:   EraLegacy,
+			why:    "the spec directs a fallback when the body is empty",
+		},
+		{
+			name:   "html error page",
+			status: 400,
+			body:   `<html><body>Bad Request</body></html>`,
+			want:   EraLegacy,
+			why:    "a non-JSON body is not a modern error",
+		},
+		{
+			name:   "2xx that is not a result envelope",
+			status: 200,
+			body:   `{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"nope"}}`,
+			want:   EraLegacy,
+			why:    "a 2xx carrying a legacy error is not a DiscoverResult",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := eraServer(tt.status, tt.body)
+			defer srv.Close()
+
+			if got := detect(t, srv); got != tt.want {
+				t.Errorf("detectEra() = %v, want %v (%s)", got, tt.want, tt.why)
+			}
+		})
+	}
+}
+
+// TestDetectEra_Unreachable: nothing answered, so no era can be determined.
+func TestDetectEra_Unreachable(t *testing.T) {
+	srv := eraServer(200, `{}`)
+	srv.Close() // closed before use, so the connection fails
+
+	if got := detect(t, srv); got != EraUnknown {
+		t.Errorf("detectEra() = %v, want %v for an unreachable target", got, EraUnknown)
+	}
+}
+
+// TestDetectEra_SendsRequiredModernFields verifies the probe is a fair test of
+// the server: a modern server rejects a request missing the required headers or
+// _meta fields, so a probe that omitted them would provoke a modern error and
+// "detect" modernity that was never demonstrated.
+func TestDetectEra_SendsRequiredModernFields(t *testing.T) {
+	var gotProtoHeader, gotMethodHeader string
+	var gotBody map[string]interface{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotProtoHeader = r.Header.Get("MCP-Protocol-Version")
+		gotMethodHeader = r.Header.Get("Mcp-Method")
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(404)
+	}))
+	defer srv.Close()
+
+	_ = detect(t, srv)
+
+	if gotProtoHeader != modernEraVersion {
+		t.Errorf("MCP-Protocol-Version header = %q, want %q", gotProtoHeader, modernEraVersion)
+	}
+	if gotMethodHeader != "server/discover" {
+		t.Errorf("Mcp-Method header = %q, want %q", gotMethodHeader, "server/discover")
+	}
+	if method, _ := gotBody["method"].(string); method != "server/discover" {
+		t.Errorf("body method = %q, want server/discover", method)
+	}
+
+	params, _ := gotBody["params"].(map[string]interface{})
+	meta, _ := params["_meta"].(map[string]interface{})
+	if meta == nil {
+		t.Fatalf("request carried no _meta; a modern server requires it")
+	}
+	if v, _ := meta[metaProtocolVersion].(string); v != modernEraVersion {
+		t.Errorf("_meta[%s] = %q, want %q", metaProtocolVersion, v, modernEraVersion)
+	}
+	// clientCapabilities is REQUIRED on every modern request, so it must be
+	// present even though this probe needs no capability.
+	if _, ok := meta[metaClientCapabilities]; !ok {
+		t.Errorf("_meta is missing the required %s", metaClientCapabilities)
+	}
+	// The header value must match the body value, or a modern server answers
+	// -32020 HeaderMismatch and the probe measures our own bug.
+	if bodyVer, _ := meta[metaProtocolVersion].(string); gotProtoHeader != bodyVer {
+		t.Errorf("header/body protocol version mismatch: %q vs %q", gotProtoHeader, bodyVer)
+	}
+}
+
+// TestIsModernError covers the reserved-range boundaries directly.
+func TestIsModernError(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"lower boundary -32020", `{"error":{"code":-32020}}`, true},
+		{"upper boundary -32099", `{"error":{"code":-32099}}`, true},
+		{"just outside, legacy side", `{"error":{"code":-32019}}`, false},
+		{"just outside, below range", `{"error":{"code":-32100}}`, false},
+		{"legacy -32000", `{"error":{"code":-32000}}`, false},
+		{"standard method not found", `{"error":{"code":-32601}}`, false},
+		{"result envelope, no error", `{"result":{}}`, false},
+		{"error without a code", `{"error":{"message":"x"}}`, false},
+		{"not json", `nope`, false},
+		{"empty", ``, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isModernError([]byte(tt.body)); got != tt.want {
+				t.Errorf("isModernError(%s) = %v, want %v", tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEraString keeps the human-facing labels stable, since they appear in the
+// operator-visible skip message.
+func TestEraString(t *testing.T) {
+	for era, want := range map[Era]string{EraUnknown: "unknown", EraLegacy: "legacy", EraModern: "modern"} {
+		if got := era.String(); got != want {
+			t.Errorf("Era(%d).String() = %q, want %q", era, got, want)
+		}
+	}
+}
+
+// TestInconclusive verifies a modern-era failure carries its reason forward
+// while a plain failure stays generic, and that both remain ErrInconclusive so
+// the engine records them as skipped rather than clean.
+func TestInconclusive(t *testing.T) {
+	modernErr := fmt.Errorf("%w: http://x/mcp speaks MCP %s (stateless era), which these rules do not yet support",
+		errModernEra, modernEraVersion)
+	got := inconclusive(modernErr)
+	if !strings.Contains(got.Error(), modernEraVersion) {
+		t.Errorf("modern-era inconclusive lost its detail: %v", got)
+	}
+	if !errors.Is(got, attack.ErrInconclusive) {
+		t.Errorf("modern-era error must still be ErrInconclusive, got %v", got)
+	}
+
+	plain := inconclusive(errors.New("no MCP server found"))
+	if plain.Error() != attack.ErrInconclusive.Error() {
+		t.Errorf("plain inconclusive should stay generic, got %q", plain.Error())
+	}
+	if !errors.Is(plain, attack.ErrInconclusive) {
+		t.Errorf("plain error must be ErrInconclusive, got %v", plain)
+	}
+}

--- a/internal/attack/mcp/era_test.go
+++ b/internal/attack/mcp/era_test.go
@@ -217,6 +217,22 @@ func TestIsModernError(t *testing.T) {
 	}
 }
 
+// TestSpecDefinedModernErrorsAreDetected guards the seam between the named
+// codes the specification defines and the range detection actually keys on. If
+// a named code fell outside the range, a modern server that identified itself
+// with that code would be misread as legacy.
+func TestSpecDefinedModernErrorsAreDetected(t *testing.T) {
+	for name, code := range specDefinedModernErrors {
+		body := fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"error":{"code":%d,"message":%q}}`, code, name)
+		if !isModernError([]byte(body)) {
+			t.Errorf("%s (%d) is defined by the specification but is not detected as a modern error", name, code)
+		}
+		if code < modernErrCodeMin || code > modernErrCodeMax {
+			t.Errorf("%s (%d) falls outside the reserved range [%d, %d]", name, code, modernErrCodeMin, modernErrCodeMax)
+		}
+	}
+}
+
 // TestEraString keeps the human-facing labels stable, since they appear in the
 // operator-visible skip message.
 func TestEraString(t *testing.T) {

--- a/internal/attack/mcp/logging_unauth.go
+++ b/internal/attack/mcp/logging_unauth.go
@@ -44,7 +44,9 @@ func (e *LoggingUnauthExecutor) Execute(ctx context.Context, target string, opts
 
 	session, err := initializeMCP(ctx, client, vars.BaseURL)
 	if err != nil {
-		return nil, attack.ErrInconclusive // not an MCP server
+		// Not reachable as a legacy MCP server; inconclusive carries the reason
+		// when the target turned out to be a modern-era server.
+		return nil, inconclusive(err)
 	}
 
 	// Skip servers that do not advertise the logging capability; probing them would

--- a/internal/attack/mcp/prompt_unauth.go
+++ b/internal/attack/mcp/prompt_unauth.go
@@ -31,7 +31,9 @@ func (e *PromptUnauthExecutor) Execute(ctx context.Context, target string, opts 
 
 	session, err := initializeMCP(ctx, client, vars.BaseURL)
 	if err != nil {
-		return nil, attack.ErrInconclusive // not an MCP server
+		// Not reachable as a legacy MCP server; inconclusive carries the reason
+		// when the target turned out to be a modern-era server.
+		return nil, inconclusive(err)
 	}
 
 	// Skip servers that do not advertise the prompts capability - probing them

--- a/internal/attack/mcp/resources_unauth.go
+++ b/internal/attack/mcp/resources_unauth.go
@@ -50,7 +50,9 @@ func (e *ResourcesUnauthExecutor) Execute(ctx context.Context, target string, op
 	// MCP requires an initialize handshake before any method calls.
 	session, err := initializeMCP(ctx, client, vars.BaseURL)
 	if err != nil {
-		return nil, attack.ErrInconclusive // not an MCP server
+		// Not reachable as a legacy MCP server; inconclusive carries the reason
+		// when the target turned out to be a modern-era server.
+		return nil, inconclusive(err)
 	}
 
 	var findings []attack.Finding
@@ -210,6 +212,21 @@ func initializeMCP(ctx context.Context, client *attack.HTTPClient, baseURL strin
 		})
 
 		return session, nil
+	}
+
+	// No candidate path completed a legacy handshake. Before reporting the target
+	// as unreachable, check whether it is actually a modern (2026-07-28) server,
+	// which has no initialize method at all. Distinguishing the two is the
+	// difference between "this scanner does not speak your protocol version" and
+	// a bare "could not connect".
+	//
+	// This runs only on the failure path, so a legacy server, still the norm,
+	// pays no extra request.
+	for _, ep := range endpoints {
+		if detectEra(ctx, client, ep) == EraModern {
+			return mcpSession{}, fmt.Errorf("%w: %s speaks MCP %s (stateless era), which these rules do not yet support",
+				errModernEra, ep, modernEraVersion)
+		}
 	}
 
 	return mcpSession{}, fmt.Errorf("no MCP server found at %s", baseURL)

--- a/internal/attack/mcp/tools_unauth.go
+++ b/internal/attack/mcp/tools_unauth.go
@@ -43,7 +43,9 @@ func (e *ToolsUnauthExecutor) Execute(ctx context.Context, target string, opts a
 
 	session, err := initializeMCP(ctx, client, vars.BaseURL)
 	if err != nil {
-		return nil, attack.ErrInconclusive // not an MCP server
+		// Not reachable as a legacy MCP server; inconclusive carries the reason
+		// when the target turned out to be a modern-era server.
+		return nil, inconclusive(err)
 	}
 
 	// Skip servers that do not advertise the tools capability; probing them would

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	attackpkg "github.com/calbebop/batesian/internal/attack"
 	// Blank imports run each executor package's init(), which registers its
@@ -120,10 +121,20 @@ func (e *Engine) runOne(ctx context.Context, target string, entry planEntry, bb 
 	// A rule that could not reach a testable endpoint is recorded as skipped, not
 	// as a (misleading) clean result and not as an error.
 	if errors.Is(err, attackpkg.ErrInconclusive) {
+		// Executors may wrap ErrInconclusive with the reason the rule could not
+		// run (for example, the target speaks a protocol era these rules do not
+		// support). Surface that detail rather than discarding it: "not tested
+		// because your server speaks MCP 2026-07-28" is actionable, while a bare
+		// "could not reach a testable endpoint" invites the operator to assume a
+		// network problem. The generic prefix is preserved either way.
+		msg := "could not reach a testable endpoint"
+		if detail := inconclusiveDetail(err); detail != "" {
+			msg += ": " + detail
+		}
 		return RunResult{
 			Rule:    r,
 			Skipped: true,
-			SkipMsg: "could not reach a testable endpoint",
+			SkipMsg: msg,
 		}
 	}
 	return RunResult{
@@ -251,4 +262,17 @@ func FindingsBySeverity(results []RunResult) map[string][]attackpkg.Finding {
 		}
 	}
 	return out
+}
+
+// inconclusiveDetail returns the reason an executor attached when wrapping
+// ErrInconclusive, or "" when it wrapped nothing. Executors wrap with
+// fmt.Errorf("%w: <reason>", attack.ErrInconclusive), so the reason is whatever
+// follows the sentinel's own message.
+func inconclusiveDetail(err error) string {
+	full := err.Error()
+	base := attackpkg.ErrInconclusive.Error()
+	if !strings.HasPrefix(full, base) {
+		return ""
+	}
+	return strings.TrimPrefix(strings.TrimPrefix(full, base), ": ")
 }

--- a/internal/engine/inconclusive_test.go
+++ b/internal/engine/inconclusive_test.go
@@ -1,6 +1,8 @@
 package engine_test
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -33,5 +35,50 @@ func TestRun_UnreachableA2ARuleIsInconclusive(t *testing.T) {
 	if !res.Skipped || !strings.Contains(res.SkipMsg, "could not reach") {
 		t.Errorf("expected inconclusive skip, got skipped=%v msg=%q err=%v findings=%d",
 			res.Skipped, res.SkipMsg, res.Err, len(res.Findings))
+	}
+}
+
+// TestRun_ModernEraServerReportsUnsupportedProtocol verifies the end-to-end
+// path: an MCP rule pointed at a stateless (2026-07-28) server is skipped with a
+// message naming the protocol era, not with a bare "could not reach". The
+// distinction matters to an operator, who would otherwise assume a network fault
+// when the real cause is that these rules do not speak the server's version.
+func TestRun_ModernEraServerReportsUnsupportedProtocol(t *testing.T) {
+	// A modern server: it has no initialize method, and answers the era probe
+	// with a spec-reserved error code.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32022,` +
+			`"message":"Unsupported protocol version","data":{"supported":["2026-07-28"]}}}`))
+	}))
+	defer srv.Close()
+
+	loaded, _, err := rules.LoadFS(batesian.RulesFS())
+	if err != nil {
+		t.Fatalf("LoadFS: %v", err)
+	}
+	var r *rules.Rule
+	for _, x := range loaded {
+		if x.ID == "mcp-tools-unauth-001" {
+			r = x
+			break
+		}
+	}
+	if r == nil {
+		t.Skip("mcp-tools-unauth-001 not present")
+	}
+
+	res := engine.New(attack.Options{TimeoutSeconds: 5}).Run(t.Context(), srv.URL, []*rules.Rule{r})[0]
+	if !res.Skipped {
+		t.Fatalf("expected a skipped result, got skipped=%v err=%v findings=%d", res.Skipped, res.Err, len(res.Findings))
+	}
+	// The generic prefix is preserved so existing reporting keeps working.
+	if !strings.Contains(res.SkipMsg, "could not reach") {
+		t.Errorf("skip message lost its generic prefix: %q", res.SkipMsg)
+	}
+	// And the actionable detail is present.
+	if !strings.Contains(res.SkipMsg, "2026-07-28") {
+		t.Errorf("skip message should name the unsupported protocol era, got %q", res.SkipMsg)
 	}
 }


### PR DESCRIPTION
## Summary

Phase 1 of the MCP 2026-07-28 response: detect which protocol era a server implements, and report a modern server as *unsupported* rather than as *unreachable*.

MCP 2026-07-28 is now the current revision and it is **stateless**: no `initialize` handshake, no `Mcp-Session-Id`, no GET stream. These rules speak the handshake era, so against such a server every MCP rule fails to initialize and reports only `could not reach a testable endpoint`. That reads as a network fault when the real cause is a protocol version this scanner does not implement.

## The load-bearing detail

Classification keys on the JSON-RPC error range the specification **reserves for itself** (`-32020` to `-32099`), not on the presence of a JSON-RPC error.

That distinction is the whole design. I probed the reference server and it answers a modern request with:

```
HTTP 400  {"error":{"code":-32000,"message":"Bad Request: Server not initialized"}}
```

`-32000` is in the range the spec calls *legacy, implementation-defined, carrying no agreed meaning*. A check for "did I get a 400 with a JSON-RPC error?" would classify **every deployed legacy server as modern**. A test posture pins that exact body.

The probe also sends the headers and `_meta` fields a modern request requires (`MCP-Protocol-Version`, `Mcp-Method`, `io.modelcontextprotocol/protocolVersion`, `clientCapabilities`). Omitting them would earn a `-32020 HeaderMismatch`, which is itself a modern signal, so a malformed probe would "detect" modernity it never demonstrated. `TestDetectEra_SendsRequiredModernFields` asserts the probe is well-formed for exactly that reason.

## Behaviour

A modern target now reports:

```
could not reach a testable endpoint: http://host/mcp speaks MCP 2026-07-28
(stateless era), which these rules do not yet support
```

The generic prefix is preserved, so existing reporting and tests are unaffected.

The engine previously **discarded** any detail wrapped around `ErrInconclusive`, despite its own doc comment inviting callers to attach some (`Wrap it with %w to attach detail`). It now appends that detail to the skip message.

## Cost on the legacy path: none

Detection runs **only after** the legacy handshake has failed. Verified against the live reference server rather than assumed: its request log shows **0 `server/discover` requests** across 7 POSTs in a full scan.

One honest caveat: under `--dry-run` the probe *does* appear, because no request succeeds in a dry run so every path falls through to detection. That is correct for a traffic preview, but worth knowing when reading dry-run output.

## Validation

- **26 subtests.** All three named spec codes, an unallocated code inside the reserved range (proving future spec codes still classify correctly), both range boundaries, the reference server's `-32000`, `-32601`, 404, 405, empty body, HTML body, and a 2xx that is not a result envelope.
- **End-to-end engine test**: an MCP rule against a modern server is skipped with a message naming the era, while keeping the generic prefix.
- **Live regression**: the real reference server still handshakes and produces all 3 expected findings. Nothing about legacy behaviour changed.
- Full `go test -race ./...`, `gofmt`, `go vet` all clean.

## Scope

Detection and reporting only. **No rule changes behaviour**, and no modern protocol support is added. That work stays gated on a real 2026-07-28 server existing to validate against, which as of this PR there is not: the reference server negotiates `2025-11-25` and does not implement the mandatory `server/discover`.

A naming note: `era.go` uses `modernEraVersion` rather than `modernVersion`, because `init_downgrade.go` already defines `modernVersion` to mean the revision that first mandated authorization. Different concepts, so they get different names.
