### PR TITLE
fix(a2a): accept the v1.0 enum spelling of task states in looksLikeTask

### DIFF
--- a/docs/rules-a2a.md
+++ b/docs/rules-a2a.md
@@ -13,6 +13,27 @@ Each finding carries a **confidence**:
 - **indicator** - a suspicious posture was observed but exploitation could not be
   proven from the response alone; manual verification is recommended.
 
+## Protocol currency
+
+These rules target **A2A v1.0** (the current released version, v1.0.1 as of this
+writing) and fall back to the **v0.3** shapes where they differ, so a deployment
+on either revision is exercised. In practice that means sending the v1.0
+PascalCase methods with the `A2A-Version: 1.0` header first and retrying with the
+v0.3 slash methods, and reading both the v1.0 `securityRequirements` and the v0.3
+`security` field from an agent card.
+
+Unlike MCP, A2A has had no restructuring revision: v1.0.1 is a patch that fixed
+specification inconsistencies rather than changing the protocol. Two of its
+changes touch this rule set:
+
+- **Task states** are documented in the proto enum form (`TASK_STATE_CANCELED`)
+  rather than the lowercase strings (`canceled`) v0.3 used. Detection accepts
+  both spellings, since a rule gated on recognizing a task state would otherwise
+  go silent against a compliant server.
+- **`application/a2a+json`** is now the preferred content type for the HTTP+JSON
+  binding. It is a SHOULD rather than a MUST, and the JSON-RPC binding these
+  rules primarily drive explicitly keeps `application/json`.
+
 | Rule ID | Attack | Severity | Confidence | CWE |
 |---|---|:---:|:---:|---|
 | `a2a-extcard-unauth-001` | [Extended Agent Card Unauthenticated Disclosure](#a2a-extcard-unauth-001) | High | confirmed | CWE-862 |

--- a/internal/attack/a2a/session_smuggle.go
+++ b/internal/attack/a2a/session_smuggle.go
@@ -239,9 +239,20 @@ func isAgentRole(v interface{}) bool {
 }
 
 // looksLikeTask returns true if the body resembles an A2A task response.
+//
+// Task states appear in two spellings. v0.3 used lowercase strings ("working"),
+// while v1.0 carries the proto enum ("TASK_STATE_WORKING"), and A2A v1.0.1
+// standardized the specification's own examples on the enum form. Both are
+// matched, because this gates whether a finding is reported at all: a server
+// whose task body carried only the enum state would otherwise be read as not a
+// task, and the rule would stay silent against a target it should flag.
 func looksLikeTask(body []byte) bool {
 	s := string(body)
-	return containsAnyStr(s, `"contextId"`, `"taskId"`, `"working"`, `"submitted"`, `"kind":"task"`)
+	return containsAnyStr(s,
+		`"contextId"`, `"taskId"`, `"kind":"task"`,
+		`"working"`, `"submitted"`,
+		"TASK_STATE_WORKING", "TASK_STATE_SUBMITTED",
+	)
 }
 
 // extractTaskContext extracts the taskId and contextId from a JSON-RPC task result.

--- a/internal/attack/a2a/taskstate_test.go
+++ b/internal/attack/a2a/taskstate_test.go
@@ -1,0 +1,98 @@
+package a2a
+
+import "testing"
+
+// A2A carries task states in two spellings. v0.3 used lowercase strings
+// ("working"), v1.0 carries the proto enum ("TASK_STATE_WORKING"), and v1.0.1
+// standardized the specification's own examples on the enum form. Detection
+// helpers that recognize a task by its state must accept both, or a rule gated
+// on them stays silent against a compliant server.
+
+func TestLooksLikeTask_AcceptsBothStateSpellings(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "v0.3 lowercase state only",
+			body: `{"result":{"status":{"state":"working"}}}`,
+			want: true,
+		},
+		{
+			name: "v1.0 enum state only",
+			body: `{"result":{"status":{"state":"TASK_STATE_WORKING"}}}`,
+			want: true,
+		},
+		{
+			name: "v1.0 enum submitted only",
+			body: `{"result":{"status":{"state":"TASK_STATE_SUBMITTED"}}}`,
+			want: true,
+		},
+		{
+			name: "id fields with no state at all",
+			body: `{"result":{"contextId":"c-1"}}`,
+			want: true,
+		},
+		{
+			name: "task kind marker",
+			body: `{"result":{"kind":"task"}}`,
+			want: true,
+		},
+		{
+			name: "not a task",
+			body: `{"result":{"messageId":"m-1","parts":[]}}`,
+			want: false,
+		},
+		{
+			name: "error envelope",
+			body: `{"error":{"code":-32001,"message":"Task not found"}}`,
+			want: false,
+		},
+		{
+			name: "empty",
+			body: ``,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := looksLikeTask([]byte(tt.body)); got != tt.want {
+				t.Errorf("looksLikeTask(%s) = %v, want %v", tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
+// bodyShowsCanceled already accepted both spellings when a2a-task-cancel-idor-001
+// was written. This pins that, so a later simplification cannot quietly drop the
+// enum form and leave the rule unable to confirm a cancellation.
+func TestBodyShowsCanceled_AcceptsBothStateSpellings(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"v0.3 lowercase", `{"result":{"status":{"state":"canceled"}}}`, true},
+		{"v1.0 enum", `{"result":{"status":{"state":"TASK_STATE_CANCELED"}}}`, true},
+		{"still working", `{"result":{"status":{"state":"working"}}}`, false},
+		{"enum working", `{"result":{"status":{"state":"TASK_STATE_WORKING"}}}`, false},
+		{
+			// "cancelable" is a different word: a not-cancelable error must not
+			// be read as proof the task was canceled.
+			name: "TaskNotCancelableError is not a cancellation",
+			body: `{"error":{"code":-32002,"message":"TaskNotCancelableError"}}`,
+			want: false,
+		},
+		{"empty", ``, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bodyShowsCanceled([]byte(tt.body)); got != tt.want {
+				t.Errorf("bodyShowsCanceled(%s) = %v, want %v", tt.body, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

A2A currency review. Unlike MCP, A2A has **no restructuring revision**: v1.0 is still current. But the review found one real staleness bug and one inaccurate doc claim.

## What the review found

The spec site says the current version is **1.0.0**. The release feed says otherwise: **v1.0.1 shipped 2026-05-28**, two months ago. Its three changes are specification-consistency fixes rather than protocol changes, and two touch this rule set:

| Change | Impact |
|---|---|
| **#1801** task states documented as the proto enum (`TASK_STATE_CANCELED`) rather than lowercase (`canceled`) | **Real bug, fixed here** |
| **#1753** `application/a2a+json` preferred for HTTP+JSON | No action: it is a **SHOULD**, and the PR explicitly keeps JSON-RPC on `application/json`, which is the binding these rules primarily drive |
| **#1627** transcoding error changes | No touchpoint |

## The bug

`looksLikeTask` matched only `"working"` and `"submitted"`, never the enum form.

That matters because it **gates whether `a2a-session-smuggle-001` reports at all** (`session_smuggle.go:102`): a body it does not recognize as a task is treated as a rejection and the rule goes silent. In practice the check also matches `contextId` / `taskId` / `kind:"task"`, so a real task body would usually still be recognized. But a server returning only the enum state and none of the id fields would be missed. That is resilience by accident, and the failure mode is the silent one this scanner exists to prevent.

Worth noting: the role check two functions away in the same file already accepted `ROLE_AGENT` alongside `"agent"`. The pattern was known, just not applied here.

`bodyShowsCanceled` already handled both spellings, deliberately, from when `a2a-task-cancel-idor-001` was written. A test now pins that so a later simplification cannot quietly drop the enum form.

## Validation

- 14 new subtests across both helpers.
- **Confirmed the test is not decoration**: reverted the fix, watched exactly the two enum cases fail, restored it and watched them pass.
- Full `go test -race ./...`, `gofmt`, `go vet`, and the unused check all clean.

## A separate pre-existing problem, flagged not bundled

While live-validating I found `a2a-session-smuggle-001` reports **nothing** against its own fixture on port 9998, which `testdata/README.md` claims covers it.

I checked whether I caused it: **main behaves identically**, so it is not a regression from this change.

Root cause is the fixture, not the rule. It accepts `role:agent` correctly, but its `GetTask` handler returns a **hardcoded** history (`"original user message"` / `"agent response with sensitive context"`) that never contains the scanner's unique marker. The rule searches history for its marker under an agent role, does not find it, and correctly declines to confirm. Declining to confirm what it cannot verify is the behaviour we want.

That is unrelated to protocol currency, so it is filed as separate work rather than folded in here.

## Doc

Adds a `Protocol currency` section to the A2A catalog, matching the one added for MCP: which revisions the rules target, how the v1.0/v0.3 fallbacks work, and what v1.0.1 did and did not change.
