### PR TITLE
fix(mcp): report an unreachable target as not tested in the OAuth-gated rules

### DIFF
--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -57,6 +57,21 @@ against a server this rule set cannot handshake with they report **inconclusive
 or skip**, never a clean pass. A target that could not be exercised is reported
 as not tested rather than as secure.
 
+## OAuth-gated rules
+
+`mcp-oauth-dcr-001`, `mcp-oauth-audience-002`, `mcp-token-replay-001`,
+`mcp-oauth-metadata-ssrf-001` and `mcp-confused-deputy-001` need an OAuth surface
+to test: an authorization-server or protected-resource document, or a registration
+endpoint. When none is advertised they report **clean**, because a server without
+OAuth is not applicable rather than insecure.
+
+That holds only for a server that answered. A target where nothing responded to an
+MCP handshake is reported as **not tested**, since a clean result there would say
+the OAuth handling is sound about a host the rule never reached. Reachability is
+settled with a single `initialize` per candidate, on the bail path only, and a
+2026-07-28 server is reported as speaking an unsupported protocol version rather
+than as unreachable.
+
 ## Endpoint discovery
 
 A target that names a path is probed as given; otherwise `/mcp`, `/`, `/api` and

--- a/internal/attack/mcp/confused_deputy.go
+++ b/internal/attack/mcp/confused_deputy.go
@@ -58,8 +58,9 @@ func (e *ConfusedDeputyExecutor) Execute(ctx context.Context, target string, opt
 	regEP, authEP := discoverOAuthEndpoints(ctx, client, vars.BaseURL)
 	if authEP == "" || regEP == "" {
 		// No authorization endpoint, or no DCR endpoint to obtain a client_id.
-		// CIMD-only (2025-11-25) and non-OAuth servers land here: not applicable.
-		return nil, nil
+		// CIMD-only (2025-11-25) and non-OAuth servers land here: not applicable,
+		// but only when something actually answered.
+		return nil, oauthNotApplicable(ctx, client, vars.BaseURL)
 	}
 
 	// Register a client with an off-origin redirect. We use a domain unrelated to

--- a/internal/attack/mcp/confused_deputy_test.go
+++ b/internal/attack/mcp/confused_deputy_test.go
@@ -3,6 +3,7 @@ package mcp_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -142,11 +143,25 @@ func TestConfusedDeputy_DCRRestricted(t *testing.T) {
 
 // TestConfusedDeputy_NotOAuth: no authorization-server metadata. The rule does
 // not apply and MUST stay silent.
+// An MCP server that exposes no OAuth surface is not applicable, which is a clean
+// result. The fixture has to answer the handshake for that to be the case: a
+// target where nothing answers was never tested (see the next test).
 func TestConfusedDeputy_NotOAuth(t *testing.T) {
-	ts := confusedDeputyServer("not-oauth")
+	ts, _ := mountedMCPServer(t)
 	defer ts.Close()
 
 	if findings := runConfusedDeputy(t, ts); len(findings) != 0 {
-		t.Errorf("expected zero findings against a non-OAuth server, got %d", len(findings))
+		t.Errorf("expected zero findings against a non-OAuth MCP server, got %d", len(findings))
+	}
+}
+
+func TestConfusedDeputy_NothingReachableIsNotTested(t *testing.T) {
+	ts := confusedDeputyServer("not-oauth") // 404s the OAuth documents and everything else
+	defer ts.Close()
+
+	_, err := mcpattack.NewConfusedDeputyExecutor(confusedDeputyRC()).
+		Execute(context.Background(), ts.URL, testOpts())
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive when nothing answered, got err=%v", err)
 	}
 }

--- a/internal/attack/mcp/init_downgrade.go
+++ b/internal/attack/mcp/init_downgrade.go
@@ -73,7 +73,7 @@ func (e *InitDowngradeExecutor) probeEndpoint(ctx context.Context, client *attac
 		// probing whether the endpoint answers initialize with a JSON-RPC
 		// response at all. A version-rejection error still counts as reached:
 		// the endpoint is testable, it just declined the offered version.
-		if !e.responsiveMCP(ctx, client, ep) {
+		if !responsiveMCP(ctx, client, ep) {
 			return nil, false // not a responsive MCP endpoint
 		}
 		return nil, true // reached, but the offered version was rejected - nothing to confirm
@@ -116,7 +116,10 @@ func (e *InitDowngradeExecutor) probeEndpoint(ctx context.Context, client *attac
 // response (a result OR an error envelope). A version-rejection error still
 // counts: the endpoint speaks MCP, it just declined the offered version, so the
 // rule reached a testable endpoint (clean) rather than being unable to test.
-func (e *InitDowngradeExecutor) responsiveMCP(ctx context.Context, client *attack.HTTPClient, ep string) bool {
+//
+// One request, and no session bookkeeping, which is why the OAuth-gated rules use
+// it rather than a full handshake to answer "is this even an MCP server".
+func responsiveMCP(ctx context.Context, client *attack.HTTPClient, ep string) bool {
 	resp, err := client.POST(ctx, ep, nil, map[string]interface{}{
 		"jsonrpc": "2.0",
 		"id":      1,

--- a/internal/attack/mcp/oauth_dcr.go
+++ b/internal/attack/mcp/oauth_dcr.go
@@ -62,8 +62,9 @@ func (e *OAuthDCRExecutor) Execute(ctx context.Context, target string, opts atta
 	// Step 1: Discover the OAuth metadata endpoint to find the registration endpoint.
 	registrationEndpoint, err := e.discoverRegistrationEndpoint(ctx, client, vars.BaseURL)
 	if err != nil {
-		// Not a finding - this MCP server may not use OAuth 2.1.
-		return nil, nil //nolint:nilerr
+		// Not a finding - this MCP server may not use OAuth 2.1. That holds only
+		// for a server that answered; an unreachable target was never tested.
+		return nil, oauthNotApplicable(ctx, client, vars.BaseURL) //nolint:nilerr
 	}
 
 	// Step 2: Unauthenticated registration requesting admin/write scopes.

--- a/internal/attack/mcp/oauth_dcr_test.go
+++ b/internal/attack/mcp/oauth_dcr_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -205,8 +206,9 @@ func TestOAuthDCR_AuthGatedRegistration(t *testing.T) {
 	}
 }
 
+// A reachable MCP server with no OAuth metadata is not applicable: clean.
 func TestOAuthDCR_NoOAuthServer(t *testing.T) {
-	ts := httptest.NewServer(http.NotFoundHandler())
+	ts, _ := mountedMCPServer(t)
 	defer ts.Close()
 
 	findings, err := mcpattack.NewOAuthDCRExecutor(oauthRC()).Execute(context.Background(), ts.URL, testOpts())
@@ -214,6 +216,17 @@ func TestOAuthDCR_NoOAuthServer(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(findings) != 0 {
-		t.Errorf("expected zero findings on non-OAuth server, got %d", len(findings))
+		t.Errorf("expected zero findings on a non-OAuth MCP server, got %d", len(findings))
+	}
+}
+
+// Nothing answered, so the rule was never exercised.
+func TestOAuthDCR_NothingReachableIsNotTested(t *testing.T) {
+	ts := httptest.NewServer(http.NotFoundHandler())
+	defer ts.Close()
+
+	_, err := mcpattack.NewOAuthDCRExecutor(oauthRC()).Execute(context.Background(), ts.URL, testOpts())
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive when nothing answered, got err=%v", err)
 	}
 }

--- a/internal/attack/mcp/oauth_metadata_ssrf.go
+++ b/internal/attack/mcp/oauth_metadata_ssrf.go
@@ -40,7 +40,9 @@ func (e *OAuthMetadataSSRFExecutor) Execute(ctx context.Context, target string, 
 
 	registrationEndpoint, ok := e.discoverRegistrationEndpoint(ctx, client, vars.BaseURL)
 	if !ok {
-		return nil, nil // server does not advertise OAuth DCR
+		// The server advertises no OAuth DCR, which is not applicable rather than
+		// clean only if the server answered at all.
+		return nil, oauthNotApplicable(ctx, client, vars.BaseURL)
 	}
 
 	// Resolve the OOB listener (external if provided, else a local one).

--- a/internal/attack/mcp/oauth_metadata_ssrf_test.go
+++ b/internal/attack/mcp/oauth_metadata_ssrf_test.go
@@ -3,6 +3,7 @@ package mcp_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -97,11 +98,23 @@ func TestMetadataSSRF_NoFetch(t *testing.T) {
 }
 
 // TestMetadataSSRF_NoOAuth: no DCR endpoint => clean skip.
+// A reachable MCP server with no DCR advertisement is not applicable: clean.
 func TestMetadataSSRF_NoOAuth(t *testing.T) {
-	ts := metadataSSRFServer("no-oauth")
+	ts, _ := mountedMCPServer(t)
 	defer ts.Close()
 
 	if findings := runMetadataSSRF(t, ts); len(findings) != 0 {
-		t.Errorf("expected zero findings against a non-OAuth server, got %d", len(findings))
+		t.Errorf("expected zero findings against a non-OAuth MCP server, got %d", len(findings))
+	}
+}
+
+func TestMetadataSSRF_NothingReachableIsNotTested(t *testing.T) {
+	ts := metadataSSRFServer("no-oauth") // 404s the metadata and everything else
+	defer ts.Close()
+
+	_, err := mcpattack.NewOAuthMetadataSSRFExecutor(omRuleCtx()).
+		Execute(context.Background(), ts.URL, testOpts())
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive when nothing answered, got err=%v", err)
 	}
 }

--- a/internal/attack/mcp/resources_unauth.go
+++ b/internal/attack/mcp/resources_unauth.go
@@ -299,18 +299,28 @@ func initializeMCP(ctx context.Context, client *attack.HTTPClient, baseURL strin
 
 	// No candidate path completed a legacy handshake. Before reporting the target
 	// as unreachable, check whether it is actually a modern (2026-07-28) server,
-	// which has no initialize method at all. Distinguishing the two is the
-	// difference between "this scanner does not speak your protocol version" and
-	// a bare "could not connect".
-	//
-	// This runs only on the failure path, so a legacy server, still the norm,
-	// pays no extra request.
-	for _, ep := range endpoints {
-		if detectEra(ctx, client, ep) == EraModern {
-			return mcpSession{}, fmt.Errorf("%w: %s speaks MCP %s (stateless era), which these rules do not yet support",
-				errModernEra, ep, modernEraVersion)
-		}
+	// which has no initialize method at all.
+	if err := modernEraReason(ctx, client, endpoints); err != nil {
+		return mcpSession{}, err
 	}
 
 	return mcpSession{}, fmt.Errorf("no MCP server found at %s", baseURL)
+}
+
+// modernEraReason returns the error to carry forward when none of endpoints
+// completed a legacy handshake but one of them turns out to speak the modern
+// (2026-07-28) revision, and nil when none does.
+//
+// Distinguishing the two is the difference between telling an operator "this
+// scanner does not speak your protocol version" and a bare "could not connect".
+// It runs only on a failure path, so a legacy server, still the norm, pays
+// nothing for it.
+func modernEraReason(ctx context.Context, client *attack.HTTPClient, endpoints []string) error {
+	for _, ep := range endpoints {
+		if detectEra(ctx, client, ep) == EraModern {
+			return fmt.Errorf("%w: %s speaks MCP %s (stateless era), which these rules do not yet support",
+				errModernEra, ep, modernEraVersion)
+		}
+	}
+	return nil
 }

--- a/internal/attack/mcp/session.go
+++ b/internal/attack/mcp/session.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/calbebop/batesian/internal/attack"
@@ -41,6 +42,34 @@ func probeCandidates(baseURL string, probe func(endpoint string) ([]attack.Findi
 		}
 	}
 	return nil, attack.ErrInconclusive
+}
+
+// oauthNotApplicable converts an OAuth-gated rule's "no OAuth surface here" into
+// the right answer for the caller.
+//
+// These rules gate on an OAuth surface: an authorization-server document, a
+// protected-resource document, a registration endpoint. When none is reachable
+// they used to report a clean pass, which covers two different situations. An MCP
+// server that exposes no OAuth is genuinely not applicable, and clean is honest.
+// A target where nothing answered at all was never exercised, and clean there
+// says the OAuth handling is sound about a host the rule never reached.
+//
+// Reachability is settled with responsiveMCP, one request per candidate, stopping
+// at the first that answers. On a server mounted at /mcp that is a single extra
+// request, paid only on the path where the rule was about to bail. Era detection
+// runs only when nothing answered, so a modern-era target is reported as speaking
+// an unsupported protocol version rather than as unreachable.
+func oauthNotApplicable(ctx context.Context, client *attack.HTTPClient, baseURL string) error {
+	endpoints := endpointCandidates(baseURL)
+	for _, ep := range endpoints {
+		if responsiveMCP(ctx, client, ep) {
+			return nil
+		}
+	}
+	if err := modernEraReason(ctx, client, endpoints); err != nil {
+		return inconclusive(err)
+	}
+	return attack.ErrInconclusive
 }
 
 // mcpSession holds the discovered MCP endpoint and the session ID returned by

--- a/internal/attack/mcp/token_replay.go
+++ b/internal/attack/mcp/token_replay.go
@@ -65,7 +65,7 @@ func (e *TokenReplayExecutor) Execute(ctx context.Context, target string, opts a
 	// separate host), and OIDC deployments expose openid-configuration. Skip when
 	// none is present.
 	if !oauthMetadataPresent(ctx, client, vars.BaseURL) {
-		return nil, nil
+		return nil, oauthNotApplicable(ctx, client, vars.BaseURL)
 	}
 
 	// Step 2: Forge the three probe tokens.

--- a/internal/attack/mcp/token_replay_test.go
+++ b/internal/attack/mcp/token_replay_test.go
@@ -3,6 +3,7 @@ package mcp_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -242,8 +243,9 @@ func TestTokenReplay_AlternateDiscoveryPaths(t *testing.T) {
 	}
 }
 
+// A reachable MCP server with no OAuth metadata is not applicable: clean.
 func TestTokenReplay_NoOAuthMetadata(t *testing.T) {
-	ts := httptest.NewServer(http.NotFoundHandler())
+	ts, _ := mountedMCPServer(t)
 	defer ts.Close()
 
 	exec := mcpattack.NewTokenReplayExecutor(tokenReplayRC())
@@ -253,6 +255,17 @@ func TestTokenReplay_NoOAuthMetadata(t *testing.T) {
 	}
 	if len(findings) != 0 {
 		t.Errorf("expected zero findings when no OAuth metadata present, got %d", len(findings))
+	}
+}
+
+func TestTokenReplay_NothingReachableIsNotTested(t *testing.T) {
+	ts := httptest.NewServer(http.NotFoundHandler())
+	defer ts.Close()
+
+	_, err := mcpattack.NewTokenReplayExecutor(tokenReplayRC()).
+		Execute(context.Background(), ts.URL, testOpts())
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive when nothing answered, got err=%v", err)
 	}
 }
 


### PR DESCRIPTION
## Defect

#131 drew this line for `oauth-audience`. The four siblings — `confused-deputy`, `oauth-dcr`, `oauth-metadata-ssrf`, `token-replay` — still returned a clean pass whenever OAuth discovery found nothing, covering both "an MCP server with no OAuth" and "nothing answered at all". The second is a host the rule never reached.

This is the follow-up S3 recorded as *"a dead-host making their OAuth GET fail is a separate follow-up"*.

## Fix, and the request cost

`responsiveMCP` is promoted from an init-downgrade method to a package function: one `initialize` per candidate, accepting a result **or** an error envelope, stopping at the first that answers.

I flagged this as costing ~10 extra requests when we discussed it. Using the lean probe instead of a full handshake, and #130's stop-on-first-answer, it is **4**: a full scan of the reference server goes 69 → 73, paid only on the path where a rule was about to bail.

`initializeMCP`'s era tail is extracted as `modernEraReason` and reused, so era detection reaches these five rules for the first time — a 2026-07-28 target is now reported as speaking an unsupported protocol version rather than as unreachable — without a third copy of that loop.

## Verification

Dead target, all four rules:

```
main:   Target appears clean
branch: could not reach a testable endpoint
```

Reference server (reachable, no OAuth): findings and skips unchanged at 10 and 17 of 35.

**The four existing tests were not testing what they claimed.** Their fixtures 404 the MCP path as well as the OAuth documents, so "non-OAuth server" was really "nothing here". Each is now two tests: a reachable MCP server with no OAuth stays clean (reusing the mounted-MCP fixture from #130), and a target where nothing answers reports not tested. Reverting the helper fails all four of the new ones.

Each rule's **later** clean returns are untouched — those mean the OAuth surface was reached and behaved correctly (registration rejected, no privileged scope, no OOB callback). Only the first bail was ambiguous.

`go test -race ./...`, `go vet` (both tags), `gofmt`, `golangci-lint` v2.11.4 clean.