### PR TITLE
fix(mcp): separate no-OAuth from nothing-answered in oauth-audience

### DIFF
--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -113,7 +113,10 @@ that rejects the registration or reduces the grant to read-only produces no find
 
 Tests whether the server's `aud` matching logic is robust to common
 implementation bugs, once the expected audience is known (via `--audience-claim`
-or RFC 9728 auto-discovery; otherwise the rule reports inconclusive and skips).
+or RFC 9728 auto-discovery). Without one, the outcome depends on whether anything
+answered: an MCP server that advertises no metadata has no audience to check
+against, so that is a **clean** result, while a target where nothing answered the
+handshake is reported as **not tested**.
 It submits a **negative control** plus three trap probes as forged HS256 JWTs:
 
 - `aud-control-unrelated` - isolates the audience logic from blanket signature

--- a/internal/attack/mcp/candidate_walk_test.go
+++ b/internal/attack/mcp/candidate_walk_test.go
@@ -123,15 +123,8 @@ func TestCandidateWalk_StopsOnceAnEndpointAnswers(t *testing.T) {
 // The boundary the change must not cross: when nothing answers, every candidate
 // is still tried and the rule reports that it could not test, rather than a clean
 // pass.
-//
-// oauth-audience is excluded. It reports a clean pass rather than inconclusive
-// when no OAuth surface is reachable, which predates this change and is a
-// separate question from the candidate walk.
 func TestCandidateWalk_NothingAnswersIsStillInconclusive(t *testing.T) {
 	for name, exec := range walkExecutors() {
-		if name == "oauth-audience" {
-			continue
-		}
 		t.Run(name, func(t *testing.T) {
 			var hits int64
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/attack/mcp/oauth_audience.go
+++ b/internal/attack/mcp/oauth_audience.go
@@ -81,12 +81,20 @@ func (e *OAuthAudienceExecutor) Execute(ctx context.Context, target string, opts
 
 	expected := strings.TrimSpace(opts.AudienceClaim)
 	if expected == "" {
-		discovered := discoverExpectedAudience(ctx, client, vars.BaseURL)
+		discovered, mcpReached := discoverExpectedAudience(ctx, client, vars.BaseURL)
 		if discovered == "" {
 			// Precondition not met: no operator input and no discoverable
-			// resource metadata. Skip silently rather than emit a misleading
-			// finding. Operators who want this rule to run should pass
+			// resource metadata. Operators who want this rule to run should pass
 			// --audience-claim or expose RFC 9728 metadata on the target.
+			//
+			// Which of two things happened decides how that is reported. An MCP
+			// server that answered but advertises no metadata is genuinely not
+			// applicable, and clean is honest. A target where nothing answered
+			// was never exercised, and clean there would claim coverage the scan
+			// does not have.
+			if !mcpReached {
+				return nil, attack.ErrInconclusive
+			}
 			return nil, nil
 		}
 		expected = discovered
@@ -227,20 +235,25 @@ func hasUpper(s string) bool {
 //
 // Returns the resource URI on success, or an empty string if nothing
 // usable was found (caller treats that as "skip").
-func discoverExpectedAudience(ctx context.Context, client *attack.HTTPClient, baseURL string) string {
-	if metaURL := probeWWWAuthenticateResourceMetadata(ctx, client, baseURL); metaURL != "" {
+func discoverExpectedAudience(ctx context.Context, client *attack.HTTPClient, baseURL string) (audience string, mcpReached bool) {
+	metaURL, mcpReached := probeWWWAuthenticateResourceMetadata(ctx, client, baseURL)
+	if metaURL != "" {
 		if resource := fetchResourceFromMetadata(ctx, client, metaURL); resource != "" {
-			return resource
+			return resource, mcpReached
 		}
 	}
 	wellKnown := baseURL + "/.well-known/oauth-protected-resource"
-	return fetchResourceFromMetadata(ctx, client, wellKnown)
+	return fetchResourceFromMetadata(ctx, client, wellKnown), mcpReached
 }
 
 // probeWWWAuthenticateResourceMetadata sends an unauth initialize request to
 // the first responsive endpoint candidate and returns the resource_metadata
 // URL advertised in the WWW-Authenticate response header, if any.
-func probeWWWAuthenticateResourceMetadata(ctx context.Context, client *attack.HTTPClient, baseURL string) string {
+// mcpReached reports whether any candidate answered the handshake, which is what
+// separates "this MCP server exposes no OAuth" from "nothing here answered at
+// all". The first is a clean result for an OAuth-gated rule; the second is a
+// target that was never tested.
+func probeWWWAuthenticateResourceMetadata(ctx context.Context, client *attack.HTTPClient, baseURL string) (metadataURL string, mcpReached bool) {
 	body := json.RawMessage(mcpInitBody)
 	for _, ep := range endpointCandidates(baseURL) {
 		// Use no Authorization header (override any opts.Token) so the server
@@ -255,16 +268,17 @@ func probeWWWAuthenticateResourceMetadata(ctx context.Context, client *attack.HT
 		// 401 is the expected discovery response; some servers also emit the
 		// header on 403. We accept any response that carries the header.
 		if u := parseResourceMetadataURL(resp.Headers.Get("WWW-Authenticate")); u != "" {
-			return u
+			// A challenge is itself proof the endpoint is live and gated.
+			return u, true
 		}
 		// An endpoint that answered the handshake is the server, and it issued no
 		// challenge. The remaining candidates are the same server at paths it does
 		// not serve, so walking them only adds 404s.
 		if isMCPInitialize(resp) {
-			return ""
+			return "", true
 		}
 	}
-	return ""
+	return "", false
 }
 
 // resourceMetadataRE extracts the resource_metadata="..." parameter from a

--- a/internal/attack/mcp/oauth_audience_test.go
+++ b/internal/attack/mcp/oauth_audience_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -217,19 +218,43 @@ func TestOAuthAudience_SecureServer_AllRejected(t *testing.T) {
 	}
 }
 
-func TestOAuthAudience_PreconditionNotMet_NoAudience(t *testing.T) {
-	// Server responds 404 to everything: no advertisement, no metadata,
-	// no operator input. Rule must skip silently.
-	srv := httptest.NewServer(http.NotFoundHandler())
+// "The precondition is not met" covers two different situations, and they are not
+// reported the same way.
+//
+// An MCP server that answers the handshake but advertises no resource metadata is
+// genuinely not applicable: there is no audience to check against, and a clean
+// result is honest.
+func TestOAuthAudience_PreconditionNotMet_MCPServerWithoutMetadata(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		initializeOK(w) // no WWW-Authenticate challenge, no metadata anywhere
+	})
+	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
 	exec := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC())
 	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("expected a clean result for an MCP server with no metadata, got err=%v", err)
 	}
 	if len(findings) != 0 {
 		t.Errorf("expected zero findings when audience cannot be resolved, got %d", len(findings))
+	}
+}
+
+// A target where nothing answers was never exercised. Reporting clean there says
+// the audience handling is sound about a host the rule never reached.
+func TestOAuthAudience_NothingReachableIsNotTested(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC())
+	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive against a 404-everything target, got err=%v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings, got %d", len(findings))
 	}
 }
 


### PR DESCRIPTION
## Defect

Without `--audience-claim` the rule discovers the expected audience from RFC 9728 metadata, and returned a **clean pass** whenever it found none. That conflated two situations:

- an MCP server that answers the handshake but advertises no metadata — no audience to check against, clean is honest
- a target where **nothing answered** — never exercised, and clean claims coverage the scan does not have

The existing test's own comment ("no advertisement, no metadata, no operator input") shows the two were conflated from the start.

## Fix

Discovery already POSTs `initialize` to each candidate, so the distinction costs **no extra requests**: `probeWWWAuthenticateResourceMetadata` now reports whether any candidate answered as MCP or issued an auth challenge, and `Execute` reports inconclusive only when neither happened.

## Verification

Dead target:

```
before:  No findings. Target appears clean for the tested rules.
after:   1 of 1 rule(s) could not reach a testable endpoint and were not exercised.
```

Against `@modelcontextprotocol/server-everything` (reachable, no OAuth) it still reports clean, and a full scan is unchanged at 10 findings / 17 of 35 skips.

The precondition test is now two tests, one per case. The boundary test from #130 no longer needs to skip this rule, so all six candidate-walk subtests cover it. Reverting the change fails both.

## Left alone

The four sibling OAuth-gated rules (`confused-deputy`, `oauth-dcr`, `oauth-metadata-ssrf`, `token-replay`) have the same shape, but none has `initialize` evidence to hand — distinguishing the cases there means adding a handshake per rule on the bail path. That is a cost/semantics decision of its own, not something to fold in here.

`go test -race ./...`, `go vet` (both tags), `gofmt`, `golangci-lint` v2.11.4 clean.