### PR TITLE
feat(mcp): run the prompts and completion unauth rules on both wires

### DIFF
--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -75,9 +75,12 @@ than as unreachable.
 ## Both protocol wires
 
 A server built on the current SDKs answers **both** the handshake-based revisions
-and 2026-07-28 on the same endpoint. `mcp-resources-unauth-001` and
-`mcp-tools-unauth-001` are exercised on each wire it serves, because the two need
-not be gated alike: a server can enforce authorization on one and not the other.
+and 2026-07-28 on the same endpoint. The four unauthenticated-access rules,
+`mcp-resources-unauth-001`, `mcp-tools-unauth-001`, `mcp-prompt-unauth-001` and
+`mcp-completion-unauth-001`, are exercised on each wire it serves, because the two
+need not be gated alike: a server can enforce authorization on one and not the
+other. Each wire is capability-gated on its own advertisement, so a surface the
+server exposes on only one era is probed only there.
 
 Findings from the 2026-07-28 wire carry a `[MCP 2026-07-28 wire]` suffix and name
 the wire in their evidence, so a surface exposed on both produces two

--- a/internal/attack/mcp/completion_unauth.go
+++ b/internal/attack/mcp/completion_unauth.go
@@ -71,18 +71,20 @@ func (e *CompletionUnauthExecutor) Execute(ctx context.Context, target string, o
 	// reachable WITHOUT authentication. Injecting opts.Token would mask the finding.
 	client := attack.NewUnauthHTTPClient(opts, vars)
 
-	session, err := initializeMCP(ctx, client, vars.BaseURL)
-	if err != nil {
-		// Not reachable as a legacy MCP server; inconclusive carries the reason
-		// when the target turned out to be a modern-era server.
-		return nil, inconclusive(err)
-	}
+	// A server may expose completion on both protocol wires, and need not gate it
+	// the same way on each, so every wire it serves is probed.
+	return runOnEachWire(ctx, client, vars.BaseURL, func(session mcpSession) []attack.Finding {
+		return e.probeSession(ctx, client, session, vars.RandID)
+	})
+}
 
+// probeSession runs the rule against one already-opened wire.
+func (e *CompletionUnauthExecutor) probeSession(ctx context.Context, client *attack.HTTPClient, session mcpSession, randID string) []attack.Finding {
 	// Skip servers that do not advertise the completions capability; probing them
 	// would produce meaningless noise. Read from the captured handshake object
 	// rather than substring-matching the body.
 	if !session.ServerSupports("completions") {
-		return nil, nil
+		return nil
 	}
 
 	// Probe real refs discovered from the live server first, preferring one that
@@ -109,7 +111,7 @@ func (e *CompletionUnauthExecutor) Execute(ctx context.Context, target string, o
 	// completion answers this with 401/403 or an auth error and stays silent.
 	if firstReachable == nil {
 		synth := completionRef{
-			params:  map[string]interface{}{"type": "ref/prompt", "name": "batesian-nonexistent-" + vars.RandID},
+			params:  map[string]interface{}{"type": "ref/prompt", "name": "batesian-nonexistent-" + randID},
 			argName: "batesian_probe",
 			real:    false,
 			label:   "synthetic probe ref",
@@ -118,7 +120,7 @@ func (e *CompletionUnauthExecutor) Execute(ctx context.Context, target string, o
 	}
 
 	if firstReachable == nil {
-		return nil, nil
+		return nil
 	}
 
 	// Base the reachability finding on the disclosure probe when one was found, so
@@ -165,7 +167,7 @@ func (e *CompletionUnauthExecutor) Execute(ctx context.Context, target string, o
 		})
 	}
 
-	return findings, nil
+	return findings
 }
 
 // probe sends a single unauthenticated completion/complete request for ref and
@@ -173,20 +175,15 @@ func (e *CompletionUnauthExecutor) Execute(ctx context.Context, target string, o
 // transport error, or a non-dispatching JSON-RPC error. Suggestion values are
 // captured only for real refs (synthetic refs never disclose real data).
 func (e *CompletionUnauthExecutor) probe(ctx context.Context, client *attack.HTTPClient, session mcpSession, ref completionRef) *completionOutcome {
-	resp, err := client.POST(ctx, session.Endpoint, session.header(), map[string]interface{}{
-		"jsonrpc": "2.0",
-		"id":      7,
-		"method":  "completion/complete",
-		// An empty value asks the server to enumerate all suggestions for the
-		// argument. Fuzzy/prefix matchers (the common implementation) return their
-		// full candidate set for the empty prefix, which is exactly the
-		// enumerate-everything behavior an attacker abuses; a non-empty probe value
-		// would be silently filtered out against namespaces that do not share its
-		// prefix (e.g. numeric identifiers).
-		"params": map[string]interface{}{
-			"ref":      ref.params,
-			"argument": map[string]interface{}{"name": ref.argName, "value": ""},
-		},
+	// An empty value asks the server to enumerate all suggestions for the
+	// argument. Fuzzy/prefix matchers (the common implementation) return their
+	// full candidate set for the empty prefix, which is exactly the
+	// enumerate-everything behavior an attacker abuses; a non-empty probe value
+	// would be silently filtered out against namespaces that do not share its
+	// prefix (e.g. numeric identifiers).
+	resp, err := session.post(ctx, client, 7, "completion/complete", map[string]interface{}{
+		"ref":      ref.params,
+		"argument": map[string]interface{}{"name": ref.argName, "value": ""},
 	})
 	if err != nil || !resp.IsSuccess() {
 		return nil
@@ -296,12 +293,7 @@ func resourceTemplateRefs(ctx context.Context, client *attack.HTTPClient, sessio
 // result object, or ok=false on any transport failure, non-2xx, or JSON-RPC
 // error (which means the listing itself is gated and yields no usable ref).
 func rpcResult(ctx context.Context, client *attack.HTTPClient, session mcpSession, method string) (map[string]interface{}, bool) {
-	resp, err := client.POST(ctx, session.Endpoint, session.header(), map[string]interface{}{
-		"jsonrpc": "2.0",
-		"id":      6,
-		"method":  method,
-		"params":  map[string]interface{}{},
-	})
+	resp, err := session.post(ctx, client, 6, method, nil)
 	if err != nil || !resp.IsSuccess() {
 		return nil, false
 	}

--- a/internal/attack/mcp/prompt_unauth.go
+++ b/internal/attack/mcp/prompt_unauth.go
@@ -29,47 +29,44 @@ func (e *PromptUnauthExecutor) Execute(ctx context.Context, target string, opts 
 	// accessible WITHOUT authentication. Injecting opts.Token would mask the finding.
 	client := attack.NewUnauthHTTPClient(opts, vars)
 
-	session, err := initializeMCP(ctx, client, vars.BaseURL)
-	if err != nil {
-		// Not reachable as a legacy MCP server; inconclusive carries the reason
-		// when the target turned out to be a modern-era server.
-		return nil, inconclusive(err)
-	}
+	// A server may expose prompts on both protocol wires, and need not gate them
+	// the same way on each, so every wire it serves is probed.
+	return runOnEachWire(ctx, client, vars.BaseURL, func(session mcpSession) []attack.Finding {
+		return e.probeSession(ctx, client, session)
+	})
+}
 
+// probeSession runs the rule against one already-opened wire.
+func (e *PromptUnauthExecutor) probeSession(ctx context.Context, client *attack.HTTPClient, session mcpSession) []attack.Finding {
 	// Skip servers that do not advertise the prompts capability - probing them
 	// would produce meaningless noise. This reads the server capabilities from
 	// the handshake captured by initializeMCP (no redundant second initialize),
 	// and parses the structured capabilities object rather than substring-matching
 	// the whole body (which could false-match "prompts" in serverInfo/instructions).
 	if !session.ServerSupports("prompts") {
-		return nil, nil
+		return nil
 	}
 
 	// Call prompts/list without any auth token.
-	listResp, err := client.POST(ctx, session.Endpoint, session.header(), map[string]interface{}{
-		"jsonrpc": "2.0",
-		"id":      3,
-		"method":  "prompts/list",
-		"params":  map[string]interface{}{},
-	})
+	listResp, err := session.post(ctx, client, 3, "prompts/list", nil)
 	if err != nil || !listResp.IsSuccess() {
-		return nil, nil
+		return nil
 	}
 
 	var listBody map[string]interface{}
 	if err := json.Unmarshal(listResp.Body, &listBody); err != nil {
-		return nil, nil
+		return nil
 	}
 
 	// JSON-RPC error means auth is enforced - not vulnerable.
 	if _, hasErr := listBody["error"]; hasErr {
-		return nil, nil
+		return nil
 	}
 
 	result, _ := listBody["result"].(map[string]interface{})
 	promptsRaw, _ := result["prompts"].([]interface{})
 	if len(promptsRaw) == 0 {
-		return nil, nil
+		return nil
 	}
 
 	// Collect prompt names for evidence.
@@ -104,25 +101,20 @@ func (e *PromptUnauthExecutor) Execute(ctx context.Context, target string, opts 
 
 	// Attempt to retrieve content of the first prompt via prompts/get.
 	if len(names) == 0 {
-		return findings, nil
+		return findings
 	}
 
-	getResp, err := client.POST(ctx, session.Endpoint, session.header(), map[string]interface{}{
-		"jsonrpc": "2.0",
-		"id":      4,
-		"method":  "prompts/get",
-		"params":  map[string]interface{}{"name": names[0]},
-	})
+	getResp, err := session.post(ctx, client, 4, "prompts/get", map[string]interface{}{"name": names[0]})
 	if err != nil || !getResp.IsSuccess() {
-		return findings, nil
+		return findings
 	}
 
 	var getBody map[string]interface{}
 	if err := json.Unmarshal(getResp.Body, &getBody); err != nil {
-		return findings, nil
+		return findings
 	}
 	if _, hasErr := getBody["error"]; hasErr {
-		return findings, nil
+		return findings
 	}
 
 	content := string(getResp.Body)
@@ -142,5 +134,5 @@ func (e *PromptUnauthExecutor) Execute(ctx context.Context, target string, opts 
 		TargetURL:   session.Endpoint,
 	})
 
-	return findings, nil
+	return findings
 }


### PR DESCRIPTION
Completes the port started in #135. Same shape: each rule's body moved into `probeSession` unchanged, POSTs routed through `session.post` so the era decides headers and params. All four unauth rules now run on every wire a target serves.

## Result

Dual-era SDK server, four unauth rules: **9 findings → 10**.

Only `prompts/list` is added, and the reason matters more than the number. That is the only surface this server exposes that #135 had not already covered:

- it advertises **no** `completions` capability on either wire, so completion correctly skips both
- its one prompt takes a required argument, so `prompts/get` discloses nothing on either wire

Each wire is capability-gated on its own advertisement, so where the wires differ, that is the server's asymmetry rather than the scanner's: the legacy handshake lists `experimental, prompts, resources, tools`; `server/discover` lists `prompts, resources, tools`.

`prompts/get` is one of the three name-bearing methods, so it needed the `Mcp-Name` header added in #135 and works here without further change — reasonable evidence that fix was right in general rather than right for two rules.

## Unchanged where it should be

Reference server (legacy-only): 10 findings, 18 of 35 skips, zero era labels.

`go test -race ./...`, `go vet` (both tags), `gofmt`, `golangci-lint` v2.11.4 clean.