### PR TITLE
fix(a2a): send the v1.0 push-config shape in push-binding too

### DIFF
--- a/docs/rules-a2a.md
+++ b/docs/rules-a2a.md
@@ -385,6 +385,11 @@ webhook hijack if accepted). Distinct from `a2a-multitenant-isolation-001`
 another principal's task): here the vector is the push-config API itself, which
 can redirect a victim task's results to an attacker URL.
 
+The config is written in whichever shape the deployment takes: on **v1.0** the
+params to `CreateTaskPushNotificationConfig` are themselves a
+`TaskPushNotificationConfig`, so the callback is a flat `url`, while **v0.3**
+nests it under `pushNotificationConfig` on `tasks/pushNotificationConfig/set`.
+
 ---
 
 ### a2a-jsonrpc-batch-bypass-001

--- a/internal/attack/a2a/push_binding.go
+++ b/internal/attack/a2a/push_binding.go
@@ -142,15 +142,21 @@ func (e *PushBindingExecutor) createTask(ctx context.Context, c *attack.HTTPClie
 }
 
 // setPush attempts to register a push-notification config for taskID, trying the
-// v1.0 method+nested-config shape then the v0.3 slash-method shape, and also the
-// flat pushNotificationUrl field some deployments use.
+// v1.0 shape then the v0.3 one.
+//
+// On v1.0 the params ARE a TaskPushNotificationConfig, whose fields are tenant,
+// id, taskId, url, token and authentication. This used to send a nested
+// pushNotificationConfig alongside a flat pushNotificationUrl; neither field
+// exists, and a2a-sdk rejects the call with -32602 "has no field named", so the
+// v1.0 attempt never registered anything. v0.3 is the shape that does nest the
+// config, and it is unchanged.
 func (e *PushBindingExecutor) setPush(ctx context.Context, c *attack.HTTPClient, endpoint string, extra map[string]string, taskID, url, token, randID string) bool {
 	cfg := map[string]string{"url": url, "token": token}
 	attempts := []struct {
 		method string
 		params map[string]interface{}
 	}{
-		{"CreateTaskPushNotificationConfig", map[string]interface{}{"taskId": taskID, "pushNotificationConfig": cfg, "pushNotificationUrl": url, "token": token}},
+		{"CreateTaskPushNotificationConfig", map[string]interface{}{"taskId": taskID, "url": url, "token": token}},
 		{"tasks/pushNotificationConfig/set", map[string]interface{}{"taskId": taskID, "pushNotificationConfig": cfg}},
 	}
 	for _, at := range attempts {

--- a/internal/attack/a2a/push_binding_test.go
+++ b/internal/attack/a2a/push_binding_test.go
@@ -18,7 +18,13 @@ import (
 //   - "unbound": any authenticated principal may set/get any task's push config.
 //   - "bound": only the task owner may set/get (secure).
 //   - "open": even unauthenticated set succeeds (no-auth control plane).
-func pushServer(mode string) *httptest.Server {
+//
+// v1Only makes the server refuse the v0.3 slash methods, which is what a
+// deployment without the compatibility layer looks like. It matters because the
+// v0.3 fallback otherwise masks a wrong v1.0 request shape.
+func pushServer(mode string) *httptest.Server { return pushServerVersioned(mode, false) }
+
+func pushServerVersioned(mode string, v1Only bool) *httptest.Server {
 	type cfg struct{ url, owner string }
 	pushCfg := map[string]cfg{} // taskId -> config
 	taskOwner := map[string]string{}
@@ -53,6 +59,11 @@ func pushServer(mode string) *httptest.Server {
 				"error": map[string]interface{}{"code": -32600, "message": msg}})
 		}
 
+		if v1Only && strings.Contains(method, "/") {
+			rpcErr("method not found")
+			return
+		}
+
 		switch method {
 		case "SendMessage", "message/send":
 			if who == "" {
@@ -64,7 +75,16 @@ func pushServer(mode string) *httptest.Server {
 			result(map[string]interface{}{"id": tid, "contextId": "ctx-" + who, "status": "working"})
 		case "CreateTaskPushNotificationConfig", "tasks/pushNotificationConfig/set":
 			tid, _ := params["taskId"].(string)
-			url := pushURL(params)
+			// Strict per method, as a2a-sdk is: on the v1.0 PascalCase call the
+			// params ARE a TaskPushNotificationConfig, so the callback is flat
+			// and a nested pushNotificationConfig is an unknown field. v0.3 is
+			// the shape that nests it. A harness that accepted either on either
+			// method would pass while a real agent answered -32602.
+			url := pushURL(params, method)
+			if url == "" {
+				rpcErr("invalid params")
+				return
+			}
 			if mode != "open" && who == "" {
 				rpcErr("auth required")
 				return
@@ -93,13 +113,21 @@ func pushServer(mode string) *httptest.Server {
 	}))
 }
 
-func pushURL(params map[string]interface{}) string {
-	if c, ok := params["pushNotificationConfig"].(map[string]interface{}); ok {
-		if u, ok := c["url"].(string); ok {
-			return u
-		}
+// pushURL reads the callback from the two shapes the protocol defines: nested
+// under pushNotificationConfig on v0.3, and flat on params for v1.0, where the
+// params ARE a TaskPushNotificationConfig.
+//
+// It used to also accept a flat pushNotificationUrl, which is the field the rule
+// happened to send and which no SDK defines. Accepting it here let the harness
+// pass while a2a-sdk answered the same request -32602, so only shapes the
+// protocol defines are read now.
+func pushURL(params map[string]interface{}, method string) string {
+	if method == "CreateTaskPushNotificationConfig" {
+		u, _ := params["url"].(string)
+		return u
 	}
-	if u, ok := params["pushNotificationUrl"].(string); ok {
+	if c, ok := params["pushNotificationConfig"].(map[string]interface{}); ok {
+		u, _ := c["url"].(string)
 		return u
 	}
 	return ""
@@ -140,6 +168,21 @@ func TestPushBinding_Unbound(t *testing.T) {
 	titles := findings[0].Title + "|" + findings[1].Title
 	if !strings.Contains(titles, "writable") || !strings.Contains(titles, "readable") {
 		t.Errorf("expected one write and one read finding, got: %s", titles)
+	}
+}
+
+// A deployment that speaks only v1.0 has no v0.3 fallback to hide behind, so the
+// rule's v1.0 request shape has to be right. It was not: the params to
+// CreateTaskPushNotificationConfig ARE a TaskPushNotificationConfig, and the rule
+// sent a nested pushNotificationConfig plus an invented pushNotificationUrl,
+// which a2a-sdk rejects with -32602.
+func TestPushBinding_UnboundV1Only(t *testing.T) {
+	ts := pushServerVersioned("unbound", true)
+	defer ts.Close()
+
+	findings := runPushBinding(t, ts, pushPrincipals())
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings against a v1.0-only server, got %d: %+v", len(findings), findings)
 	}
 }
 

--- a/testdata/a2a_push_binding_server.py
+++ b/testdata/a2a_push_binding_server.py
@@ -53,10 +53,20 @@ def error(req_id, msg):
 
 
 def push_url(params):
+    """Read the callback from the two shapes the protocol defines.
+
+    v0.3 nests it under pushNotificationConfig. v1.0 params ARE a
+    TaskPushNotificationConfig, so the callback is a flat `url` alongside taskId
+    and token.
+
+    A flat `pushNotificationUrl` used to be accepted here as well. No SDK defines
+    that field, a2a-sdk rejects it with -32602, and accepting it meant this
+    fixture agreed with the scanner instead of with the protocol.
+    """
     cfg = params.get("pushNotificationConfig")
     if isinstance(cfg, dict) and cfg.get("url"):
         return cfg["url"]
-    return params.get("pushNotificationUrl", "")
+    return params.get("url", "")
 
 
 async def rpc(request: Request) -> Response:


### PR DESCRIPTION
## Defect

#126 fixed this shape in push-ssrf and was scoped to that rule. `push-binding` had the same bug: its v1.0 set sent a nested `pushNotificationConfig` plus a flat `pushNotificationUrl`, and the params to `CreateTaskPushNotificationConfig` **are** a `TaskPushNotificationConfig` (`tenant, id, taskId, url, token, authentication`). a2a-sdk answers `-32602 ... has no field named "pushNotificationConfig"`.

Found by dumping every request body with `scan --dry-run` and replaying each distinct shape against a live a2a-sdk 1.1.2 agent. Seven of eight A2A shapes were schema-accepted; this was the one that wasn't. The read-back (`{taskId, id}`) is correct and unchanged.

## Impact

The v0.3 fallback works, so the rule still functioned against deployments with the compatibility layer. Only a v1.0-only agent was untestable.

## Verification

Corrected v1.0 set against a2a-sdk: accepted, returns the config. Fixture on port 3107 still yields 2 findings.

That same v0.3 fallback is what kept the harness green, so this adds a **v1.0-only posture** that refuses the slash methods — without it no test can tell the two shapes apart. Restoring the old shape fails it with 0 findings instead of 2.

Both fixtures were vouching for the bug again: the Go harness accepted either shape on either method, and the Python fixture read a flat `pushNotificationUrl`. Both are now strict per method, as the SDK is.

`go test -race ./...`, `go vet`, `gofmt`, `golangci-lint` v2.11.4 clean.