### PR TITLE
fix(mcp): report header-body-split as not tested on a pre-SEP-2243 wire

### DIFF
--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -390,7 +390,7 @@ principal. The A2A counterpart is `a2a-context-fixation-001`.
 SEP-2243 mirrors the JSON-RPC `method` into an `Mcp-Method` HTTP header so
 intermediaries can route/police Streamable HTTP traffic without parsing the body,
 and requires servers to reject a header/body mismatch with `400` and JSON-RPC
-error `-32001`. This rule confirms a "policy on headers, execute on body"
+error `-32020` (`HeaderMismatch`). This rule confirms a "policy on headers, execute on body"
 split-brain with a participation discriminator (so it never flags servers that
 simply don't implement SEP-2243), all with body `method = tools/list`:
 
@@ -401,6 +401,15 @@ simply don't implement SEP-2243), all with body `method = tools/list`:
    when the server still executes the body's `tools/list` instead of rejecting -
    it enforces header *presence* but not header/body *consistency*, so a gateway
    that routes or rate-limits on `Mcp-Method` can be bypassed.
+
+**Currency.** SEP-2243 arrived in **2026-07-28**, and these rules negotiate an
+earlier revision, so in practice step 1 is accepted and the rule stops there. That
+is reported as **not tested**, naming the revision, rather than as clean: a server
+on a wire with no such requirement was never asked the question. A server that does
+enforce header presence is tested on its merits whatever version it advertises, and
+one on 2026-07-28 or later that ignores the header reports clean, since this rule's
+subject is the mismatch rather than the absence. Exercising the requirement on its
+own wire needs modern-era transport support, which is tracked separately.
 
 ---
 

--- a/internal/attack/mcp/header_body_split.go
+++ b/internal/attack/mcp/header_body_split.go
@@ -30,28 +30,69 @@ func (e *HeaderBodySplitExecutor) Execute(ctx context.Context, target string, op
 	vars := attack.NewVars(target, opts.OOBListenerURL)
 	client := attack.NewHTTPClient(opts, vars)
 
-	return probeCandidates(vars.BaseURL, func(ep string) ([]attack.Finding, bool) {
-		return e.probe(ctx, client, ep)
+	// Set only when the server turned out not to enforce Mcp-Method presence, in
+	// which case it carries the version that session negotiated. A server that
+	// does enforce presence is tested on its merits and never sets this, whatever
+	// version it advertises.
+	unawareAt := ""
+	findings, err := probeCandidates(vars.BaseURL, func(ep string) ([]attack.Finding, bool) {
+		f, reached, unaware := e.probe(ctx, client, ep)
+		if unaware != "" {
+			unawareAt = unaware
+		}
+		return f, reached
 	})
+	if err != nil || len(findings) > 0 {
+		return findings, err
+	}
+
+	// The server did not enforce Mcp-Method presence, so the rule stopped at its
+	// first probe. Whether that is a clean result depends on the revision.
+	//
+	// Mcp-Method mirroring and its -32020 HeaderMismatch rejection were introduced
+	// by SEP-2243 in 2026-07-28. On an earlier wire there is no requirement to
+	// violate, so probe 1 is always accepted and nothing is ever tested. Calling
+	// that clean asserted header/body consistency about a server that was never
+	// asked, on every scan. A server on 2026-07-28 or later that ignores the header
+	// is a different matter and still reports clean here, because this rule's
+	// subject is the mismatch, not the absence.
+	//
+	// The dated revisions sort lexicographically, which is what makes the compare
+	// safe.
+	if unawareAt != "" && unawareAt < headerValidationVersion {
+		return nil, fmt.Errorf("%w: no SEP-2243 surface at MCP %s; Mcp-Method validation was introduced in %s",
+			attack.ErrInconclusive, unawareAt, headerValidationVersion)
+	}
+	return nil, nil
 }
 
-func (e *HeaderBodySplitExecutor) probe(ctx context.Context, client *attack.HTTPClient, ep string) ([]attack.Finding, bool) {
+// headerValidationVersion is the revision that introduced Mcp-Method mirroring
+// and the -32020 HeaderMismatch rejection this rule tests for.
+const headerValidationVersion = modernEraVersion
+
+// probe returns the findings, whether the endpoint answered as MCP, and, only
+// when the server turned out not to enforce Mcp-Method presence, the version the
+// session negotiated. Callers use that last value to decide whether "no
+// enforcement" is expected for the revision in play.
+func (e *HeaderBodySplitExecutor) probe(ctx context.Context, client *attack.HTTPClient, ep string) (findings []attack.Finding, reached bool, unawareAt string) {
 	session, ok := e.initialize(ctx, client, ep)
 	if !ok {
-		return nil, false // not an MCP endpoint here
+		return nil, false, "" // not an MCP endpoint here
 	}
 
 	// Probe 1: omit Mcp-Method. If the server still executes tools/list, it does
 	// not enforce header presence (not SEP-2243-aware) - nothing to confirm.
 	if e.toolsList(ctx, client, ep, session, nil) {
-		return nil, true
+		return nil, true, session.ProtocolVersion
 	}
 
 	// Probe 2: matching Mcp-Method. Must be accepted, otherwise we cannot drive
 	// the mismatch test (the endpoint may require headers we are not sending).
+	// Presence is enforced by this point, so the rule is testing a server that
+	// implements SEP-2243 whatever version it advertises.
 	matched := "tools/list"
 	if !e.toolsList(ctx, client, ep, session, &matched) {
-		return nil, true
+		return nil, true, ""
 	}
 
 	// Probe 3: mismatched Mcp-Method. A compliant server MUST reject; if it
@@ -79,9 +120,9 @@ func (e *HeaderBodySplitExecutor) probe(ctx context.Context, client *attack.HTTP
 				ep),
 			Remediation: e.rule.Remediation,
 			TargetURL:   ep,
-		}}, true
+		}}, true, ""
 	}
-	return nil, true
+	return nil, true, ""
 }
 
 // initialize performs an MCP initialize (sending a matching Mcp-Method so a

--- a/internal/attack/mcp/header_body_split_test.go
+++ b/internal/attack/mcp/header_body_split_test.go
@@ -3,6 +3,7 @@ package mcp_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -21,7 +22,12 @@ func hbsRuleCtx() attack.RuleContext {
 //   - "split":     requires Mcp-Method presence but ignores its VALUE (vulnerable)
 //   - "strict":    rejects missing OR mismatched Mcp-Method with 400/-32020
 //   - "unaware":   ignores Mcp-Method entirely (not SEP-2243-aware)
-func splitServer(mode string) *httptest.Server {
+func splitServer(mode string) *httptest.Server { return splitServerAt(mode, "2025-06-18") }
+
+// splitServerAt advertises the given protocol revision, which decides whether
+// "ignores Mcp-Method" is expected for that wire or a gap on a wire that requires
+// the header.
+func splitServerAt(mode, version string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req map[string]interface{}
 		_ = json.NewDecoder(r.Body).Decode(&req)
@@ -49,7 +55,7 @@ func splitServer(mode string) *httptest.Server {
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"jsonrpc": "2.0", "id": id,
 				"result": map[string]interface{}{
-					"protocolVersion": "2025-06-18",
+					"protocolVersion": version,
 					"serverInfo":      map[string]interface{}{"name": "split-fixture", "version": "1.0"},
 					"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
 				},
@@ -115,13 +121,40 @@ func TestSplit_Strict(t *testing.T) {
 	}
 }
 
-// TestSplit_Unaware: ignores Mcp-Method entirely => not SEP-2243-aware, no finding.
-func TestSplit_Unaware(t *testing.T) {
+// TestSplit_UnawareOnALegacyWireIsNotTested: a server that ignores Mcp-Method on a
+// pre-2026-07-28 wire has no requirement to violate, so the rule stops at its
+// first probe having tested nothing.
+//
+// This used to report clean, which asserted header/body consistency about a
+// server that was never asked, on every scan of every legacy target. Since
+// SEP-2243 arrived in 2026-07-28 and these rules negotiate an earlier revision,
+// that was the outcome for every server in practice.
+func TestSplit_UnawareOnALegacyWireIsNotTested(t *testing.T) {
 	ts := splitServer("unaware")
 	defer ts.Close()
 
+	findings, err := mcpattack.NewHeaderBodySplitExecutor(hbsRuleCtx()).
+		Execute(context.Background(), ts.URL, testOpts())
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive on a legacy wire, got err=%v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings, got %d: %+v", len(findings), findings)
+	}
+	if !strings.Contains(err.Error(), "2026-07-28") {
+		t.Errorf("skip reason should name the revision that introduced the requirement, got %q", err)
+	}
+}
+
+// On a wire that does carry the requirement, a server ignoring the header is a
+// real observation rather than an untested one. It is still not this rule's
+// subject, which is the mismatch, so the result is clean and not a finding.
+func TestSplit_UnawareOnAModernWireIsClean(t *testing.T) {
+	ts := splitServerAt("unaware", "2026-07-28")
+	defer ts.Close()
+
 	if findings := runSplit(t, ts); len(findings) != 0 {
-		t.Errorf("expected zero findings against a header-unaware server, got %d: %+v", len(findings), findings)
+		t.Errorf("expected zero findings, got %d: %+v", len(findings), findings)
 	}
 }
 


### PR DESCRIPTION
## Defect

The rule could not fire against **any** server. `Mcp-Method` mirroring and its `-32020 HeaderMismatch` rejection arrived with SEP-2243 in **2026-07-28**; the rule opens a session at a hardcoded `2025-06-18`. Its first probe — omit the header, see whether the server still executes — is therefore always accepted, so it exited before testing anything and reported clean. On every scan of every server.

Verified against the official Python SDK v2, which implements the requirement correctly on its modern wire:

| Request (modern wire) | Response |
|---|---|
| mismatched `Mcp-Method` | `-32020 "mcp-method header does not match the request body's method"` |
| matching | result |
| omitted | `-32020` |

Against **that same server** the rule reported `Target appears clean` — it negotiated `2025-06-18` and never touched the wire where the requirement exists.

## Fix

```
SKIP mcp-header-body-split-001: could not reach a testable endpoint: no SEP-2243
surface at MCP 2025-06-18; Mcp-Method validation was introduced in 2026-07-28
```

**The version check is scoped to the first probe, not the whole rule.** A server that *does* enforce header presence is tested on its merits whatever revision it advertises. My first attempt keyed on the negotiated version alone, which turned the `strict` fixture into a skip even though it demonstrably implements the requirement — so the vulnerable and strict postures now behave exactly as before, and only the "ignores the header" case changes.

A server on 2026-07-28 or later that ignores the header still reports clean: this rule's subject is the mismatch, not the absence. There's a test for that side too.

## Verification

Reference server and dual-era SDK server both move from `Target appears clean` to the skip above. Full scan of the reference server: **17 skips → 18**, findings unchanged at 10. That's a visible change on every MCP scan, and it's the accurate one. Reverting the check fails the new test.

Also corrects the catalog, which gave the rejection code as `-32001`; the spec, `era.go`'s `HeaderMismatch` entry and the SDK all say `-32020`.

`go test -race ./...`, `go vet` (both tags), `gofmt`, `golangci-lint` v2.11.4 clean.