### PR TITLE
fix(mcp): judge session-fixation reachability apart from the attack

### DIFF
--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -335,9 +335,15 @@ server that instead **adopts a client-chosen id** is vulnerable to session
 fixation. The rule confirms the failure with a control to avoid false positives
 on servers that track no sessions at all:
 
-1. `initialize` carrying a client-chosen `Mcp-Session-Id`. If the server returns
-   its **own** id instead, it mints the id server-side, which is secure, so no
-   finding is raised.
+0. An ordinary `initialize` establishes that the target is a reachable MCP
+   server. Reachability is judged here, and not from the seeded handshake below,
+   because a server may reject that handshake outright: the reference
+   implementation answers it `400` / `-32000 "Bad Request: No valid session ID
+   provided"`. That refusal is the defence this rule tests for, so it is graded
+   as a clean pass rather than as an untestable target.
+1. `initialize` carrying a client-chosen `Mcp-Session-Id`. If the server rejects
+   it, or returns its **own** id instead, the id is not client-controllable and
+   no finding is raised.
 2. A follow-up call presenting the attacker-chosen id must be **accepted**.
 3. Control: the same call presenting a different, **never-initialized** random id
    must be **rejected** (404). If it is also accepted, the server enforces no

--- a/internal/attack/mcp/session_fixation.go
+++ b/internal/attack/mcp/session_fixation.go
@@ -62,10 +62,29 @@ func (e *SessionFixationExecutor) ExecuteChained(ctx context.Context, target str
 	fixed := "batesian-fixed-" + vars.RandID
 	unseeded := "batesian-unseeded-" + vars.RandID
 
-	// Step 1: initialize while presenting a client-chosen session id.
-	ep, assigned, ok := e.initWithSession(ctx, client, vars.BaseURL, fixed)
+	// Reachability is established with an ordinary handshake, separately from
+	// the attack. A server that refuses the seeded id at initialize is the
+	// defence this rule tests for, and reading that refusal as "nothing here"
+	// made the rule report inconclusive against exactly the servers it covers:
+	// the reference implementation answers the seeded initialize with
+	// HTTP 400 -32000 "Bad Request: No valid session ID provided", while a
+	// plain initialize on the same endpoint returns 200 and a session id.
+	//
+	// Going through initializeMCP also gives this rule era detection, so a
+	// modern-era target is reported as speaking an unsupported protocol version
+	// rather than as unreachable.
+	session, err := initializeMCP(ctx, client, vars.BaseURL)
+	if err != nil {
+		return nil, inconclusive(err)
+	}
+	ep := session.Endpoint
+
+	// Step 1: initialize again, this time presenting a client-chosen session id.
+	assigned, ok := e.initWithSession(ctx, client, ep, fixed)
 	if !ok {
-		return nil, attack.ErrInconclusive // not a responsive MCP server
+		// The endpoint is a working MCP server, so this is a rejection of the
+		// seeded id rather than an unreachable target. That is secure.
+		return nil, nil
 	}
 	// Discriminator: the server returned its OWN session id, ignoring the
 	// supplied one. That is the correct, secure behavior - no finding.
@@ -120,31 +139,32 @@ func (e *SessionFixationExecutor) ExecuteChained(ctx context.Context, target str
 	return []attack.Finding{e.finding(ep, fixed, crossPrincipal, chain)}, nil
 }
 
-// initWithSession sends an initialize request carrying a client-chosen
-// Mcp-Session-Id header and returns the working endpoint, the session id the
-// server actually assigned (its response header, possibly empty), and whether a
-// responsive MCP server was found.
-func (e *SessionFixationExecutor) initWithSession(ctx context.Context, client *attack.HTTPClient, baseURL, supplied string) (endpoint, assigned string, ok bool) {
-	for _, ep := range endpointCandidates(baseURL) {
-		resp, err := client.POST(ctx, ep, map[string]string{"Mcp-Session-Id": supplied}, map[string]interface{}{
-			"jsonrpc": "2.0",
-			"id":      1,
-			"method":  "initialize",
-			"params": map[string]interface{}{
-				"protocolVersion": latestStable,
-				"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
-				"clientInfo":      map[string]interface{}{"name": "batesian", "version": "1.0"},
-			},
-		})
-		if err != nil || !resp.IsSuccess() {
-			continue
-		}
-		if !resp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
-			continue
-		}
-		return ep, resp.Headers.Get("Mcp-Session-Id"), true
+// initWithSession sends an initialize request to a known endpoint carrying a
+// client-chosen Mcp-Session-Id header. It returns the session id the server
+// assigned (its response header, possibly empty) and whether the handshake was
+// accepted at all.
+//
+// ok is false only when the server refused this handshake. The endpoint is
+// already known to speak MCP, so a refusal here means the seeded id was
+// rejected, which is the secure behaviour rather than an unreachable target.
+func (e *SessionFixationExecutor) initWithSession(ctx context.Context, client *attack.HTTPClient, endpoint, supplied string) (assigned string, ok bool) {
+	resp, err := client.POST(ctx, endpoint, map[string]string{"Mcp-Session-Id": supplied}, map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]interface{}{
+			"protocolVersion": latestStable,
+			"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+			"clientInfo":      map[string]interface{}{"name": "batesian", "version": "1.0"},
+		},
+	})
+	if err != nil || !resp.IsSuccess() {
+		return "", false
 	}
-	return "", "", false
+	if !resp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
+		return "", false
+	}
+	return resp.Headers.Get("Mcp-Session-Id"), true
 }
 
 // sessionAccepted reports whether a follow-up call presenting sessionID is

--- a/internal/attack/mcp/session_fixation_test.go
+++ b/internal/attack/mcp/session_fixation_test.go
@@ -41,6 +41,9 @@ func writeToolsResult(w http.ResponseWriter, id interface{}) {
 //   - "fixable":      adopts a client-supplied Mcp-Session-Id; rejects unknown ids (404)
 //   - "server-minted": ignores the supplied id and mints its own; rejects unknown ids
 //   - "sessionless":  does not track sessions at all (accepts any id, never 404)
+//   - "rejects-seeded": refuses an initialize that carries a client-chosen id,
+//     which is what the reference implementation does and what this rule tests
+//     for. A plain initialize on the same endpoint still succeeds.
 func fixationServer(mode string) *httptest.Server {
 	var mu sync.Mutex
 	valid := map[string]bool{}
@@ -58,6 +61,21 @@ func fixationServer(mode string) *httptest.Server {
 		case "initialize":
 			sid := ""
 			switch mode {
+			case "rejects-seeded":
+				if supplied != "" {
+					// Byte-for-byte what @modelcontextprotocol/server-everything
+					// answers a seeded initialize.
+					w.WriteHeader(http.StatusBadRequest)
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"jsonrpc": "2.0", "id": nil,
+						"error": map[string]interface{}{
+							"code": -32000, "message": "Bad Request: No valid session ID provided",
+						},
+					})
+					return
+				}
+				counter++
+				sid = fmt.Sprintf("srv-%d", counter)
 			case "fixable":
 				if supplied != "" {
 					sid = supplied // VULNERABLE: trusts the client-chosen id
@@ -157,11 +175,37 @@ func TestSessionFixation_SessionlessIsNotFixation(t *testing.T) {
 }
 
 // TestSessionFixation_NotMCPServer: a non-MCP server yields no findings.
+//
+// This is the boundary the fix below must not erase. Refusing the seeded id and
+// not being an MCP server at all look identical from the seeded handshake alone,
+// and only the second is untested.
 func TestSessionFixation_NotMCPServer(t *testing.T) {
 	srv := httptest.NewServer(http.NotFoundHandler())
 	defer srv.Close()
 
 	assertInconclusive(t, mcpattack.NewSessionFixationExecutor(sfRuleCtx()), srv.URL, testOpts())
+}
+
+// TestSessionFixation_RejectsSeededSessionIsClean: a server that refuses an
+// initialize carrying a client-chosen session id is doing the right thing, and
+// the rule must report a clean pass.
+//
+// The rule used to use the seeded handshake as its only reachability probe, so
+// this refusal read as "no MCP server here" and the rule reported inconclusive
+// against every server that implements the defence. The reference
+// implementation is one of them.
+func TestSessionFixation_RejectsSeededSessionIsClean(t *testing.T) {
+	srv := fixationServer("rejects-seeded")
+	defer srv.Close()
+
+	findings, err := mcpattack.NewSessionFixationExecutor(sfRuleCtx()).
+		Execute(context.Background(), srv.URL, testOpts())
+	if err != nil {
+		t.Fatalf("expected a clean pass, got err=%v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected no findings against a server that rejects the seeded id, got %d: %+v", len(findings), findings)
+	}
 }
 
 // TestSessionFixation_CrossPrincipal: with a second principal configured the


### PR DESCRIPTION
## Defect

`initWithSession` was both the reachability probe and the attack. It sends `initialize` carrying a client-chosen `Mcp-Session-Id`; the reference server answers `400` / `-32000 "Bad Request: No valid session ID provided"`, which the rule read as "no MCP server here" and reported inconclusive. A plain `initialize` on the same endpoint returns 200 with a session id.

That refusal is the defence the rule tests for, so it was inconclusive by construction against every server implementing it.

## Fix

Reachability comes from an ordinary handshake via `initializeMCP`; the seeded `initialize` is judged only as the attack, and a rejection is a clean pass. Side effects: the seeded attempt is one POST instead of a walk over every candidate path, and the rule inherits era detection it previously had no access to.

## Verification

Live against `@modelcontextprotocol/server-everything`:

```
before:  1 of 1 rule(s) could not reach a testable endpoint
after:   No findings. Target appears clean for the tested rules.
```

Full scan of the same server: skips 13 → 12, findings unchanged at 10. Vulnerable fixture (port 7786) still fires.

The harness had four postures and none was a server that refuses the seeded id, which is why this shipped. Added one answering exactly what the reference server does; reverting the fix fails it with the original symptom. `TestSessionFixation_NotMCPServer` still asserts inconclusive, since refusing the seeded id and not being an MCP server are indistinguishable from that handshake alone and only the second is untested.

`go test -race ./...`, `go vet` (both tags), `gofmt`, `golangci-lint` v2.11.4 clean.