### PR TITLE
feat(mcp): drive the SEP-2243 check on the modern wire

### DIFF
--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -423,14 +423,17 @@ simply don't implement SEP-2243), all with body `method = tools/list`:
    it enforces header *presence* but not header/body *consistency*, so a gateway
    that routes or rate-limits on `Mcp-Method` can be bypassed.
 
-**Currency.** SEP-2243 arrived in **2026-07-28**, and these rules negotiate an
-earlier revision, so in practice step 1 is accepted and the rule stops there. That
-is reported as **not tested**, naming the revision, rather than as clean: a server
-on a wire with no such requirement was never asked the question. A server that does
-enforce header presence is tested on its merits whatever version it advertises, and
+**Currency.** SEP-2243 arrived in **2026-07-28**, so the check is driven on every
+wire a server serves and is only meaningful on that one. A server whose modern wire
+enforces presence is tested on its merits there, and a legacy wire that ignores the
+header contributes nothing.
+
+**Not tested** is reported only when no wire exercised the check and the reason was
+the revision: a legacy-only server has no such requirement to violate, and calling
+that clean would assert header/body consistency about a server never asked. A
+server that enforces header presence is tested whatever version it advertises, and
 one on 2026-07-28 or later that ignores the header reports clean, since this rule's
-subject is the mismatch rather than the absence. Exercising the requirement on its
-own wire needs modern-era transport support, which is tracked separately.
+subject is the mismatch rather than the absence.
 
 ---
 

--- a/internal/attack/mcp/header_body_split.go
+++ b/internal/attack/mcp/header_body_split.go
@@ -30,32 +30,47 @@ func (e *HeaderBodySplitExecutor) Execute(ctx context.Context, target string, op
 	vars := attack.NewVars(target, opts.OOBListenerURL)
 	client := attack.NewHTTPClient(opts, vars)
 
-	// Set only when the server turned out not to enforce Mcp-Method presence, in
-	// which case it carries the version that session negotiated. A server that
-	// does enforce presence is tested on its merits and never sets this, whatever
-	// version it advertises.
+	sessions, err := openSessions(ctx, client, vars.BaseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set when a wire turned out not to enforce Mcp-Method presence, carrying the
+	// version that wire speaks. A wire that does enforce presence is tested on its
+	// merits and never sets this.
 	unawareAt := ""
-	findings, err := probeCandidates(vars.BaseURL, func(ep string) ([]attack.Finding, bool) {
-		f, reached, unaware := e.probe(ctx, client, ep)
+	anyTested := false
+	var findings []attack.Finding
+	for _, session := range sessions {
+		f, unaware, tested := e.probe(ctx, client, session)
+		findings = append(findings, labelEra(session, f)...)
 		if unaware != "" {
 			unawareAt = unaware
 		}
-		return f, reached
-	})
-	if err != nil || len(findings) > 0 {
-		return findings, err
+		if tested {
+			anyTested = true
+		}
+	}
+	if len(findings) > 0 {
+		return findings, nil
+	}
+	// A wire that got past the presence probe exercised the rule, so a clean result
+	// is a real one even when another wire had no such requirement. Without this a
+	// dual-era server whose modern wire validates the header correctly would still
+	// be reported as not tested, on the strength of its legacy wire.
+	if anyTested {
+		return nil, nil
 	}
 
-	// The server did not enforce Mcp-Method presence, so the rule stopped at its
-	// first probe. Whether that is a clean result depends on the revision.
+	// Nothing found. Whether that is a clean result depends on the wires available.
 	//
 	// Mcp-Method mirroring and its -32020 HeaderMismatch rejection were introduced
 	// by SEP-2243 in 2026-07-28. On an earlier wire there is no requirement to
-	// violate, so probe 1 is always accepted and nothing is ever tested. Calling
-	// that clean asserted header/body consistency about a server that was never
-	// asked, on every scan. A server on 2026-07-28 or later that ignores the header
-	// is a different matter and still reports clean here, because this rule's
-	// subject is the mismatch, not the absence.
+	// violate, so probe 1 is always accepted and nothing is tested. Reporting that
+	// as clean asserted header/body consistency about a server that was never
+	// asked. A server on 2026-07-28 or later that ignores the header is a different
+	// matter and reports clean, because this rule's subject is the mismatch, not
+	// the absence.
 	//
 	// The dated revisions sort lexicographically, which is what makes the compare
 	// safe.
@@ -70,35 +85,32 @@ func (e *HeaderBodySplitExecutor) Execute(ctx context.Context, target string, op
 // and the -32020 HeaderMismatch rejection this rule tests for.
 const headerValidationVersion = modernEraVersion
 
-// probe returns the findings, whether the endpoint answered as MCP, and, only
-// when the server turned out not to enforce Mcp-Method presence, the version the
-// session negotiated. Callers use that last value to decide whether "no
-// enforcement" is expected for the revision in play.
-func (e *HeaderBodySplitExecutor) probe(ctx context.Context, client *attack.HTTPClient, ep string) (findings []attack.Finding, reached bool, unawareAt string) {
-	session, ok := e.initialize(ctx, client, ep)
-	if !ok {
-		return nil, false, "" // not an MCP endpoint here
-	}
+// probe runs the three-step check against one already-opened wire.
+//
+// unawareAt is set only when the server did not enforce Mcp-Method presence, and
+// carries the version that wire speaks. tested says whether the mismatch was
+// actually driven, which is what separates a clean result from one where the rule
+// never got far enough to judge.
+func (e *HeaderBodySplitExecutor) probe(ctx context.Context, client *attack.HTTPClient, session mcpSession) (findings []attack.Finding, unawareAt string, tested bool) {
+	wireVersion := session.ProtocolVersion
 
 	// Probe 1: omit Mcp-Method. If the server still executes tools/list, it does
 	// not enforce header presence (not SEP-2243-aware) - nothing to confirm.
-	if e.toolsList(ctx, client, ep, session, nil) {
-		return nil, true, session.ProtocolVersion
+	if e.toolsList(ctx, client, session, omitMethodHeader) {
+		return nil, wireVersion, false
 	}
 
 	// Probe 2: matching Mcp-Method. Must be accepted, otherwise we cannot drive
 	// the mismatch test (the endpoint may require headers we are not sending).
 	// Presence is enforced by this point, so the rule is testing a server that
 	// implements SEP-2243 whatever version it advertises.
-	matched := "tools/list"
-	if !e.toolsList(ctx, client, ep, session, &matched) {
-		return nil, true, ""
+	if !e.toolsList(ctx, client, session, matchMethodHeader) {
+		return nil, "", false
 	}
 
 	// Probe 3: mismatched Mcp-Method. A compliant server MUST reject; if it
 	// executes the body's tools/list, header value is not validated.
-	mismatched := "tools/call"
-	if e.toolsList(ctx, client, ep, session, &mismatched) {
+	if e.toolsList(ctx, client, session, mismatchMethodHeader) {
 		return []attack.Finding{{
 			RuleID:     e.rule.ID,
 			RuleName:   e.rule.Name,
@@ -113,67 +125,34 @@ func (e *HeaderBodySplitExecutor) probe(ctx context.Context, client *attack.HTTP
 					"Because the header is enforced for "+
 					"presence but not value, an intermediary that routes or rate-limits on Mcp-Method can "+
 					"be bypassed by labelling a sensitive body operation with an innocuous method.",
-				ep),
+				session.Endpoint),
 			Evidence: fmt.Sprintf(
 				"endpoint: %s\nomit Mcp-Method: rejected (presence enforced)\nMcp-Method: tools/list (match): executed\n"+
 					"Mcp-Method: tools/call (mismatch) + body tools/list: EXECUTED body (should be 400/-32020)",
-				ep),
+				session.Endpoint),
 			Remediation: e.rule.Remediation,
-			TargetURL:   ep,
-		}}, true, ""
+			TargetURL:   session.Endpoint,
+		}}, "", true
 	}
-	return nil, true, ""
+	return nil, "", true
 }
 
-// initialize performs an MCP initialize (sending a matching Mcp-Method so a
-// header-enforcing server accepts it) and returns the session.
-func (e *HeaderBodySplitExecutor) initialize(ctx context.Context, client *attack.HTTPClient, ep string) (mcpSession, bool) {
-	resp, err := client.POST(ctx, ep, map[string]string{"Mcp-Method": "initialize"}, map[string]interface{}{
-		"jsonrpc": "2.0",
-		"id":      1,
-		"method":  "initialize",
-		"params": map[string]interface{}{
-			"protocolVersion": "2025-06-18",
-			"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
-			"clientInfo":      map[string]interface{}{"name": "batesian", "version": "1.0"},
-		},
-	})
-	if err != nil || !resp.IsSuccess() {
-		return mcpSession{}, false
-	}
-	if !resp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
-		return mcpSession{}, false
-	}
-	session := mcpSession{Endpoint: ep, SessionID: resp.Headers.Get("Mcp-Session-Id"), ProtocolVersion: negotiatedVersion(resp.Body), RawInit: resp.Body}
-	initedHeaders := session.header()
-	if initedHeaders == nil {
-		initedHeaders = map[string]string{}
-	}
-	initedHeaders["Mcp-Method"] = "notifications/initialized"
-	_, _ = client.POST(ctx, ep, initedHeaders, map[string]interface{}{
-		"jsonrpc": "2.0",
-		"method":  "notifications/initialized",
-	})
-	return session, true
-}
+// The two deliberate malformations. Omitting the header tests whether presence is
+// enforced at all; mismatching it tests whether the value is validated, which is
+// the split-brain this rule confirms.
+func omitMethodHeader(h map[string]string) { delete(h, "Mcp-Method") }
+
+// The matching header is set explicitly rather than left to the era: a modern
+// request already carries it, but a legacy one does not, and probe 2 has to send
+// it on either wire for the mismatch in probe 3 to mean anything.
+func matchMethodHeader(h map[string]string)    { h["Mcp-Method"] = "tools/list" }
+func mismatchMethodHeader(h map[string]string) { h["Mcp-Method"] = "tools/call" }
 
 // toolsList sends a tools/list body. methodHeader controls the Mcp-Method header:
 // nil omits it; otherwise it is set to the given (possibly mismatched) value. It
 // reports whether the server EXECUTED tools/list (returned a result.tools array).
-func (e *HeaderBodySplitExecutor) toolsList(ctx context.Context, client *attack.HTTPClient, ep string, session mcpSession, methodHeader *string) bool {
-	headers := session.header()
-	if headers == nil {
-		headers = map[string]string{}
-	}
-	if methodHeader != nil {
-		headers["Mcp-Method"] = *methodHeader
-	}
-	resp, err := client.POST(ctx, ep, headers, map[string]interface{}{
-		"jsonrpc": "2.0",
-		"id":      2,
-		"method":  "tools/list",
-		"params":  map[string]interface{}{},
-	})
+func (e *HeaderBodySplitExecutor) toolsList(ctx context.Context, client *attack.HTTPClient, session mcpSession, shape func(map[string]string)) bool {
+	resp, err := session.postShaping(ctx, client, 2, "tools/list", nil, shape)
 	if err != nil || !resp.IsSuccess() {
 		return false
 	}

--- a/internal/attack/mcp/header_body_split_test.go
+++ b/internal/attack/mcp/header_body_split_test.go
@@ -165,3 +165,87 @@ func TestSplit_NotMCP(t *testing.T) {
 
 	assertInconclusive(t, mcpattack.NewHeaderBodySplitExecutor(hbsRuleCtx()), ts.URL, attack.Options{TimeoutSeconds: 5})
 }
+
+// The case this rule was written for and could never reach until the modern
+// transport existed: a server whose 2026-07-28 wire enforces Mcp-Method presence
+// but not its value. Until now the rule opened a 2025-era session, where the
+// requirement does not exist, and stopped at its first probe.
+func TestSplit_VulnerableOnTheModernWire(t *testing.T) {
+	ts := modernSplitServer(t, false)
+	defer ts.Close()
+
+	findings, err := mcpattack.NewHeaderBodySplitExecutor(hbsRuleCtx()).
+		Execute(context.Background(), ts.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding on the modern wire, got %d: %+v", len(findings), findings)
+	}
+	if findings[0].Confidence != attack.ConfirmedExploit || findings[0].Severity != "high" {
+		t.Errorf("want high/ConfirmedExploit, got %q/%q", findings[0].Severity, findings[0].Confidence)
+	}
+	if !strings.Contains(findings[0].Title, "2026-07-28 wire") {
+		t.Errorf("a modern-wire finding should say so: %q", findings[0].Title)
+	}
+}
+
+// A modern wire that validates the value is secure, and must stay silent.
+func TestSplit_StrictOnTheModernWire(t *testing.T) {
+	ts := modernSplitServer(t, true)
+	defer ts.Close()
+
+	findings, err := mcpattack.NewHeaderBodySplitExecutor(hbsRuleCtx()).
+		Execute(context.Background(), ts.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings against a strict modern server, got %d: %+v", len(findings), findings)
+	}
+}
+
+// modernSplitServer serves only the 2026-07-28 wire. It always rejects a missing
+// Mcp-Method, as the SDK does; strict decides whether it also rejects a mismatched
+// one, which is the difference between secure and the split-brain.
+func modernSplitServer(t *testing.T, strict bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method, _ := body["method"].(string)
+		id := body["id"]
+		w.Header().Set("Content-Type", "application/json")
+
+		// No legacy wire here: the handshake is refused, so the rule can only
+		// reach this server through server/discover.
+		if r.Header.Get("MCP-Protocol-Version") != "2026-07-28" {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": -32022, "message": "UnsupportedProtocolVersion"},
+			})
+			return
+		}
+		hdr := r.Header.Get("Mcp-Method")
+		if hdr == "" || (strict && hdr != method) {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": -32020, "message": "HeaderMismatch"},
+			})
+			return
+		}
+		result := map[string]interface{}{"cacheScope": "private", "resultType": "complete"}
+		switch method {
+		case "server/discover":
+			result["supportedVersions"] = []string{"2026-07-28"}
+			result["capabilities"] = map[string]interface{}{"tools": map[string]interface{}{}}
+		case "tools/list":
+			result["tools"] = []interface{}{map[string]interface{}{"name": "echo"}}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": id, "result": result,
+		})
+	}))
+}

--- a/internal/attack/mcp/wire.go
+++ b/internal/attack/mcp/wire.go
@@ -41,9 +41,10 @@ var nameBearingMethods = map[string]string{
 	"resources/read": "uri",
 }
 
-// post sends a JSON-RPC request on whichever wire this session belongs to,
-// building the headers and params each era requires.
-func (s mcpSession) post(ctx context.Context, client *attack.HTTPClient, id interface{}, method string, params map[string]interface{}) (*attack.Response, error) {
+// request builds the headers and body this session's era requires for one call.
+// It is split out of post so postShaping can reshape the headers without
+// duplicating the era rules.
+func (s mcpSession) request(id interface{}, method string, params map[string]interface{}) (map[string]string, map[string]interface{}) {
 	if params == nil {
 		params = map[string]interface{}{}
 	}
@@ -72,13 +73,36 @@ func (s mcpSession) post(ctx context.Context, client *attack.HTTPClient, id inte
 			}
 		}
 	}
+	if headers == nil {
+		headers = map[string]string{}
+	}
 
-	return client.POST(ctx, s.Endpoint, headers, map[string]interface{}{
+	return headers, map[string]interface{}{
 		"jsonrpc": "2.0",
 		"id":      id,
 		"method":  method,
 		"params":  params,
-	})
+	}
+}
+
+// post sends a JSON-RPC request on whichever wire this session belongs to,
+// building the headers and params each era requires.
+func (s mcpSession) post(ctx context.Context, client *attack.HTTPClient, id interface{}, method string, params map[string]interface{}) (*attack.Response, error) {
+	headers, body := s.request(id, method, params)
+	return client.POST(ctx, s.Endpoint, headers, body)
+}
+
+// postShaping is post for a rule that must send a deliberately malformed request.
+// shape receives the headers this era would have sent and may change or delete
+// any of them, which is how the SEP-2243 rule omits or mismatches Mcp-Method
+// without also having to rebuild the _meta block the era requires.
+func (s mcpSession) postShaping(ctx context.Context, client *attack.HTTPClient, id interface{}, method string,
+	params map[string]interface{}, shape func(map[string]string)) (*attack.Response, error) {
+	headers, body := s.request(id, method, params)
+	if shape != nil {
+		shape(headers)
+	}
+	return client.POST(ctx, s.Endpoint, headers, body)
 }
 
 // modernMeta is the _meta block every modern request must carry. clientCapabilities


### PR DESCRIPTION
This rule has never been able to fire. `Mcp-Method` validation exists only in 2026-07-28, the rule opened a 2025-era session, and #133 made it say so rather than report a clean pass. The transport primitive removes the blocker.

## Result

Dual-era SDK server, whose modern wire enforces both presence and value:

```
before:  could not reach a testable endpoint
after:   Target appears clean
```

That is now a **real** clean pass — the three probes ran on a wire where the requirement exists. Legacy-only server still reports the currency skip, and the reference server is unchanged at 10 findings / 18 of 35 skips.

New tests cover a modern wire that ignores the header value (**finding**, labelled as the modern wire) and one that validates it (**clean**). Skipping the modern wire fails the first.

## Two things the port needed beyond wiring

**The matching probe now sets `Mcp-Method` explicitly** rather than letting the era supply it. A modern request already carries the header; a legacy one does not, and probe 2 must send it on either wire for probe 3's mismatch to mean anything. Leaving it to the era broke the vulnerable fixture, which enforces presence on a 2025-era wire — caught by the existing test.

**The currency skip is now conditional on no wire having tested.** Tracking only "which version was unaware" wasn't enough: a dual-era server whose modern wire validates the header correctly was *still* reported as not tested, on the strength of its legacy wire. That was my first cut, and the live run against the SDK is what exposed it. `probe` now reports whether it got past the presence check, and the skip fires only when nothing did.

## Primitive additions

`postShaping` lets a rule send a deliberately malformed request without rebuilding the `_meta` block its era requires; `request()` is factored out of `post()` so both share one copy of the era rules. The rule's own `initialize` is gone, replaced by `openSessions`.

`go test -race ./...`, `go vet` (both tags), `gofmt`, `golangci-lint` v2.11.4 clean.