### PR TITLE
fix(mcp): match the Authorization header form the bearer pattern was missing

### DIFF
--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -141,9 +141,9 @@ retrieves data directly. All findings are **confirmed** (the data was actually
 returned without a token). Severity is **impact-graded**: an unauthenticated list
 and a readable resource are **high**; the read is escalated to **critical** only
 when the returned content matches a credential pattern (AWS/OpenAI/GitHub keys,
-private keys, JWTs, password/bearer assignments, credentials in a URI userinfo
-section such as `postgresql://user:pass@host/db`), and the matched pattern is
-cited in the evidence.
+private keys, JWTs, password assignments, `Authorization: Bearer <token>` headers,
+credentials in a URI userinfo section such as `postgresql://user:pass@host/db`),
+and the matched pattern is cited in the evidence.
 
 Up to five resources are read, stopping at the first one that matches, and the
 finding reports that resource. Reading only the first would leave the severity to

--- a/internal/attack/mcp/credentials_test.go
+++ b/internal/attack/mcp/credentials_test.go
@@ -108,11 +108,80 @@ func TestCredentialPatterns_ExistingShapesStillMatch(t *testing.T) {
 	}
 }
 
-// Known gap, deliberately not asserted either way so that fixing it does not
-// have to fight a test: the bearer pattern is
-// (bearer|authorization)\s*[=:]\s*\S{10,}, which cannot match the canonical
-// header form "Authorization: Bearer <token>". After "authorization:" the next
-// token is "Bearer", only six characters, and after "bearer" there is no
-// separator at all. So the one shape an operator is most likely to find in a
-// leaked config is the one shape this does not catch. Left alone here because
-// it is a separate change from the URI userinfo gap this file was added for.
+// The canonical header form is what an operator is most likely to find in a
+// leaked config, and it used to be the one shape the bearer pattern could not
+// see: after "authorization:" the next token is "Bearer", six characters, which
+// failed the \S{10,} the pattern needs.
+func TestCredentialPatterns_AuthorizationHeader(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			name:  "canonical header form",
+			input: "Authorization: Bearer sk_live_51H8xQ2eZvKYlo2C",
+			want:  true,
+		},
+		{
+			name:  "lowercase header",
+			input: "authorization: bearer abcdefghijklmnop",
+			want:  true,
+		},
+		{
+			name:  "yaml style with quotes",
+			input: `authorization: "Bearer ghp_abcdefghijklmnopqrst"`,
+			want:  true,
+		},
+		{
+			// Content is matched against the raw JSON-RPC body, so a quote
+			// inside a resource arrives escaped.
+			name:  "json escaped quote before the value",
+			input: `{"text":"authorization: \"Bearer ghp_abcdefghijklmnopqrst\""}`,
+			want:  true,
+		},
+		{
+			name:  "no bearer prefix, token directly after the separator",
+			input: "Authorization=abcdefghijklmnopqrst",
+			want:  true,
+		},
+		{
+			// Making the separator optional to catch a bare "Bearer <token>"
+			// would match this, so the separator stays required.
+			name:  "prose about authorization",
+			input: "Authorization requirements documented in the handbook",
+			want:  false,
+		},
+		{
+			name:  "header naming a scheme but no token",
+			input: "Authorization: required",
+			want:  false,
+		},
+		{
+			name:  "bearer prefix with too short a token",
+			input: "Authorization: Bearer short",
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchesAnyCredentialPattern(tt.input); got != tt.want {
+				t.Errorf("matchesAnyCredentialPattern(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// Deliberate boundary: a standalone "Bearer <token>" with no Authorization
+// keyword and no separator still does not match, because keying on a bare
+// "bearer" would fire on prose. The common case is covered anyway, since a JWT
+// matches the eyJ pattern whatever precedes it.
+func TestCredentialPatterns_StandaloneBearerBoundary(t *testing.T) {
+	if matchesAnyCredentialPattern("bearer instruments outstanding at year end") {
+		t.Error("a bare bearer keyword in prose must not match")
+	}
+	if !matchesAnyCredentialPattern("Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NSJ9") {
+		t.Error("a bearer-prefixed JWT should still match, via the JWT pattern")
+	}
+}

--- a/internal/attack/mcp/resources_unauth.go
+++ b/internal/attack/mcp/resources_unauth.go
@@ -17,8 +17,20 @@ var credentialPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)(password|passwd|pwd)\s*[=:]\s*\S{6,}`),         // Password
 	regexp.MustCompile(`-----BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY-----`),   // Private keys
 	regexp.MustCompile(`(?i)ghp_[a-zA-Z0-9]{36}`),                           // GitHub token
-	regexp.MustCompile(`(?i)(bearer|authorization)\s*[=:]\s*\S{10,}`),       // Bearer/auth token
-	regexp.MustCompile(`(?i)eyJ[A-Za-z0-9-_]{10,}\.[A-Za-z0-9-_]{10,}`),     // JWT
+	// The optional "Bearer " after the separator is what lets this match the
+	// canonical header form, Authorization: Bearer <token>. Without it the
+	// pattern reached "Bearer", six characters, and gave up against the
+	// \S{10,} it needs; the one shape most likely to appear in a leaked config
+	// was the one shape it could not see. The separator stays required, because
+	// making it optional would match any long word following the keyword, as in
+	// "Authorization requirements documented".
+	//
+	// The quote class is not cosmetic: content is matched against the raw
+	// JSON-RPC response body, so a resource holding `authorization: "Bearer x"`
+	// arrives with the quote escaped, as \" , sitting between the separator and
+	// the value.
+	regexp.MustCompile(`(?i)(bearer|authorization)\s*[=:]\s*[\\"']*\s*(bearer\s+)?\S{10,}`), // Bearer/auth token
+	regexp.MustCompile(`(?i)eyJ[A-Za-z0-9-_]{10,}\.[A-Za-z0-9-_]{10,}`),                     // JWT
 	// Credentials in a URI userinfo section, as in
 	// postgresql://admin:hunter2@db.internal:5432/prod. Connection strings are
 	// a routine thing to expose through a resource and the password pattern


### PR DESCRIPTION
## The gap

```go
regexp.MustCompile(`(?i)(bearer|authorization)\s*[=:]\s*\S{10,}`)
```

This cannot match `Authorization: Bearer <token>`. After `authorization:` the next token is `Bearer`, six characters, which fails the `\S{10,}` the pattern needs; and after `bearer` there is no separator at all. The canonical header form was the one shape it could not see, and it is the shape most likely to turn up in a config exposed through an MCP resource.

Found while writing the pattern tests in #121, and deliberately left out of that PR as a separate change from the URI userinfo gap it was scoped to.

## The fix

```go
regexp.MustCompile(`(?i)(bearer|authorization)\s*[=:]\s*[\\"']*\s*(bearer\s+)?\S{10,}`)
```

An optional `Bearer ` after the separator. The separator itself **stays required**: making it optional would match any long word following the keyword, as in `Authorization requirements documented`.

The quote class is not cosmetic. Content is matched against the **raw JSON-RPC response body**, so a resource holding `authorization: "Bearer x"` arrives with the quote escaped, sitting exactly where the value was expected. Without it the YAML and JSON cases below both miss.

## Deliberate boundary

A standalone `Bearer <token>` with no keyword and no separator still does not match, because keying on a bare `bearer` would fire on prose (`bearer instruments outstanding at year end`). The common case is covered regardless: a JWT matches the `eyJ` pattern whatever precedes it. `TestCredentialPatterns_StandaloneBearerBoundary` pins both halves.

## Tests

| Input | Expected |
|---|---|
| `Authorization: Bearer sk_live_51H8xQ2eZvKYlo2C` | match |
| `authorization: bearer abcdefghijklmnop` | match |
| `authorization: "Bearer ghp_abcdefghijklmnopqrst"` | match |
| `{"text":"authorization: \"Bearer ghp_...\""}` | match |
| `Authorization=abcdefghijklmnopqrst` | match, as before |
| `Authorization requirements documented in the handbook` | no match |
| `Authorization: required` | no match |
| `Authorization: Bearer short` | no match |

Verified non-vacuous: restoring the old pattern fails four of these with `want true`. The seven existing credential shapes still match, and the URI userinfo cases from #121 are unaffected.

Full `go test -race ./...`, `go vet`, `gofmt` and `golangci-lint` at the pinned v2.11.4 clean. Rule catalog updated to list the header form.