### PR TITLE
fix(mcp): grade the resource read on what leaks, not on list order

### DIFF
--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -141,8 +141,16 @@ retrieves data directly. All findings are **confirmed** (the data was actually
 returned without a token). Severity is **impact-graded**: an unauthenticated list
 and a readable resource are **high**; the read is escalated to **critical** only
 when the returned content matches a credential pattern (AWS/OpenAI/GitHub keys,
-private keys, JWTs, password/bearer assignments), and the matched pattern is cited
-in the evidence.
+private keys, JWTs, password/bearer assignments, credentials in a URI userinfo
+section such as `postgresql://user:pass@host/db`), and the matched pattern is
+cited in the evidence.
+
+Up to five resources are read, stopping at the first one that matches, and the
+finding reports that resource. Reading only the first would leave the severity to
+the server's list order, so a deployment that lists a public README ahead of its
+database credentials would be graded high. The evidence states how many resources
+were examined against how many were listed, so a run that stopped at the bound is
+distinguishable from one that saw everything.
 
 ---
 

--- a/internal/attack/mcp/credentials_test.go
+++ b/internal/attack/mcp/credentials_test.go
@@ -1,0 +1,118 @@
+package mcp
+
+import "testing"
+
+// matchesAnyCredentialPattern mirrors what the rule does with a resource body.
+func matchesAnyCredentialPattern(s string) bool {
+	for _, re := range credentialPatterns {
+		if re.MatchString(s) {
+			return true
+		}
+	}
+	return false
+}
+
+// Credentials carried positionally in a URI userinfo section are a routine way
+// for a resource to leak a secret, and the password pattern cannot see one: it
+// looks for password=value, not scheme://user:secret@host. A false negative
+// here costs a critical finding, since the rule escalates on nothing else.
+func TestCredentialPatterns_URIUserinfo(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			name:  "postgres connection string",
+			input: "postgresql://admin:password123@db.internal:5432/prod",
+			want:  true,
+		},
+		{
+			name:  "database url assignment",
+			input: "DATABASE_URL=postgresql://admin:hunter2@db.internal/prod",
+			want:  true,
+		},
+		{
+			name:  "mongodb srv",
+			input: "mongodb+srv://svc:s3cr3t@cluster0.example.net/app",
+			want:  true,
+		},
+		{
+			// Some clients pass the secret with an empty username.
+			name:  "redis with no username",
+			input: "redis://:mypassword@cache.internal:6379/0",
+			want:  true,
+		},
+		{
+			name:  "https basic auth in url",
+			input: "https://svc-account:tokenvalue@api.example.com/v1",
+			want:  true,
+		},
+		{
+			// The common shape that must NOT match: a port is a colon too, and
+			// treating one as a password would fire on almost any URL.
+			name:  "ordinary url with a port",
+			input: "http://db.internal:5432/prod",
+			want:  false,
+		},
+		{
+			name:  "url with a port and a path that has an at sign",
+			input: "https://example.com:8443/users/me@example.com",
+			want:  false,
+		},
+		{
+			// A username with no password is not a secret.
+			name:  "userinfo without a password",
+			input: "https://someuser@github.com/org/repo.git",
+			want:  false,
+		},
+		{
+			name:  "bare email address",
+			input: "contact: support@example.com",
+			want:  false,
+		},
+		{
+			name:  "plain prose",
+			input: "Welcome to the public configuration overview page.",
+			want:  false,
+		},
+		{
+			name:  "json config with no secret",
+			input: `{"debug": false, "log_level": "info", "allowed_origins": ["https://app.example.com"]}`,
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchesAnyCredentialPattern(tt.input); got != tt.want {
+				t.Errorf("matchesAnyCredentialPattern(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// The patterns that were already here keep working; this guards against a later
+// edit to the URI pattern accidentally reordering or replacing one of them.
+func TestCredentialPatterns_ExistingShapesStillMatch(t *testing.T) {
+	for _, s := range []string{
+		"AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE",
+		"API_KEY=SG.test_api_key_value_here",
+		"password: supersecret",
+		"-----BEGIN RSA PRIVATE KEY-----",
+		"Authorization=abcdefghijklmnopqrst",
+	} {
+		if !matchesAnyCredentialPattern(s) {
+			t.Errorf("expected a credential match for %q", s)
+		}
+	}
+}
+
+// Known gap, deliberately not asserted either way so that fixing it does not
+// have to fight a test: the bearer pattern is
+// (bearer|authorization)\s*[=:]\s*\S{10,}, which cannot match the canonical
+// header form "Authorization: Bearer <token>". After "authorization:" the next
+// token is "Bearer", only six characters, and after "bearer" there is no
+// separator at all. So the one shape an operator is most likely to find in a
+// leaked config is the one shape this does not catch. Left alone here because
+// it is a separate change from the URI userinfo gap this file was added for.

--- a/internal/attack/mcp/resources_credentials_test.go
+++ b/internal/attack/mcp/resources_credentials_test.go
@@ -1,0 +1,240 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+// Reading only the first listed resource made the escalation to critical an
+// accident of list order: a server that lists a public README ahead of its
+// database credentials was reported as merely readable. The order is the
+// server's choice, so it must not decide the severity.
+//
+// The harnesses below serve per-URI content, which the shared one in
+// resources_unauth_test.go does not: it returns the same body for every read, so
+// it cannot tell "read the first" from "read until something leaks".
+
+// perURIResourceServer lists the given URIs and serves each one its own content.
+// A URI present in contents is readable; any other listed URI is refused with a
+// JSON-RPC error, which is how a real server denies one resource while serving
+// its neighbours. reads counts resources/read calls received.
+func perURIResourceServer(t *testing.T, uris []string, contents map[string]string) (*httptest.Server, *int) {
+	t.Helper()
+
+	reads := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		method, _ := req["method"].(string)
+		id := req["id"]
+		w.Header().Set("Content-Type", "application/json")
+
+		switch method {
+		case "initialize":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      id,
+				"result": map[string]interface{}{
+					"protocolVersion": "2025-03-26",
+					"serverInfo":      map[string]interface{}{"name": "test", "version": "1.0"},
+					"capabilities":    map[string]interface{}{"resources": map[string]interface{}{}},
+				},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusOK)
+		case "resources/list":
+			list := make([]map[string]interface{}, 0, len(uris))
+			for _, u := range uris {
+				list = append(list, map[string]interface{}{"uri": u, "name": u, "mimeType": "text/plain"})
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      id,
+				"result":  map[string]interface{}{"resources": list},
+			})
+		case "resources/read":
+			reads++
+			params, _ := req["params"].(map[string]interface{})
+			uri, _ := params["uri"].(string)
+			text, readable := contents[uri]
+			if !readable {
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"jsonrpc": "2.0",
+					"id":      id,
+					"error":   map[string]interface{}{"code": -32002, "message": "Resource not found"},
+				})
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      id,
+				"result": map[string]interface{}{
+					"contents": []interface{}{
+						map[string]interface{}{"uri": uri, "mimeType": "text/plain", "text": text},
+					},
+				},
+			})
+		default:
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      id,
+				"error":   map[string]interface{}{"code": -32601, "message": "Method not found"},
+			})
+		}
+	}))
+	return srv, &reads
+}
+
+// A credential in a later resource must still escalate, and the finding must
+// name that resource rather than the benign one that happened to be listed
+// first.
+func TestResourcesUnauth_CredentialInALaterResource(t *testing.T) {
+	uris := []string{"config://readme", "config://app", "config://database"}
+	contents := map[string]string{
+		"config://readme":   "Welcome to the public configuration overview page.",
+		"config://app":      `{"debug": false, "log_level": "info"}`,
+		"config://database": "postgresql://admin:hunter2@db.internal:5432/prod",
+	}
+
+	ts, _ := perURIResourceServer(t, uris, contents)
+	defer ts.Close()
+
+	exec := mcpattack.NewResourcesUnauthExecutor(resourcesRC())
+	findings, err := exec.Execute(context.Background(), ts.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings (list + read), got %d", len(findings))
+	}
+
+	read := findings[1]
+	if read.Severity != "critical" {
+		t.Errorf("severity = %q, want critical: the third resource leaks a connection string", read.Severity)
+	}
+	if !strings.Contains(read.Title, "config://database") {
+		t.Errorf("title should name the leaking resource, got %q", read.Title)
+	}
+	if !strings.Contains(read.Description, "Credential pattern detected") {
+		t.Errorf("description should cite the matched pattern, got %q", read.Description)
+	}
+}
+
+// Once a credential is found there is nothing stronger to look for, so the
+// remaining budget is not spent.
+func TestResourcesUnauth_StopsReadingOnceCredentialFound(t *testing.T) {
+	uris := []string{"config://readme", "config://database", "config://extra1", "config://extra2"}
+	contents := map[string]string{
+		"config://readme":   "Public overview.",
+		"config://database": "postgresql://admin:hunter2@db.internal:5432/prod",
+		"config://extra1":   "more",
+		"config://extra2":   "more",
+	}
+
+	ts, reads := perURIResourceServer(t, uris, contents)
+	defer ts.Close()
+
+	exec := mcpattack.NewResourcesUnauthExecutor(resourcesRC())
+	if _, err := exec.Execute(context.Background(), ts.URL, testOpts()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if *reads != 2 {
+		t.Errorf("reads = %d, want 2 (stop at the leaking resource)", *reads)
+	}
+}
+
+// With nothing to escalate on, the behaviour is as before: the first readable
+// resource is reported, at high.
+func TestResourcesUnauth_NoCredentialAnywhereReportsFirst(t *testing.T) {
+	uris := []string{"config://readme", "config://app"}
+	contents := map[string]string{
+		"config://readme": "Welcome to the public configuration overview page.",
+		"config://app":    `{"debug": false, "log_level": "info"}`,
+	}
+
+	ts, _ := perURIResourceServer(t, uris, contents)
+	defer ts.Close()
+
+	exec := mcpattack.NewResourcesUnauthExecutor(resourcesRC())
+	findings, err := exec.Execute(context.Background(), ts.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(findings))
+	}
+	if findings[1].Severity != "high" {
+		t.Errorf("severity = %q, want high with no credential present", findings[1].Severity)
+	}
+	if !strings.Contains(findings[1].Title, "config://readme") {
+		t.Errorf("title should name the first readable resource, got %q", findings[1].Title)
+	}
+}
+
+// The cap bounds cost on a server that lists many resources, and the evidence
+// has to say so: a bounded run must not read as an exhaustive one.
+func TestResourcesUnauth_ReadsAreCappedAndTheCapIsReported(t *testing.T) {
+	const listed = 12
+	uris := make([]string, 0, listed)
+	contents := map[string]string{}
+	for i := 0; i < listed; i++ {
+		u := fmt.Sprintf("config://item%d", i)
+		uris = append(uris, u)
+		contents[u] = "nothing sensitive here"
+	}
+
+	ts, reads := perURIResourceServer(t, uris, contents)
+	defer ts.Close()
+
+	exec := mcpattack.NewResourcesUnauthExecutor(resourcesRC())
+	findings, err := exec.Execute(context.Background(), ts.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if *reads != 5 {
+		t.Errorf("reads = %d, want 5 (the cap)", *reads)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(findings))
+	}
+	want := fmt.Sprintf("resources examined: 5 of %d listed", listed)
+	if !strings.Contains(findings[1].Evidence, want) {
+		t.Errorf("evidence must state the bound, want %q in:\n%s", want, findings[1].Evidence)
+	}
+}
+
+// A resource that cannot be read must not stop the search: the leak may be in
+// the next one.
+func TestResourcesUnauth_SkipsUnreadableResources(t *testing.T) {
+	uris := []string{"config://denied", "config://database"}
+	contents := map[string]string{
+		"config://database": "postgresql://admin:hunter2@db.internal:5432/prod",
+	}
+
+	// config://denied is listed but absent from contents, so the server refuses
+	// it with a JSON-RPC error while still serving the one after it.
+	ts, _ := perURIResourceServer(t, uris, contents)
+	defer ts.Close()
+
+	exec := mcpattack.NewResourcesUnauthExecutor(resourcesRC())
+	findings, err := exec.Execute(context.Background(), ts.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(findings))
+	}
+	if findings[1].Severity != "critical" || !strings.Contains(findings[1].Title, "config://database") {
+		t.Errorf("want critical finding for config://database, got %q at %q", findings[1].Title, findings[1].Severity)
+	}
+}

--- a/internal/attack/mcp/resources_unauth.go
+++ b/internal/attack/mcp/resources_unauth.go
@@ -19,7 +19,20 @@ var credentialPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)ghp_[a-zA-Z0-9]{36}`),                           // GitHub token
 	regexp.MustCompile(`(?i)(bearer|authorization)\s*[=:]\s*\S{10,}`),       // Bearer/auth token
 	regexp.MustCompile(`(?i)eyJ[A-Za-z0-9-_]{10,}\.[A-Za-z0-9-_]{10,}`),     // JWT
+	// Credentials in a URI userinfo section, as in
+	// postgresql://admin:hunter2@db.internal:5432/prod. Connection strings are
+	// a routine thing to expose through a resource and the password pattern
+	// above cannot see one, because it looks for password=value rather than a
+	// positional secret. Requiring the @ is what keeps an ordinary
+	// http://host:8080/path from matching on its port.
+	regexp.MustCompile(`(?i)[a-z][a-z0-9+.-]*://[^/\s:@]*:[^/\s:@]+@[^/\s]+`), // URI userinfo credentials
 }
+
+// maxResourceReads bounds how many resources one run will read. A server may
+// list hundreds, and reading all of them makes a scan's cost a function of the
+// target rather than of the rule. The count actually read is reported in the
+// evidence, so a bounded run never reads as an exhaustive one.
+const maxResourceReads = 5
 
 // ResourcesUnauthExecutor probes MCP resources/list and resources/read without
 // authentication (rule mcp-resources-unauth-001).
@@ -109,54 +122,36 @@ func (e *ResourcesUnauthExecutor) Execute(ctx context.Context, target string, op
 		TargetURL:   session.Endpoint,
 	})
 
-	// Step 2: read the first resource
-	if len(uris) == 0 {
+	// Step 2: read resources, preferring one that demonstrates a credential leak.
+	//
+	// Reading only the first resource made the escalation to critical an accident
+	// of list order: a server that lists a public README ahead of its database
+	// credentials was reported as merely readable. The listing order is the
+	// server's choice, so the rule cannot let it decide the severity.
+	read, examined := e.readResources(ctx, client, session, uris)
+	if read == nil {
 		return findings, nil
 	}
 
-	readResp, err := client.POST(ctx, session.Endpoint, session.header(), map[string]interface{}{
-		"jsonrpc": "2.0",
-		"id":      4,
-		"method":  "resources/read",
-		"params":  map[string]interface{}{"uri": uris[0]},
-	})
-	if err != nil || !readResp.IsSuccess() {
-		return findings, nil
-	}
-
-	var readBody map[string]interface{}
-	if err := json.Unmarshal(readResp.Body, &readBody); err != nil {
-		return findings, nil
-	}
-	if _, hasErr := readBody["error"]; hasErr {
-		return findings, nil
-	}
-
-	content := string(readResp.Body)
 	// Baseline: unauthenticated read of resource content is high. Escalate to
 	// critical only when the content actually contains a detected secret -
 	// severity should track demonstrated impact, not be flat-critical for every
 	// readable resource (which may be benign, e.g. a public README).
 	sev := "high"
-
-	var credEvidence string
-	for _, re := range credentialPatterns {
-		if loc := re.FindStringIndex(content); loc != nil {
-			credEvidence = fmt.Sprintf("Pattern matched: %s at byte offset %d", re.String(), loc[0])
-			sev = "critical"
-			break
-		}
+	if read.credEvidence != "" {
+		sev = "critical"
 	}
 
-	evidenceLines := fmt.Sprintf("HTTP %d from %s\nresource URI: %s\ncontent snippet: %.400s", readResp.StatusCode, session.Endpoint, uris[0], content)
-	title := fmt.Sprintf("MCP resource %q content readable without authentication", uris[0])
+	evidenceLines := fmt.Sprintf("HTTP %d from %s\nresource URI: %s\nresources examined: %d of %d listed\ncontent snippet: %.400s",
+		read.statusCode, session.Endpoint, read.uri, examined, len(uris), read.content)
+	title := fmt.Sprintf("MCP resource %q content readable without authentication", read.uri)
 	description := fmt.Sprintf("resources/read for %s returned content without authentication. "+
-		"Resource data is directly accessible to any unauthenticated caller.", uris[0])
+		"Resource data is directly accessible to any unauthenticated caller.", read.uri)
 
-	if credEvidence != "" {
-		title = fmt.Sprintf("MCP resource %q contains potential credentials and is readable without authentication", uris[0])
-		description += "\n\nCredential pattern detected in content: " + credEvidence
-		evidenceLines += "\n" + credEvidence
+	if read.credEvidence != "" {
+		title = fmt.Sprintf("MCP resource %q contains potential credentials and is readable without authentication", read.uri)
+		description += "\n\nCredential pattern detected in content: " + read.credEvidence
+		evidenceLines += "\n" + read.credEvidence
 	}
 
 	findings = append(findings, attack.Finding{
@@ -172,6 +167,82 @@ func (e *ResourcesUnauthExecutor) Execute(ctx context.Context, target string, op
 	})
 
 	return findings, nil
+}
+
+// resourceRead is one successfully read resource.
+type resourceRead struct {
+	uri          string
+	statusCode   int
+	content      string
+	credEvidence string
+}
+
+// readResources reads resources until one yields a credential, up to
+// maxResourceReads. It returns that resource if any content matched, otherwise
+// the first resource that could be read at all, along with the number of
+// resources it attempted. A nil result means nothing could be read.
+//
+// examined is reported in the finding's evidence, because a run that stopped at
+// the cap has not looked at everything and must not read as though it had.
+func (e *ResourcesUnauthExecutor) readResources(ctx context.Context, client *attack.HTTPClient, session mcpSession, uris []string) (result *resourceRead, examined int) {
+	var first *resourceRead
+
+	for i, uri := range uris {
+		if examined >= maxResourceReads {
+			break
+		}
+		examined++
+
+		read := e.readResource(ctx, client, session, uri, i)
+		if read == nil {
+			continue
+		}
+		// A credential is the strongest evidence available, so stop as soon as
+		// one turns up rather than spending the remaining budget.
+		if read.credEvidence != "" {
+			return read, examined
+		}
+		if first == nil {
+			first = read
+		}
+	}
+
+	return first, examined
+}
+
+// readResource performs one resources/read and classifies its content. It
+// returns nil when the read did not produce content, which covers a transport
+// failure, a non-2xx reply, an unparseable body and a JSON-RPC error.
+func (e *ResourcesUnauthExecutor) readResource(ctx context.Context, client *attack.HTTPClient, session mcpSession, uri string, i int) *resourceRead {
+	resp, err := client.POST(ctx, session.Endpoint, session.header(), map[string]interface{}{
+		"jsonrpc": "2.0",
+		// Distinct ids per read: reusing one id across requests makes a
+		// server's replies ambiguous to correlate.
+		"id":     4 + i,
+		"method": "resources/read",
+		"params": map[string]interface{}{"uri": uri},
+	})
+	if err != nil || !resp.IsSuccess() {
+		return nil
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		return nil
+	}
+	if _, hasErr := body["error"]; hasErr {
+		return nil
+	}
+
+	content := string(resp.Body)
+	read := &resourceRead{uri: uri, statusCode: resp.StatusCode, content: content}
+	for _, re := range credentialPatterns {
+		if loc := re.FindStringIndex(content); loc != nil {
+			read.credEvidence = fmt.Sprintf("Pattern matched: %s at byte offset %d", re.String(), loc[0])
+			break
+		}
+	}
+	return read
 }
 
 // initializeMCP performs the MCP initialize handshake and returns a session


### PR DESCRIPTION
## Two reasons a critical finding was being reported as high

`mcp-resources-unauth-001` escalates to critical only when a read resource contains a credential. Both halves of that were broken on real content.

**It read the first listed resource and stopped.** Which resource comes first is the server's choice, so a deployment that lists a public README ahead of its database credentials was graded high. The listing order should not decide the severity.

**The credential patterns could not see a URI userinfo section.** All eight expected a name and a separator, as in `password=value`, so this carried a password straight past every one of them:

```
postgresql://admin:hunter2@db.internal:5432/prod
```

Connection strings are a routine thing to expose through a resource.

## The fix

Read up to **five** resources, stop at the first that matches, report that one. The evidence states `resources examined: N of M listed`, so a run that stopped at the bound is distinguishable from one that saw everything. A resource that cannot be read is skipped rather than ending the search.

New pattern:

```go
regexp.MustCompile(`(?i)[a-z][a-z0-9+.-]*://[^/\s:@]*:[^/\s:@]+@[^/\s]+`)
```

Requiring the `@` is what keeps an ordinary `http://host:5432/path` from matching on its port. A username with no password does not match either, since that is not a secret. Covered both ways in `credentials_test.go`, including `mongodb+srv://`, the empty-username `redis://:pass@host` form, and negatives for a bare email address and a path containing an `@`.

## Confirmed against the fixture

`testdata/mcp_unauth_resources_server.py` returns a connection string and documents itself as leaking credentials. It reported high right up to this change.

```
before:  [!] HIGH      MCP resource "config://database" content readable without authentication
after:   [!] CRITICAL  MCP resource "config://database" contains potential credentials and is readable ...
                       resources examined: 1 of 3 listed
                       Pattern matched: (?i)[a-z][a-z0-9+.-]*://[^/\s:@]*:[^/\s:@]+@[^/\s]+ at byte offset 79
```

## Tests

The existing harness in `resources_unauth_test.go` returns the same body for every read, so it cannot tell "read the first" from "read until something leaks". The new one serves per-URI content.

- credential in resource 3 of 3, first two benign: critical, and the finding names resource 3
- stops reading once a credential is found (asserts the server saw exactly 2 reads, not 4)
- no credential anywhere: high, first readable resource reported, as before
- 12 resources listed: exactly 5 reads, and the evidence says `5 of 12 listed`
- a resource that returns a JSON-RPC error is skipped, and the leak in the next one is still found

Verified non-vacuous by reverting both behaviours and confirming each of these fails. Full `go test -race ./...`, `go vet`, `gofmt` and `golangci-lint` at the pinned v2.11.4 clean.

## Also

Reads now carry distinct JSON-RPC ids. Reusing one id across several requests makes a server's replies ambiguous to correlate.

## One gap left in place

The bearer pattern is `(bearer|authorization)\s*[=:]\s*\S{10,}`, which **cannot** match `Authorization: Bearer <token>`. After `authorization:` the next token is `Bearer`, six characters, and after `bearer` there is no separator at all. The canonical header form is the one shape it misses, and it is the shape most likely to turn up in a leaked config.

Found while writing these tests. Left out because it is a separate change from the two this PR was scoped to, and recorded as a comment in `credentials_test.go` rather than pinned by an assertion, so fixing it does not have to fight a test.