### PR TITLE
fix(a2a): stop taking an MCP server for an A2A agent during discovery

### DIFF
--- a/docs/rules-a2a.md
+++ b/docs/rules-a2a.md
@@ -34,6 +34,24 @@ changes touch this rule set:
   binding. It is a SHOULD rather than a MUST, and the JSON-RPC binding these
   rules primarily drive explicitly keeps `application/json`.
 
+## Endpoint discovery
+
+The JSON-RPC transport is not required to live at the target root, so discovery
+prefers the URL the agent card declares for the JSON-RPC interface, pinned to the
+target's own scheme and host. Only when no card names one does it probe the
+conventional paths.
+
+A probed path is judged by a read-only task lookup for a non-existent id, in both
+the v0.3 (`tasks/get`) and v1.0 (`GetTask`) spellings. **"Method not found" is
+treated as weak evidence**: every JSON-RPC service answers an unknown method that
+way, so accepting it meant an MCP server was taken for an A2A agent and the rules
+ran against it. When that is all a path offers, it is asked whether it answers an
+MCP `initialize`; a valid MCP result disqualifies it.
+
+The check is negative on purpose. A2A agents exist that implement neither
+task-get spelling, so requiring a task-shaped answer would lose them. A target
+where no A2A endpoint is found is reported as **not tested**, not as clean.
+
 | Rule ID | Attack | Severity | Confidence | CWE |
 |---|---|:---:|:---:|---|
 | `a2a-extcard-unauth-001` | [Extended Agent Card Unauthenticated Disclosure](#a2a-extcard-unauth-001) | High | confirmed | CWE-862 |

--- a/internal/attack/a2a/endpoint.go
+++ b/internal/attack/a2a/endpoint.go
@@ -132,15 +132,30 @@ func candidateEndpoints(baseURL string) []string {
 	return endpoint.Candidates(baseURL, candidatePaths)
 }
 
-// probeJSONRPCEndpoint reports whether a path answers JSON-RPC. It sends a
-// read-only task lookup for a non-existent id and treats a JSON-RPC envelope
-// (result or error) or an auth rejection (401/403) as a live endpoint; a 404 or
-// transport error means this is not the endpoint.
+// methodNotFound is the JSON-RPC code for an unimplemented method. It is the
+// one error a task lookup can earn that says nothing about what the server is.
+const methodNotFound = -32601
+
+// probeJSONRPCEndpoint reports whether a path answers JSON-RPC as an A2A agent.
+// It sends a read-only task lookup for a non-existent id and treats a JSON-RPC
+// envelope (result or error) or an auth rejection (401/403) as a live endpoint;
+// a 404 or transport error means this is not the endpoint.
 //
 // It tries both the v0.3 (tasks/get) and v1.0 (GetTask) method names, because a
 // server that does not implement one may answer 404 for it while still being a
 // JSON-RPC endpoint that handles the other. Probing only one method would miss
 // such servers.
+//
+// "Method not found" is treated as weak evidence rather than as proof. Any
+// JSON-RPC service answers an unknown method that way, so an MCP server was
+// being accepted here as an A2A agent: point the scanner at one and sixteen A2A
+// rules reported clean rather than skipped, which turns "could not test" into
+// "tested, nothing found". When that is all a candidate offers, the endpoint is
+// asked whether it is an MCP server before it is accepted.
+//
+// The check is deliberately negative rather than a stricter test for A2A. A2A
+// servers exist that implement neither task-get spelling, including two of this
+// repository's own fixtures, and requiring a task-shaped answer would lose them.
 func probeJSONRPCEndpoint(ctx context.Context, client *attack.HTTPClient, endpoint string) bool {
 	probes := []struct {
 		method  string
@@ -149,6 +164,8 @@ func probeJSONRPCEndpoint(ctx context.Context, client *attack.HTTPClient, endpoi
 		{"tasks/get", nil},
 		{"GetTask", map[string]string{"A2A-Version": "1.0"}},
 	}
+
+	sawMethodNotFound := false
 	for _, p := range probes {
 		resp, err := client.POST(ctx, endpoint, p.headers, map[string]interface{}{
 			"jsonrpc": "2.0",
@@ -165,11 +182,65 @@ func probeJSONRPCEndpoint(ctx context.Context, client *attack.HTTPClient, endpoi
 		if resp.StatusCode == 404 {
 			continue
 		}
+		if code, ok := jsonRPCErrorCode(resp.Body); ok && code == methodNotFound {
+			sawMethodNotFound = true
+			continue
+		}
+		// Anything else on a JSON-RPC envelope is an answer only something
+		// implementing the method could give: a TaskNotFound, an invalid-params
+		// rejection of our probe's shape, or an actual result.
 		if isJSONRPCError(resp.Body) || resp.ContainsAny(`"jsonrpc"`, `"result"`) {
 			return true
 		}
 	}
+
+	if sawMethodNotFound {
+		return !answersMCPInitialize(ctx, client, endpoint)
+	}
 	return false
+}
+
+// answersMCPInitialize reports whether the endpoint identifies itself as an MCP
+// server. MCP opens with an initialize handshake whose result carries a
+// protocolVersion, and no A2A method produces that, so a valid MCP result here
+// is conclusive.
+//
+// This is deliberately not the MCP package's initializeMCP, which does much more
+// (candidate paths, session ids, protocol negotiation, era detection). All that
+// is wanted here is a yes or no about one URL that has already been located.
+func answersMCPInitialize(ctx context.Context, client *attack.HTTPClient, endpoint string) bool {
+	resp, err := client.POST(ctx, endpoint, nil, map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      "batesian-a2a-discovery-mcp",
+		"method":  "initialize",
+		"params": map[string]interface{}{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]interface{}{},
+			"clientInfo":      map[string]interface{}{"name": "batesian", "version": attack.Version},
+		},
+	})
+	if err != nil || !resp.IsAccepted() {
+		return false
+	}
+	return resp.ContainsAny(`"protocolVersion"`)
+}
+
+// jsonRPCErrorCode extracts the numeric code from a JSON-RPC error envelope. ok
+// is false when the body is not JSON, carries no error object, or the error has
+// no numeric code.
+func jsonRPCErrorCode(body []byte) (int, bool) {
+	var envelope struct {
+		Error *struct {
+			Code *float64 `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return 0, false
+	}
+	if envelope.Error == nil || envelope.Error.Code == nil {
+		return 0, false
+	}
+	return int(*envelope.Error.Code), true
 }
 
 // hasHTTPScheme reports whether rawURL is an absolute http(s) URL.

--- a/internal/attack/a2a/endpoint_test.go
+++ b/internal/attack/a2a/endpoint_test.go
@@ -172,6 +172,86 @@ func TestResolveA2AEndpoint_TargetNamesTheEndpointPath(t *testing.T) {
 	}
 }
 
+// jsonRPCServer answers every POST with the given body, whatever the path. It
+// stands in for a JSON-RPC service that is not an A2A agent.
+func jsonRPCServer(reply func(method string) string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		method, _ := req["method"].(string)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(reply(method)))
+	}))
+}
+
+// An MCP server answers a task lookup with "method not found", exactly as an
+// A2A agent that implements neither spelling does. Accepting that as an A2A
+// endpoint made sixteen A2A rules report clean against an MCP target instead of
+// skipping, which is the difference between "tested, nothing found" and "could
+// not test".
+func TestResolveA2AEndpoint_MCPServerIsNotAnA2AEndpoint(t *testing.T) {
+	srv := jsonRPCServer(func(method string) string {
+		if method == "initialize" {
+			return `{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18",` +
+				`"serverInfo":{"name":"mcp","version":"1.0"},"capabilities":{}}}`
+		}
+		return `{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}`
+	})
+	defer srv.Close()
+
+	if ep, ok := resolveA2AEndpoint(context.Background(), newClient(srv.URL), srv.URL); ok {
+		t.Errorf("resolved %q against an MCP server, want ok=false so the rules skip", ep)
+	}
+}
+
+// The reason the check is negative rather than a stricter test for A2A: agents
+// exist that implement neither task-get spelling and answer "method not found"
+// for both, including this repository's own delegation and push-binding
+// fixtures. They must still be discovered.
+func TestResolveA2AEndpoint_AgentWithoutTaskMethodsStillFound(t *testing.T) {
+	srv := jsonRPCServer(func(string) string {
+		return `{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}`
+	})
+	defer srv.Close()
+
+	ep, ok := resolveA2AEndpoint(context.Background(), newClient(srv.URL), srv.URL)
+	if !ok {
+		t.Fatal("expected ok=true: a JSON-RPC service that is not MCP stays an A2A candidate")
+	}
+	if ep != srv.URL+"/" {
+		t.Errorf("endpoint = %q, want %s/", ep, srv.URL)
+	}
+}
+
+// A task lookup answered with anything other than "method not found" is
+// evidence only something implementing the method could give, so it is accepted
+// without the MCP question being asked at all.
+func TestResolveA2AEndpoint_TaskNotFoundNeedsNoDisambiguation(t *testing.T) {
+	mcpProbes := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		method, _ := req["method"].(string)
+		if method == "initialize" {
+			mcpProbes++
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32001,"message":"Task not found"}}`))
+	}))
+	defer srv.Close()
+
+	if _, ok := resolveA2AEndpoint(context.Background(), newClient(srv.URL), srv.URL); !ok {
+		t.Fatal("expected ok=true for a server answering TaskNotFound")
+	}
+	if mcpProbes != 0 {
+		t.Errorf("sent %d MCP initialize probes, want 0 when the answer already settles it", mcpProbes)
+	}
+}
+
 // The origin form is unchanged: appending still finds a handler mounted at a
 // conventional path.
 func TestResolveA2AEndpoint_OriginTargetUnchanged(t *testing.T) {


### PR DESCRIPTION
## The bug

Endpoint discovery judged a probed path by sending a task lookup and accepting **any** JSON-RPC envelope. Every JSON-RPC service answers an unknown method with `-32601`, so an MCP server passed:

```
$ curl -s -X POST http://127.0.0.1:7799/mcp -d '{"jsonrpc":"2.0","id":"batesian-a2a-discovery","method":"tasks/get",...}'
{"jsonrpc":"2.0","id":"batesian-a2a-discovery","error":{"code":-32601,"message":"Method not found","data":"tasks/get"}}
```

Point the scanner at an MCP server and sixteen A2A rules reported **clean** rather than skipped. That turns "could not test" into "tested, nothing found", which is the exact distinction the S3 inconclusive work exists to protect.

Surfaced by #119: fixing path targets widened the set of configurations where this is reachable, and the PR noted it as pre-existing and out of scope.

## The fix

`-32601` becomes weak evidence rather than proof. Any **other** JSON-RPC answer, a `TaskNotFound`, an invalid-params rejection of the probe's shape, or a result, is something only an implementation of the method could produce, and is still accepted immediately. When method-not-found is all a path offers, the endpoint is asked whether it answers an MCP `initialize`; a valid MCP result disqualifies it.

**The check is negative on purpose, and I got here by testing rather than reasoning.** My first design was to reject any path that answered `-32601` for both spellings, on the theory that a real agent implements at least one. Checking the fixtures killed that: `a2a_delegation_server.py` and `a2a_push_binding_server.py` implement **neither** task-get spelling and answer method-not-found for both. A stricter test for A2A would have silently lost them. Both were verified to still be discovered after this change.

Cost is one extra request, only on the weak-evidence path. A server that answers the task lookup settles it on the first probe, and `TestResolveA2AEndpoint_TaskNotFoundNeedsNoDisambiguation` asserts no MCP probe is sent in that case.

`answersMCPInitialize` is deliberately not the MCP package's `initializeMCP`, which does candidate paths, session ids, protocol negotiation and era detection. All that is wanted here is a yes or no about one URL that has already been located.

## Measured, not asserted

| Target | Before | After |
|---|---|---|
| MCP server (official Python SDK), path target | 1 A2A rule reported could-not-test | **5** |
| A2A lab fixture, port 9998 | 6 findings | 6 findings, unchanged |
| Cardless delegation fixture (`-32601` both spellings) | 0 A2A skips | 0 A2A skips, still discovered |

Tests verified non-vacuous: restoring the old accept-anything behaviour fails `TestResolveA2AEndpoint_MCPServerIsNotAnA2AEndpoint` with `resolved "..." against an MCP server, want ok=false`.

## Why 5 and not 17

Three of the eight rules that report could-not-test against an unreachable target still report **clean** against an MCP one: `a2a-extcard-unauth-001`, `a2a-push-ssrf-001` and `a2a-session-smuggle-001`. They keep their own `reached` flag, set by any non-404 response, independent of what discovery concluded. A `-32601` at HTTP 200 sets it.

The remaining nine A2A rules gate on an agent card rather than on the JSON-RPC endpoint, and report nothing when none is served.

Both are the same defect one layer up, and both want the treatment the MCP executors got in the S3 wave: a shared notion of "reached a testable endpoint" rather than a per-rule flag. That is a larger change than this one and is not in here. Flagging it because 5-of-8 could otherwise read as complete.

Full `go test -race ./...`, `go vet`, `gofmt` and `golangci-lint` at the pinned v2.11.4 clean. `docs/rules-a2a.md` gains an Endpoint discovery section.