### PR TITLE
fix(release): pass --bundle, which cosign v3 requires

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -70,6 +70,16 @@ signs:
     args:
       - sign-blob
       - "--yes"
+      # cosign v3 made --bundle required. Omitting it fails the release with
+      # "create bundle file: open : no such file or directory", because cosign
+      # is handed an empty path.
+      #
+      # GoReleaser only uploads the files named by `signature` and
+      # `certificate`, so a bundle written next to the artifact would be
+      # generated and then silently dropped. It goes to a scratch path instead:
+      # the flag is satisfied, and the release keeps publishing exactly the
+      # checksums.txt.sig and checksums.txt.pem that existing verifiers fetch.
+      - "--bundle=${artifact}.cosign-bundle.tmp"
       - "--output-signature=${signature}"
       - "--output-certificate=${certificate}"
       - "${artifact}"


### PR DESCRIPTION
## Summary

The **v1.6.0 release failed** at the signing step:

```
Error: signing dist/checksums.txt: create bundle file: open : no such file or directory
```

## Root cause

cosign **v3 made `--bundle` required**, where it had been optional. From the v3 release notes:

> the `--bundle` flag specifying an output file to write the Sigstore bundle (which contains all relevant verification material) has moved from optional to required in v3.

Without it, cosign receives an empty path and cannot create the bundle.

**Two corrections worth stating**, because my first reading of this was wrong:

1. The breaking change is **cosign v2 → v3**, not "cosign v4". The `cosign-installer` **action** we bumped to v4.1.2 installs the **cosign v3.0.6 binary** — confirmed in the failed run's log (`cosign-release: v3.0.6`). Action version and tool version are different things here.
2. This is a **configuration incompatibility, not a transient Sigstore failure** like the one during v1.2.0. Re-running the job cannot fix it. This is exactly the risk flagged when the release-critical Dependabot majors were merged: the release job skips on PRs, so a tag is the first real test.

## The fix, and why the bundle goes to a scratch path

GoReleaser uploads only the files named by `signature` and `certificate`. A bundle written next to the artifact would be generated and then **silently dropped** — a file that exists during the build and never reaches the release.

Sending it to a scratch path satisfies cosign's requirement while the release keeps publishing exactly the `checksums.txt.sig` and `checksums.txt.pem` that existing verifiers fetch. No change to what consumers download or how they verify.

## Validation, stated honestly

- `goreleaser check` passes, run at **v2.17.1** — the exact version CI uses.
- The signing path **only executes on a tag** and needs a real OIDC token, so it is not reproducible locally. The next tag is what exercises it.

## After merging

`v1.6.0` was tagged and its release run failed, so no release was published. The tag needs deleting and re-pushing once this lands, since the fix must be in the commit the tag points at.