### PR TITLE
fix(testdata): make the A2A lab fixture actually exercise two rules it claims

### DIFF
--- a/testdata/README.md
+++ b/testdata/README.md
@@ -26,7 +26,7 @@ fixtures for live-validation / manual smoke testing.
 
 | File | Port | Rules covered |
 |---|---|---|
-| `a2a_vulnerable_server.py` | 9998 | `a2a-extcard-unauth-001`, `a2a-push-ssrf-001`, `a2a-session-smuggle-001`, `a2a-task-idor-001`, `a2a-peer-impersonation-001`, `a2a-jws-algconf-001` |
+| `a2a_vulnerable_server.py` | 9998 | `a2a-extcard-unauth-001`, `a2a-push-ssrf-001`, `a2a-session-smuggle-001`, `a2a-peer-impersonation-001`; `a2a-task-idor-001` and `a2a-jws-algconf-001` are silent here by design (see note below) |
 | `a2a_new_rules_server.py` | 3101 | `a2a-wellknown-hostinject-001`, `a2a-artifact-tamper-001` |
 | `a2a_multitenant_server.py` | 3102 | `a2a-multitenant-isolation-001` (two tenants; needs two `--principal`s) |
 | `a2a_delegation_server.py` | 3103 | `a2a-delegation-integrity-001` (two principals; needs two `--principal`s) |
@@ -69,6 +69,24 @@ blackboard.
 > Note: some multi-rule Python servers may still carry leftover routes from rules
 > that were pruned from the scanner. Only the rule IDs listed in the table above
 > are part of the current rule set.
+
+**A rule staying silent against its fixture is not always a fixture bug.** Two
+rules on `a2a_vulnerable_server.py` are silent by design, because the fixture
+does not exhibit what they test for:
+
+- `a2a-task-idor-001` requires authentication to be enforced on task creation, so
+  that reading a task back without credentials demonstrates broken *authorization*
+  rather than absent *authentication*. This fixture enforces no authentication at
+  all, so the rule's discriminator correctly suppresses the finding. That
+  no-auth exposure is `a2a-peer-impersonation-001`'s territory, and it does fire.
+- `a2a-jws-algconf-001` analyses JWS signatures on the agent card. This fixture
+  deliberately serves an unsigned card, so there is nothing to analyse.
+
+When adding a fixture, confirm the rule actually fires against it rather than
+assuming coverage from the registry table. `a2a-session-smuggle-001` was listed
+here for a long time while the fixture returned a hardcoded task history that
+could never contain the scanner's marker, so the rule could never confirm the
+injection and always reported nothing.
 
 ---
 

--- a/testdata/a2a_vulnerable_server.py
+++ b/testdata/a2a_vulnerable_server.py
@@ -148,6 +148,17 @@ async def handle_send_message(req_id, params: dict) -> Response:
                 "parts": [{"text": f"Echo: {text_in}" + (f"\n{delegation_note}" if delegation_note else "")}]
             }
         ],
+        # Vulnerability: the submitted message is stored in history with the role
+        # the CLIENT claimed, rather than being normalized to the user role. This
+        # is what makes the smuggling real: a client-supplied role:agent turn ends
+        # up in the conversation history an LLM later reads as server-originated.
+        # Storing the message verbatim also means a scanner's unique marker is
+        # retrievable, so the injection can actually be confirmed rather than
+        # merely suspected.
+        "history": [
+            {"role": 1, "parts": [{"text": "original user message"}]},
+            {"role": role, "parts": parts},
+        ],
     }
     TASK_STORE[task_id] = task
 
@@ -160,15 +171,20 @@ def handle_get_task(req_id, params: dict) -> Response:
     task = TASK_STORE.get(task_id)
     if task is None:
         return jsonrpc_error(req_id, -32602, "Task not found")
-    return JSONResponse({"jsonrpc": "2.0", "id": req_id, "result": {**task, "history": [
-        {"role": 1, "parts": [{"text": "original user message"}]},
-        {"role": 2, "parts": [{"text": "agent response with sensitive context"}]},
-    ]}})
+    # The task already carries the history recorded when the message was
+    # submitted. Returning that, rather than a canned transcript, is what lets a
+    # caller observe which role the server actually stored.
+    return JSONResponse({"jsonrpc": "2.0", "id": req_id, "result": task})
 
 
 async def handle_push_config(req_id, params: dict) -> Response:
+    # Deployments carry the callback either nested under pushNotificationConfig
+    # (the v0.3 shape) or flat on params (the shape the a2a-sdk v1.0 two-step
+    # uses). Accept both, so this fixture exercises a caller that sends either.
     config = params.get("pushNotificationConfig", {})
-    callback_url = config.get("url", "")
+    callback_url = config.get("url", "") or params.get("pushNotificationUrl", "")
+    if not config:
+        config = {"url": callback_url, "token": params.get("token", "")}
 
     # Vulnerability: makes outbound HTTP request to caller-supplied URL
     if callback_url:


### PR DESCRIPTION
## Summary

The registry listed `a2a_vulnerable_server.py` (port 9998) as covering six rules. **Two of them could never fire against it**, so both had been shipping with no end-to-end validation at all, only unit harnesses.

Scanning the fixture went from **2 findings to 5**.

## The two gaps

**`a2a-session-smuggle-001`** confirms the injection by sending a message carrying a unique marker, then reading the task history back to see whether that marker was stored under an *agent* role. The fixture discarded the submitted message and returned a hardcoded transcript:

```json
"history":[{"role":1,"parts":[{"text":"original user message"}]},
           {"role":2,"parts":[{"text":"agent response with sensitive context"}]}]
```

The marker was never present, so confirmation always failed and the rule reported nothing. The fixture now records the submitted message in history **with the role the client claimed**, which is what makes the smuggling real: a client-supplied agent turn ends up in the history an LLM later reads as server-originated.

Verified end to end, with evidence citing the actual marker:

```
confidence: confirmed
taskId: 4ed9b05e-...
injected marker stored as agent role in history
marker: batesian-roleinj-9424035166bb
```

**`a2a-push-ssrf-001`** sends the callback flat on `params` as `pushNotificationUrl` (the shape the a2a-sdk v1.0 two-step uses), while the fixture read it only from the nested `pushNotificationConfig` object. The URL was empty, so no outbound request fired. The fixture now accepts either shape, and the rule gets an **OOB-confirmed** finding.

**Neither change touches rule code.** Both rules were behaving correctly, including declining to confirm what they could not verify.

## Registry corrected

I initially wrote that `push-ssrf` merely "needs `--oob-url`". Testing showed it did not fire even with the built-in OOB listener, which is what led to the nested-vs-flat discovery. Worth noting because the first explanation was plausible and wrong.

Two rules are silent here **by design**, now documented rather than implied:

- `a2a-task-idor-001` needs authentication enforced on task creation, so that reading a task back without credentials demonstrates broken *authorization* rather than absent *authentication*. This fixture enforces none, so the discriminator correctly suppresses. That exposure is `a2a-peer-impersonation-001`'s territory, and it does fire.
- `a2a-jws-algconf-001` analyses JWS signatures on the agent card; this fixture deliberately serves an unsigned one.

Added a note that a silent rule is not always a fixture bug, and that coverage should be confirmed by running the rule rather than inferred from the table.

## Result

| Rule | Before | After |
|---|---|---|
| `a2a-extcard-unauth-001` | 2 findings | 2 findings |
| `a2a-peer-impersonation-001` | 1 finding | 1 finding |
| `a2a-session-smuggle-001` | **silent** | **1 high/confirmed** |
| `a2a-push-ssrf-001` | **silent** | **1 high, OOB-confirmed** |
| `a2a-task-idor-001` | silent | silent (by design, documented) |
| `a2a-jws-algconf-001` | silent | silent (by design, documented) |

## Test plan

Full `go test -race ./...` green (no rule code changed), fixture compiles, no em-dashes. All six rules re-run against the fixture to confirm no regression in the ones that already worked.
