### PR TITLE
rule(mcp): add mcp-era-downgrade-001, auth enforced on one wire only

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -147,7 +147,7 @@ release:
     ## Batesian {{.Version}}
 
     Adversarial red-team CLI for AI agent protocols (A2A and MCP).
-    35 bundled attack rules (17 A2A + 18 MCP). Single binary. No runtime dependencies.
+    36 bundled attack rules (17 A2A + 19 MCP). Single binary. No runtime dependencies.
 
     Every release is published with a cosign signature over `checksums.txt`, a
     CycloneDX SBOM per archive, and SLSA build provenance.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ CLI for adversarial testing of [A2A](https://a2a-protocol.org) and [MCP](https:/
 
 ## What ships
 
-Bundled rules: **17 A2A, 18 MCP (35 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
+Bundled rules: **17 A2A, 19 MCP (36 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
 
 - [A2A rules](docs/rules-a2a.md) (17)
 - [MCP rules](docs/rules-mcp.md) (18)

--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -1,6 +1,6 @@
 # MCP Attack Rules
 
-Batesian ships **18 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
+Batesian ships **19 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
 Every rule is an active probe: it sends crafted protocol traffic and judges the
 server's actual response. Rules are deliberately scoped to MCP-specific semantics
 (OAuth 2.1 authorization, DCR, audience binding, discovery-chain metadata-fetch
@@ -113,6 +113,7 @@ candidate answers does a rule report that it could not test.
 | `mcp-logging-unauth-001` | [logging/setLevel Without Authentication](#mcp-logging-unauth-001) | Medium | confirmed | CWE-862 |
 | `mcp-task-idor-001` | [Task Readable Across Authorization Contexts](#mcp-task-idor-001) | Critical / High | confirmed | CWE-639 / CWE-200 |
 | `mcp-init-downgrade-001` | [Protocol Version Downgrade Auth Bypass](#mcp-init-downgrade-001) | Critical | confirmed | CWE-757 |
+| `mcp-era-downgrade-001` | [Protocol Era Downgrade Auth Bypass](#mcp-era-downgrade-001) | Critical | confirmed | CWE-757 |
 | `mcp-session-fixation-001` | [Session ID Fixation](#mcp-session-fixation-001) | High | confirmed | CWE-384 |
 | `mcp-header-body-split-001` | [Header/Body Routing Split-Brain (SEP-2243)](#mcp-header-body-split-001) | High | confirmed | CWE-444 |
 | `mcp-sse-resume-replay-001` | [SSE Resumption Cross-Session Replay](#mcp-sse-resume-replay-001) | High | confirmed | CWE-488 |
@@ -368,6 +369,45 @@ modern path and mask the bug. A **confirmed** finding is reported only when the
 modern session is rejected (auth enforced) but the legacy session succeeds. If
 both succeed, the server simply has no auth (owned by `mcp-resources-unauth-001`);
 if both are rejected, the server is secure - neither produces a finding here.
+
+---
+
+### mcp-era-downgrade-001
+
+**Protocol Era Downgrade Auth Bypass** | Severity: Critical | CWE-757
+
+The sibling of `mcp-init-downgrade-001`, with wires in place of versions. The
+2026-07-28 revision is a second, independent request path: no handshake, no
+session, the protocol version and client capabilities carried in each request's
+`_meta`. Servers built on the current Tier-1 SDKs serve it alongside the
+handshake revisions at the same URL by default, so an authorization check added to
+one request path leaves the other reachable and a caller asks on the wire that
+answers.
+
+Serving both eras is spec-compliant and is **not** reported. The finding is the
+asymmetry, confirmed by asking the same read-only listing on each wire with no
+credentials:
+
+- one wire **refused**, the other **answered** => **confirmed** bypass. Direction
+  is irrelevant: whichever wire is open is the one that gets used.
+- both answered => the server gates nothing, which is `mcp-resources-unauth-001`
+  and `mcp-tools-unauth-001` territory, so this is suppressed rather than
+  double-counted.
+- both refused => the gate is applied uniformly (secure).
+- only one era served => nothing to compare (not applicable).
+
+The listing method is chosen per wire from that wire's **own** advertised
+capabilities, since the two need not match: on a server built on the Python SDK
+the handshake reports `experimental, prompts, resources, tools` while
+`server/discover` reports `prompts, resources, tools`. Comparing a method one wire
+does not implement would measure the capability difference rather than the gate.
+
+**Scope.** This compares access at the method level on wires that both open
+unauthenticated. A server that gates the handshake itself, so only one wire opens
+at all, is not reported here. And no reference implementation currently exhibits
+the bug: the SDKs serve both eras correctly and apply no authorization, so the rule
+is validated against `testdata/mcp_era_downgrade_server.py` rather than against
+one of them.
 
 ---
 

--- a/internal/attack/mcp/era_downgrade.go
+++ b/internal/attack/mcp/era_downgrade.go
@@ -1,0 +1,157 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// EraDowngradeExecutor probes whether a server that serves both protocol wires
+// gates them differently (rule mcp-era-downgrade-001).
+//
+// The 2026-07-28 revision is a second, independent entry point. A server built on
+// the current SDKs serves it alongside the handshake revisions on the same URL, so
+// an authorization check bolted onto one request path leaves the other open, and a
+// caller simply asks on the wire that answers. This is
+// mcp-init-downgrade-001's bug with wires in place of versions.
+type EraDowngradeExecutor struct {
+	rule attack.RuleContext
+}
+
+func init() {
+	attack.Register("mcp-era-downgrade", func(rc attack.RuleContext) attack.Executor {
+		return NewEraDowngradeExecutor(rc)
+	})
+}
+
+func NewEraDowngradeExecutor(r attack.RuleContext) *EraDowngradeExecutor {
+	return &EraDowngradeExecutor{rule: r}
+}
+
+func (e *EraDowngradeExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
+	vars := attack.NewVars(target, opts.OOBListenerURL)
+	// Probe UNAUTHENTICATED, for the reason mcp-init-downgrade-001 does: attaching
+	// opts.Token would have a gated wire grant the call too, and the discriminator
+	// below could never fire. Reaching protected functionality without credentials
+	// is the whole claim.
+	client := attack.NewUnauthHTTPClient(opts, vars)
+
+	sessions, err := openSessions(ctx, client, vars.BaseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	var legacy, modern *mcpSession
+	for i := range sessions {
+		switch sessions[i].Era {
+		case EraLegacy:
+			legacy = &sessions[i]
+		case EraModern:
+			modern = &sessions[i]
+		case EraUnknown:
+			// openSessions never returns one; nothing to compare against.
+		}
+	}
+	if legacy == nil || modern == nil {
+		// One wire cannot disagree with itself. A server serving a single era is
+		// covered by the unauth rules, not here.
+		return nil, nil
+	}
+
+	legacyOutcome := e.probeList(ctx, client, *legacy)
+	modernOutcome := e.probeList(ctx, client, *modern)
+	if legacyOutcome.method == "" || modernOutcome.method == "" {
+		// Neither wire advertised a listable capability, so there is nothing whose
+		// gating could be compared.
+		return nil, nil
+	}
+
+	// Both granted means the server gates nothing, which is
+	// mcp-resources-unauth-001 and mcp-tools-unauth-001 territory rather than a
+	// difference between wires. Both refused is the secure outcome. Either way
+	// there is no asymmetry to report.
+	if legacyOutcome.granted == modernOutcome.granted {
+		return nil, nil
+	}
+
+	open, closed := legacyOutcome, modernOutcome
+	if modernOutcome.granted {
+		open, closed = modernOutcome, legacyOutcome
+	}
+	return []attack.Finding{e.finding(*legacy, open, closed)}, nil
+}
+
+// listOutcome is one wire's answer to a read-only list call.
+type listOutcome struct {
+	era    Era
+	method string // "" when the wire advertised nothing listable
+	status int
+	body   string
+	// granted is true when the call was answered with a JSON-RPC result rather
+	// than refused, which for an unauthenticated probe means no gate stopped it.
+	granted bool
+}
+
+// probeList asks one wire for a listing, choosing a method that wire advertises.
+//
+// The capability is read from that wire's own advertisement, because the two need
+// not agree: on a server built on the Python SDK the handshake reports
+// experimental, prompts, resources and tools while server/discover reports
+// prompts, resources and tools. Comparing a method one wire does not implement
+// against one it does would measure the capability difference, not the gate.
+func (e *EraDowngradeExecutor) probeList(ctx context.Context, client *attack.HTTPClient, session mcpSession) listOutcome {
+	out := listOutcome{era: session.Era}
+
+	for _, c := range []struct{ capability, method string }{
+		{"tools", "tools/list"},
+		{"resources", "resources/list"},
+		{"prompts", "prompts/list"},
+	} {
+		if !session.ServerSupports(c.capability) {
+			continue
+		}
+		out.method = c.method
+		break
+	}
+	if out.method == "" {
+		return out
+	}
+
+	resp, err := session.post(ctx, client, 2, out.method, nil)
+	if err != nil {
+		// A transport failure is not a refusal, and treating it as one would invent
+		// an asymmetry out of a dropped connection. Leaving method set with granted
+		// false would do exactly that, so the outcome is blanked.
+		out.method = ""
+		return out
+	}
+	out.status = resp.StatusCode
+	out.body = resp.BodyString()
+	out.granted = resp.IsAccepted()
+	return out
+}
+
+func (e *EraDowngradeExecutor) finding(session mcpSession, open, closed listOutcome) attack.Finding {
+	return attack.Finding{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "critical",
+		Confidence: attack.ConfirmedExploit,
+		Title: fmt.Sprintf("MCP authorization enforced on the %s wire but not the %s wire (era downgrade bypass)",
+			closed.era, open.era),
+		Description: fmt.Sprintf(
+			"At %s, an unauthenticated %s was REFUSED on the %s wire but ANSWERED on the %s wire. "+
+				"The server serves both protocol eras on one endpoint and applies its authorization "+
+				"check to only one of them, so a caller reaches protected functionality by asking on "+
+				"the other. Nothing about the two eras changes who is allowed to read what.",
+			session.Endpoint, open.method, closed.era, open.era),
+		Evidence: fmt.Sprintf(
+			"endpoint: %s\n%s wire: %s -> HTTP %d, refused\n%s wire: %s -> HTTP %d, answered\nanswered body: %.300s",
+			session.Endpoint,
+			closed.era, closed.method, closed.status,
+			open.era, open.method, open.status, open.body),
+		Remediation: e.rule.Remediation,
+		TargetURL:   session.Endpoint,
+	}
+}

--- a/internal/attack/mcp/era_downgrade_test.go
+++ b/internal/attack/mcp/era_downgrade_test.go
@@ -1,0 +1,236 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+func eraDowngradeRC() attack.RuleContext {
+	return attack.RuleContext{
+		ID: "mcp-era-downgrade-001", Name: "MCP Protocol Era Downgrade Auth Bypass",
+		Severity: "critical", Remediation: "Gate both request paths in one place.",
+	}
+}
+
+// dualEraGateServer serves both wires and gates tools/list on whichever of them
+// gateLegacy / gateModern say. Any combination is expressible, which is what the
+// rule's discriminator has to be judged against.
+//
+// Both wires are always openable: the handshake and server/discover are never
+// gated, so the rule is comparing method-level access rather than which era it
+// could reach at all.
+func dualEraGateServer(t *testing.T, gateLegacy, gateModern bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mcp" {
+			http.NotFound(w, r)
+			return
+		}
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method, _ := body["method"].(string)
+		id := body["id"]
+		modern := r.Header.Get("MCP-Protocol-Version") == "2026-07-28"
+		w.Header().Set("Content-Type", "application/json")
+
+		result := func(v map[string]interface{}) {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id, "result": v})
+		}
+		refuse := func() {
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": -32001, "message": "Unauthorized"},
+			})
+		}
+
+		switch method {
+		case "server/discover":
+			if !modern {
+				refuse()
+				return
+			}
+			result(map[string]interface{}{
+				"supportedVersions": []string{"2026-07-28"}, "resultType": "complete",
+				"capabilities": map[string]interface{}{"tools": map[string]interface{}{}},
+			})
+		case "initialize":
+			if modern {
+				refuse()
+				return
+			}
+			w.Header().Set("Mcp-Session-Id", "sess-1")
+			result(map[string]interface{}{
+				"protocolVersion": "2025-06-18",
+				"serverInfo":      map[string]interface{}{"name": "gate", "version": "1"},
+				"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			if (modern && gateModern) || (!modern && gateLegacy) {
+				refuse()
+				return
+			}
+			result(map[string]interface{}{"tools": []interface{}{map[string]interface{}{"name": "echo"}}})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": -32601, "message": "Method not found"},
+			})
+		}
+	}))
+}
+
+func runEraDowngrade(t *testing.T, ts *httptest.Server) []attack.Finding {
+	t.Helper()
+	findings, err := mcpattack.NewEraDowngradeExecutor(eraDowngradeRC()).
+		Execute(context.Background(), ts.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return findings
+}
+
+// The bug: the gate is on the handshake era only, so the stateless era answers
+// without credentials.
+func TestEraDowngrade_ModernWireUngated(t *testing.T) {
+	ts := dualEraGateServer(t, true, false)
+	defer ts.Close()
+
+	findings := runEraDowngrade(t, ts)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Severity != "critical" || f.Confidence != attack.ConfirmedExploit {
+		t.Errorf("want critical/ConfirmedExploit, got %q/%q", f.Severity, f.Confidence)
+	}
+	if !strings.Contains(f.Evidence, "modern wire: tools/list") {
+		t.Errorf("evidence should name the answering wire and method, got:\n%s", f.Evidence)
+	}
+}
+
+// The same bug the other way round, which is just as exploitable: whichever wire
+// is open is the one that gets used.
+func TestEraDowngrade_LegacyWireUngated(t *testing.T) {
+	ts := dualEraGateServer(t, false, true)
+	defer ts.Close()
+
+	findings := runEraDowngrade(t, ts)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %+v", len(findings), findings)
+	}
+	if !strings.Contains(findings[0].Title, "not the legacy wire") {
+		t.Errorf("title should name the open wire, got %q", findings[0].Title)
+	}
+}
+
+// No auth anywhere is the unauth rules' finding, not an asymmetry. Reporting it
+// here would double-count every unauthenticated server.
+func TestEraDowngrade_NoGateAnywhereIsSuppressed(t *testing.T) {
+	ts := dualEraGateServer(t, false, false)
+	defer ts.Close()
+
+	if findings := runEraDowngrade(t, ts); len(findings) != 0 {
+		t.Errorf("expected zero findings when the server gates nothing, got %d: %+v", len(findings), findings)
+	}
+}
+
+func TestEraDowngrade_GatedOnBothWiresIsSecure(t *testing.T) {
+	ts := dualEraGateServer(t, true, true)
+	defer ts.Close()
+
+	if findings := runEraDowngrade(t, ts); len(findings) != 0 {
+		t.Errorf("expected zero findings when both wires are gated, got %d: %+v", len(findings), findings)
+	}
+}
+
+// A server serving one era cannot disagree with itself.
+func TestEraDowngrade_SingleEraIsNotApplicable(t *testing.T) {
+	for name, srv := range map[string]*httptest.Server{
+		"legacy-only": legacyOnlyGateServer(t),
+		"modern-only": modernOnlyGateServer(t),
+	} {
+		t.Run(name, func(t *testing.T) {
+			defer srv.Close()
+			if findings := runEraDowngrade(t, srv); len(findings) != 0 {
+				t.Errorf("expected zero findings against a single-era server, got %d", len(findings))
+			}
+		})
+	}
+}
+
+func TestEraDowngrade_NothingReachableIsNotTested(t *testing.T) {
+	ts := httptest.NewServer(http.NotFoundHandler())
+	defer ts.Close()
+
+	_, err := mcpattack.NewEraDowngradeExecutor(eraDowngradeRC()).
+		Execute(context.Background(), ts.URL, testOpts())
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive, got %v", err)
+	}
+}
+
+func legacyOnlyGateServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method, _ := body["method"].(string)
+		id := body["id"]
+		w.Header().Set("Content-Type", "application/json")
+		if r.Header.Get("MCP-Protocol-Version") == "2026-07-28" {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": -32022, "message": "UnsupportedProtocolVersion"}})
+			return
+		}
+		switch method {
+		case "initialize":
+			w.Header().Set("Mcp-Session-Id", "s")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{"protocolVersion": "2025-06-18",
+					"serverInfo":   map[string]interface{}{"name": "legacy", "version": "1"},
+					"capabilities": map[string]interface{}{"tools": map[string]interface{}{}}}})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{"tools": []interface{}{}}})
+		}
+	}))
+}
+
+func modernOnlyGateServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method, _ := body["method"].(string)
+		id := body["id"]
+		w.Header().Set("Content-Type", "application/json")
+		if r.Header.Get("MCP-Protocol-Version") != "2026-07-28" {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": -32000, "message": "Bad Request"}})
+			return
+		}
+		result := map[string]interface{}{"resultType": "complete"}
+		if method == "server/discover" {
+			result["supportedVersions"] = []string{"2026-07-28"}
+			result["capabilities"] = map[string]interface{}{"tools": map[string]interface{}{}}
+		} else {
+			result["tools"] = []interface{}{}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id, "result": result})
+	}))
+}

--- a/rules/mcp/era-downgrade-001.yaml
+++ b/rules/mcp/era-downgrade-001.yaml
@@ -1,0 +1,62 @@
+id: mcp-era-downgrade-001
+info:
+  name: MCP Protocol Era Downgrade Auth Bypass
+  author: batesian
+  severity: critical
+  description: |
+    Tests whether a server that serves BOTH MCP protocol eras on one endpoint
+    applies its authorization check to only one of them.
+
+    The 2026-07-28 revision is a second, independent request path: no handshake,
+    no session, the protocol version and client capabilities carried in each
+    request's _meta. Servers built on the current Tier-1 SDKs serve it alongside
+    the handshake-based revisions at the same URL, by default. An authorization
+    check added to one request path therefore leaves the other reachable, and a
+    caller simply asks on the wire that answers.
+
+    Serving both eras is SPEC-COMPLIANT and is NOT reported. The finding is
+    specifically the asymmetry, confirmed by asking the same read-only listing on
+    each wire with no credentials and comparing:
+
+    - one wire REFUSED and the other ANSWERED => confirmed bypass
+      (critical / ConfirmedExploit). Direction does not matter: whichever wire is
+      open is the one an attacker uses.
+    - both answered => the server gates nothing; that is reported by
+      mcp-resources-unauth-001 and mcp-tools-unauth-001, not here.
+    - both refused => the gate is applied uniformly (secure).
+    - only one era served => nothing to compare (not applicable).
+
+    The listing method is chosen per wire from that wire's own advertised
+    capabilities, because the two need not match; comparing a method one wire does
+    not implement would measure the capability difference rather than the gate.
+
+    Scope: this compares access at the METHOD level, on wires that both open
+    unauthenticated. A server that instead gates the handshake itself, so that only
+    one wire opens at all, is not reported here.
+
+  references:
+    - https://modelcontextprotocol.io/specification/2026-07-28
+    - https://modelcontextprotocol.io/docs/concepts/authorization
+    - https://cwe.mitre.org/data/definitions/757.html
+
+  tags:
+    - mcp
+    - auth-bypass
+    - era-downgrade
+    - protocol
+    - cwe-757
+
+attack:
+  protocol: mcp
+  type: mcp-era-downgrade
+
+remediation: |
+  1. Apply authentication and authorization in one place that both request paths
+     traverse, rather than per handler or per transport. If the check lives in the
+     handshake, the stateless era has no handshake to carry it.
+  2. Treat the 2026-07-28 entry point as a full second surface in review and
+     testing: every method reachable on it needs the same gate as its
+     handshake-era counterpart.
+  3. If only one era is intended to be served, disable the other explicitly
+     (for example the TypeScript SDK's `legacy` option) rather than leaving it
+     enabled and ungated.

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -25,7 +25,7 @@ starting.
 
 ## Server Registry
 
-The bundled rule set is **17 A2A + 18 MCP = 35 rules**. Every rule's primary
+The bundled rule set is **17 A2A + 19 MCP = 36 rules**. Every rule's primary
 validation is an in-process `net/http/httptest` harness in its Go
 `*_test.go` (multiple server postures: vulnerable must fire / patched / open /
 benign must stay silent). The Python servers below are optional standalone
@@ -60,8 +60,9 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_logging_unauth_server.py` | 7797 | `mcp-logging-unauth-001` |
 | `mcp_task_idor_server.py` | 7798 | `mcp-task-idor-001` (two principals; needs two `--principal`s) |
 | `mcp_modern_era_server.py` | 7799 | none, by design: an era-detection target, see below |
+| `mcp_era_downgrade_server.py` | 7800 | `mcp-era-downgrade-001` (gates the handshake wire only) |
 
-**Coverage.** 34 of the 35 rules have a standalone Python fixture above. The
+**Coverage.** 35 of the 36 rules have a standalone Python fixture above. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
 (`internal/attack/mcp/token_replay_test.go`); the same is true of the per-rule
 edge-case harnesses for every other rule. `mockserver.go` is a Go helper used by

--- a/testdata/mcp_era_downgrade_server.py
+++ b/testdata/mcp_era_downgrade_server.py
@@ -1,0 +1,98 @@
+"""
+Batesian MCP validation target: era downgrade auth bypass (mcp-era-downgrade-001).
+
+Serves BOTH protocol eras on one endpoint, and enforces its bearer check on the
+handshake era only. The stateless 2026-07-28 path was added later and nobody put
+the gate on it, which is the mistake this rule looks for and the shape a real
+deployment reaches by bolting authorization onto one request path.
+
+This is hand-rolled rather than built on the MCP SDK on purpose: the SDK serves
+both eras correctly and applies no authorization at all, so it cannot exhibit the
+asymmetry. That also means this rule has no reference implementation to be
+validated against, only this fixture.
+
+Run:
+    python testdata/mcp_era_downgrade_server.py
+
+Endpoint: http://127.0.0.1:7800/mcp
+
+Expect: mcp-era-downgrade-001 confirms, and the unauth rules stay silent on the
+legacy wire while reporting the modern one.
+"""
+import json
+
+import uvicorn
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+PORT = 7800
+MODERN = "2026-07-28"
+VALID_TOKEN = "Bearer letmein"
+
+TOOLS = [{"name": "echo", "description": "Echoes input"}]
+
+
+def rpc_error(req_id, code, message):
+    return JSONResponse(
+        {"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}},
+        status_code=401 if code == -32001 else 400,
+    )
+
+
+async def mcp(request: Request) -> JSONResponse:
+    try:
+        body = await request.json()
+    except Exception:
+        return rpc_error(None, -32700, "Parse error")
+
+    method = body.get("method")
+    req_id = body.get("id")
+    modern = request.headers.get("mcp-protocol-version") == MODERN
+    authorized = request.headers.get("authorization") == VALID_TOKEN
+
+    # --- 2026-07-28: stateless, no handshake. The gate was never added here. ---
+    if modern:
+        if request.headers.get("mcp-method") != method:
+            return rpc_error(req_id, -32020, "mcp-method header does not match the body's method")
+        params = body.get("params") or {}
+        if not isinstance(params.get("_meta"), dict):
+            return rpc_error(req_id, -32602, "params._meta is required")
+
+        envelope = {"cacheScope": "private", "resultType": "complete", "ttlMs": 0, "_meta": {}}
+        if method == "server/discover":
+            envelope["supportedVersions"] = [MODERN]
+            envelope["capabilities"] = {"tools": {"listChanged": False}}
+        elif method == "tools/list":
+            # VULNERABILITY: no authorization check on this wire.
+            envelope["tools"] = TOOLS
+        else:
+            return rpc_error(req_id, -32601, "Method not found")
+        return JSONResponse({"jsonrpc": "2.0", "id": req_id, "result": envelope})
+
+    # --- handshake era: the bearer check lives here, and only here. ---
+    if method == "initialize":
+        return JSONResponse(
+            {"jsonrpc": "2.0", "id": req_id, "result": {
+                "protocolVersion": "2025-06-18",
+                "serverInfo": {"name": "era-downgrade-target", "version": "1.0"},
+                "capabilities": {"tools": {"listChanged": False}},
+            }},
+            headers={"Mcp-Session-Id": "era-downgrade-session"},
+        )
+    if method == "notifications/initialized":
+        return JSONResponse({}, status_code=202)
+    if method == "tools/list":
+        if not authorized:
+            return rpc_error(req_id, -32001, "Unauthorized")
+        return JSONResponse({"jsonrpc": "2.0", "id": req_id, "result": {"tools": TOOLS}})
+    return rpc_error(req_id, -32601, "Method not found")
+
+
+app = Starlette(routes=[Route("/mcp", mcp, methods=["POST"])])
+
+if __name__ == "__main__":
+    print(f"Starting MCP era-downgrade target on http://127.0.0.1:{PORT}/mcp")
+    print(json.dumps({"gated": "2025-06-18 wire", "open": f"{MODERN} wire"}))
+    uvicorn.run(app, host="127.0.0.1", port=PORT, log_level="warning")


### PR DESCRIPTION
The 2026-07-28 revision is a second, independent request path, and the current SDKs serve it alongside the handshake revisions at the same URL **by default**. An authorization check added to one path leaves the other reachable. This is `mcp-init-downgrade-001`'s bug with wires in place of versions, and it becomes the normal production shape as the SDKs are adopted.

## Discriminator

Serving both eras is spec-compliant and is not reported. The rule asks the same read-only listing on each wire with no credentials:

| Legacy | Modern | Verdict |
|---|---|---|
| refused | answered | **confirmed**, critical |
| answered | refused | **confirmed**, critical — direction is irrelevant |
| answered | answered | suppressed: gates nothing, the unauth rules report that |
| refused | refused | secure |
| one era only | — | not applicable |

The listing method is chosen **per wire from that wire's own advertisement**, since the two need not agree: on a Python SDK server the handshake reports `experimental, prompts, resources, tools` while `server/discover` reports `prompts, resources, tools`. Comparing a method one wire doesn't implement would measure the capability difference rather than the gate. A transport failure blanks the outcome rather than counting as a refusal, so a dropped connection can't invent an asymmetry.

## Validation, stated plainly

`testdata/mcp_era_downgrade_server.py` gates the handshake wire only:

```
legacy wire: tools/list -> HTTP 401, refused
modern wire: tools/list -> HTTP 200, answered
```

**No reference implementation can demonstrate this**, as I flagged in the brief: the SDKs serve both eras correctly and apply no authorization, so both wires answer and the rule correctly stays silent — which is the negative control I did run against the real SDK. The fixture is hand-rolled rather than SDK-based for exactly that reason.

Six unit postures cover both bypass directions, both suppressions, single-era, and nothing-reachable.

A full scan of the fixture shows the rules are complementary rather than overlapping: this one reports the asymmetry, `mcp-tools-unauth-001` separately reports the open wire labelled as 2026-07-28.

## Scope left out

A server that gates the *handshake itself*, so only one wire opens at all, is a different signal and is not reported here. The rule description says so.

Counts updated in `README.md`, `docs/rules-mcp.md`, `testdata/README.md` and the release header: 19 MCP, 36 total.

`go test -race ./...`, `go vet` (both tags), `gofmt`, `golangci-lint` v2.11.4 clean.