### PR TITLE
feat(mcp): run the resources and tools unauth rules on both wires

### DIFF
--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -72,6 +72,24 @@ settled with a single `initialize` per candidate, on the bail path only, and a
 2026-07-28 server is reported as speaking an unsupported protocol version rather
 than as unreachable.
 
+## Both protocol wires
+
+A server built on the current SDKs answers **both** the handshake-based revisions
+and 2026-07-28 on the same endpoint. `mcp-resources-unauth-001` and
+`mcp-tools-unauth-001` are exercised on each wire it serves, because the two need
+not be gated alike: a server can enforce authorization on one and not the other.
+
+Findings from the 2026-07-28 wire carry a `[MCP 2026-07-28 wire]` suffix and name
+the wire in their evidence, so a surface exposed on both produces two
+distinguishable results rather than what looks like a duplicate. A legacy-only
+target reports exactly what it reported before, with no suffix.
+
+A modern request carries no session: the protocol version and client capabilities
+travel in `params._meta`, the method is mirrored into `Mcp-Method`, and for
+`tools/call`, `prompts/get` and `resources/read` the named subject is mirrored into
+`Mcp-Name`. Every one of those is mandatory, and a mismatch or omission earns
+`-32020`.
+
 ## Endpoint discovery
 
 A target that names a path is probed as given; otherwise `/mcp`, `/`, `/api` and

--- a/internal/attack/mcp/resources_unauth.go
+++ b/internal/attack/mcp/resources_unauth.go
@@ -72,41 +72,37 @@ func (e *ResourcesUnauthExecutor) Execute(ctx context.Context, target string, op
 	// opts.Token were injected the finding would be misleading.
 	client := attack.NewUnauthHTTPClient(opts, vars)
 
-	// MCP requires an initialize handshake before any method calls.
-	session, err := initializeMCP(ctx, client, vars.BaseURL)
-	if err != nil {
-		// Not reachable as a legacy MCP server; inconclusive carries the reason
-		// when the target turned out to be a modern-era server.
-		return nil, inconclusive(err)
-	}
+	// A server may expose resources on both protocol wires, and need not gate them
+	// the same way on each, so every wire it serves is probed.
+	return runOnEachWire(ctx, client, vars.BaseURL, func(session mcpSession) []attack.Finding {
+		return e.probeSession(ctx, client, session)
+	})
+}
 
+// probeSession runs the rule against one already-opened wire.
+func (e *ResourcesUnauthExecutor) probeSession(ctx context.Context, client *attack.HTTPClient, session mcpSession) []attack.Finding {
 	var findings []attack.Finding
 
 	// Step 1: resources/list - enumerate available resources
-	listResp, err := client.POST(ctx, session.Endpoint, session.header(), map[string]interface{}{
-		"jsonrpc": "2.0",
-		"id":      3,
-		"method":  "resources/list",
-		"params":  map[string]interface{}{},
-	})
+	listResp, err := session.post(ctx, client, 3, "resources/list", nil)
 	if err != nil || !listResp.IsSuccess() {
-		return nil, nil
+		return nil
 	}
 
 	var listBody map[string]interface{}
 	if err := json.Unmarshal(listResp.Body, &listBody); err != nil {
-		return nil, nil
+		return nil
 	}
 
 	// JSON-RPC error means the endpoint exists but rejected the call - not vulnerable.
 	if _, hasErr := listBody["error"]; hasErr {
-		return nil, nil
+		return nil
 	}
 
 	result, _ := listBody["result"].(map[string]interface{})
 	resourcesRaw, _ := result["resources"].([]interface{})
 	if len(resourcesRaw) == 0 {
-		return nil, nil
+		return nil
 	}
 
 	// Build a display list of resource URIs
@@ -142,7 +138,7 @@ func (e *ResourcesUnauthExecutor) Execute(ctx context.Context, target string, op
 	// server's choice, so the rule cannot let it decide the severity.
 	read, examined := e.readResources(ctx, client, session, uris)
 	if read == nil {
-		return findings, nil
+		return findings
 	}
 
 	// Baseline: unauthenticated read of resource content is high. Escalate to
@@ -178,7 +174,7 @@ func (e *ResourcesUnauthExecutor) Execute(ctx context.Context, target string, op
 		TargetURL:   session.Endpoint,
 	})
 
-	return findings, nil
+	return findings
 }
 
 // resourceRead is one successfully read resource.
@@ -226,14 +222,9 @@ func (e *ResourcesUnauthExecutor) readResources(ctx context.Context, client *att
 // returns nil when the read did not produce content, which covers a transport
 // failure, a non-2xx reply, an unparseable body and a JSON-RPC error.
 func (e *ResourcesUnauthExecutor) readResource(ctx context.Context, client *attack.HTTPClient, session mcpSession, uri string, i int) *resourceRead {
-	resp, err := client.POST(ctx, session.Endpoint, session.header(), map[string]interface{}{
-		"jsonrpc": "2.0",
-		// Distinct ids per read: reusing one id across requests makes a
-		// server's replies ambiguous to correlate.
-		"id":     4 + i,
-		"method": "resources/read",
-		"params": map[string]interface{}{"uri": uri},
-	})
+	// Distinct ids per read: reusing one id across requests makes a server's
+	// replies ambiguous to correlate.
+	resp, err := session.post(ctx, client, 4+i, "resources/read", map[string]interface{}{"uri": uri})
 	if err != nil || !resp.IsSuccess() {
 		return nil
 	}

--- a/internal/attack/mcp/tools_unauth.go
+++ b/internal/attack/mcp/tools_unauth.go
@@ -41,45 +41,42 @@ func (e *ToolsUnauthExecutor) Execute(ctx context.Context, target string, opts a
 	// accessible WITHOUT authentication. Injecting opts.Token would mask the finding.
 	client := attack.NewUnauthHTTPClient(opts, vars)
 
-	session, err := initializeMCP(ctx, client, vars.BaseURL)
-	if err != nil {
-		// Not reachable as a legacy MCP server; inconclusive carries the reason
-		// when the target turned out to be a modern-era server.
-		return nil, inconclusive(err)
-	}
+	// A server may expose tools on both protocol wires, and need not gate them the
+	// same way on each, so every wire it serves is probed.
+	return runOnEachWire(ctx, client, vars.BaseURL, func(session mcpSession) []attack.Finding {
+		return e.probeSession(ctx, client, session, vars.RandID)
+	})
+}
 
+// probeSession runs the rule against one already-opened wire.
+func (e *ToolsUnauthExecutor) probeSession(ctx context.Context, client *attack.HTTPClient, session mcpSession, randID string) []attack.Finding {
 	// Skip servers that do not advertise the tools capability; probing them would
 	// produce meaningless noise. Read from the captured handshake capabilities
 	// rather than substring-matching the body.
 	if !session.ServerSupports("tools") {
-		return nil, nil
+		return nil
 	}
 
 	// Step 1: tools/list without any auth token.
-	listResp, err := client.POST(ctx, session.Endpoint, session.header(), map[string]interface{}{
-		"jsonrpc": "2.0",
-		"id":      3,
-		"method":  "tools/list",
-		"params":  map[string]interface{}{},
-	})
+	listResp, err := session.post(ctx, client, 3, "tools/list", nil)
 	if err != nil || !listResp.IsSuccess() {
-		return nil, nil
+		return nil
 	}
 
 	var listBody map[string]interface{}
 	if err := json.Unmarshal(listResp.Body, &listBody); err != nil {
-		return nil, nil
+		return nil
 	}
 
 	// A JSON-RPC error means auth is enforced on tool methods - not vulnerable.
 	if _, hasErr := listBody["error"]; hasErr {
-		return nil, nil
+		return nil
 	}
 
 	result, _ := listBody["result"].(map[string]interface{})
 	toolsRaw, _ := result["tools"].([]interface{})
 	if len(toolsRaw) == 0 {
-		return nil, nil
+		return nil
 	}
 
 	// Collect tool names for evidence.
@@ -114,25 +111,21 @@ func (e *ToolsUnauthExecutor) Execute(ctx context.Context, target string, opts a
 	// nothing. Reaching that error proves the invocation path accepts
 	// unauthenticated calls; an auth-enforcing server rejects with 401/403 or an
 	// auth error before tool dispatch.
-	bogusTool := "batesian-nonexistent-" + vars.RandID
-	callResp, err := client.POST(ctx, session.Endpoint, session.header(), map[string]interface{}{
-		"jsonrpc": "2.0",
-		"id":      4,
-		"method":  "tools/call",
-		"params":  map[string]interface{}{"name": bogusTool, "arguments": map[string]interface{}{}},
-	})
+	bogusTool := "batesian-nonexistent-" + randID
+	callResp, err := session.post(ctx, client, 4, "tools/call",
+		map[string]interface{}{"name": bogusTool, "arguments": map[string]interface{}{}})
 	if err != nil || !callResp.IsSuccess() {
-		return findings, nil // auth gate (401/403) or unreachable; the list finding stands
+		return findings // auth gate (401/403) or unreachable; the list finding stands
 	}
 
 	var callBody map[string]interface{}
 	if err := json.Unmarshal(callResp.Body, &callBody); err != nil {
-		return findings, nil
+		return findings
 	}
 
 	reachable, reason := callDispatchReachable(callBody)
 	if !reachable {
-		return findings, nil
+		return findings
 	}
 
 	findings = append(findings, attack.Finding{
@@ -150,7 +143,7 @@ func (e *ToolsUnauthExecutor) Execute(ctx context.Context, target string, opts a
 		TargetURL:   session.Endpoint,
 	})
 
-	return findings, nil
+	return findings
 }
 
 // callDispatchReachable reports whether a tools/call response for a non-existent

--- a/internal/attack/mcp/wire.go
+++ b/internal/attack/mcp/wire.go
@@ -29,6 +29,18 @@ import (
 //     is a quiet way to think you are testing one era while testing the other.
 //   - No server/discover call is needed first. Methods work immediately.
 
+// nameBearingMethods maps each modern-era method that addresses a named subject to
+// the params field carrying that name, which the Mcp-Name header must mirror.
+//
+// Taken from the SDK's own NAME_BEARING_METHODS table rather than inferred: it is
+// exactly three methods, and the server only checks the header when the body
+// carries the field.
+var nameBearingMethods = map[string]string{
+	"tools/call":     "name",
+	"prompts/get":    "name",
+	"resources/read": "uri",
+}
+
 // post sends a JSON-RPC request on whichever wire this session belongs to,
 // building the headers and params each era requires.
 func (s mcpSession) post(ctx context.Context, client *attack.HTTPClient, id interface{}, method string, params map[string]interface{}) (*attack.Response, error) {
@@ -49,6 +61,15 @@ func (s mcpSession) post(ctx context.Context, client *attack.HTTPClient, id inte
 		headers = map[string]string{
 			"MCP-Protocol-Version": modernEraVersion,
 			"Mcp-Method":           method,
+		}
+		// Methods that address a named subject must mirror it into Mcp-Name as
+		// well, and a mismatch is the same -32020 a wrong Mcp-Method earns. A rule
+		// that omitted it would read that rejection as a server refusing the call
+		// and report clean.
+		if key, ok := nameBearingMethods[method]; ok {
+			if name, ok := params[key].(string); ok && name != "" {
+				headers["Mcp-Name"] = name
+			}
 		}
 	}
 
@@ -134,6 +155,42 @@ func discoverModern(ctx context.Context, client *attack.HTTPClient, ep string) (
 		ProtocolVersion: modernEraVersion,
 		RawInit:         resp.Body,
 	}, true
+}
+
+// runOnEachWire opens every wire the target serves and runs probe against each,
+// returning the findings from all of them.
+//
+// A server that serves both eras is exposed on both, and the two need not behave
+// alike, so each is exercised. Findings from the modern wire are labelled; see
+// labelEra.
+func runOnEachWire(ctx context.Context, client *attack.HTTPClient, baseURL string,
+	probe func(mcpSession) []attack.Finding) ([]attack.Finding, error) {
+	sessions, err := openSessions(ctx, client, baseURL)
+	if err != nil {
+		return nil, err
+	}
+	var out []attack.Finding
+	for _, s := range sessions {
+		out = append(out, labelEra(s, probe(s))...)
+	}
+	return out, nil
+}
+
+// labelEra tags findings produced on the modern wire, so that on a server serving
+// both they are not read as duplicates of the legacy ones. It also tells an
+// operator which surface to fix, which is the point: the two wires can differ.
+//
+// Legacy findings are returned untouched, so a scan of a legacy-only server, still
+// the norm, reports exactly what it reported before.
+func labelEra(session mcpSession, findings []attack.Finding) []attack.Finding {
+	if session.Era != EraModern {
+		return findings
+	}
+	for i := range findings {
+		findings[i].Title += fmt.Sprintf(" [MCP %s wire]", modernEraVersion)
+		findings[i].Evidence = fmt.Sprintf("wire: MCP %s (stateless)\n%s", modernEraVersion, findings[i].Evidence)
+	}
+	return findings
 }
 
 // modernResultPayload strips the envelope a modern result wraps its payload in.

--- a/internal/attack/mcp/wire_test.go
+++ b/internal/attack/mcp/wire_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/calbebop/batesian/internal/attack"
@@ -70,6 +71,18 @@ func wireServer(t *testing.T, serveLegacy, serveModern bool) (*httptest.Server, 
 				})
 				return
 			}
+			// The SDK also requires Mcp-Name to mirror the named subject, for the
+			// three methods that address one.
+			if key, bearing := nameBearingMethods[method]; bearing {
+				if want, ok := params[key].(string); ok && want != "" && r.Header.Get("Mcp-Name") != want {
+					w.WriteHeader(http.StatusBadRequest)
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"jsonrpc": "2.0", "id": body["id"],
+						"error": map[string]interface{}{"code": -32020, "message": "mcp-name header does not match"},
+					})
+					return
+				}
+			}
 			if _, ok := params["_meta"].(map[string]interface{}); !ok {
 				w.WriteHeader(http.StatusBadRequest)
 				_ = json.NewEncoder(w).Encode(map[string]interface{}{
@@ -90,6 +103,10 @@ func wireServer(t *testing.T, serveLegacy, serveModern bool) (*httptest.Server, 
 				}
 			case "tools/list":
 				result["tools"] = []interface{}{map[string]interface{}{"name": "echo"}}
+			case "resources/read":
+				result["contents"] = []interface{}{
+					map[string]interface{}{"uri": params["uri"], "text": "content"},
+				}
 			}
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"jsonrpc": "2.0", "id": body["id"], "result": result,
@@ -297,4 +314,88 @@ func keysOf(m map[string]json.RawMessage) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// A rule ported onto runOnEachWire must exercise both wires of a dual-era server
+// and label the modern findings, so that on a server exposing the same surface
+// twice the two results are distinguishable rather than looking like duplicates.
+func TestRunOnEachWire_LabelsModernFindingsOnly(t *testing.T) {
+	srv, _ := wireServer(t, true, true)
+	defer srv.Close()
+
+	var eras []Era
+	findings, err := runOnEachWire(context.Background(), wireClient(), srv.URL,
+		func(s mcpSession) []attack.Finding {
+			eras = append(eras, s.Era)
+			return []attack.Finding{{Title: "surface exposed", Evidence: "body"}}
+		})
+	if err != nil {
+		t.Fatalf("runOnEachWire: %v", err)
+	}
+	if len(eras) != 2 || eras[0] != EraLegacy || eras[1] != EraModern {
+		t.Fatalf("probe should run on legacy then modern, ran on %v", eras)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("expected a finding per wire, got %d", len(findings))
+	}
+	if findings[0].Title != "surface exposed" {
+		t.Errorf("legacy finding was relabelled to %q; a legacy-only scan must be unchanged", findings[0].Title)
+	}
+	if !strings.Contains(findings[1].Title, modernEraVersion) {
+		t.Errorf("modern finding is unlabelled: %q", findings[1].Title)
+	}
+	if !strings.Contains(findings[1].Evidence, "wire: MCP "+modernEraVersion) {
+		t.Errorf("modern evidence should name the wire, got %q", findings[1].Evidence)
+	}
+}
+
+// A legacy-only server must produce exactly what it produced before the port: one
+// pass, no labels.
+func TestRunOnEachWire_LegacyOnlyIsUnchanged(t *testing.T) {
+	srv, _ := wireServer(t, true, false)
+	defer srv.Close()
+
+	findings, err := runOnEachWire(context.Background(), wireClient(), srv.URL,
+		func(mcpSession) []attack.Finding {
+			return []attack.Finding{{Title: "surface exposed", Evidence: "body"}}
+		})
+	if err != nil {
+		t.Fatalf("runOnEachWire: %v", err)
+	}
+	if len(findings) != 1 || findings[0].Title != "surface exposed" {
+		t.Fatalf("expected one unlabelled finding, got %+v", findings)
+	}
+}
+
+// The header a rule cannot omit without being told the call was refused. Only
+// tools/call, prompts/get and resources/read carry a named subject; everything
+// else must not send it.
+func TestSessionPost_ModernMirrorsMcpName(t *testing.T) {
+	srv, seen := wireServer(t, false, true)
+	defer srv.Close()
+
+	sessions, err := openSessions(context.Background(), wireClient(), srv.URL)
+	if err != nil {
+		t.Fatalf("openSessions: %v", err)
+	}
+	s := sessions[0]
+
+	resp, err := s.post(context.Background(), wireClient(), 1, "resources/read",
+		map[string]interface{}{"uri": "spike://notes"})
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	if !resp.IsAccepted() {
+		t.Fatalf("resources/read rejected, Mcp-Name is probably missing: %s", resp.BodyString())
+	}
+	if got := (*seen)[len(*seen)-1].headers.Get("Mcp-Name"); got != "spike://notes" {
+		t.Errorf("Mcp-Name = %q, want the uri parameter", got)
+	}
+
+	if _, err := s.post(context.Background(), wireClient(), 2, "tools/list", nil); err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	if got := (*seen)[len(*seen)-1].headers.Get("Mcp-Name"); got != "" {
+		t.Errorf("tools/call is name-bearing but tools/list is not; sent Mcp-Name=%q", got)
+	}
 }


### PR DESCRIPTION
Both rules now open every wire the target serves and probe each. A server on the current SDKs answers the handshake revisions and 2026-07-28 on one endpoint and need not gate them alike, so testing only the first wire reported on one era while the other went untested.

## Result

Dual-era SDK server, these two rules: **4 findings → 8**. Every surface exposed on the legacy wire is also exposed on the modern one.

```
[!] HIGH  MCP resources/list accessible without authentication (1 resources)
[!] HIGH  MCP resources/list accessible without authentication (1 resources) [MCP 2026-07-28 wire]
...
```

Modern findings carry the suffix and name the wire in their evidence, so the pair reads as two surfaces rather than a duplicate. Legacy findings are untouched: the reference server is unchanged at 10 findings / 18 of 35 skips, with zero suffixes anywhere.

## A gap in #134 this exposed

The modern era also requires **`Mcp-Name`**, mirroring the named subject for the three methods that address one. #134 sent only `Mcp-Method`, so `resources/read` and `tools/call` earned `-32020` on the modern wire and the rules read that as a server refusing the call.

The first live run of this port showed **6** findings, not 8 — which is why the two missing ones were worth chasing rather than accepting the bigger number. The mapping is the SDK's own `NAME_BEARING_METHODS` table (`tools/call`→`name`, `prompts/get`→`name`, `resources/read`→`uri`), read from the source, not inferred.

The unit fixture now enforces `Mcp-Name` the way the SDK does, so omitting it fails rather than looking like a secure server. Removing the header fails that test with the real `-32020`.

## Shape

Each rule's body moved into `probeSession` unchanged, taking the session it runs on; the POSTs go through `session.post` so the era decides headers and params. Nothing else in either rule changed.

The remaining two unauth rules, prompts and completion, follow next on the same pattern.

`go test -race ./...`, `go vet` (both tags), `gofmt`, `golangci-lint` v2.11.4 clean.