### PR TITLE
fix(a2a): send the push-notification shapes a real agent accepts

### DIFF
--- a/docs/rules-a2a.md
+++ b/docs/rules-a2a.md
@@ -129,6 +129,18 @@ a push-notification config is normal A2A behaviour and is **not** reported.
 Supplying `--oob-url` points the callback at an external collector and emits
 operator guidance for manual confirmation.
 
+Two bindings are driven. On **v1.0** the callback is registered through
+`CreateTaskPushNotificationConfig`, whose params are a `TaskPushNotificationConfig`
+carrying a flat `url`; there is no way to attach one to a send, because
+`SendMessageConfiguration` has no such field. On **v0.3** it travels inline on
+`message/send` under `configuration.pushNotificationConfig`, and is also set
+explicitly with `tasks/pushNotificationConfig/set`.
+
+A callback can only fire for a task that is still running: a config registered
+against a task the agent has already completed has no status update left to
+notify on. Against a long-running agent on the official SDK this reports a
+confirmed finding, with the echoed token as evidence.
+
 Confirmed unfixed in the reference `a2a-python` SDK as of April 2026
 ([issue #786](https://github.com/google-a2a/a2a-python/issues/786)).
 

--- a/internal/attack/a2a/push_ssrf.go
+++ b/internal/attack/a2a/push_ssrf.go
@@ -96,14 +96,19 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 		// Got a task - try to register push notification config for it
 		taskID, _ := extractTaskContext(sendResp.Body)
 		if taskID != "" {
+			// params IS a TaskPushNotificationConfig, whose fields are taskId,
+			// url, token, id, tenant and authentication. The callback is named
+			// url; there is no pushNotificationUrl, and sending one earns
+			// -32602 "has no field named" from a2a-sdk v1, so this step never
+			// registered anything against a real v1 agent.
 			pushResp, pushErr := client.POST(ctx, endpoint, a2aHeaders, map[string]interface{}{
 				"jsonrpc": "2.0",
 				"id":      "batesian-push-" + vars.RandID,
 				"method":  "CreateTaskPushNotificationConfig",
 				"params": map[string]interface{}{
-					"taskId":              taskID,
-					"pushNotificationUrl": callbackURL,
-					"token":               token,
+					"taskId": taskID,
+					"url":    callbackURL,
+					"token":  token,
 				},
 			})
 			if pushErr == nil && pushResp.IsAccepted() {
@@ -113,15 +118,44 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 		}
 	}
 
-	// Attempt 2: Legacy JSONRPC v0.3 tasks/send with embedded pushNotification config
+	// Attempt 2: JSON-RPC v0.3. message/send carries the callback inline under
+	// configuration, and tasks/pushNotificationConfig/set registers it against a
+	// task that already exists. Both are tried because a server may ignore the
+	// inline form.
+	//
+	// This used to send tasks/send, a v0.2-era method name. a2a-sdk answers it
+	// -32601 Method not found, so the whole v0.3 path was dead against any
+	// current server.
 	if !taskAccepted {
-		jsonrpcResp, err2 := client.POST(ctx, endpoint, map[string]string{}, buildJSONRPCRequest(callbackURL, token, vars.RandID))
-		if err2 == nil && jsonrpcResp.StatusCode != 404 {
+		sendResp2, err2 := client.POST(ctx, endpoint, map[string]string{}, buildV03SendRequest(callbackURL, token, vars.RandID))
+		if err2 == nil && sendResp2.StatusCode != 404 {
 			reached = true
 		}
-		if err2 == nil && jsonrpcResp.IsAccepted() {
-			taskAccepted = true
-			acceptedBinding = "JSONRPC/v0.3-tasks-send"
+		if err2 == nil && sendResp2.IsAccepted() {
+			// A task id is what makes this a registration rather than a plain
+			// echo: an agent that answers with a Message has nothing to attach a
+			// push config to, and claiming otherwise would have the rule wait
+			// for a callback nobody agreed to send.
+			if taskID, _ := extractTaskContext(sendResp2.Body); taskID != "" {
+				taskAccepted = true
+				acceptedBinding = "JSONRPC/v0.3-message-send"
+
+				setResp, setErr := client.POST(ctx, endpoint, map[string]string{}, map[string]interface{}{
+					"jsonrpc": "2.0",
+					"id":      "batesian-set-" + vars.RandID,
+					"method":  "tasks/pushNotificationConfig/set",
+					"params": map[string]interface{}{
+						"taskId": taskID,
+						"pushNotificationConfig": map[string]string{
+							"url":   callbackURL,
+							"token": token,
+						},
+					},
+				})
+				if setErr == nil && setResp.IsAccepted() {
+					acceptedBinding = "JSONRPC/v0.3-pushNotificationConfig-set"
+				}
+			}
 		}
 	}
 
@@ -203,27 +237,30 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 	return findings, nil
 }
 
-// buildJSONRPCRequest creates the A2A task/send request body for JSONRPC binding.
-// Includes both pushNotificationConfig (v1.0 spec) and pushNotification (v0.3 legacy)
-// to maximize compatibility with real-world deployments.
-func buildJSONRPCRequest(callbackURL, token, taskID string) map[string]interface{} {
-	pushConfig := map[string]string{"url": callbackURL, "token": token}
+// buildV03SendRequest creates a v0.3 message/send carrying the push callback in
+// the configuration block, which is where that revision puts it. There is no
+// equivalent on the v1.0 side: SendMessageConfiguration has no
+// pushNotificationConfig field, so v1.0 registers the callback only through the
+// separate CreateTaskPushNotificationConfig call.
+func buildV03SendRequest(callbackURL, token, randID string) map[string]interface{} {
 	return map[string]interface{}{
 		"jsonrpc": "2.0",
-		"id":      "batesian-" + taskID,
-		"method":  "tasks/send",
+		"id":      "batesian-" + randID,
+		"method":  "message/send",
 		"params": map[string]interface{}{
-			"id": "batesian-" + taskID,
 			"message": map[string]interface{}{
-				"role": "user",
+				"role":      "user",
+				"messageId": "batesian-" + randID,
 				"parts": []interface{}{
-					map[string]string{"type": "text", "text": "ping"},
+					map[string]string{"kind": "text", "text": "ping"},
 				},
 			},
-			// v1.0 spec field name
-			"pushNotificationConfig": pushConfig,
-			// v0.3 legacy field name (some deployed servers use this)
-			"pushNotification": pushConfig,
+			"configuration": map[string]interface{}{
+				"pushNotificationConfig": map[string]string{
+					"url":   callbackURL,
+					"token": token,
+				},
+			},
 		},
 	}
 }

--- a/internal/attack/a2a/push_ssrf_test.go
+++ b/internal/attack/a2a/push_ssrf_test.go
@@ -14,9 +14,15 @@ import (
 )
 
 // pushSSRFServer builds a mock A2A server. When callBack is true, the
-// CreateTaskPushNotificationConfig handler actually performs an outbound GET to
-// the attacker-supplied pushNotificationUrl - simulating the SSRF. When false,
-// it accepts the config but never calls back (the normal, non-vulnerable case).
+// CreateTaskPushNotificationConfig handler actually performs an outbound POST to
+// the attacker-supplied callback - simulating the SSRF. When false, it accepts
+// the config but never calls back (the normal, non-vulnerable case).
+//
+// It reads the callback from `url`, which is the field a2a-sdk v1 actually
+// defines on TaskPushNotificationConfig. The harness used to read
+// pushNotificationUrl, matching what the rule sent rather than what the protocol
+// says, so it went on passing while the rule could not register a callback with
+// any real agent. Reading only the real field is what keeps that from recurring.
 func pushSSRFServer(t *testing.T, callBack bool) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -36,7 +42,7 @@ func pushSSRFServer(t *testing.T, callBack bool) *httptest.Server {
 		case "CreateTaskPushNotificationConfig":
 			if callBack {
 				params, _ := req["params"].(map[string]interface{})
-				if url, _ := params["pushNotificationUrl"].(string); url != "" {
+				if url, _ := params["url"].(string); url != "" {
 					// Outbound request to the attacker-controlled callback = SSRF.
 					token, _ := params["token"].(string)
 					hc := &http.Client{Timeout: 3 * time.Second}
@@ -74,6 +80,108 @@ func TestPushSSRF_VulnerableCallbackConfirmed(t *testing.T) {
 	}
 	if findings[0].Severity != "high" || findings[0].Confidence != attack.ConfirmedExploit {
 		t.Errorf("want high/ConfirmedExploit, got %q/%q", findings[0].Severity, findings[0].Confidence)
+	}
+}
+
+// v03PushServer speaks only the v0.3 methods: SendMessage is unknown, message/send
+// returns a task, and tasks/pushNotificationConfig/set performs the outbound
+// call. It exists because the v0.3 path used to send tasks/send, a v0.2-era
+// method name that a2a-sdk answers -32601, so that whole branch was dead against
+// any current server and no test noticed.
+func v03PushServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		req := readBody(r)
+		method, _ := req["method"].(string)
+		id := req["id"]
+		params, _ := req["params"].(map[string]interface{})
+
+		switch method {
+		case "message/send":
+			writeJSON(w, map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{"id": "task-v03-001", "contextId": "ctx-v03-001"},
+			})
+		case "tasks/pushNotificationConfig/set":
+			cfg, _ := params["pushNotificationConfig"].(map[string]interface{})
+			if url, _ := cfg["url"].(string); url != "" {
+				token, _ := cfg["token"].(string)
+				hc := &http.Client{Timeout: 3 * time.Second}
+				if cbReq, err := http.NewRequest(http.MethodPost, url, nil); err == nil {
+					cbReq.Header.Set("X-A2A-Notification-Token", token)
+					if resp, err := hc.Do(cbReq); err == nil {
+						_ = resp.Body.Close()
+					}
+				}
+			}
+			writeJSON(w, map[string]interface{}{"jsonrpc": "2.0", "id": id, "result": map[string]interface{}{"ok": true}})
+		default:
+			// Covers SendMessage and tasks/send alike: a v0.3-only server knows
+			// neither.
+			writeJSON(w, jsonRPCError(-32601, "Method not found"))
+		}
+	}))
+}
+
+func TestPushSSRF_V03BindingConfirmed(t *testing.T) {
+	ts := v03PushServer(t)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	findings, err := a2a.NewPushSSRFExecutor(testRuleCtx()).Execute(ctx, ts.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one confirmed SSRF finding over the v0.3 binding, got %d: %+v", len(findings), findings)
+	}
+	if findings[0].Severity != "high" || findings[0].Confidence != attack.ConfirmedExploit {
+		t.Errorf("want high/ConfirmedExploit, got %q/%q", findings[0].Severity, findings[0].Confidence)
+	}
+}
+
+// A server that answers message/send with a Message rather than a Task has
+// nothing to attach a push config to. Treating that as an accepted registration
+// would have the rule wait for a callback nobody agreed to send, and, on the
+// external-OOB path, report a task acceptance that never happened.
+func TestPushSSRF_MessageReplyIsNotARegistration(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		req := readBody(r)
+		method, _ := req["method"].(string)
+		if method == "message/send" {
+			writeJSON(w, map[string]interface{}{
+				"jsonrpc": "2.0", "id": req["id"],
+				"result": map[string]interface{}{
+					"kind": "message", "messageId": "m-1", "role": "agent",
+					"parts": []interface{}{map[string]string{"kind": "text", "text": "Echo: ping"}},
+				},
+			})
+			return
+		}
+		writeJSON(w, jsonRPCError(-32601, "Method not found"))
+	}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+	findings, err := a2a.NewPushSSRFExecutor(testRuleCtx()).Execute(ctx, ts.URL, attack.Options{
+		TimeoutSeconds: 5,
+		OOBListenerURL: "http://oob.batesian.invalid",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected no finding when the agent replies with a Message, got %d: %+v", len(findings), findings)
 	}
 }
 

--- a/testdata/a2a_vulnerable_server.py
+++ b/testdata/a2a_vulnerable_server.py
@@ -178,11 +178,20 @@ def handle_get_task(req_id, params: dict) -> Response:
 
 
 async def handle_push_config(req_id, params: dict) -> Response:
-    # Deployments carry the callback either nested under pushNotificationConfig
-    # (the v0.3 shape) or flat on params (the shape the a2a-sdk v1.0 two-step
-    # uses). Accept both, so this fixture exercises a caller that sends either.
+    # Two real shapes, both taken from the protocol rather than from what our own
+    # scanner happens to send:
+    #   v0.3  tasks/pushNotificationConfig/set -> params.pushNotificationConfig.url
+    #   v1.0  CreateTaskPushNotificationConfig -> params IS a
+    #         TaskPushNotificationConfig, whose callback field is a flat `url`
+    #         (fields: tenant, id, taskId, url, token, authentication).
+    #
+    # An earlier version of this fixture also accepted a flat
+    # `pushNotificationUrl`, on the mistaken belief that it was the v1.0 shape.
+    # No SDK defines that field: a2a-sdk v1 rejects it with -32602 "has no field
+    # named". Accepting it here made the fixture vouch for a request no real
+    # agent answers, which is the reverse of what a validation target is for.
     config = params.get("pushNotificationConfig", {})
-    callback_url = config.get("url", "") or params.get("pushNotificationUrl", "")
+    callback_url = config.get("url", "") or params.get("url", "")
     if not config:
         config = {"url": callback_url, "token": params.get("token", "")}
 


### PR DESCRIPTION
## A high-severity rule that could not fire

`a2a-push-ssrf-001` could not register a callback with any current agent, so it silently found nothing. Both JSON-RPC paths were wrong, for unrelated reasons. Everything below was verified by probing **a2a-sdk 1.1.2**.

| Request | SDK response |
|---|---|
| **v1.0 as sent:** `CreateTaskPushNotificationConfig` `{taskId, pushNotificationUrl, token}` | `-32602` no such field |
| v1.0 corrected: `{taskId, url, token}` | populated `TaskPushNotificationConfig` result |
| **v0.3 as sent:** `tasks/send` + inline config | `-32601 Method not found` |
| v0.3 `message/send` + `configuration.pushNotificationConfig` | accepted |
| v0.3 `tasks/pushNotificationConfig/set` + nested config | accepted |
| v1.0 `SendMessage` + `configuration.pushNotificationConfig` | `-32602` — `SendMessageConfiguration` has no such field |

`params` to `CreateTaskPushNotificationConfig` **is** a `TaskPushNotificationConfig`: `tenant, id, taskId, url, token, authentication`. The callback field is a flat `url`. And there is no way to attach one to a send on v1.0, so the two-step structure was right and only the field name was wrong.

The v0.3 branch was worse: `tasks/send` is a v0.2-era name the SDK does not implement at all.

## Confirmed end to end against the official SDK

An agent built on a2a-sdk with a **long-running** task, so a status update remains to notify on:

```
before:  Scan Results (0 finding(s))
after:   [!] HIGH  A2A server made outbound request to attacker-controlled push notification URL
         severity: high | confidence: confirmed
         Target accepted task with pushNotificationConfig.url="http://.../batesian-cc7de40394b2"
           (binding: JSONRPC/v1.0-CreateTaskPushNotificationConfig)
         OOB callback received: POST /batesian-cc7de40394b2
         Callback token echoed: true
```

That outbound request comes from the SDK's own `BasePushNotificationSender`, not from anything we wrote.

Worth stating precisely: **registration** is what was broken. A config attached to an already-completed task has no status update left to fire, which is why the agent has to still be working for a callback to arrive. Against the same SDK agent completing synchronously, the corrected call registers successfully and no callback follows, which is correct.

## Both harnesses were vouching for the bug

The Go mock read `params["pushNotificationUrl"]`, and `a2a_vulnerable_server.py` was taught to accept the same invented field in #116 — on my claim that it was "the shape the a2a-sdk v1.0 two-step uses". I read that off our own rule rather than off the protocol. No SDK defines it.

So the fixtures passed while the rule could not talk to a real agent. Both now accept **only** what the SDK defines, which is what makes a regression to the invented name fail rather than pass.

## Also

A reply carrying no task id is no longer treated as a registration. An agent answering with a Message has nothing to attach a config to; treating that as accepted made the rule wait for a callback nobody agreed to send, and on the external-OOB path report an acceptance that never happened. `TestPushSSRF_MessageReplyIsNotARegistration` pins it.

## Tests

- `TestPushSSRF_V03BindingConfirmed`: a v0.3-only server (`SendMessage` unknown, `message/send` returns a task, `tasks/pushNotificationConfig/set` calls back). The old code never reached it.
- Existing v1.0 confirmation test, with the harness reading the real field.
- Non-vacuous: restoring either old wire shape fails the matching test with `expected one confirmed SSRF finding, got 0`.
- Corrected Python fixture re-run: `a2a-push-ssrf-001` still fires, full A2A scan unchanged at 6 findings.

`go test -race ./...`, `go vet`, `gofmt` and `golangci-lint` at the pinned v2.11.4 all clean.

## Left alone

Attempt 3 posts to `/tasks/send` on the HTTP+JSON binding. That is the same era of path name as the v0.3 method removed here and is likely just as stale, but it needs its own check against the REST binding rather than a guess, so it is not in this PR.