### PR TITLE
fix(a2a): drive the push-notification REST binding from the agent card

### DIFF
--- a/docs/rules-a2a.md
+++ b/docs/rules-a2a.md
@@ -129,12 +129,15 @@ a push-notification config is normal A2A behaviour and is **not** reported.
 Supplying `--oob-url` points the callback at an external collector and emits
 operator guidance for manual confirmation.
 
-Two bindings are driven. On **v1.0** the callback is registered through
+Three bindings are driven. On **v1.0** the callback is registered through
 `CreateTaskPushNotificationConfig`, whose params are a `TaskPushNotificationConfig`
 carrying a flat `url`; there is no way to attach one to a send, because
 `SendMessageConfiguration` has no such field. On **v0.3** it travels inline on
 `message/send` under `configuration.pushNotificationConfig`, and is also set
-explicitly with `tasks/pushNotificationConfig/set`.
+explicitly with `tasks/pushNotificationConfig/set`. The **HTTP+JSON** binding is
+driven only when the agent card advertises one, at the URL the card gives: its
+prefix is a deployment choice, so there is no path to fall back on and an agent
+without that interface is not probed for it.
 
 A callback can only fire for a task that is still running: a config registered
 against a task the agent has already completed has no status update left to

--- a/internal/attack/a2a/endpoint.go
+++ b/internal/attack/a2a/endpoint.go
@@ -40,6 +40,37 @@ func (i a2aDiscoveryInterface) isJSONRPC() bool {
 	return strings.EqualFold(i.ProtocolBinding, "JSONRPC") || strings.EqualFold(i.Transport, "JSONRPC")
 }
 
+func (i a2aDiscoveryInterface) isHTTPJSON() bool {
+	return strings.EqualFold(i.ProtocolBinding, "HTTP+JSON") || strings.EqualFold(i.Transport, "HTTP+JSON")
+}
+
+// resolveHTTPJSONBase returns the base URL of the card's HTTP+JSON (REST)
+// interface, pinned to the target host, or "" when none is advertised.
+//
+// The REST binding's paths cannot be guessed. a2a-sdk mounts them under a
+// caller-chosen prefix and lets the deployment decide which protocol version
+// sits where, so on one server /message:send is the v1.0 route and
+// /v1/message:send is the v0.3 compatibility route. The card is the only thing
+// that says where the binding lives, and an agent that advertises no HTTP+JSON
+// interface has none to probe.
+func resolveHTTPJSONBase(ctx context.Context, client *attack.HTTPClient, baseURL string) string {
+	card, found := fetchDiscoveryCard(ctx, client, baseURL)
+	if !found {
+		return ""
+	}
+	for _, group := range [][]a2aDiscoveryInterface{card.SupportedInterfaces, card.AdditionalInterfaces} {
+		for _, iface := range group {
+			if iface.isHTTPJSON() && hasHTTPScheme(iface.URL) {
+				return strings.TrimSuffix(pinToTargetHost(iface.URL, baseURL), "/")
+			}
+		}
+	}
+	if strings.EqualFold(card.PreferredTransport, "HTTP+JSON") && hasHTTPScheme(card.URL) {
+		return strings.TrimSuffix(pinToTargetHost(card.URL, baseURL), "/")
+	}
+	return ""
+}
+
 // resolveA2AEndpoint returns the JSON-RPC endpoint to probe and whether a usable
 // endpoint was found. It prefers the URL the agent card declares for the JSON-RPC
 // transport; failing that, it probes a small set of conventional paths. The

--- a/internal/attack/a2a/push_ssrf.go
+++ b/internal/attack/a2a/push_ssrf.go
@@ -159,20 +159,38 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 		}
 	}
 
-	// Attempt 3: HTTP+JSON binding (REST API style, some older deployments)
-	if !taskAccepted {
-		httpResp, err3 := client.POST(ctx, vars.BaseURL+"/tasks/send", map[string]string{}, buildHTTPTaskRequest(callbackURL, token, vars.RandID))
-		if err3 == nil && httpResp.StatusCode != 404 {
+	// Attempt 3: the HTTP+JSON (REST) binding, where the card advertises one.
+	//
+	// This used to POST a fixed /tasks/send. No such route exists: the REST
+	// binding names its methods message:send and
+	// tasks/{id}/pushNotificationConfigs, and a2a-sdk answers /tasks/send 404.
+	// Nor can the prefix be guessed, since the deployment chooses it and chooses
+	// which protocol version sits under it. So the base comes from the card, and
+	// an agent that advertises no HTTP+JSON interface is not probed at all.
+	if restBase := resolveHTTPJSONBase(ctx, client, vars.BaseURL); !taskAccepted && restBase != "" {
+		sendResp3, err3 := client.POST(ctx, restBase+"/message:send", map[string]string{"A2A-Version": "1.0"},
+			buildRESTSendRequest(vars.RandID))
+		if err3 == nil && sendResp3.StatusCode != 404 {
 			reached = true
 		}
-		// The HTTP+JSON binding returns a task object rather than a JSON-RPC
-		// envelope, so IsAccepted is the wrong test here. An explicit error
-		// envelope still has to be excluded: without that, any service answering
-		// 200 with a JSON error body counts as having accepted a task, and the
-		// rule goes on to wait for a callback that was never registered.
-		if err3 == nil && httpResp.IsSuccess() && httpResp.IsJSON() && !isJSONRPCError(httpResp.Body) {
-			taskAccepted = true
-			acceptedBinding = "HTTP+JSON"
+		// The REST binding answers with a task object rather than a JSON-RPC
+		// envelope, so IsAccepted is the wrong test. An explicit error body still
+		// has to be excluded: without that, any service answering 200 with a JSON
+		// error counts as having accepted a task, and the rule goes on to wait
+		// for a callback that was never registered.
+		if err3 == nil && sendResp3.IsSuccess() && sendResp3.IsJSON() && !isJSONRPCError(sendResp3.Body) {
+			// As on JSON-RPC v1.0, the callback cannot ride along with the send:
+			// the configuration block has no push field. It is registered against
+			// the task that came back.
+			if taskID := restTaskID(sendResp3.Body); taskID != "" {
+				cfgResp, cfgErr := client.POST(ctx, restBase+"/tasks/"+taskID+"/pushNotificationConfigs",
+					map[string]string{"A2A-Version": "1.0"},
+					map[string]interface{}{"url": callbackURL, "token": token})
+				if cfgErr == nil && cfgResp.IsSuccess() && cfgResp.IsJSON() && !isJSONRPCError(cfgResp.Body) {
+					taskAccepted = true
+					acceptedBinding = "HTTP+JSON/pushNotificationConfigs"
+				}
+			}
 		}
 	}
 
@@ -265,19 +283,37 @@ func buildV03SendRequest(callbackURL, token, randID string) map[string]interface
 	}
 }
 
-// buildHTTPTaskRequest creates the A2A task/send request body for HTTP+JSON binding.
-func buildHTTPTaskRequest(callbackURL, token, taskID string) map[string]interface{} {
-	pushConfig := map[string]string{"url": callbackURL, "token": token}
+// restTaskID pulls the task id out of a REST message:send reply. The REST
+// binding has no JSON-RPC envelope, so extractTaskContext, which requires a
+// result object, finds nothing here. a2a-sdk answers with the SendMessageResponse
+// oneof, {"task":{...}}; the bare task object is accepted too, since the wrapper
+// is a proto detail rather than something the binding guarantees.
+func restTaskID(body []byte) string {
+	var m map[string]interface{}
+	if err := json.Unmarshal(body, &m); err != nil {
+		return ""
+	}
+	if task, ok := m["task"].(map[string]interface{}); ok {
+		if id, _ := task["id"].(string); id != "" {
+			return id
+		}
+	}
+	id, _ := m["id"].(string)
+	return id
+}
+
+// buildRESTSendRequest creates the body for a REST message:send. It is a
+// SendMessageRequest, so the message sits under `message` and carries no push
+// config; the callback is registered separately against the returned task.
+func buildRESTSendRequest(randID string) map[string]interface{} {
 	return map[string]interface{}{
-		"id": "batesian-" + taskID,
 		"message": map[string]interface{}{
-			"role": "user",
+			"messageId": "batesian-" + randID,
+			"role":      "ROLE_USER",
 			"parts": []interface{}{
-				map[string]string{"type": "text", "text": "ping"},
+				map[string]string{"text": "ping"},
 			},
 		},
-		"pushNotificationConfig": pushConfig,
-		"pushNotification":       pushConfig,
 	}
 }
 

--- a/internal/attack/a2a/push_ssrf_test.go
+++ b/internal/attack/a2a/push_ssrf_test.go
@@ -2,6 +2,7 @@ package a2a_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -185,6 +186,96 @@ func TestPushSSRF_MessageReplyIsNotARegistration(t *testing.T) {
 	}
 }
 
+// restPushServer speaks only the HTTP+JSON binding, mounted under a prefix the
+// card advertises. JSON-RPC is dead here, so the rule can only get there through
+// the card.
+//
+// The REST attempt used to POST a fixed /tasks/send. No binding defines that
+// path, and the prefix cannot be guessed either: a2a-sdk takes it as a parameter
+// and lets the deployment choose which protocol version sits under it.
+func restPushServer(t *testing.T, prefix string) *httptest.Server {
+	t.Helper()
+	var host string
+	mux := http.NewServeMux()
+	srv := httptest.NewUnstartedServer(mux)
+
+	mux.HandleFunc("/.well-known/agent-card.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"REST Agent","supportedInterfaces":[` +
+			`{"url":"` + host + prefix + `","protocolBinding":"HTTP+JSON","protocolVersion":"1.0"}]}`))
+	})
+	mux.HandleFunc(prefix+"/message:send", func(w http.ResponseWriter, r *http.Request) {
+		// The shape a2a-sdk actually returns from REST message:send.
+		writeJSON(w, map[string]interface{}{
+			"task": map[string]interface{}{"id": "task-rest-001", "contextId": "ctx-rest-001"},
+		})
+	})
+	mux.HandleFunc(prefix+"/tasks/task-rest-001/pushNotificationConfigs", func(w http.ResponseWriter, r *http.Request) {
+		body := readBody(r)
+		if url, _ := body["url"].(string); url != "" {
+			token, _ := body["token"].(string)
+			hc := &http.Client{Timeout: 3 * time.Second}
+			if cbReq, err := http.NewRequest(http.MethodPost, url, nil); err == nil {
+				cbReq.Header.Set("X-A2A-Notification-Token", token)
+				if resp, err := hc.Do(cbReq); err == nil {
+					_ = resp.Body.Close()
+				}
+			}
+		}
+		writeJSON(w, map[string]interface{}{"taskId": "task-rest-001", "url": "registered"})
+	})
+
+	srv.Start()
+	host = srv.URL
+	return srv
+}
+
+func TestPushSSRF_RESTBindingFromCard(t *testing.T) {
+	ts := restPushServer(t, "/v1")
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	findings, err := a2a.NewPushSSRFExecutor(testRuleCtx()).Execute(ctx, ts.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected one confirmed SSRF finding over the REST binding, got %d: %+v", len(findings), findings)
+	}
+	if findings[0].Severity != "high" || findings[0].Confidence != attack.ConfirmedExploit {
+		t.Errorf("want high/ConfirmedExploit, got %q/%q", findings[0].Severity, findings[0].Confidence)
+	}
+}
+
+// An agent that advertises no HTTP+JSON interface must not be probed for one.
+// The old code POSTed /tasks/send at every target regardless, which was a
+// guaranteed 404 on each scan.
+func TestPushSSRF_NoRESTInterfaceIsNotProbed(t *testing.T) {
+	var restProbes int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/agent-card.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"JSONRPC Only","preferredTransport":"JSONRPC"}`))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, ":send") || strings.Contains(r.URL.Path, "tasks/send") {
+			restProbes++
+		}
+		writeJSON(w, jsonRPCError(-32601, "Method not found"))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+	_, _ = a2a.NewPushSSRFExecutor(testRuleCtx()).Execute(ctx, ts.URL, testOpts())
+
+	if restProbes != 0 {
+		t.Errorf("sent %d REST probes to an agent that advertises no HTTP+JSON interface, want 0", restProbes)
+	}
+}
+
 // TestPushSSRF_AcceptedNoCallback: the server accepts the push config but never
 // calls back (normal A2A behaviour). No SSRF is demonstrated, so the rule MUST
 // stay silent rather than flag the by-design feature.
@@ -238,7 +329,12 @@ func TestPushSSRF_DryRunBindsNoListener(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if _, err := a2a.NewPushSSRFExecutor(testRuleCtx()).Execute(ctx, "http://target.invalid", opts); err != nil {
+	// A dry run answers every request with a synthetic 200 {} and reaches no
+	// agent, so ErrInconclusive is the truthful outcome and is accepted here.
+	// What this test is actually about is the two assertions below: no socket,
+	// and the placeholder callback in the recorded plan.
+	_, err := a2a.NewPushSSRFExecutor(testRuleCtx()).Execute(ctx, "http://target.invalid", opts)
+	if err != nil && !errors.Is(err, attack.ErrInconclusive) {
 		t.Fatalf("dry-run Execute returned error: %v", err)
 	}
 


### PR DESCRIPTION
## Defect

The HTTP+JSON attempt POSTed a fixed `/tasks/send`. No binding defines that path; a2a-sdk answers 404. So it was a wasted request on every scan, and a REST-only agent could not be tested at all.

The real paths are `message:send` and `tasks/{id}/pushNotificationConfigs`, but the **prefix cannot be guessed**: a2a-sdk takes it as a parameter and lets the deployment choose which protocol version sits under it. On the agent I probed, `/message:send` is the 1.0 route and `/v1/message:send` is the 0.3 compatibility route, the reverse of the obvious reading.

## Fix

Read the HTTP+JSON interface URL from the agent card, pinned to the target host. An agent advertising none is not probed for one. The callback is registered against the returned task, as on JSON-RPC v1.0, and `restTaskID` reads the REST reply shape since it carries no JSON-RPC envelope.

## Verification

An a2a-sdk agent exposing **only** REST, card advertising `/api/a2a`:

```
before:  0 findings, "could not reach a testable endpoint"
after:   [!] HIGH  A2A server made outbound request to attacker-controlled push notification URL
```

A2A lab fixture unchanged at 6 findings. New tests cover the card-driven REST path and assert zero REST probes against a JSON-RPC-only agent.

The dry-run test now tolerates `ErrInconclusive`: a dry run answers everything with a synthetic `200 {}`, resolves no card, and truthfully tests nothing. Its real assertions (no socket, placeholder callback recorded) are unchanged.

`go test -race ./...`, `go vet` (both tags), `gofmt`, `golangci-lint` v2.11.4 clean.