### PR TITLE
feat(mcp): add the transport primitive for both protocol eras

### DIFF
--- a/.github/workflows/mcp-era-watch.yml
+++ b/.github/workflows/mcp-era-watch.yml
@@ -80,7 +80,7 @@ jobs:
           exit 1
 
       - name: Check era detection against it
-        run: go test -tags=integration -run 'TestDetectEra_Live|TestInitializeMCP_Live' -v ./internal/attack/mcp/
+        run: go test -tags=integration -run 'TestDetectEra_Live|TestInitializeMCP_Live|TestOpenSessions_Live' -v ./internal/attack/mcp/
         env:
           BATESIAN_LIVE_MCP_ENDPOINT: http://127.0.0.1:7799/mcp
 

--- a/internal/attack/mcp/session.go
+++ b/internal/attack/mcp/session.go
@@ -81,6 +81,9 @@ func oauthNotApplicable(ctx context.Context, client *attack.HTTPClient, baseURL 
 type mcpSession struct {
 	Endpoint  string
 	SessionID string
+	// Era is the wire this session speaks. The zero value, EraUnknown, behaves as
+	// legacy so the handshake-based rules that predate era support are unchanged.
+	Era Era
 	// ProtocolVersion is the MCP version in effect for this session: the
 	// protocolVersion the server returned in its initialize result, or the
 	// offered version if the server did not echo one. Sent on subsequent

--- a/internal/attack/mcp/wire.go
+++ b/internal/attack/mcp/wire.go
@@ -1,0 +1,156 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// MCP carries the same methods over two incompatible wires, and a server may
+// serve both. This file is the transport primitive that lets a rule drive either
+// one without knowing which it is on.
+//
+// Legacy (2024-11-05 through 2025-11-25): an initialize handshake mints a session,
+// and every later request echoes Mcp-Session-Id plus the negotiated
+// Mcp-Protocol-Version.
+//
+// Modern (2026-07-28): no handshake and no session. Each request stands alone,
+// carrying the protocol version and client capabilities in params._meta, and must
+// mirror its own method into the Mcp-Method header. The requirements below were
+// taken from the official Python SDK rather than from the specification text:
+//
+//   - Mcp-Method is mandatory. Omitting it earns -32020, the same code as a
+//     mismatch.
+//   - params._meta is mandatory. Omitting it earns -32602.
+//   - MCP-Protocol-Version is what selects the wire. Omit it on an SDK server that
+//     serves both and the request is answered by the legacy handler instead, which
+//     is a quiet way to think you are testing one era while testing the other.
+//   - No server/discover call is needed first. Methods work immediately.
+
+// post sends a JSON-RPC request on whichever wire this session belongs to,
+// building the headers and params each era requires.
+func (s mcpSession) post(ctx context.Context, client *attack.HTTPClient, id interface{}, method string, params map[string]interface{}) (*attack.Response, error) {
+	if params == nil {
+		params = map[string]interface{}{}
+	}
+
+	headers := s.header()
+	if s.Era == EraModern {
+		// Copy rather than mutate: callers reuse their params map across eras.
+		withMeta := make(map[string]interface{}, len(params)+1)
+		for k, v := range params {
+			withMeta[k] = v
+		}
+		withMeta["_meta"] = modernMeta()
+		params = withMeta
+
+		headers = map[string]string{
+			"MCP-Protocol-Version": modernEraVersion,
+			"Mcp-Method":           method,
+		}
+	}
+
+	return client.POST(ctx, s.Endpoint, headers, map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"method":  method,
+		"params":  params,
+	})
+}
+
+// modernMeta is the _meta block every modern request must carry. clientCapabilities
+// is present and empty on purpose: the probes here ask what a server exposes, so
+// they claim no capability of their own.
+func modernMeta() map[string]interface{} {
+	return map[string]interface{}{
+		metaProtocolVersion: modernEraVersion,
+		metaClientInfo: map[string]interface{}{
+			"name":    "batesian",
+			"version": attack.Version,
+		},
+		metaClientCapabilities: map[string]interface{}{},
+	}
+}
+
+// openSessions returns one session per wire the target serves, in the order a
+// rule should exercise them: legacy first, then modern.
+//
+// Both are returned when a server serves both, which is the default for a server
+// built on the current SDKs. A rule that only walked the first wire would report
+// on one era while the other went untested, and the two need not behave the same:
+// a server can enforce authorization on one and not the other, which is the shape
+// mcp-init-downgrade-001 already looks for across protocol versions.
+//
+// The error is ErrInconclusive when neither wire answered, carrying the reason
+// from the legacy attempt so a modern-era detail is not lost.
+func openSessions(ctx context.Context, client *attack.HTTPClient, baseURL string) ([]mcpSession, error) {
+	var out []mcpSession
+
+	legacy, legacyErr := initializeMCP(ctx, client, baseURL)
+
+	// Where to look for a modern wire. A successful handshake already located the
+	// server, so only that endpoint is probed; otherwise every candidate is tried,
+	// which is also the path a modern-only server takes.
+	endpoints := endpointCandidates(baseURL)
+	if legacyErr == nil {
+		legacy.Era = EraLegacy
+		out = append(out, legacy)
+		endpoints = []string{legacy.Endpoint}
+	}
+
+	for _, ep := range endpoints {
+		if modern, ok := discoverModern(ctx, client, ep); ok {
+			out = append(out, modern)
+			break
+		}
+	}
+
+	if len(out) == 0 {
+		return nil, inconclusive(legacyErr)
+	}
+	return out, nil
+}
+
+// discoverModern asks ep for a modern DiscoverResult and builds a session from it.
+//
+// server/discover is not required before calling a method, but it is what reports
+// the server's capabilities, and the rules that gate on a capability need them.
+// The result carries them under the same result.capabilities path an initialize
+// result uses, so ServerSupports reads either without knowing the difference.
+func discoverModern(ctx context.Context, client *attack.HTTPClient, ep string) (mcpSession, bool) {
+	probe := mcpSession{Endpoint: ep, Era: EraModern}
+	resp, err := probe.post(ctx, client, "batesian-discover", "server/discover", nil)
+	if err != nil || !resp.IsAccepted() {
+		return mcpSession{}, false
+	}
+	if !resp.ContainsAny(`"capabilities"`, `"supportedVersions"`, `"resultType"`) {
+		return mcpSession{}, false
+	}
+	return mcpSession{
+		Endpoint:        ep,
+		Era:             EraModern,
+		ProtocolVersion: modernEraVersion,
+		RawInit:         resp.Body,
+	}, true
+}
+
+// modernResultPayload strips the envelope a modern result wraps its payload in.
+//
+// A 2026-07-28 result carries cacheScope, resultType, ttlMs and _meta alongside
+// the fields a legacy result would have had. Rules that read a named field
+// (result.tools, result.resources) are unaffected, but anything that treats the
+// result object as the payload needs the envelope keys removed first.
+func modernResultPayload(body []byte) (map[string]json.RawMessage, error) {
+	var envelope struct {
+		Result map[string]json.RawMessage `json:"result"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, fmt.Errorf("parsing modern result: %w", err)
+	}
+	for _, k := range []string{"cacheScope", "resultType", "ttlMs", "_meta"} {
+		delete(envelope.Result, k)
+	}
+	return envelope.Result, nil
+}

--- a/internal/attack/mcp/wire_live_test.go
+++ b/internal/attack/mcp/wire_live_test.go
@@ -1,0 +1,54 @@
+//go:build integration
+
+package mcp
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// The transport primitive was written from probing the official Python SDK, so
+// this checks it against that SDK rather than only against a fixture that encodes
+// the same understanding. It runs under the integration tag, alongside the era
+// detection checks the weekly job already drives.
+//
+// Run it by hand with:
+//
+//	python testdata/mcp_modern_era_server.py &
+//	BATESIAN_LIVE_MCP_ENDPOINT=http://127.0.0.1:7799/mcp \
+//	  go test -tags=integration -run TestOpenSessions_Live ./internal/attack/mcp/
+
+func TestOpenSessions_LiveDualEraServer(t *testing.T) {
+	ep := os.Getenv(liveEndpointEnv)
+	if ep == "" {
+		t.Fatalf("%s must be set to the endpoint of a running modern-era server", liveEndpointEnv)
+	}
+
+	client := attack.NewUnauthHTTPClient(attack.Options{TimeoutSeconds: 20}, attack.NewVars("", ""))
+	sessions, err := openSessions(context.Background(), client, ep)
+	if err != nil {
+		t.Fatalf("openSessions: %v", err)
+	}
+
+	// The SDK serves both eras from one server, which is the case a rule that
+	// only walked the first wire would half-test.
+	if len(sessions) != 2 {
+		t.Fatalf("expected both wires from an SDK server, got %d: %+v", len(sessions), sessions)
+	}
+
+	for _, s := range sessions {
+		resp, err := s.post(context.Background(), client, 1, "tools/list", nil)
+		if err != nil {
+			t.Fatalf("%v tools/list: %v", s.Era, err)
+		}
+		if !resp.IsAccepted() {
+			t.Fatalf("%v tools/list rejected by the SDK: %s", s.Era, resp.BodyString())
+		}
+		if !resp.ContainsAny(`"tools"`) {
+			t.Errorf("%v tools/list returned no tools: %s", s.Era, resp.BodyString())
+		}
+	}
+}

--- a/internal/attack/mcp/wire_test.go
+++ b/internal/attack/mcp/wire_test.go
@@ -1,0 +1,300 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// These pin the transport contract each era imposes, taken from probing the
+// official Python SDK. Getting any of them wrong is silent: the request is
+// answered by the wrong handler, or rejected in a way a rule reads as "secure".
+
+type captured struct {
+	method   string
+	headers  http.Header
+	params   map[string]interface{}
+	protoHdr string
+	methHdr  string
+}
+
+// wireServer records what it receives and answers as the requested eras allow.
+// serveLegacy and serveModern decide which wires exist, so a dual-era server, a
+// legacy-only one and a modern-only one are all expressible.
+func wireServer(t *testing.T, serveLegacy, serveModern bool) (*httptest.Server, *[]captured) {
+	t.Helper()
+
+	var seen []captured
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mcp" {
+			http.NotFound(w, r)
+			return
+		}
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method, _ := body["method"].(string)
+		params, _ := body["params"].(map[string]interface{})
+		seen = append(seen, captured{
+			method:   method,
+			headers:  r.Header.Clone(),
+			params:   params,
+			protoHdr: r.Header.Get("MCP-Protocol-Version"),
+			methHdr:  r.Header.Get("Mcp-Method"),
+		})
+
+		w.Header().Set("Content-Type", "application/json")
+		modern := r.Header.Get("MCP-Protocol-Version") == modernEraVersion
+
+		// A modern server enforces the header mirror and the _meta block, exactly
+		// as the SDK does, so a malformed probe fails here rather than passing
+		// quietly.
+		if modern {
+			if !serveModern {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"jsonrpc": "2.0", "id": body["id"],
+					"error": map[string]interface{}{"code": -32022, "message": "UnsupportedProtocolVersion"},
+				})
+				return
+			}
+			if r.Header.Get("Mcp-Method") != method {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"jsonrpc": "2.0", "id": body["id"],
+					"error": map[string]interface{}{"code": -32020, "message": "HeaderMismatch"},
+				})
+				return
+			}
+			if _, ok := params["_meta"].(map[string]interface{}); !ok {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"jsonrpc": "2.0", "id": body["id"],
+					"error": map[string]interface{}{"code": -32602, "message": "params._meta is required"},
+				})
+				return
+			}
+			result := map[string]interface{}{
+				"cacheScope": "private", "resultType": "complete", "ttlMs": 0,
+				"_meta": map[string]interface{}{},
+			}
+			switch method {
+			case "server/discover":
+				result["supportedVersions"] = []string{modernEraVersion}
+				result["capabilities"] = map[string]interface{}{
+					"tools": map[string]interface{}{}, "resources": map[string]interface{}{},
+				}
+			case "tools/list":
+				result["tools"] = []interface{}{map[string]interface{}{"name": "echo"}}
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": body["id"], "result": result,
+			})
+			return
+		}
+
+		if !serveLegacy {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": body["id"],
+				"error": map[string]interface{}{"code": -32000, "message": "Bad Request"},
+			})
+			return
+		}
+		switch method {
+		case "initialize":
+			w.Header().Set("Mcp-Session-Id", "sess-1")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": body["id"],
+				"result": map[string]interface{}{
+					"protocolVersion": "2025-06-18",
+					"serverInfo":      map[string]interface{}{"name": "wire", "version": "1"},
+					"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+				},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": body["id"],
+				"result": map[string]interface{}{"tools": []interface{}{map[string]interface{}{"name": "echo"}}},
+			})
+		}
+	}))
+	return srv, &seen
+}
+
+func wireClient() *attack.HTTPClient {
+	return attack.NewUnauthHTTPClient(attack.Options{TimeoutSeconds: 5}, attack.NewVars("", ""))
+}
+
+// A dual-era server must yield both wires. A rule that walked only the first
+// would report on one era while the other went untested.
+func TestOpenSessions_DualEraYieldsBothWires(t *testing.T) {
+	srv, _ := wireServer(t, true, true)
+	defer srv.Close()
+
+	sessions, err := openSessions(context.Background(), wireClient(), srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("expected 2 sessions (legacy + modern), got %d", len(sessions))
+	}
+	if sessions[0].Era != EraLegacy || sessions[1].Era != EraModern {
+		t.Errorf("expected legacy then modern, got %v then %v", sessions[0].Era, sessions[1].Era)
+	}
+	if sessions[0].SessionID == "" {
+		t.Error("legacy session carries no session id")
+	}
+	if sessions[1].SessionID != "" {
+		t.Error("modern session must carry no session id: the era has none")
+	}
+}
+
+func TestOpenSessions_LegacyOnly(t *testing.T) {
+	srv, _ := wireServer(t, true, false)
+	defer srv.Close()
+
+	sessions, err := openSessions(context.Background(), wireClient(), srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].Era != EraLegacy {
+		t.Fatalf("expected one legacy session, got %d: %+v", len(sessions), sessions)
+	}
+}
+
+// A modern-only server is the case the legacy handshake cannot reach at all, and
+// the one era detection was built for.
+func TestOpenSessions_ModernOnly(t *testing.T) {
+	srv, _ := wireServer(t, false, true)
+	defer srv.Close()
+
+	sessions, err := openSessions(context.Background(), wireClient(), srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].Era != EraModern {
+		t.Fatalf("expected one modern session, got %d: %+v", len(sessions), sessions)
+	}
+	if !sessions[0].ServerSupports("tools") {
+		t.Error("capabilities from server/discover should read through ServerSupports unchanged")
+	}
+}
+
+func TestOpenSessions_NeitherWireIsInconclusive(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	defer srv.Close()
+
+	if _, err := openSessions(context.Background(), wireClient(), srv.URL); !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive, got %v", err)
+	}
+}
+
+// The three requirements a modern request must satisfy. The fixture rejects each
+// violation the way the SDK does, so a regression fails here rather than being
+// mistaken for a secure server.
+func TestSessionPost_ModernCarriesHeadersAndMeta(t *testing.T) {
+	srv, seen := wireServer(t, false, true)
+	defer srv.Close()
+
+	sessions, err := openSessions(context.Background(), wireClient(), srv.URL)
+	if err != nil {
+		t.Fatalf("openSessions: %v", err)
+	}
+	resp, err := sessions[0].post(context.Background(), wireClient(), 1, "tools/list", nil)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	if !resp.IsAccepted() {
+		t.Fatalf("modern tools/list was rejected: %s", resp.BodyString())
+	}
+
+	last := (*seen)[len(*seen)-1]
+	if last.protoHdr != modernEraVersion {
+		t.Errorf("MCP-Protocol-Version = %q, want %q: it is what selects the wire", last.protoHdr, modernEraVersion)
+	}
+	if last.methHdr != "tools/list" {
+		t.Errorf("Mcp-Method = %q, want the body's method", last.methHdr)
+	}
+	if _, ok := last.params["_meta"].(map[string]interface{}); !ok {
+		t.Errorf("params._meta missing; the SDK rejects that with -32602")
+	}
+	if last.headers.Get("Mcp-Session-Id") != "" {
+		t.Error("a modern request must not carry a session id")
+	}
+}
+
+// The legacy wire is unchanged: session id and negotiated version, no _meta and
+// no Mcp-Method.
+func TestSessionPost_LegacyUnchanged(t *testing.T) {
+	srv, seen := wireServer(t, true, false)
+	defer srv.Close()
+
+	sessions, err := openSessions(context.Background(), wireClient(), srv.URL)
+	if err != nil {
+		t.Fatalf("openSessions: %v", err)
+	}
+	if _, err := sessions[0].post(context.Background(), wireClient(), 2, "tools/list", nil); err != nil {
+		t.Fatalf("post: %v", err)
+	}
+
+	last := (*seen)[len(*seen)-1]
+	if last.headers.Get("Mcp-Session-Id") != "sess-1" {
+		t.Errorf("legacy request lost its session id, got %q", last.headers.Get("Mcp-Session-Id"))
+	}
+	if last.methHdr != "" {
+		t.Errorf("legacy request should not carry Mcp-Method, got %q", last.methHdr)
+	}
+	if _, ok := last.params["_meta"]; ok {
+		t.Error("legacy request should not carry params._meta")
+	}
+}
+
+// post must not write into the caller's params, because a rule driving both wires
+// reuses one map.
+func TestSessionPost_DoesNotMutateCallerParams(t *testing.T) {
+	srv, _ := wireServer(t, false, true)
+	defer srv.Close()
+
+	sessions, err := openSessions(context.Background(), wireClient(), srv.URL)
+	if err != nil {
+		t.Fatalf("openSessions: %v", err)
+	}
+	params := map[string]interface{}{"uri": "file://a"}
+	if _, err := sessions[0].post(context.Background(), wireClient(), 3, "resources/read", params); err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	if _, injected := params["_meta"]; injected {
+		t.Error("post injected _meta into the caller's map")
+	}
+}
+
+func TestModernResultPayload_StripsTheEnvelope(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"cacheScope":"private","resultType":"complete",` +
+		`"ttlMs":0,"_meta":{},"tools":[{"name":"echo"}]}}`)
+
+	payload, err := modernResultPayload(body)
+	if err != nil {
+		t.Fatalf("modernResultPayload: %v", err)
+	}
+	if len(payload) != 1 {
+		t.Fatalf("expected only the payload key to survive, got %v", keysOf(payload))
+	}
+	if _, ok := payload["tools"]; !ok {
+		t.Errorf("payload lost its tools key, got %v", keysOf(payload))
+	}
+}
+
+func keysOf(m map[string]json.RawMessage) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
Groundwork for exercising the 2026-07-28 wire. **No rule uses it yet**, so scan results are unchanged: a full scan of the reference server still reports 10 findings and 18 of 35 skips.

## What the modern wire actually requires

Probed against the official Python SDK, not read from the spec, because three of these are silent when got wrong:

| Element | Behaviour |
|---|---|
| `Mcp-Method` | mandatory; omitting earns `-32020`, same code as a mismatch |
| `params._meta` | mandatory; omitting earns `-32602` |
| `MCP-Protocol-Version` | **selects the wire**. Omit it on a dual-era server and the legacy handler answers |
| `server/discover` | not needed before a method, but it reports capabilities — under the same `result.capabilities` path an initialize result uses, so `ServerSupports` reads either unchanged |

That third one is the trap: without the header you believe you are testing one era while testing the other.

## The primitive

**`openSessions`** returns one session per wire the target serves, legacy first. Both when a server serves both, which is the default for anything on the current SDKs. Walking only the first wire would report on one era while the other went untested, and the two need not agree — a server can enforce authorization on one and not the other, which is `mcp-init-downgrade-001`'s shape transposed to eras.

**`session.post`** builds the headers and params its era requires. It copies the params map rather than injecting `_meta` into the caller's, since a rule driving both wires reuses one map; there's a test for that.

**`modernResultPayload`** strips the `cacheScope` / `resultType` / `ttlMs` / `_meta` envelope. Rules reading a named field are unaffected; anything treating the result object as the payload needs it.

## Verification

The unit fixture rejects each malformed shape the way the SDK does, so a regression fails rather than being mistaken for a secure server. Three server shapes covered: dual-era, legacy-only, modern-only, plus neither-wire → inconclusive.

A live test drives both wires against the SDK itself and asserts `tools/list` is accepted on each; the weekly era job now runs it alongside the detection checks.

`go test -race ./...`, `go vet` (both tags), `gofmt`, `golangci-lint` v2.11.4 clean.