### PR TITLE
chore(ci): watch for the MCP era gate, and stop hand-writing release notes

### DIFF
--- a/.github/scripts/mcp_era_probe.py
+++ b/.github/scripts/mcp_era_probe.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Probe the MCP reference server to see whether it speaks the 2026-07-28 era.
+
+Batesian's MCP rules target the handshake-based revisions. Modern-era rule work
+is gated on a real stateless server existing to validate against, and this
+script is what watches for that. It boots the reference server, sends a modern
+server/discover request, and classifies the reply.
+
+Classification mirrors internal/attack/mcp/era.go exactly: the MCP
+specification reserves JSON-RPC error codes -32020 to -32099 for itself, so a
+code in that range can only come from a modern server, while -32000 to -32019
+is implementation-defined and says nothing about era. The reference server
+answers this probe with -32000 "Server not initialized", so a check for "did I
+get a JSON-RPC error" would call every legacy server modern.
+
+Writes era=legacy|modern|unknown to GITHUB_OUTPUT. Exits non-zero only when the
+probe itself could not be run, so a genuine "still legacy" result is a quiet
+success rather than a failing job.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+PORT = os.environ.get("PROBE_PORT", "3180")
+ENDPOINT = f"http://127.0.0.1:{PORT}/mcp"
+MODERN_VERSION = "2026-07-28"
+
+# The range the specification reserves for itself. Keep in sync with
+# modernErrCodeMin / modernErrCodeMax in internal/attack/mcp/era.go.
+MODERN_ERR_MIN = -32099
+MODERN_ERR_MAX = -32020
+
+
+def parse_body(raw: bytes, content_type: str):
+    """Decode a JSON-RPC body, unwrapping an SSE frame when the server streams.
+
+    An SSE event's payload may span several data: lines, and blank data: lines
+    are keep-alives, so take the first non-empty one that parses.
+    """
+    text = raw.decode("utf-8", errors="replace")
+    if "event-stream" in content_type:
+        for line in text.splitlines():
+            if line.startswith("data:"):
+                payload = line[5:].strip()
+                if payload:
+                    try:
+                        return json.loads(payload)
+                    except json.JSONDecodeError:
+                        continue
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+def classify(status: int, body) -> str:
+    """Return 'modern' or 'legacy' for a server/discover reply."""
+    if isinstance(body, dict):
+        # A DiscoverResult means the server implements the modern discovery RPC.
+        if isinstance(body.get("result"), dict) and 200 <= status < 300:
+            return "modern"
+        error = body.get("error")
+        if isinstance(error, dict):
+            code = error.get("code")
+            if isinstance(code, int) and MODERN_ERR_MIN <= code <= MODERN_ERR_MAX:
+                return "modern"
+    return "legacy"
+
+
+def probe():
+    """Send a well-formed modern server/discover request and classify the reply.
+
+    The request carries the headers and _meta fields a modern request requires.
+    A malformed probe would earn -32020 HeaderMismatch, which is itself a modern
+    signal, so it would report modernity it never demonstrated.
+    """
+    payload = json.dumps({
+        "jsonrpc": "2.0",
+        "id": "era-watch",
+        "method": "server/discover",
+        "params": {
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": MODERN_VERSION,
+                "io.modelcontextprotocol/clientInfo": {"name": "batesian-era-watch", "version": "1.0"},
+                "io.modelcontextprotocol/clientCapabilities": {},
+            }
+        },
+    }).encode()
+
+    request = urllib.request.Request(
+        ENDPOINT,
+        data=payload,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+            "MCP-Protocol-Version": MODERN_VERSION,
+            "Mcp-Method": "server/discover",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            status, raw = response.status, response.read()
+            ctype = response.headers.get("Content-Type", "")
+    except urllib.error.HTTPError as exc:
+        # A rejection is expected and informative: the body decides the era.
+        status, raw = exc.code, exc.read()
+        ctype = exc.headers.get("Content-Type", "") if exc.headers else ""
+    except Exception as exc:  # noqa: BLE001 - any transport failure is inconclusive
+        return "unknown", f"probe could not reach {ENDPOINT}: {exc}"
+
+    body = parse_body(raw, ctype)
+    era = classify(status, body)
+    rendered = json.dumps(body) if body is not None else raw.decode("utf-8", errors="replace")
+    detail = f"HTTP {status}\n{rendered[:600]}"
+    return era, detail
+
+
+def emit(era: str, detail: str) -> None:
+    print(f"era={era}")
+    print(detail)
+    out = os.environ.get("GITHUB_OUTPUT")
+    if not out:
+        return
+    with open(out, "a", encoding="utf-8") as handle:
+        handle.write(f"era={era}\n")
+        # Multi-line values need the heredoc form.
+        handle.write("detail<<PROBE_EOF\n")
+        handle.write(detail + "\n")
+        handle.write("PROBE_EOF\n")
+
+
+def main() -> int:
+    # shell=True on Windows, where npx is a .cmd shim that Popen cannot exec
+    # directly. CI runs Linux, but keeping this portable means the script can be
+    # run by hand to check the gate without waiting for the weekly job.
+    npx = ["npx", "-y", "@modelcontextprotocol/server-everything", "streamableHttp"]
+    server = subprocess.Popen(
+        " ".join(npx) if os.name == "nt" else npx,
+        shell=os.name == "nt",
+        env={**os.environ, "PORT": PORT},
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        # npx may need to fetch the package before the server binds.
+        deadline = time.time() + 120
+        while time.time() < deadline:
+            if server.poll() is not None:
+                emit("unknown", "reference server exited before it accepted connections")
+                return 1
+            try:
+                urllib.request.urlopen(f"http://127.0.0.1:{PORT}/", timeout=2)
+                break
+            except urllib.error.HTTPError:
+                break  # answering at all means it is listening
+            except Exception:  # noqa: BLE001
+                time.sleep(2)
+        else:
+            emit("unknown", "reference server did not start within the timeout")
+            return 1
+
+        era, detail = probe()
+        emit(era, detail)
+        # Only a broken probe is a failure. "Still legacy" is the expected
+        # steady state and must not page anyone.
+        return 1 if era == "unknown" else 0
+    finally:
+        server.terminate()
+        try:
+            server.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            server.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/mcp-era-watch.yml
+++ b/.github/workflows/mcp-era-watch.yml
@@ -1,0 +1,99 @@
+name: MCP era watch
+
+# Batesian's MCP rules target the handshake-based protocol revisions. The
+# 2026-07-28 revision is stateless and is the current specification, but as of
+# writing no reference implementation speaks it: the reference server still
+# negotiates 2025-11-25 and does not implement the mandatory server/discover.
+#
+# Adding modern-era rules before a real server exists would mean writing
+# detection nobody can validate, which is how false negatives have reached this
+# repository before. So that work is deliberately gated on the ecosystem moving.
+#
+# This job watches for that. It boots the reference server each week and asks it
+# server/discover. When the answer stops looking legacy, it opens an issue. It
+# does nothing at all while the answer stays the same, so a quiet repo means the
+# gate is still closed rather than that someone forgot to look.
+
+on:
+  schedule:
+    # Weekly, Tuesday 07:23 UTC. An odd minute keeps this off the top-of-hour
+    # spike that every scheduled workflow lands on.
+    - cron: '23 7 * * 2'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: Probe the reference server
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Probe for modern-era support
+        id: probe
+        run: python3 .github/scripts/mcp_era_probe.py
+        env:
+          PROBE_PORT: '3180'
+
+      - name: Open an issue when the ecosystem has moved
+        if: steps.probe.outputs.era == 'modern'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const marker = '<!-- mcp-era-watch -->';
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'mcp-era',
+            });
+            if (existing.data.some(i => i.body && i.body.includes(marker))) {
+              core.info('An open era-watch issue already exists; not filing another.');
+              return;
+            }
+            const detail = process.env.PROBE_DETAIL || '(no detail captured)';
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'MCP reference server now speaks the 2026-07-28 era',
+              labels: ['mcp-era'],
+              body: [
+                marker,
+                '',
+                'The weekly era probe found that the reference MCP server now answers',
+                '`server/discover` as a modern-era server. The gate on Phase 2 and Phase 3',
+                'of the 2026-07-28 work is therefore lifted: there is now a real server to',
+                'validate modern-era rules against.',
+                '',
+                '## What the probe saw',
+                '',
+                '```',
+                detail,
+                '```',
+                '',
+                '## What this unblocks',
+                '',
+                '- **Phase 2**: modern transport support (`server/discover`, per-request `_meta`,',
+                '  the required `MCP-Protocol-Version` / `Mcp-Method` / `Mcp-Name` headers).',
+                '- **Phase 3**: per-rule triage. Most unauth rules port (the methods survive,',
+                '  only the transport changed). `mcp-logging-unauth-001` targets a method the',
+                '  revision removes. `mcp-sse-resume-replay-001` loses its surface entirely.',
+                '  `mcp-task-idor-001` needs rewriting for the tasks extension shape.',
+                '- New surface the revision introduces: `x-mcp-header` injection, MRTR state',
+                '  handling, and `cacheScope: public` on sensitive results.',
+                '',
+                'Era detection itself already ships, so until this work lands a modern server',
+                'is reported as unsupported rather than as unreachable.',
+              ].join('\n'),
+            });
+        env:
+          PROBE_DETAIL: ${{ steps.probe.outputs.detail }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -125,35 +125,28 @@ release:
   draft: false
   prerelease: auto
   name_template: "v{{.Version}}"
-  # The rule count and any per-release sections in the header below are reviewed
-  # before each tag. Keep them current; the auto-generated changelog lists the
-  # commits.
+  # The header is intentionally evergreen: it describes what Batesian is, not
+  # what changed in a particular release. Per-release narrative used to live here
+  # and went stale every time, because it had to be rewritten by hand before each
+  # tag and nothing failed when it was not. The generated changelog below already
+  # lists every change, grouped by Security, New attack rules, Features and Bug
+  # fixes, with a link to each PR.
+  #
+  # The one value here that still needs a human is the rule count, since
+  # goreleaser has no variable for it. Verify it against `ls rules/*/*.yaml | wc -l`
+  # before tagging.
   header: |
     ## Batesian {{.Version}}
 
     Adversarial red-team CLI for AI agent protocols (A2A and MCP).
     35 bundled attack rules (17 A2A + 18 MCP). Single binary. No runtime dependencies.
 
-    ### Detection accuracy
+    Every release is published with a cosign signature over `checksums.txt`, a
+    CycloneDX SBOM per archive, and SLSA build provenance. Verify provenance with:
 
-    This release fixes several false negatives and false positives in the core
-    detection logic, surfaced by validating against third-party reference servers
-    rather than self-authored fixtures. The HTTP client no longer follows
-    redirects: a 302 to a login page was being read as a successful call, and a
-    redirect could carry the operator's bearer token to a third-party host. A 2xx
-    response that is not valid JSON with a `result` envelope is no longer treated
-    as a successful JSON-RPC call. MCP rules now report inconclusive instead of
-    clean when no endpoint is reachable, offer current protocol versions so
-    current servers no longer reject the handshake, send the `Mcp-Protocol-Version`
-    header on follow-ups, rejoin multi-line SSE events so chunked responses are
-    not dropped, and treat any non-auth JSON-RPC error (not only `-32602`) as proof
-    an unauthenticated probe reached the handler.
-
-    ### New rule
-
-    `mcp-task-idor-001` covers the MCP 2025-11-25 tasks surface: cross-context
-    reads of task state (`tasks/get`) and the underlying tool output
-    (`tasks/result`), plus enumeration of another context's tasks via `tasks/list`.
+    ```bash
+    gh attestation verify batesian_<version>_<platform>.tar.gz --repo calbebop/batesian
+    ```
 
     ### Install
 


### PR DESCRIPTION
## Summary

Removes two recurring manual steps, both of which had already failed in practice.

## 1. The release header stops going stale

It carried a hand-written per-release narrative that was wrong before every tag:

- **v1.4.0** shipped describing a CVE it had already fixed, and claiming to be the first release with SLSA provenance.
- **v1.5.0**'s detection-accuracy narrative was stale the moment it published.

Nothing failed when the prose was wrong, so it stayed wrong until someone noticed. The pattern was the problem, not any individual lapse.

The header is now **evergreen**: what Batesian is, plus the supply-chain guarantees every release carries (cosign signature, per-archive SBOM, SLSA provenance, with the verify command). Per-release detail comes from the generated changelog, which already does this well. From v1.5.0's actual output:

```
### Security
* fix(security): MCP rules report inconclusive when no endpoint is reachable (#101)
* fix(security): detect MCP dispatch without auth for non-(-32602) errors (#104)
...
### Features
* feat(mcp-task-idor-001): detect cross-context MCP task and result access (#93)
```

Grouped, PR-linked, one line per change. I checked that before deleting the prose rather than assuming it would suffice.

The **rule count** is the one value still needing a human, because goreleaser has no variable for it. The comment says so and gives the command to verify it.

## 2. The MCP era gate is now watched, not remembered

Phase 2 and 3 of the 2026-07-28 work are gated on a real stateless server existing to validate against, because writing detection nobody can verify is exactly how the false negatives in #100-#104 reached this repo. That gate depended on someone remembering to check, which is not a mechanism.

A weekly workflow now boots the reference server, sends a modern `server/discover` request, and **opens an issue only when the answer stops looking legacy**. It is silent otherwise, so a quiet repo means the gate is genuinely still closed rather than unchecked. The issue it files spells out what becomes unblocked (Phase 2 transport, Phase 3 per-rule triage, and the new surface the revision introduces).

### The probe mirrors the scanner

Classification keys on the JSON-RPC range the spec **reserves for itself** (`-32020` to `-32099`), matching `internal/attack/mcp/era.go`. The reference server answers this probe with:

```
HTTP 400  {"error":{"code":-32000,"message":"Bad Request: Server not initialized"}}
```

`-32000` is implementation-defined, so keying on "did I get an error" would report **every deployed legacy server as modern**.

## Validation

- **Ran the probe end to end** against the live reference server: correctly reports `legacy`, writes valid `GITHUB_OUTPUT` (including the multi-line heredoc), exits **0**.
- **Ten classification cases** checked against the Go implementation, including all three named spec codes, an unallocated code inside the reserved range, both boundaries, the `-32000` case, `-32601`, 404, 405, and a 2xx carrying a legacy error. Zero mismatches.
- Only a broken probe exits non-zero, so "still legacy" does not fail the job.
- Both YAML files parse, the script compiles, every workflow action is SHA-pinned, `go test -race ./...` and the unused check are clean.

One fix worth noting: I initially labelled the `github-script` pin `v7.0.1`; resolving the SHA through the API showed it is **v7.1.0**. The pin was right, the comment was wrong, and a wrong comment misleads the next reader.
