### PR TITLE
fix(testdata): port the resources fixture to the MCP Python SDK v2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ add a new file only if no existing server is a natural host. Either way:
 - Print startup confirmation lines so the caller can wait for readiness.
 - Implement only the minimum routes needed to trigger the rule(s).
 - Stay within the project test-server dependency set:
-  `pip install starlette uvicorn httpx mcp`. Do not introduce new third-party
+  `pip install starlette uvicorn httpx "mcp>=2"`. Do not introduce new third-party
   packages without updating `testdata/README.md`.
 - Include a module docstring listing every rule ID the server covers and how
   to run it.

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -11,8 +11,15 @@ They are intentionally misconfigured to be exploitable.
 ## Prerequisites
 
 ```sh
-pip install starlette uvicorn httpx mcp
+pip install starlette uvicorn httpx "mcp>=2"
 ```
+
+Only `mcp_unauth_resources_server.py` uses the MCP Python SDK; the rest are plain
+Starlette. The SDK's v2 line is what `pip install mcp` now gives you, and it
+renamed `FastMCP` to `MCPServer` with no compatibility alias, so that fixture
+does not run on 1.x. The version is pinned above rather than left bare so a
+future major bump is a deliberate change here instead of a fixture that stops
+starting.
 
 ---
 
@@ -112,7 +119,7 @@ batesian scan --target http://127.0.0.1:9998 --rule-ids a2a-push-ssrf-001 -v
 
 When adding a new test server, pick the next free port, document it in the
 Server Registry table above before merging. Prefer the `77xx` band for servers
-in this directory that bind with uvicorn (Starlette or FastMCP). The `31xx`
+in this directory that bind with uvicorn (Starlette or the MCP SDK). The `31xx`
 band is used for selected multi-rule MCP/A2A servers; `9998` is reserved for
 the main A2A lab server. Do not reuse a port already listed in the registry.
 

--- a/testdata/mcp_unauth_resources_server.py
+++ b/testdata/mcp_unauth_resources_server.py
@@ -4,14 +4,18 @@ Batesian MCP validation target: unauthenticated resource access (mcp-resources-u
 This server exposes MCP resources without any authentication, including one that
 returns a simulated database connection string containing credentials.
 
+Requires the MCP Python SDK v2 (`pip install "mcp>=2"`), which is what
+`pip install mcp` now gives you. v2 renamed FastMCP to MCPServer with no
+compatibility alias, so this file does not run on the 1.x line.
+
 Run:
     python testdata/mcp_unauth_resources_server.py
 
 Endpoint: http://localhost:7787/mcp
 """
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
-mcp = FastMCP("UnauthResourcesTarget", stateless_http=True, json_response=True)
+mcp = MCPServer("UnauthResourcesTarget")
 
 
 @mcp.resource("config://database")
@@ -48,4 +52,8 @@ def ping() -> str:
 if __name__ == "__main__":
     import uvicorn
     print("Starting MCP unauthenticated resources server on http://localhost:7787/mcp")
-    uvicorn.run(mcp.streamable_http_app(), host="127.0.0.1", port=7787)
+    # v2 moved stateless_http and json_response off the constructor and onto the
+    # app factory. Both matter here: stateless keeps every probe independent of a
+    # session, and JSON responses keep the fixture readable with curl.
+    app = mcp.streamable_http_app(json_response=True, stateless_http=True)
+    uvicorn.run(app, host="127.0.0.1", port=7787)


### PR DESCRIPTION
## The break

`pip install mcp` now installs the **2.x** line, and that is exactly the command [testdata/README.md](testdata/README.md) tells people to run. v2 removed `FastMCP` with no compatibility alias and moved `stateless_http` / `json_response` off the constructor onto the app factory, so the fixture failed at import on any fresh setup.

```python
# before, dead on a fresh install
from mcp.server.fastmcp import FastMCP
mcp = FastMCP("UnauthResourcesTarget", stateless_http=True, json_response=True)

# after
from mcp.server.mcpserver import MCPServer
mcp = MCPServer("UnauthResourcesTarget")
...
app = mcp.streamable_http_app(json_response=True, stateless_http=True)
```

`mcp_unauth_resources_server.py` is the only fixture that uses the SDK. The rest are plain Starlette, so nothing else in `testdata/` is affected.

## Validated on both SDK lines

To show the port changes nothing the rules can see, I ran the **original** file against `mcp` 1.29.0 and **this** file against `mcp` 2.0.0, in separate virtualenvs, scanning each with the same binary:

| | mcp 1.29.0, original fixture | mcp 2.0.0, this fixture |
|---|---|---|
| `resources/list` finding | HIGH, 3 resources | HIGH, 3 resources |
| `resources/read` finding | HIGH, `config://database` | HIGH, `config://database` |

Identical. Both installs were transient and local; nothing was added to the repo.

## Pinned, not bare

The dependency line becomes `pip install starlette uvicorn httpx "mcp>=2"` in both `testdata/README.md` and `CONTRIBUTING.md`. Pinning the major means the next one is a deliberate change here rather than a fixture that quietly stops starting, which is the failure this PR is cleaning up.

## Two gaps I did not fix here

The read finding grades **high**, not critical, on both SDK lines. The fixture's docstring says the database resource returns "a simulated database connection string containing credentials", and it does:

```
postgresql://admin:password123@db.internal:5432/prod
```

That does not escalate, for two independent reasons:

1. `credentialPatterns` in [resources_unauth.go:13](internal/attack/mcp/resources_unauth.go:13) matches `password=value` and `password: value`, not a URI userinfo section. Connection strings with inline credentials are a common leak shape and none of the eight patterns cover them.
2. The rule reads only the **first** resource ([resources_unauth.go:112](internal/attack/mcp/resources_unauth.go:112), "Step 2: read the first resource"). `config://secrets` on this same fixture contains `SENDGRID_API_KEY=SG.test_api_key_value_here`, which *would* match, and is never fetched. `mcp-completion-unauth-001` already had this shape of problem and was changed to try several refs, preferring one that leaks.

Both are rule gaps rather than fixture gaps, and neither is new, so they are out of scope for a fixture repair. Worth taking next.