### PR TITLE
fix(scan): probe the target path itself when discovering an endpoint

### DIFF
--- a/internal/attack/a2a/endpoint.go
+++ b/internal/attack/a2a/endpoint.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/calbebop/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/endpoint"
 )
 
 // A2A agent cards declare where the JSON-RPC transport actually lives; it is not
@@ -120,15 +121,15 @@ func pinToTargetHost(cardURL, baseURL string) string {
 	return pinned.String()
 }
 
-// candidateEndpoints lists JSON-RPC paths to probe when the card does not declare
+// candidatePaths lists JSON-RPC paths to probe when the card does not declare
 // one. Root is first so servers that mount JSON-RPC at the root keep working.
+var candidatePaths = []string{"/", "/a2a/jsonrpc", "/a2a", "/rpc"}
+
+// candidateEndpoints returns the URLs to probe under baseURL. A target that
+// already names a path is probed as given before these paths are appended to
+// it; see endpoint.Candidates.
 func candidateEndpoints(baseURL string) []string {
-	return []string{
-		baseURL + "/",
-		baseURL + "/a2a/jsonrpc",
-		baseURL + "/a2a",
-		baseURL + "/rpc",
-	}
+	return endpoint.Candidates(baseURL, candidatePaths)
 }
 
 // probeJSONRPCEndpoint reports whether a path answers JSON-RPC. It sends a

--- a/internal/attack/a2a/endpoint_test.go
+++ b/internal/attack/a2a/endpoint_test.go
@@ -80,16 +80,12 @@ func newClient(target string) *attack.HTTPClient {
 	return attack.NewUnauthHTTPClient(attack.Options{TimeoutSeconds: 5}, attack.NewVars(target, ""))
 }
 
-// a2aMock serves an optional card and answers JSON-RPC at rpcPath (a TaskNotFound
-// error), 404 elsewhere.
-func a2aMock(card string, rpcPath string) *httptest.Server {
+// a2aMock answers JSON-RPC at rpcPath (a TaskNotFound error) and 404s
+// elsewhere. It deliberately serves no agent card: these are the cardless cases,
+// where discovery has to fall back to probing paths. Card-driven discovery
+// builds its own server, in TestResolveA2AEndpoint_FromCard.
+func a2aMock(rpcPath string) *httptest.Server {
 	mux := http.NewServeMux()
-	if card != "" {
-		mux.HandleFunc("/.well-known/agent-card.json", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(card))
-		})
-	}
 	if rpcPath != "" {
 		mux.HandleFunc(rpcPath, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodPost {
@@ -128,7 +124,7 @@ func TestResolveA2AEndpoint_FromCard(t *testing.T) {
 
 func TestResolveA2AEndpoint_FallbackToCardlessPath(t *testing.T) {
 	// No card; JSON-RPC mounted at /a2a/jsonrpc. Discovery must probe and find it.
-	srv := a2aMock("", "/a2a/jsonrpc")
+	srv := a2aMock("/a2a/jsonrpc")
 	defer srv.Close()
 	ep, ok := resolveA2AEndpoint(context.Background(), newClient(srv.URL), srv.URL)
 	if !ok || ep != srv.URL+"/a2a/jsonrpc" {
@@ -138,7 +134,7 @@ func TestResolveA2AEndpoint_FallbackToCardlessPath(t *testing.T) {
 
 func TestResolveA2AEndpoint_FallbackToRoot(t *testing.T) {
 	// No card; JSON-RPC at root, like our existing fixtures. Must resolve to "/".
-	srv := a2aMock("", "/")
+	srv := a2aMock("/")
 	defer srv.Close()
 	ep, ok := resolveA2AEndpoint(context.Background(), newClient(srv.URL), srv.URL)
 	if !ok || ep != srv.URL+"/" {
@@ -154,5 +150,36 @@ func TestResolveA2AEndpoint_NothingReachable(t *testing.T) {
 	defer srv.Close()
 	if _, ok := resolveA2AEndpoint(context.Background(), newClient(srv.URL), srv.URL); ok {
 		t.Error("expected ok=false when no JSON-RPC endpoint responds")
+	}
+}
+
+// A target that already names the JSON-RPC path must be probed as given.
+// Discovery only ever appended to the target, so /a2a became /a2a/,
+// /a2a/a2a/jsonrpc, /a2a/a2a and /a2a/rpc, and the endpoint the operator had
+// pointed at was never tried. There is no agent card here, which is the case
+// that matters: with a card, discovery takes the URL the card declares.
+func TestResolveA2AEndpoint_TargetNamesTheEndpointPath(t *testing.T) {
+	srv := a2aMock("/a2a/jsonrpc")
+	defer srv.Close()
+
+	for _, target := range []string{srv.URL + "/a2a/jsonrpc", srv.URL + "/a2a/jsonrpc/"} {
+		t.Run(target, func(t *testing.T) {
+			ep, ok := resolveA2AEndpoint(context.Background(), newClient(target), target)
+			if !ok || ep != srv.URL+"/a2a/jsonrpc" {
+				t.Errorf("endpoint = %q ok = %v, want %s/a2a/jsonrpc true", ep, ok, srv.URL)
+			}
+		})
+	}
+}
+
+// The origin form is unchanged: appending still finds a handler mounted at a
+// conventional path.
+func TestResolveA2AEndpoint_OriginTargetUnchanged(t *testing.T) {
+	srv := a2aMock("/a2a/jsonrpc")
+	defer srv.Close()
+
+	ep, ok := resolveA2AEndpoint(context.Background(), newClient(srv.URL), srv.URL)
+	if !ok || ep != srv.URL+"/a2a/jsonrpc" {
+		t.Errorf("endpoint = %q ok = %v, want %s/a2a/jsonrpc true", ep, ok, srv.URL)
 	}
 }

--- a/internal/attack/mcp/path_target_test.go
+++ b/internal/attack/mcp/path_target_test.go
@@ -1,0 +1,156 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+// An operator scanning an MCP server usually has its published URL, and that URL
+// carries the path the handler is mounted at: https://host/mcp is the
+// convention. Endpoint discovery used to only ever append to the target, so it
+// probed /mcp/mcp, /mcp/, /mcp/api and /mcp/rpc and never /mcp itself. Every MCP
+// rule then reported that it could not reach a testable endpoint, and a real
+// exposure went unreported.
+//
+// The servers below answer at one path and 404 everywhere else, which is what
+// makes them a regression test: a handler that replies on any path (as the other
+// harnesses in this package do) is satisfied by the first appended candidate and
+// cannot catch this.
+
+// mountedResourcesServer serves the unauthenticated resources handler at
+// mountPath only.
+func mountedResourcesServer(t *testing.T, mountPath string) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(mountPath, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != mountPath {
+			http.NotFound(w, r)
+			return
+		}
+		var req map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		method, _ := req["method"].(string)
+		id := req["id"]
+		w.Header().Set("Content-Type", "application/json")
+
+		switch method {
+		case "initialize":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      id,
+				"result": map[string]interface{}{
+					"protocolVersion": "2025-03-26",
+					"serverInfo":      map[string]interface{}{"name": "mounted", "version": "1.0"},
+					"capabilities":    map[string]interface{}{"resources": map[string]interface{}{}},
+				},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusOK)
+		case "resources/list":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      id,
+				"result": map[string]interface{}{
+					"resources": []map[string]interface{}{
+						{"uri": "config://database", "name": "DB Config", "mimeType": "text/plain"},
+					},
+				},
+			})
+		case "resources/read":
+			params, _ := req["params"].(map[string]interface{})
+			uri, _ := params["uri"].(string)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      id,
+				"result": map[string]interface{}{
+					"contents": []interface{}{
+						map[string]interface{}{
+							"uri":      uri,
+							"mimeType": "text/plain",
+							"text":     "Welcome to the public configuration overview page.",
+						},
+					},
+				},
+			})
+		default:
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      id,
+				"error":   map[string]interface{}{"code": -32601, "message": "Method not found"},
+			})
+		}
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func TestResourcesUnauth_TargetNamesTheEndpointPath(t *testing.T) {
+	ts := mountedResourcesServer(t, "/mcp")
+	defer ts.Close()
+
+	exec := mcpattack.NewResourcesUnauthExecutor(resourcesRC())
+
+	for _, target := range []string{ts.URL + "/mcp", ts.URL + "/mcp/"} {
+		t.Run(target, func(t *testing.T) {
+			findings, err := exec.Execute(context.Background(), target, testOpts())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(findings) < 2 {
+				t.Fatalf("expected at least 2 findings (list + read), got %d", len(findings))
+			}
+		})
+	}
+}
+
+// A handler mounted somewhere other than a conventional path is only reachable
+// when the target itself is probed, so this pins that the fix is not just
+// "/mcp works now".
+func TestResourcesUnauth_TargetNamesAnUnconventionalPath(t *testing.T) {
+	ts := mountedResourcesServer(t, "/services/agent/jsonrpc")
+	defer ts.Close()
+
+	exec := mcpattack.NewResourcesUnauthExecutor(resourcesRC())
+	findings, err := exec.Execute(context.Background(), ts.URL+"/services/agent/jsonrpc", testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) < 2 {
+		t.Fatalf("expected at least 2 findings (list + read), got %d", len(findings))
+	}
+}
+
+// The origin form must keep working unchanged: a server mounted at /mcp is
+// still found when the operator passes only the origin.
+func TestResourcesUnauth_OriginTargetStillReachesMountedHandler(t *testing.T) {
+	ts := mountedResourcesServer(t, "/mcp")
+	defer ts.Close()
+
+	exec := mcpattack.NewResourcesUnauthExecutor(resourcesRC())
+	findings, err := exec.Execute(context.Background(), ts.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) < 2 {
+		t.Fatalf("expected at least 2 findings (list + read), got %d", len(findings))
+	}
+}
+
+// A target naming a path that has no handler must still report that it could not
+// test, rather than being rescued into a clean pass by the appended candidates.
+func TestResourcesUnauth_WrongPathTargetIsStillInconclusive(t *testing.T) {
+	ts := mountedResourcesServer(t, "/mcp")
+	defer ts.Close()
+
+	exec := mcpattack.NewResourcesUnauthExecutor(resourcesRC())
+	assertInconclusive(t, exec, ts.URL+"/not-the-handler", testOpts())
+}

--- a/internal/attack/mcp/session.go
+++ b/internal/attack/mcp/session.go
@@ -1,18 +1,20 @@
 package mcp
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/calbebop/batesian/internal/endpoint"
+)
 
 // candidatePaths are tried in order when discovering an MCP endpoint.
 // Servers commonly mount the JSON-RPC handler at /mcp, /, /api, or /rpc.
 var candidatePaths = []string{"/mcp", "/", "/api", "/rpc"}
 
-// endpointCandidates returns candidate URLs to try for the given base URL.
+// endpointCandidates returns candidate URLs to try for the given base URL. A
+// target that already names a path is probed as given before the conventional
+// paths are appended to it; see endpoint.Candidates.
 func endpointCandidates(baseURL string) []string {
-	out := make([]string, len(candidatePaths))
-	for i, p := range candidatePaths {
-		out[i] = baseURL + p
-	}
-	return out
+	return endpoint.Candidates(baseURL, candidatePaths)
 }
 
 // mcpSession holds the discovered MCP endpoint and the session ID returned by

--- a/internal/endpoint/candidates.go
+++ b/internal/endpoint/candidates.go
@@ -1,0 +1,71 @@
+// Package endpoint builds the list of URLs to probe when locating a JSON-RPC
+// handler under a target.
+//
+// The A2A and MCP rule sets and the probe command each need this, with their
+// own conventional paths, and they need to agree on how a target that already
+// names a path is treated. Keeping the rule in one place is deliberate: three
+// copies of the same question have drifted apart in this repository before.
+package endpoint
+
+import (
+	"net/url"
+	"strings"
+)
+
+// Candidates returns the URLs to try under baseURL, in probe order.
+//
+// Each entry in paths is appended to the target, which is how a bare origin is
+// searched: https://host yields https://host/mcp, https://host/ and so on.
+//
+// A target that already names a path is a different case. An operator scanning
+// an MCP server almost always has its published URL to hand, and that URL
+// usually carries the path the handler is mounted at (https://host/mcp is the
+// convention). Appending to that reaches https://host/mcp/mcp and friends but
+// never https://host/mcp itself, so nothing answers and every rule reports that
+// it could not find a testable endpoint. The target the operator actually named
+// is therefore probed first, ahead of the conventional paths.
+//
+// Only the appended forms are tried for a bare origin, exactly as before: with
+// no path to preserve there is nothing to put first, so probe order for the
+// common case is unchanged.
+//
+// One trailing slash is trimmed from baseURL first, so https://host/mcp/ is
+// treated as https://host/mcp rather than producing https://host/mcp//mcp.
+func Candidates(baseURL string, paths []string) []string {
+	base := strings.TrimSuffix(baseURL, "/")
+
+	out := make([]string, 0, len(paths)+1)
+	if hasPath(base) {
+		out = append(out, base)
+	}
+	for _, p := range paths {
+		out = append(out, base+p)
+	}
+	return dedupe(out)
+}
+
+// hasPath reports whether the URL names a path beyond the root. A URL that will
+// not parse is treated as having none, which keeps the caller on the historical
+// append-only behaviour rather than failing.
+func hasPath(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	return strings.Trim(u.Path, "/") != ""
+}
+
+// dedupe removes repeated entries while preserving order, so a path target
+// whose conventional suffix matches its own path is not probed twice.
+func dedupe(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := in[:0]
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/endpoint/candidates_test.go
+++ b/internal/endpoint/candidates_test.go
@@ -1,0 +1,136 @@
+package endpoint
+
+import (
+	"reflect"
+	"testing"
+)
+
+// mcpPaths mirrors the MCP rule set's conventional paths, so the cases below
+// read as the situations an operator actually hits.
+var mcpPaths = []string{"/mcp", "/", "/api", "/rpc"}
+
+func TestCandidates(t *testing.T) {
+	tests := []struct {
+		name  string
+		base  string
+		paths []string
+		want  []string
+	}{
+		{
+			// The historical behaviour, unchanged: nothing to preserve, so the
+			// list is exactly the appended forms in the original order.
+			name:  "bare origin appends only",
+			base:  "http://127.0.0.1:3181",
+			paths: mcpPaths,
+			want: []string{
+				"http://127.0.0.1:3181/mcp",
+				"http://127.0.0.1:3181/",
+				"http://127.0.0.1:3181/api",
+				"http://127.0.0.1:3181/rpc",
+			},
+		},
+		{
+			// The bug this fixes. Appending alone reaches /mcp/mcp and friends
+			// but never /mcp, so every rule reported no testable endpoint.
+			name:  "path target is probed as given, first",
+			base:  "http://127.0.0.1:3181/mcp",
+			paths: mcpPaths,
+			want: []string{
+				"http://127.0.0.1:3181/mcp",
+				"http://127.0.0.1:3181/mcp/mcp",
+				"http://127.0.0.1:3181/mcp/",
+				"http://127.0.0.1:3181/mcp/api",
+				"http://127.0.0.1:3181/mcp/rpc",
+			},
+		},
+		{
+			// A trailing slash is the same target, and previously produced a
+			// doubled separator (http://host/mcp//mcp) that servers 404.
+			name:  "trailing slash on a path target",
+			base:  "http://127.0.0.1:3181/mcp/",
+			paths: mcpPaths,
+			want: []string{
+				"http://127.0.0.1:3181/mcp",
+				"http://127.0.0.1:3181/mcp/mcp",
+				"http://127.0.0.1:3181/mcp/",
+				"http://127.0.0.1:3181/mcp/api",
+				"http://127.0.0.1:3181/mcp/rpc",
+			},
+		},
+		{
+			name:  "trailing slash on an origin is not a path",
+			base:  "https://mcp.example.com/",
+			paths: mcpPaths,
+			want: []string{
+				"https://mcp.example.com/mcp",
+				"https://mcp.example.com/",
+				"https://mcp.example.com/api",
+				"https://mcp.example.com/rpc",
+			},
+		},
+		{
+			name:  "nested path target",
+			base:  "https://example.com/services/agent/mcp",
+			paths: []string{"/mcp", "/"},
+			want: []string{
+				"https://example.com/services/agent/mcp",
+				"https://example.com/services/agent/mcp/mcp",
+				"https://example.com/services/agent/mcp/",
+			},
+		},
+		{
+			// A2A's list leads with "/", which for a path target collides with
+			// nothing but must not reorder the rest.
+			name:  "a2a paths on a path target",
+			base:  "https://example.com/a2a",
+			paths: []string{"/", "/a2a/jsonrpc", "/a2a", "/rpc"},
+			want: []string{
+				"https://example.com/a2a",
+				"https://example.com/a2a/",
+				"https://example.com/a2a/a2a/jsonrpc",
+				"https://example.com/a2a/a2a",
+				"https://example.com/a2a/rpc",
+			},
+		},
+		{
+			// An empty path entry would otherwise repeat the target.
+			name:  "duplicates are collapsed, order preserved",
+			base:  "https://example.com/mcp",
+			paths: []string{"", "/mcp", ""},
+			want: []string{
+				"https://example.com/mcp",
+				"https://example.com/mcp/mcp",
+			},
+		},
+		{
+			// Nothing here should panic or drop the caller's paths just because
+			// the target will not parse.
+			name:  "unparseable target still yields the appended forms",
+			base:  "http://[::1",
+			paths: []string{"/mcp"},
+			want:  []string{"http://[::1/mcp"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Candidates(tt.base, tt.paths)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Candidates(%q, %v):\n got %q\nwant %q", tt.base, tt.paths, got, tt.want)
+			}
+		})
+	}
+}
+
+// The caller's slice of paths is package-level state in both rule sets, so
+// Candidates must not write through to it.
+func TestCandidates_DoesNotMutateInput(t *testing.T) {
+	paths := []string{"/mcp", "/", "/api", "/rpc"}
+	before := append([]string(nil), paths...)
+
+	Candidates("https://example.com/mcp", paths)
+
+	if !reflect.DeepEqual(paths, before) {
+		t.Errorf("Candidates mutated its paths argument: got %q, want %q", paths, before)
+	}
+}

--- a/internal/protocol/mcp/client.go
+++ b/internal/protocol/mcp/client.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/calbebop/batesian/internal/endpoint"
 	"github.com/calbebop/batesian/internal/sse"
 )
 
@@ -125,16 +126,16 @@ type PromptArgument struct {
 }
 
 // Initialize performs the MCP initialize handshake and returns a Session.
-// It tries candidate endpoint paths until one succeeds.
+// It tries candidate endpoints until one succeeds.
 func (c *Client) Initialize(ctx context.Context) (*Session, error) {
-	for _, path := range candidatePaths {
-		ep := c.baseURL + path
+	candidates := endpoint.Candidates(c.baseURL, candidatePaths)
+	for _, ep := range candidates {
 		session, err := c.tryInitialize(ctx, ep)
 		if err == nil {
 			return session, nil
 		}
 	}
-	return nil, fmt.Errorf("no MCP server found at %s (tried %v)", c.baseURL, candidatePaths)
+	return nil, fmt.Errorf("no MCP server found at %s (tried %v)", c.baseURL, candidates)
 }
 
 // ListTools calls tools/list and returns all available tools.


### PR DESCRIPTION
## The bug

Endpoint discovery only ever **appended** a conventional path to the target. Given `https://host/mcp` it probed:

```
/mcp/mcp   404
/mcp/      307  -> redirects to /mcp, which we do not follow
/mcp/api   404
/mcp/rpc   404
```

and never `/mcp`. Nothing answered, so every MCP rule reported that it could not reach a testable endpoint and the scan finished with no findings.

That is the URL operators have to hand. MCP servers are published as `https://host/mcp`, so pasting the published URL is the likely first thing anyone does, and it disabled the entire MCP rule set. The one candidate that could have worked is the appended trailing slash, and we refuse to follow that redirect on purpose: following redirects once carried the operator's bearer token off-host.

The S3 inconclusive work is what kept this from being silent. The run says "18 of 35 rules could not reach a testable endpoint" rather than reporting a clean scan.

## Confirmed against a real server

A server built on the official Python SDK **v2.0.0**, mounted at `/mcp`. No protocol code of ours involved.

| Target | Before | After |
|---|---|---|
| `http://127.0.0.1:3181/mcp` | 0 findings, 18 of 35 skipped | **5 findings**, MCP set fully exercised |
| `http://127.0.0.1:3181` (origin) | 5 findings | 5 findings, unchanged |

## The fix

The rule moves to `internal/endpoint`, shared by the A2A rules, the MCP rules and the probe command. All three asked this question separately, and helpers that ask the same question in three places have drifted apart in this repository before.

- A target that names a path is probed **as given, first**; the appended forms follow.
- A bare origin is **unchanged**, so the common case keeps its existing probe order and there is no regression surface in the existing suite.
- One trailing slash is trimmed, which also stops `https://host/mcp/` producing `https://host/mcp//mcp`.

A target naming a path with **no** handler still reports that it could not test. The fix must not rescue a wrong target into a clean pass, and `TestResourcesUnauth_WrongPathTargetIsStillInconclusive` pins that.

## Tests

`internal/endpoint/candidates_test.go` covers origin, path, trailing slash on both, nested path, the A2A path list, duplicate collapsing, an unparseable target, and non-mutation of the caller's slice.

The end-to-end tests matter more. Existing harnesses in this package answer on **any** path, so they are satisfied by the first appended candidate and cannot catch this. The new ones mount at exactly one path and 404 elsewhere. Verified non-vacuous by reverting the behaviour and watching them fail with `rule could not reach a testable endpoint`.

## One thing this does not fix

A2A endpoint discovery accepts **any** JSON-RPC responder as an A2A endpoint. Point the scanner at an MCP server and 16 A2A rules now report clean rather than skipped, because the MCP handler answers `tasks/get` with `-32601` and that looks live.

This is pre-existing, not a regression. I verified it by mounting the same SDK server at the root and scanning it with the previous build: identical behaviour, 1 A2A skip out of 17. Widening the reachable configurations is what surfaced it. Worth tightening separately, since converting "could not test" into "tested clean" is the same honesty axis S3 was about.

## Also

`a2aMock` lost its `card` parameter, which every caller passed empty. `unparam` started flagging it once the new tests raised the caller count.

Full `go test -race ./...`, `go vet`, `gofmt` and `golangci-lint run` at the pinned v2.11.4 all clean.