### PR TITLE
fix(a2a): report a non-A2A target as not tested, not as clean

### DIFF
--- a/docs/rules-a2a.md
+++ b/docs/rules-a2a.md
@@ -52,6 +52,29 @@ The check is negative on purpose. A2A agents exist that implement neither
 task-get spelling, so requiring a task-shaped answer would lose them. A target
 where no A2A endpoint is found is reported as **not tested**, not as clean.
 
+## Clean, or never tested
+
+A rule that finds nothing distinguishes two outcomes, and reports them
+differently:
+
+- **Clean.** The target is an A2A agent and this attack did not work against it,
+  or the feature the rule targets is absent. A card that advertises no required
+  extension leaves `a2a-extension-downgrade-001` nothing to downgrade, and that
+  is a real result.
+- **Not tested.** Nothing at the target identifies as an A2A agent. Every rule
+  reports this rather than a clean pass, because a scan that says "no findings"
+  for a host it never exercised claims coverage it does not have.
+
+A target counts as testable when endpoint discovery finds a JSON-RPC endpoint
+**or** an agent card is served. Either alone is enough: agents exist that serve
+no card, and agents exist whose card is served while their transport is not
+where discovery looks.
+
+The three card-analysis rules (`a2a-card-trust-001`, `a2a-jws-algconf-001`,
+`a2a-wellknown-hostinject-001`) are stricter, and report **not tested** whenever
+no card is served, even against a target that is plainly an agent by other
+evidence. A card rule with no card has nothing to say either way.
+
 | Rule ID | Attack | Severity | Confidence | CWE |
 |---|---|:---:|:---:|---|
 | `a2a-extcard-unauth-001` | [Extended Agent Card Unauthenticated Disclosure](#a2a-extcard-unauth-001) | High | confirmed | CWE-862 |

--- a/internal/attack/a2a/card_trust.go
+++ b/internal/attack/a2a/card_trust.go
@@ -51,7 +51,10 @@ func (e *CardTrustExecutor) Execute(ctx context.Context, target string, opts att
 	primaryBody, primaryCacheControl, primaryOK := fetchCard(ctx, client, primaryURL)
 	legacyBody, _, legacyOK := fetchCard(ctx, client, legacyURL)
 	if !primaryOK && !legacyOK {
-		return nil, nil // not a responsive A2A card server
+		// This rule analyses the card, so no card means it was not exercised.
+		// It used to return clean here, which reads as "the card is fine" for a
+		// target that served none.
+		return nil, attack.ErrInconclusive
 	}
 
 	// Use whichever path actually served a card as the basis for the cache and

--- a/internal/attack/a2a/card_trust_test.go
+++ b/internal/attack/a2a/card_trust_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -171,12 +172,18 @@ func TestCardTrust_Clean(t *testing.T) {
 	}
 }
 
-// TestCardTrust_NotACardServer: no well-known card => no findings.
+// TestCardTrust_NotACardServer: no well-known card means the rule was never
+// exercised, not that the card is sound. It used to report clean here, which is
+// indistinguishable from a target whose card passed every check.
 func TestCardTrust_NotACardServer(t *testing.T) {
 	ts := httptest.NewServer(http.NotFoundHandler())
 	defer ts.Close()
 
-	if findings := runCardTrust(t, ts); len(findings) != 0 {
+	findings, err := a2a.NewCardTrustExecutor(testRuleCtx()).Execute(context.Background(), ts.URL, attack.Options{TimeoutSeconds: 5})
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive against a non-card server, got err=%v", err)
+	}
+	if len(findings) != 0 {
 		t.Errorf("expected zero findings against a non-card server, got %d", len(findings))
 	}
 }

--- a/internal/attack/a2a/extcard.go
+++ b/internal/attack/a2a/extcard.go
@@ -56,7 +56,7 @@ func (e *ExtCardExecutor) Execute(ctx context.Context, target string, opts attac
 	// /v1/message:send are tried since the endpoint varies by binding type. One
 	// finding max, preferring the invalid-token (critical) signal.
 	reached := false
-	jsonrpcEP, _ := resolveA2AEndpoint(ctx, unauthClient, vars.BaseURL)
+	jsonrpcEP, endpointOK := resolveA2AEndpoint(ctx, unauthClient, vars.BaseURL)
 	for _, ep := range []string{jsonrpcEP, vars.BaseURL + "/v1/message:send"} {
 		resp, usable := e.probeJSONRPC(ctx, unauthClient, ep, invalidToken, vars.RandID)
 		if resp != nil && resp.StatusCode != 404 {
@@ -92,8 +92,13 @@ func (e *ExtCardExecutor) Execute(ctx context.Context, target string, opts attac
 
 	// No disclosure found. If nothing was even reachable, the rule could not be
 	// exercised against a testable endpoint.
-	if len(findings) == 0 && !reached {
-		return nil, attack.ErrInconclusive
+	if len(findings) == 0 {
+		if !reached {
+			return nil, attack.ErrInconclusive
+		}
+		// reached only records a response that was not a 404. Confirm the target
+		// is an A2A agent before reporting no disclosure as a clean result.
+		return nil, notTestableGiven(ctx, unauthClient, vars.BaseURL, endpointOK)
 	}
 	return findings, nil
 }

--- a/internal/attack/a2a/extcard_test.go
+++ b/internal/attack/a2a/extcard_test.go
@@ -3,6 +3,7 @@ package a2a_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -148,11 +149,14 @@ func TestExtCardExecutor_HTMLLoginNotFinding(t *testing.T) {
 	defer ts.Close()
 
 	findings, err := a2a.NewExtCardExecutor(testRuleCtx()).Execute(context.Background(), ts.URL, testOpts())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
 	if len(findings) != 0 {
 		t.Errorf("expected zero findings for a 200 HTML login page, got %d: %+v", len(findings), findings)
+	}
+	// Nothing here identifies as an A2A agent: every path answers with the same
+	// login page. Silence is the right finding count, but the run must say it
+	// could not test rather than that the target is clean.
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Errorf("expected ErrInconclusive against a login-page server, got err=%v", err)
 	}
 }
 

--- a/internal/attack/a2a/extension_downgrade.go
+++ b/internal/attack/a2a/extension_downgrade.go
@@ -56,11 +56,14 @@ func (e *ExtensionDowngradeExecutor) Execute(ctx context.Context, target string,
 	vars := attack.NewVars(target, opts.OOBListenerURL)
 	client := attack.NewHTTPClient(opts, vars)
 
-	required := e.requiredExtensions(ctx, client, vars.BaseURL)
+	required, cardServed := e.requiredExtensions(ctx, client, vars.BaseURL)
+	endpoint, ok := resolveA2AEndpoint(ctx, client, vars.BaseURL)
 	if len(required) == 0 {
+		if !cardServed && !ok {
+			return nil, attack.ErrInconclusive // nothing here is an A2A agent
+		}
 		return nil, nil // no required extension advertised => nothing to downgrade
 	}
-	endpoint, ok := resolveA2AEndpoint(ctx, client, vars.BaseURL)
 	if !ok {
 		return nil, attack.ErrInconclusive
 	}
@@ -83,7 +86,13 @@ func (e *ExtensionDowngradeExecutor) Execute(ctx context.Context, target string,
 
 // requiredExtensions fetches the agent card and returns the URIs of every
 // extension the card marks `required: true`.
-func (e *ExtensionDowngradeExecutor) requiredExtensions(ctx context.Context, client *attack.HTTPClient, baseURL string) []string {
+//
+// cardServed is reported separately from the result, because an empty list means
+// two different things. A card that advertises no required extension leaves
+// nothing to downgrade, which is a clean result. No card at all means the target
+// was never identified as an A2A agent, and returning clean for that claims
+// coverage the scan does not have.
+func (e *ExtensionDowngradeExecutor) requiredExtensions(ctx context.Context, client *attack.HTTPClient, baseURL string) (uris []string, cardServed bool) {
 	for _, path := range []string{cardPathPrimary, cardPathLegacy} {
 		resp, err := client.GET(ctx, baseURL+path, nil)
 		if err != nil || !resp.IsSuccess() {
@@ -100,6 +109,7 @@ func (e *ExtensionDowngradeExecutor) requiredExtensions(ctx context.Context, cli
 		if err := json.Unmarshal(resp.Body, &card); err != nil {
 			continue
 		}
+		cardServed = true
 		var out []string
 		for _, ext := range card.Capabilities.Extensions {
 			if ext.Required && ext.URI != "" {
@@ -107,10 +117,10 @@ func (e *ExtensionDowngradeExecutor) requiredExtensions(ctx context.Context, cli
 			}
 		}
 		if len(out) > 0 {
-			return out
+			return out, true
 		}
 	}
-	return nil
+	return nil, cardServed
 }
 
 // sendMessage issues a SendMessage with the given extra headers. When forceShape

--- a/internal/attack/a2a/extension_downgrade_test.go
+++ b/internal/attack/a2a/extension_downgrade_test.go
@@ -3,6 +3,7 @@ package a2a_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -126,12 +127,18 @@ func TestExtDowngrade_ControlRejected(t *testing.T) {
 	}
 }
 
-// TestExtDowngrade_NotACardServer: no card => no finding.
+// TestExtDowngrade_NotACardServer: no card at all means nothing identified as an
+// A2A agent, which is different from an agent whose card declares no required
+// extension. The first was not tested; only the second is clean.
 func TestExtDowngrade_NotACardServer(t *testing.T) {
 	ts := httptest.NewServer(http.NotFoundHandler())
 	defer ts.Close()
 
-	if findings := runExtDowngrade(t, ts); len(findings) != 0 {
+	findings, err := a2a.NewExtensionDowngradeExecutor(testRuleCtx()).Execute(context.Background(), ts.URL, attack.Options{TimeoutSeconds: 5})
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive against a non-card server, got err=%v", err)
+	}
+	if len(findings) != 0 {
 		t.Errorf("expected zero findings against a non-card server, got %d", len(findings))
 	}
 }

--- a/internal/attack/a2a/jws_algconf.go
+++ b/internal/attack/a2a/jws_algconf.go
@@ -50,12 +50,17 @@ func (e *JWSAlgConfExecutor) Execute(ctx context.Context, target string, opts at
 	cardURL := vars.BaseURL + "/.well-known/agent-card.json"
 	resp, err := client.GET(ctx, cardURL, nil)
 	if err != nil || !resp.IsSuccess() {
-		return nil, nil
+		// The rule analyses signatures on the card. Without one it was not
+		// exercised, and reporting clean would read as "the signatures are
+		// sound" for a target that served no card at all. This holds even when
+		// the target is plainly an A2A agent by other evidence: a card rule with
+		// no card has nothing to say either way.
+		return nil, attack.ErrInconclusive
 	}
 
 	var card map[string]interface{}
 	if err := json.Unmarshal(resp.Body, &card); err != nil {
-		return nil, nil
+		return nil, attack.ErrInconclusive
 	}
 
 	var findings []attack.Finding

--- a/internal/attack/a2a/jws_algconf_test.go
+++ b/internal/attack/a2a/jws_algconf_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -171,8 +172,10 @@ func TestJWSAlgConfExecutor_NoSignatures(t *testing.T) {
 	}
 }
 
-// TestJWSAlgConfExecutor_NotFound verifies that a 404 response from the card
-// endpoint produces zero findings and a nil error.
+// TestJWSAlgConfExecutor_NotFound verifies that a 404 from the card endpoint is
+// reported as not tested rather than as clean. The rule analyses signatures on
+// the card; with no card there is nothing to analyse, and a clean result would
+// read as "the signatures are sound".
 func TestJWSAlgConfExecutor_NotFound(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
@@ -181,8 +184,8 @@ func TestJWSAlgConfExecutor_NotFound(t *testing.T) {
 
 	ex := a2a.NewJWSAlgConfExecutor(testRuleCtx())
 	findings, err := ex.Execute(context.Background(), ts.URL, testOpts())
-	if err != nil {
-		t.Fatalf("expected nil error for 404, got: %v", err)
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive for a 404 card path, got: %v", err)
 	}
 	if len(findings) != 0 {
 		t.Errorf("expected zero findings for 404, got %d: %+v", len(findings), findings)

--- a/internal/attack/a2a/push_ssrf.go
+++ b/internal/attack/a2a/push_ssrf.go
@@ -62,7 +62,7 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 	}
 
 	client := attack.NewHTTPClient(opts, vars)
-	endpoint, _ := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
+	endpoint, endpointOK := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
 	reached := false
 	callbackURL := listenerURL + "/batesian-" + vars.RandID
 	token := "batesian-" + vars.RandID
@@ -131,7 +131,12 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 		if err3 == nil && httpResp.StatusCode != 404 {
 			reached = true
 		}
-		if err3 == nil && httpResp.IsSuccess() && httpResp.IsJSON() {
+		// The HTTP+JSON binding returns a task object rather than a JSON-RPC
+		// envelope, so IsAccepted is the wrong test here. An explicit error
+		// envelope still has to be excluded: without that, any service answering
+		// 200 with a JSON error body counts as having accepted a task, and the
+		// rule goes on to wait for a callback that was never registered.
+		if err3 == nil && httpResp.IsSuccess() && httpResp.IsJSON() && !isJSONRPCError(httpResp.Body) {
 			taskAccepted = true
 			acceptedBinding = "HTTP+JSON"
 		}
@@ -143,7 +148,10 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 		if !reached {
 			return nil, attack.ErrInconclusive
 		}
-		return nil, nil
+		// reached only records a response that was not a 404, which any JSON-RPC
+		// service satisfies. Confirm the target is an A2A agent before calling
+		// this not applicable.
+		return nil, notTestableGiven(ctx, client, vars.BaseURL, endpointOK)
 	}
 
 	// Wait for OOB callback.

--- a/internal/attack/a2a/reachable.go
+++ b/internal/attack/a2a/reachable.go
@@ -1,0 +1,58 @@
+package a2a
+
+import (
+	"context"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// A rule that finds nothing has to say which of two things happened: the target
+// is an A2A agent and this attack did not work against it, or nothing here is an
+// A2A agent at all. The first is a clean result. The second is a target that was
+// never tested, and reporting it as clean is how a scan claims coverage it does
+// not have.
+//
+// Rules used to draw that line individually, and drew it differently. Some
+// returned nil when their feature gate found nothing, without ever asking
+// whether a card was served. Three kept a local "reached" flag set by any
+// response that was not a 404, which an unrelated JSON-RPC service satisfies.
+// The MCP executors were converged onto one rule for this; these are the A2A
+// half of the same work.
+//
+// The test is deliberately generous: an agent card at either path, or a
+// discovered JSON-RPC endpoint. A2A agents exist that serve no card, and agents
+// exist whose card is served but whose JSON-RPC transport is not where we look,
+// so requiring both would skip real targets.
+
+// cardServed reports whether either card path serves something that parses as an
+// agent card. It is the cheapest evidence that a target is an A2A agent, and
+// most rules have already made this call for their own reasons.
+func cardServed(ctx context.Context, client *attack.HTTPClient, baseURL string) bool {
+	for _, path := range []string{cardPathPrimary, cardPathLegacy} {
+		if _, _, ok := fetchCard(ctx, client, baseURL+path); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// notTestableGiven converts "this rule found nothing" into the right answer for
+// a rule that has already run endpoint discovery. If the target is an A2A agent
+// the empty result stands; if nothing here is one, the rule reports that it
+// could not be exercised.
+//
+// The card is only fetched when discovery came up empty, which is the only case
+// where it can change the answer, so the common path costs nothing.
+//
+// Rules that analyse the agent card do not use this. A card rule with no card
+// has nothing to say whether or not the target is an agent by other evidence, so
+// those report inconclusive directly.
+func notTestableGiven(ctx context.Context, client *attack.HTTPClient, baseURL string, endpointOK bool) error {
+	if endpointOK {
+		return nil
+	}
+	if cardServed(ctx, client, baseURL) {
+		return nil
+	}
+	return attack.ErrInconclusive
+}

--- a/internal/attack/a2a/reachable_test.go
+++ b/internal/attack/a2a/reachable_test.go
@@ -1,0 +1,143 @@
+package a2a_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack/a2a"
+)
+
+// A rule that finds nothing has to distinguish "this agent is not vulnerable to
+// this" from "nothing here is an A2A agent". These pin both sides of that line,
+// because a fix that only widens the inconclusive case is easy to write and
+// turns every clean scan into a skipped one.
+
+// cardlessAgentServer answers a task lookup the way an A2A agent with no such
+// task does, and method-not-found for everything else. It serves no agent card,
+// which several real agents and three of this repository's fixtures also do.
+func cardlessAgentServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		method, _ := req["method"].(string)
+		w.Header().Set("Content-Type", "application/json")
+		switch method {
+		case "tasks/get", "GetTask":
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32001,"message":"Task not found"}}`))
+		default:
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}`))
+		}
+	}))
+}
+
+// mcpLikeServer answers method-not-found for A2A methods and a valid MCP
+// initialize result, which is what made endpoint discovery accept it.
+func mcpLikeServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		method, _ := req["method"].(string)
+		w.Header().Set("Content-Type", "application/json")
+		if method == "initialize" {
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18",` +
+				`"serverInfo":{"name":"mcp","version":"1.0"},"capabilities":{}}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}`))
+	}))
+}
+
+// cardOnlyServer serves a valid agent card that advertises no capabilities, and
+// 404s everything else. This is an A2A agent, so a rule whose feature is absent
+// here is genuinely reporting a clean result.
+func cardOnlyServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/agent-card.json" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"Minimal Agent","url":"http://example.invalid/","capabilities":{}}`))
+	}))
+}
+
+func executors() map[string]attack.Executor {
+	rc := testRuleCtx()
+	return map[string]attack.Executor{
+		"card-trust":           a2a.NewCardTrustExecutor(rc),
+		"jws-algconf":          a2a.NewJWSAlgConfExecutor(rc),
+		"wellknown-hostinject": a2a.NewWellKnownHostInjectExecutor(rc),
+		"extension-downgrade":  a2a.NewExtensionDowngradeExecutor(rc),
+		"extcard":              a2a.NewExtCardExecutor(rc),
+		"session-smuggle":      a2a.NewSessionSmuggleExecutor(rc),
+		"push-ssrf":            a2a.NewPushSSRFExecutor(rc),
+	}
+}
+
+// Every rule that used to report clean against a non-A2A target must now report
+// that it could not test.
+func TestRules_NonA2ATargetIsNotTested(t *testing.T) {
+	ts := mcpLikeServer()
+	defer ts.Close()
+
+	for name, exec := range executors() {
+		t.Run(name, func(t *testing.T) {
+			findings, err := exec.Execute(context.Background(), ts.URL, attack.Options{TimeoutSeconds: 5})
+			if len(findings) != 0 {
+				t.Fatalf("expected no findings against a non-A2A target, got %d: %+v", len(findings), findings)
+			}
+			if !errors.Is(err, attack.ErrInconclusive) {
+				t.Errorf("expected ErrInconclusive, got err=%v", err)
+			}
+		})
+	}
+}
+
+// The regression this change could easily cause: an agent that serves no card is
+// still an agent when its JSON-RPC endpoint answers, and must stay testable.
+// a2a_delegation_server.py and a2a_push_binding_server.py are both cardless.
+func TestRules_CardlessAgentStaysTestable(t *testing.T) {
+	ts := cardlessAgentServer()
+	defer ts.Close()
+
+	// The card rules genuinely cannot run without a card, so they are excluded:
+	// this asserts the endpoint rules are not skipped for want of one.
+	for _, name := range []string{"extension-downgrade", "extcard", "session-smuggle"} {
+		t.Run(name, func(t *testing.T) {
+			_, err := executors()[name].Execute(context.Background(), ts.URL, attack.Options{TimeoutSeconds: 5})
+			if errors.Is(err, attack.ErrInconclusive) {
+				t.Errorf("rule reported it could not test a cardless agent whose endpoint answers")
+			}
+		})
+	}
+}
+
+// The other regression: a card is served and the rule's feature is simply not
+// present. That is a real clean result and must not become a skip.
+func TestRules_CardServedButFeatureAbsentIsClean(t *testing.T) {
+	ts := cardOnlyServer()
+	defer ts.Close()
+
+	// extension-downgrade is the clearest case: a card advertising no required
+	// extension leaves nothing to downgrade.
+	findings, err := executors()["extension-downgrade"].Execute(context.Background(), ts.URL, attack.Options{TimeoutSeconds: 5})
+	if err != nil {
+		t.Fatalf("expected a clean result for a card with no required extensions, got err=%v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected no findings, got %d: %+v", len(findings), findings)
+	}
+}

--- a/internal/attack/a2a/session_smuggle.go
+++ b/internal/attack/a2a/session_smuggle.go
@@ -51,7 +51,7 @@ func (e *SessionSmuggleExecutor) Execute(ctx context.Context, target string, opt
 
 	// The A2A JSON-RPC endpoint is POST / in most implementations.
 	// Some HTTP+JSON bindings also use /v1/message:send.
-	jsonrpcEP, _ := resolveA2AEndpoint(ctx, client, vars.BaseURL)
+	jsonrpcEP, endpointOK := resolveA2AEndpoint(ctx, client, vars.BaseURL)
 	endpoints := []string{jsonrpcEP, vars.BaseURL + "/v1/message:send"}
 
 	// A2A-sdk v1.0.x uses gRPC-style PascalCase methods and requires
@@ -114,7 +114,10 @@ func (e *SessionSmuggleExecutor) Execute(ctx context.Context, target string, opt
 	if !reached {
 		return nil, attack.ErrInconclusive
 	}
-	return nil, nil
+	// reached only records that something answered without a 404, which any
+	// JSON-RPC service satisfies. Confirm the target is an A2A agent before
+	// reporting this as a clean result.
+	return nil, notTestableGiven(ctx, client, vars.BaseURL, endpointOK)
 }
 
 // evaluateAcceptance reads the created task's history and classifies the result.

--- a/internal/attack/a2a/wellknown_hostinject.go
+++ b/internal/attack/a2a/wellknown_hostinject.go
@@ -55,6 +55,10 @@ func (e *WellKnownHostInjectExecutor) Execute(ctx context.Context, target string
 
 	var findings []attack.Finding
 	seen := map[string]bool{}
+	// A card has to be served for the reflection test to mean anything. Without
+	// one, every probe falls through the continues below and the rule returns an
+	// empty slice, which reads as "no reflection" rather than "never tested".
+	cardParsed := false
 
 	for _, path := range cardPaths {
 		for _, probe := range probes {
@@ -70,6 +74,7 @@ func (e *WellKnownHostInjectExecutor) Execute(ctx context.Context, target string
 			if err := json.Unmarshal(resp.Body, &card); err != nil {
 				continue
 			}
+			cardParsed = true
 
 			reflections := findReflections(card, hostInjectCanary)
 			if len(reflections) == 0 {
@@ -132,6 +137,9 @@ func (e *WellKnownHostInjectExecutor) Execute(ctx context.Context, target string
 		}
 	}
 
+	if len(findings) == 0 && !cardParsed {
+		return nil, attack.ErrInconclusive
+	}
 	return findings, nil
 }
 


### PR DESCRIPTION
## What was wrong

Seven rules reported a **clean pass** against a target that is not an A2A agent at all.

Measured against a server built on the official MCP Python SDK, with two principals configured so the multi-principal rules were not confounded:

| | Before | After |
|---|---|---|
| A2A rules reporting could-not-test | 10 of 17 | **17 of 17** |

Each of the seven drew the line between "this agent is not vulnerable to this" and "nothing here is an A2A agent" in its own way, or not at all:

| Rule | How it got there |
|---|---|
| `a2a-card-trust-001`, `a2a-jws-algconf-001`, `a2a-wellknown-hostinject-001` | no inconclusive path whatsoever |
| `a2a-extcard-unauth-001`, `a2a-session-smuggle-001`, `a2a-push-ssrf-001` | local `reached` flag set by any non-404 response; two of them discarded the `ok` discovery already returned (`jsonrpcEP, _ :=`) |
| `a2a-extension-downgrade-001` | returned clean on "no required extension advertised" before discovery ran, unable to tell that from "no card at all" |

## A correction to what I told you in #124

That PR put the residual at twelve rules. It was measured **without principals configured**, which counted five multi-principal rules as "reported clean" when they were correctly declining to run. The real number is seven.

## One rule for it

A target is testable when endpoint discovery finds a JSON-RPC endpoint **or** a card is served. Either alone is enough: agents exist that serve no card, and agents exist whose card is served while their transport is not where discovery looks. Requiring both would skip real targets.

This is the A2A half of the work the MCP executors got, where fourteen sites were converged on the same distinction.

**The card rules are deliberately stricter** and report not tested whenever no card is served, even against a target that is plainly an agent by other evidence. A card rule with no card has nothing to say either way.

No rule gains a request on the path where it finds something; the card is only fetched when discovery has already come up empty.

## A bug the new tests caught

`push_ssrf` counted **any** 2xx JSON body as an accepted task on the HTTP+JSON binding, including an explicit JSON-RPC error envelope. A server answering 200 with an error was recorded as having registered a callback, and the rule then waited ten seconds for one that was never coming. That ten-second hang in my test run is how I found it.

Same success-oracle defect the S2 wave fixed elsewhere. It survived because the HTTP+JSON binding returns a task object rather than a JSON-RPC envelope, so the shared `IsAccepted` was not the right test and the site was left with a weaker one.

## Behaviour changes worth knowing

Against a **cardless** agent, the three card rules move from clean to not tested. Verified against `a2a_delegation_server.py`: 1 finding before and after, skips 1 → 4. That is the intended direction, and it will make some existing scans report more skips than before.

## Verification

- Non-A2A target: 10 of 17 → 17 of 17 could-not-test.
- A2A lab fixture (9998): **6 findings before and after**, no rule newly inconclusive.
- Cardless delegation fixture (3103): finding preserved, three card rules now honest about not running.
- Four existing tests asserted the old contract (404-everything and login-page servers producing a clean result) and now assert inconclusive. The finding counts they were really guarding are unchanged.
- New `reachable_test.go` pins **both** sides, since a fix that only widens the inconclusive case is easy to write and turns every clean scan into a skipped one: a cardless agent whose endpoint answers must stay testable, and a card served with the feature absent must stay clean.
- Non-vacuous: reverting the behaviour while keeping the tests fails 12 of them.

`go test -race ./...`, `go vet`, `gofmt` and `golangci-lint` at the pinned v2.11.4 all clean.