### PR TITLE
perf(mcp): stop the endpoint walk once a path answers as MCP

### DIFF
--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -57,6 +57,14 @@ against a server this rule set cannot handshake with they report **inconclusive
 or skip**, never a clean pass. A target that could not be exercised is reported
 as not tested rather than as secure.
 
+## Endpoint discovery
+
+A target that names a path is probed as given; otherwise `/mcp`, `/`, `/api` and
+`/rpc` are tried in that order. The walk **stops at the first path that answers as
+an MCP endpoint**, because the remaining candidates are the same server at paths
+it does not serve, so probing them yields 404s rather than coverage. Only when no
+candidate answers does a rule report that it could not test.
+
 | Rule ID | Attack | Severity | Confidence | CWE |
 |---|---|:---:|:---:|---|
 | `mcp-oauth-dcr-001` | [OAuth DCR Scope Escalation](#mcp-oauth-dcr-001) | High | indicator | CWE-284 |

--- a/internal/attack/mcp/candidate_walk_test.go
+++ b/internal/attack/mcp/candidate_walk_test.go
@@ -1,0 +1,152 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+// Endpoint discovery tries /mcp, /, /api and /rpc. Several rules used to keep
+// walking that list after a candidate had already answered as an MCP server,
+// which buys nothing: the rest of the list is the same server at paths it does
+// not serve. Measured against @modelcontextprotocol/server-everything it was 30%
+// of a scan's requests, and 75% of one rule's.
+//
+// The server below answers at /mcp only and counts every request that lands
+// anywhere else, so a rule that keeps walking fails.
+
+// mountedMCPServer serves a working MCP endpoint at /mcp and 404s every other
+// path, counting the strays.
+func mountedMCPServer(t *testing.T) (*httptest.Server, *int64) {
+	t.Helper()
+
+	var strays int64
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mcp" {
+			// Only the other candidate paths count. A rule may legitimately fetch
+			// well-known OAuth metadata, which is discovery of a different kind.
+			switch r.URL.Path {
+			case "/", "/api", "/rpc":
+				atomic.AddInt64(&strays, 1)
+			}
+			http.NotFound(w, r)
+			return
+		}
+
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		method, _ := req["method"].(string)
+		id := req["id"]
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Mcp-Session-Id", "srv-session-1")
+
+		write := func(result interface{}) {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id, "result": result,
+			})
+		}
+
+		switch method {
+		case "initialize":
+			write(map[string]interface{}{
+				"protocolVersion": "2025-06-18",
+				"serverInfo":      map[string]interface{}{"name": "walk-fixture", "version": "1.0"},
+				"capabilities": map[string]interface{}{
+					"tools": map[string]interface{}{}, "resources": map[string]interface{}{},
+					"prompts": map[string]interface{}{}, "logging": map[string]interface{}{},
+				},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			write(map[string]interface{}{"tools": []interface{}{
+				map[string]interface{}{"name": "echo", "description": "echo"},
+			}})
+		case "resources/list":
+			write(map[string]interface{}{"resources": []interface{}{
+				map[string]interface{}{"uri": "file://a", "name": "a"},
+			}})
+		case "prompts/list":
+			write(map[string]interface{}{"prompts": []interface{}{
+				map[string]interface{}{"name": "p"},
+			}})
+		case "tools/call":
+			write(map[string]interface{}{"content": []interface{}{
+				map[string]string{"type": "text", "text": "ok"},
+			}})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": -32601, "message": "Method not found"},
+			})
+		}
+	})
+
+	return httptest.NewServer(mux), &strays
+}
+
+func walkExecutors() map[string]attack.Executor {
+	rc := attack.RuleContext{ID: "mcp-test-001", Name: "Test", Severity: "high", Remediation: "Fix"}
+	return map[string]attack.Executor{
+		"secret-canary":        mcpattack.NewSecretCanaryExecutor(rc),
+		"init-downgrade":       mcpattack.NewInitDowngradeExecutor(rc),
+		"sse-resume-replay":    mcpattack.NewSSEResumeReplayExecutor(rc),
+		"header-body-split":    mcpattack.NewHeaderBodySplitExecutor(rc),
+		"jsonrpc-batch-bypass": mcpattack.NewBatchBypassExecutor(rc),
+		"oauth-audience":       mcpattack.NewOAuthAudienceExecutor(rc),
+	}
+}
+
+func TestCandidateWalk_StopsOnceAnEndpointAnswers(t *testing.T) {
+	for name, exec := range walkExecutors() {
+		t.Run(name, func(t *testing.T) {
+			ts, strays := mountedMCPServer(t)
+			defer ts.Close()
+
+			_, _ = exec.Execute(context.Background(), ts.URL, testOpts())
+
+			if n := atomic.LoadInt64(strays); n != 0 {
+				t.Errorf("kept walking after /mcp answered: %d request(s) to other candidate paths", n)
+			}
+		})
+	}
+}
+
+// The boundary the change must not cross: when nothing answers, every candidate
+// is still tried and the rule reports that it could not test, rather than a clean
+// pass.
+//
+// oauth-audience is excluded. It reports a clean pass rather than inconclusive
+// when no OAuth surface is reachable, which predates this change and is a
+// separate question from the candidate walk.
+func TestCandidateWalk_NothingAnswersIsStillInconclusive(t *testing.T) {
+	for name, exec := range walkExecutors() {
+		if name == "oauth-audience" {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			var hits int64
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				atomic.AddInt64(&hits, 1)
+				http.NotFound(w, r)
+			}))
+			defer ts.Close()
+
+			_, err := exec.Execute(context.Background(), ts.URL, testOpts())
+			if !errors.Is(err, attack.ErrInconclusive) {
+				t.Errorf("expected ErrInconclusive against a 404-everything server, got err=%v", err)
+			}
+			if atomic.LoadInt64(&hits) == 0 {
+				t.Error("no candidate was tried at all")
+			}
+		})
+	}
+}

--- a/internal/attack/mcp/header_body_split.go
+++ b/internal/attack/mcp/header_body_split.go
@@ -30,20 +30,9 @@ func (e *HeaderBodySplitExecutor) Execute(ctx context.Context, target string, op
 	vars := attack.NewVars(target, opts.OOBListenerURL)
 	client := attack.NewHTTPClient(opts, vars)
 
-	var reached bool
-	for _, ep := range endpointCandidates(vars.BaseURL) {
-		f, epReached := e.probe(ctx, client, ep)
-		if epReached {
-			reached = true
-		}
-		if f != nil {
-			return f, nil
-		}
-	}
-	if !reached {
-		return nil, attack.ErrInconclusive
-	}
-	return nil, nil
+	return probeCandidates(vars.BaseURL, func(ep string) ([]attack.Finding, bool) {
+		return e.probe(ctx, client, ep)
+	})
 }
 
 func (e *HeaderBodySplitExecutor) probe(ctx context.Context, client *attack.HTTPClient, ep string) ([]attack.Finding, bool) {

--- a/internal/attack/mcp/init_downgrade.go
+++ b/internal/attack/mcp/init_downgrade.go
@@ -59,20 +59,9 @@ func (e *InitDowngradeExecutor) Execute(ctx context.Context, target string, opts
 	// WITHOUT proper credentials, so the probe must run with no bearer token.
 	client := attack.NewUnauthHTTPClient(opts, vars)
 
-	var reached bool
-	for _, ep := range endpointCandidates(vars.BaseURL) {
-		findings, epReached := e.probeEndpoint(ctx, client, ep)
-		if epReached {
-			reached = true
-		}
-		if findings != nil {
-			return findings, nil
-		}
-	}
-	if !reached {
-		return nil, attack.ErrInconclusive
-	}
-	return nil, nil
+	return probeCandidates(vars.BaseURL, func(ep string) ([]attack.Finding, bool) {
+		return e.probeEndpoint(ctx, client, ep)
+	})
 }
 
 func (e *InitDowngradeExecutor) probeEndpoint(ctx context.Context, client *attack.HTTPClient, ep string) ([]attack.Finding, bool) {

--- a/internal/attack/mcp/jsonrpc_batch_bypass.go
+++ b/internal/attack/mcp/jsonrpc_batch_bypass.go
@@ -51,20 +51,9 @@ func (e *BatchBypassExecutor) Execute(ctx context.Context, target string, opts a
 	// server's auth gate. Injecting opts.Token would mask the bypass.
 	client := attack.NewUnauthHTTPClient(opts, vars)
 
-	var reached bool
-	for _, ep := range endpointCandidates(vars.BaseURL) {
-		f, epReached := e.probeEndpoint(ctx, client, ep)
-		if epReached {
-			reached = true
-		}
-		if f != nil {
-			return f, nil
-		}
-	}
-	if !reached {
-		return nil, attack.ErrInconclusive
-	}
-	return nil, nil
+	return probeCandidates(vars.BaseURL, func(ep string) ([]attack.Finding, bool) {
+		return e.probeEndpoint(ctx, client, ep)
+	})
 }
 
 // probeEndpoint runs the bypass check against a single candidate endpoint.

--- a/internal/attack/mcp/oauth_audience.go
+++ b/internal/attack/mcp/oauth_audience.go
@@ -257,6 +257,12 @@ func probeWWWAuthenticateResourceMetadata(ctx context.Context, client *attack.HT
 		if u := parseResourceMetadataURL(resp.Headers.Get("WWW-Authenticate")); u != "" {
 			return u
 		}
+		// An endpoint that answered the handshake is the server, and it issued no
+		// challenge. The remaining candidates are the same server at paths it does
+		// not serve, so walking them only adds 404s.
+		if isMCPInitialize(resp) {
+			return ""
+		}
 	}
 	return ""
 }

--- a/internal/attack/mcp/secret_canary.go
+++ b/internal/attack/mcp/secret_canary.go
@@ -36,20 +36,9 @@ func (e *SecretCanaryExecutor) Execute(ctx context.Context, target string, opts 
 	canaryOpts.Token = canary
 	client := attack.NewHTTPClient(canaryOpts, vars)
 
-	var reached bool
-	for _, ep := range endpointCandidates(vars.BaseURL) {
-		f, epReached := e.probe(ctx, client, ep, canary)
-		if epReached {
-			reached = true
-		}
-		if f != nil {
-			return f, nil
-		}
-	}
-	if !reached {
-		return nil, attack.ErrInconclusive
-	}
-	return nil, nil
+	return probeCandidates(vars.BaseURL, func(ep string) ([]attack.Finding, bool) {
+		return e.probe(ctx, client, ep, canary)
+	})
 }
 
 func (e *SecretCanaryExecutor) probe(ctx context.Context, client *attack.HTTPClient, ep, canary string) ([]attack.Finding, bool) {

--- a/internal/attack/mcp/session.go
+++ b/internal/attack/mcp/session.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"encoding/json"
 
+	"github.com/calbebop/batesian/internal/attack"
 	"github.com/calbebop/batesian/internal/endpoint"
 )
 
@@ -15,6 +16,31 @@ var candidatePaths = []string{"/mcp", "/", "/api", "/rpc"}
 // paths are appended to it; see endpoint.Candidates.
 func endpointCandidates(baseURL string) []string {
 	return endpoint.Candidates(baseURL, candidatePaths)
+}
+
+// probeCandidates runs probe against each candidate endpoint under baseURL and
+// returns the first findings produced.
+//
+// probe reports whether the candidate answered as an MCP endpoint, and the walk
+// stops there whether or not that candidate yielded a finding. The candidate list
+// exists to locate the server, not to test several of them: once a path has
+// answered, the remaining candidates are the same server at paths it does not
+// serve, so probing them buys 404s rather than coverage. Measured against
+// @modelcontextprotocol/server-everything, that walk was 30% of a scan's requests.
+//
+// When no candidate answers, the rule was never exercised, which is
+// ErrInconclusive rather than a clean pass.
+func probeCandidates(baseURL string, probe func(endpoint string) ([]attack.Finding, bool)) ([]attack.Finding, error) {
+	for _, ep := range endpointCandidates(baseURL) {
+		findings, reached := probe(ep)
+		if findings != nil {
+			return findings, nil
+		}
+		if reached {
+			return nil, nil
+		}
+	}
+	return nil, attack.ErrInconclusive
 }
 
 // mcpSession holds the discovered MCP endpoint and the session ID returned by

--- a/internal/attack/mcp/sse_resume_replay.go
+++ b/internal/attack/mcp/sse_resume_replay.go
@@ -44,20 +44,9 @@ func (e *SSEResumeReplayExecutor) Execute(ctx context.Context, target string, op
 		tokenA, tokenB = opts.Principals[0].Token, opts.Principals[1].Token
 	}
 
-	var reached bool
-	for _, ep := range endpointCandidates(vars.BaseURL) {
-		f, epReached := e.probe(ctx, client, raw, ep, tokenA, tokenB)
-		if epReached {
-			reached = true
-		}
-		if f != nil {
-			return f, nil
-		}
-	}
-	if !reached {
-		return nil, attack.ErrInconclusive
-	}
-	return nil, nil
+	return probeCandidates(vars.BaseURL, func(ep string) ([]attack.Finding, bool) {
+		return e.probe(ctx, client, raw, ep, tokenA, tokenB)
+	})
 }
 
 func (e *SSEResumeReplayExecutor) probe(ctx context.Context, client *attack.HTTPClient, raw *http.Client, ep, tokenA, tokenB string) ([]attack.Finding, bool) {


### PR DESCRIPTION
## Defect

Discovery tries `/mcp`, `/`, `/api`, `/rpc`. Six rules kept walking after a candidate had already answered — the rest of the list is the same server at paths it does not serve, so it buys 404s, not coverage.

Measured through a recording proxy in front of `@modelcontextprotocol/server-everything`: **30 of a scan's 99 requests**, and 12 of secret-canary's 16.

## Fix

Five of the six had the same loop, copied. They now share `probeCandidates`, which encodes the stop rule once — five copies of one decision is how the S-series findings started.

`oauth-audience` needed a different change: its `WWW-Authenticate` walk has no notion of "reached", so it stops when a candidate answers the handshake without issuing a challenge. Its second loop already stopped at the first responding endpoint and is untouched.

## Measured

| | requests | walk 404s |
|---|---|---|
| the six rules, before | 52 | 30 |
| the six rules, after | 22 | 0 |
| full MCP scan, before | 99 | 30 |
| full MCP scan, after | 69 | 0 |

Findings unchanged at 10, skip count unchanged at 17 of 35.

The test asserts request counts directly against a server mounted at `/mcp` that counts anything hitting the other candidates. It also pins the boundary — when nothing answers, every candidate is still tried and the rule reports it could not test, which is exactly what a careless version of this change turns into a clean pass. Restoring the old behaviour fails all six subtests.

## Left alone

`oauth-audience` reports a clean pass rather than inconclusive when no OAuth surface is reachable. That predates this change, so the boundary test skips it rather than asserting a contract it does not hold to.

`go test -race ./...`, `go vet` (both tags), `gofmt`, `golangci-lint` v2.11.4 clean.