### PR TITLE
fix(release): publish the Sigstore bundle cosign v3 produces

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,25 +63,23 @@ sboms:
 # GitHub Actions OIDC token. Verifiers can confirm the binary came from this
 # repo's release pipeline. Requires cosign on the runner and id-token: write
 # permission on the release job.
+#
+# cosign v3 removed --output-signature and --output-certificate from sign-blob
+# and made --bundle required: the Sigstore bundle now carries the signature,
+# the certificate and the transparency-log entry in one file, and replaces the
+# separate .sig and .pem rather than accompanying them. GoReleaser publishes
+# whatever `signature` names, so the bundle is named there.
+#
+# Releases up to v1.5.0 published checksums.txt.sig and checksums.txt.pem and
+# remain verifiable exactly as before; from v1.6.0 the artifact is
+# checksums.txt.sigstore.json instead.
 signs:
   - cmd: cosign
-    signature: "${artifact}.sig"
-    certificate: "${artifact}.pem"
+    signature: "${artifact}.sigstore.json"
     args:
       - sign-blob
       - "--yes"
-      # cosign v3 made --bundle required. Omitting it fails the release with
-      # "create bundle file: open : no such file or directory", because cosign
-      # is handed an empty path.
-      #
-      # GoReleaser only uploads the files named by `signature` and
-      # `certificate`, so a bundle written next to the artifact would be
-      # generated and then silently dropped. It goes to a scratch path instead:
-      # the flag is satisfied, and the release keeps publishing exactly the
-      # checksums.txt.sig and checksums.txt.pem that existing verifiers fetch.
-      - "--bundle=${artifact}.cosign-bundle.tmp"
-      - "--output-signature=${signature}"
-      - "--output-certificate=${certificate}"
+      - "--bundle=${signature}"
       - "${artifact}"
     artifacts: checksum
     output: true
@@ -152,10 +150,17 @@ release:
     35 bundled attack rules (17 A2A + 18 MCP). Single binary. No runtime dependencies.
 
     Every release is published with a cosign signature over `checksums.txt`, a
-    CycloneDX SBOM per archive, and SLSA build provenance. Verify provenance with:
+    CycloneDX SBOM per archive, and SLSA build provenance.
 
     ```bash
+    # Build provenance
     gh attestation verify batesian_<version>_<platform>.tar.gz --repo calbebop/batesian
+
+    # Checksums signature (Sigstore bundle)
+    cosign verify-blob checksums.txt \
+      --bundle checksums.txt.sigstore.json \
+      --certificate-identity-regexp 'https://github.com/calbebop/batesian/.*' \
+      --certificate-oidc-issuer https://token.actions.githubusercontent.com
     ```
 
     ### Install


### PR DESCRIPTION
## Summary

Follow-up to #117, which got signing to succeed but moved the failure one step later:

```
failed to upload checksums.txt.sig: open dist/checksums.txt.sig: no such file or directory
```

## What I got wrong

#117 assumed the bundle would **accompany** the detached `.sig` and `.pem`. It does not: in cosign v3 the bundle **replaces** them. `--output-signature` and `--output-certificate` no longer exist on `sign-blob`, and the bundle carries the signature, certificate and transparency-log entry in one file.

So signing succeeded (`Wrote bundle to file dist/checksums.txt.cosign-bundle.tmp`), and then GoReleaser tried to upload a `.sig` that nothing had written.

The v3 release notes only say `--bundle` moved from optional to required; the removal of the output flags is visible in the current `sign-blob` flag documentation, which no longer lists them.

## The fix

Name the bundle as the `signature` GoReleaser publishes, and drop the `certificate` field that no longer has a producer. This is the idiom GoReleaser documents for cosign.

## This changes the published artifact

| Release | Signing artifact | Verify with |
|---|---|---|
| up to v1.5.0 | `checksums.txt.sig` + `checksums.txt.pem` | unchanged, still verifiable |
| v1.6.0 onward | `checksums.txt.sigstore.json` | `cosign verify-blob --bundle` |

Older releases are untouched and keep working exactly as before. The release header carried the old instructions, so it now shows the bundle form alongside the provenance check. No other doc referenced `.sig`/`.pem` (checked).

## Validation, stated plainly

- `goreleaser check` passes at **v2.17.1**, the version CI runs.
- The signing path only executes on a tag with a real OIDC token, so it **cannot be exercised locally**. What the previous attempt did establish is that signing itself now succeeds; this addresses the upload step that followed it.

## After merging

`v1.6.0` is tagged at the old commit and published no release, so it needs deleting and re-pushing again once this lands.