### PR TITLE
fix(mcp): read supportedVersions before declaring a modern wire

### DIFF
--- a/internal/attack/mcp/era.go
+++ b/internal/attack/mcp/era.go
@@ -117,6 +117,39 @@ func isModernError(body []byte) bool {
 	return code >= modernErrCodeMin && code <= modernErrCodeMax
 }
 
+// modernWireAdvertised reports whether a server/discover reply lists the modern
+// revision among the versions the server says it supports.
+//
+// Answering server/discover is not the same as serving the modern wire. The
+// specification requires every server to implement the RPC, and describes
+// supportedVersions as the list from which "the client should choose a version
+// for use in subsequent requests". A server built on the Go SDK takes that
+// literally: a handshake-only (non-stateless) deployment answers discovery with
+// only 2025-era versions, then rejects any 2026-07-28 request with a plain-text
+// HTTP 400 saying the version needs a stateless server. Keying on "discovery
+// answered" read that refusal as an authorization refusal, and reported a
+// critical era-downgrade bypass against a server enforcing no authorization at
+// all.
+//
+// A reply without supportedVersions is not a DiscoverResult: the field is
+// required in the specification and in all three official SDKs.
+func modernWireAdvertised(body []byte) bool {
+	var envelope struct {
+		Result *struct {
+			SupportedVersions []string `json:"supportedVersions"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil || envelope.Result == nil {
+		return false
+	}
+	for _, v := range envelope.Result.SupportedVersions {
+		if v == modernEraVersion {
+			return true
+		}
+	}
+	return false
+}
+
 // jsonRPCErrorCode extracts the numeric code from a JSON-RPC error envelope.
 // ok is false when the body is not JSON, carries no error object, or the error
 // has no numeric code.
@@ -138,12 +171,15 @@ func jsonRPCErrorCode(body []byte) (int, bool) {
 // detectEra determines which protocol era the server at endpoint implements by
 // sending a modern server/discover request and classifying the reply.
 //
-// server/discover is the right probe because a modern server MUST implement it,
-// so its absence is itself diagnostic. The classification follows the rule the
-// Streamable HTTP binding gives for backward compatibility: attempt a modern
-// request, and on a rejection inspect the body before concluding anything. A
-// recognized modern error means the server speaks a modern revision (the client
-// should correct its request rather than fall back); anything else means legacy.
+// server/discover is the right probe because its reply names the versions the
+// server serves, which is the question being asked. Answering it is not itself
+// the signal: every server MUST implement the RPC, so a handshake-only server
+// answers too and names only handshake-era versions. The classification follows
+// the rule the Streamable HTTP binding gives for backward compatibility: attempt
+// a modern request, and on a rejection inspect the body before concluding
+// anything. A recognized modern error means the server speaks a modern revision
+// (the client should correct its request rather than fall back); anything else
+// means legacy.
 //
 // Only a transport failure yields EraUnknown. Any HTTP reply, including 404 or
 // 405, tells us something answered, and absent a modern error that answer is
@@ -178,8 +214,10 @@ func detectEra(ctx context.Context, client *attack.HTTPClient, endpoint string) 
 		return EraUnknown
 	}
 
-	// A DiscoverResult means the server implements the modern discovery RPC.
-	if resp.IsAccepted() {
+	// A DiscoverResult that advertises the modern revision means the server
+	// serves that wire. Discovery answering at all does not, because every
+	// server implements the RPC whatever era it serves; see modernWireAdvertised.
+	if resp.IsAccepted() && modernWireAdvertised(resp.Body) {
 		return EraModern
 	}
 	// A spec-reserved error code can only come from a modern server, whatever

--- a/internal/attack/mcp/era_downgrade_test.go
+++ b/internal/attack/mcp/era_downgrade_test.go
@@ -169,6 +169,65 @@ func TestEraDowngrade_SingleEraIsNotApplicable(t *testing.T) {
 	}
 }
 
+// The false positive this rule shipped with, reproduced. A server built on the
+// Go SDK without StreamableHTTPOptions.Stateless answers server/discover, as
+// every server must, advertises only handshake-era versions, and rejects a
+// 2026-07-28 request with a plain-text HTTP 400 saying the version needs a
+// stateless server. Nothing here is gated.
+//
+// Taking the discovery answer as a modern wire made that 400 the "refused" half
+// of an asymmetry, and the rule reported a critical authorization bypass against
+// a server enforcing no authorization at all.
+func TestEraDowngrade_DiscoveryWithoutModernVersionIsNotAnAsymmetry(t *testing.T) {
+	ts := discoveryOnLegacyServer(t)
+	defer ts.Close()
+
+	if findings := runEraDowngrade(t, ts); len(findings) != 0 {
+		t.Errorf("expected zero findings: the modern wire is absent, not gated. Got %d: %+v",
+			len(findings), findings)
+	}
+}
+
+func discoveryOnLegacyServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method, _ := body["method"].(string)
+		id := body["id"]
+
+		if method == "server/discover" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{"resultType": "complete",
+					"supportedVersions": []string{"2025-11-25", "2025-06-18"},
+					"capabilities":      map[string]interface{}{"tools": map[string]interface{}{}}}})
+			return
+		}
+		if r.Header.Get("MCP-Protocol-Version") == "2026-07-28" {
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`Bad Request: protocol version "2026-07-28" is only supported on stateless HTTP servers`))
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		switch method {
+		case "initialize":
+			w.Header().Set("Mcp-Session-Id", "s")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{"protocolVersion": "2025-06-18",
+					"serverInfo":   map[string]interface{}{"name": "discovery-only", "version": "1"},
+					"capabilities": map[string]interface{}{"tools": map[string]interface{}{}}}})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{"tools": []interface{}{map[string]interface{}{"name": "echo"}}}})
+		}
+	}))
+}
+
 func TestEraDowngrade_NothingReachableIsNotTested(t *testing.T) {
 	ts := httptest.NewServer(http.NotFoundHandler())
 	defer ts.Close()

--- a/internal/attack/mcp/era_live_test.go
+++ b/internal/attack/mcp/era_live_test.go
@@ -43,9 +43,10 @@ func liveClient() *attack.HTTPClient {
 	return attack.NewUnauthHTTPClient(opts, attack.NewVars("", ""))
 }
 
-// A server that answers server/discover must be classified modern. If the
-// specification or the SDK changes the shape of that reply, this is where we
-// find out.
+// A server whose server/discover reply advertises the modern revision must be
+// classified modern. Detection reads that reply's supportedVersions rather than
+// the fact that it answered, so if the specification or the SDK changes the shape
+// of the field, this is where we find out.
 func TestDetectEra_LiveModernServer(t *testing.T) {
 	ep := liveEndpoint(t)
 

--- a/internal/attack/mcp/era_test.go
+++ b/internal/attack/mcp/era_test.go
@@ -118,6 +118,24 @@ func TestDetectEra(t *testing.T) {
 			want:   EraLegacy,
 			why:    "a 2xx carrying a legacy error is not a DiscoverResult",
 		},
+		{
+			// The shape a handshake-only server built on the Go SDK returns. It
+			// answers discovery, as every server must, and names only the eras it
+			// actually serves. Reading the answer itself as modern classified it
+			// as a wire it rejects with HTTP 400.
+			name:   "discover result advertising only handshake-era versions",
+			status: 200,
+			body:   `{"jsonrpc":"2.0","id":"x","result":{"resultType":"complete","supportedVersions":["2025-11-25","2025-06-18","2024-11-05"],"capabilities":{}}}`,
+			want:   EraLegacy,
+			why:    "the server names the versions it serves and the modern revision is not among them",
+		},
+		{
+			name:   "discover result carrying no supportedVersions",
+			status: 200,
+			body:   `{"jsonrpc":"2.0","id":"x","result":{"resultType":"complete","capabilities":{}}}`,
+			want:   EraLegacy,
+			why:    "supportedVersions is required on a DiscoverResult, so a reply without it is not one",
+		},
 	}
 
 	for _, tt := range tests {
@@ -212,6 +230,38 @@ func TestIsModernError(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := isModernError([]byte(tt.body)); got != tt.want {
 				t.Errorf("isModernError(%s) = %v, want %v", tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestModernWireAdvertised covers the discriminator directly, because both
+// detectEra and discoverModern rest on it and the interesting cases are all in
+// how a DiscoverResult is shaped rather than in the HTTP exchange around it.
+func TestModernWireAdvertised(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"modern only", `{"result":{"supportedVersions":["2026-07-28"],"capabilities":{}}}`, true},
+		{"modern among others", `{"result":{"supportedVersions":["2026-07-28","2025-11-25"],"capabilities":{}}}`, true},
+		{"modern last", `{"result":{"supportedVersions":["2025-06-18","2026-07-28"],"capabilities":{}}}`, true},
+		{"handshake eras only", `{"result":{"supportedVersions":["2025-11-25","2024-11-05"],"capabilities":{}}}`, false},
+		{"empty list", `{"result":{"supportedVersions":[],"capabilities":{}}}`, false},
+		{"field absent", `{"result":{"capabilities":{},"resultType":"complete"}}`, false},
+		{"no result object", `{"jsonrpc":"2.0","id":1,"error":{"code":-32601}}`, false},
+		// The version must be read from result.supportedVersions and nowhere
+		// else: a server may mention the revision in instructions or _meta
+		// without serving it, and a substring match would take that as proof.
+		{"version named outside supportedVersions", `{"result":{"supportedVersions":["2025-11-25"],"instructions":"upgrading to 2026-07-28 soon","capabilities":{}}}`, false},
+		{"not json", `Bad Request: protocol version "2026-07-28" is only supported on stateless HTTP servers`, false},
+		{"empty", ``, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := modernWireAdvertised([]byte(tt.body)); got != tt.want {
+				t.Errorf("modernWireAdvertised(%s) = %v, want %v", tt.body, got, tt.want)
 			}
 		})
 	}

--- a/internal/attack/mcp/wire.go
+++ b/internal/attack/mcp/wire.go
@@ -164,13 +164,18 @@ func openSessions(ctx context.Context, client *attack.HTTPClient, baseURL string
 // the server's capabilities, and the rules that gate on a capability need them.
 // The result carries them under the same result.capabilities path an initialize
 // result uses, so ServerSupports reads either without knowing the difference.
+//
+// A reply is only taken as a modern wire when it advertises the modern revision
+// in its own supportedVersions. Every server implements server/discover whatever
+// era it serves, so answering it proves nothing on its own; see
+// modernWireAdvertised for what treating the answer as proof cost.
 func discoverModern(ctx context.Context, client *attack.HTTPClient, ep string) (mcpSession, bool) {
 	probe := mcpSession{Endpoint: ep, Era: EraModern}
 	resp, err := probe.post(ctx, client, "batesian-discover", "server/discover", nil)
 	if err != nil || !resp.IsAccepted() {
 		return mcpSession{}, false
 	}
-	if !resp.ContainsAny(`"capabilities"`, `"supportedVersions"`, `"resultType"`) {
+	if !modernWireAdvertised(resp.Body) {
 		return mcpSession{}, false
 	}
 	return mcpSession{

--- a/internal/attack/mcp/wire_test.go
+++ b/internal/attack/mcp/wire_test.go
@@ -204,6 +204,87 @@ func TestOpenSessions_ModernOnly(t *testing.T) {
 	}
 }
 
+// discoveryOnlyServer serves the handshake wire, answers server/discover on any
+// version while naming only handshake-era versions, and rejects every modern
+// request with the plain-text 400 the Go SDK returns. Nothing is gated.
+//
+// This is the shape that made the modern wire look present when it is not: a
+// server built on the Go SDK without StreamableHTTPOptions.Stateless. Every
+// server must implement the discovery RPC, so answering it says nothing about
+// which wire is served.
+func discoveryOnlyServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mcp" {
+			http.NotFound(w, r)
+			return
+		}
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method, _ := body["method"].(string)
+		id := body["id"]
+
+		if method == "server/discover" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{
+					"resultType":        "complete",
+					"supportedVersions": []string{"2025-11-25", "2025-06-18", "2024-11-05"},
+					"capabilities":      map[string]interface{}{"tools": map[string]interface{}{}},
+				},
+			})
+			return
+		}
+		if r.Header.Get("MCP-Protocol-Version") == modernEraVersion {
+			// Not a JSON-RPC error and not an authorization refusal: the version
+			// is simply not served here.
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`Bad Request: protocol version "2026-07-28" is only supported on stateless HTTP servers`))
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		switch method {
+		case "initialize":
+			w.Header().Set("Mcp-Session-Id", "sess-1")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{
+					"protocolVersion": "2025-06-18",
+					"serverInfo":      map[string]interface{}{"name": "discovery-only", "version": "1"},
+					"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+				},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{"tools": []interface{}{map[string]interface{}{"name": "echo"}}},
+			})
+		}
+	}))
+}
+
+// A server that answers discovery without advertising the modern revision serves
+// one wire, so only one session may come back. A second, phantom session would
+// have every dual-wire rule probing a surface that answers HTTP 400 to
+// everything, and each of those 400s reads as a refusal.
+func TestOpenSessions_DiscoveryWithoutModernVersionIsLegacyOnly(t *testing.T) {
+	srv := discoveryOnlyServer(t)
+	defer srv.Close()
+
+	sessions, err := openSessions(context.Background(), wireClient(), srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].Era != EraLegacy {
+		t.Fatalf("expected one legacy session, got %d: %+v", len(sessions), sessions)
+	}
+}
+
 func TestOpenSessions_NeitherWireIsInconclusive(t *testing.T) {
 	srv := httptest.NewServer(http.NotFoundHandler())
 	defer srv.Close()

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -60,7 +60,7 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_logging_unauth_server.py` | 7797 | `mcp-logging-unauth-001` |
 | `mcp_task_idor_server.py` | 7798 | `mcp-task-idor-001` (two principals; needs two `--principal`s) |
 | `mcp_modern_era_server.py` | 7799 | none, by design: an era-detection target, see below |
-| `mcp_era_downgrade_server.py` | 7800 | `mcp-era-downgrade-001` (gates the handshake wire only) |
+| `mcp_era_downgrade_server.py` | 7800 | `mcp-era-downgrade-001` (two postures, see below) |
 
 **Coverage.** 35 of the 36 rules have a standalone Python fixture above. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
@@ -72,9 +72,12 @@ unit tests via `net/http/httptest`; it is not a standalone server.
 vulnerable.** It is built on the official MCP Python SDK and speaks the
 2026-07-28 revision, so era detection (`internal/attack/mcp/era.go`) can be
 checked against a real modern server instead of against the specification alone.
-No rule fires against it, and a scan reporting nothing is the expected result.
-`.github/workflows/mcp-era-watch.yml` starts it weekly and runs the
-integration-tagged tests in `internal/attack/mcp/era_live_test.go` against it:
+It is not, however, a silent target: the SDK applies no authorization, so the
+unauth rules fire against it on both wires and report roughly ten findings. What
+this fixture proves is that the era is detected and driven correctly, not that a
+scan comes back clean. `.github/workflows/mcp-era-watch.yml` starts it weekly and
+runs the integration-tagged tests in `internal/attack/mcp/era_live_test.go`
+against it:
 
 ```sh
 python testdata/mcp_modern_era_server.py &
@@ -85,6 +88,24 @@ BATESIAN_LIVE_MCP_ENDPOINT=http://127.0.0.1:7799/mcp \
 Because the SDK serves both eras from one server, it also answers the 2025-era
 `initialize` handshake, which is why the existing rules still work against
 current deployments.
+
+**`mcp_era_downgrade_server.py` takes a posture argument**, defaulting to
+`vulnerable`:
+
+```sh
+python testdata/mcp_era_downgrade_server.py vulnerable      # rule must fire
+python testdata/mcp_era_downgrade_server.py discovery-only  # rule must stay silent
+```
+
+`discovery-only` serves one wire and gates nothing, while still answering
+`server/discover` (which every server implements whatever era it serves) with a
+`supportedVersions` list that names only handshake-era revisions. It is the
+posture a server built on the Go SDK has when `StreamableHTTPOptions.Stateless`
+is left false. It exists because era detection used to read "discovery answered"
+as "the modern wire is served", which turned that server's `400 Bad Request:
+protocol version "2026-07-28" is only supported on stateless HTTP servers` into
+the refused half of an authorization asymmetry and produced a critical
+`mcp-era-downgrade-001` finding against a target with no authorization at all.
 
 The multi-tenant and delegation fixtures exercise the chained rules: they require
 two principals supplied with `--principal name=...,token=...,tenant=...` (or a

--- a/testdata/mcp_era_downgrade_server.py
+++ b/testdata/mcp_era_downgrade_server.py
@@ -1,37 +1,60 @@
 """
 Batesian MCP validation target: era downgrade auth bypass (mcp-era-downgrade-001).
 
-Serves BOTH protocol eras on one endpoint, and enforces its bearer check on the
-handshake era only. The stateless 2026-07-28 path was added later and nobody put
-the gate on it, which is the mistake this rule looks for and the shape a real
-deployment reaches by bolting authorization onto one request path.
+Two postures, selected by the first argument.
 
-This is hand-rolled rather than built on the MCP SDK on purpose: the SDK serves
-both eras correctly and applies no authorization at all, so it cannot exhibit the
-asymmetry. That also means this rule has no reference implementation to be
-validated against, only this fixture.
+`vulnerable` (the default) serves BOTH protocol eras on one endpoint and enforces
+its bearer check on the handshake era only. The stateless 2026-07-28 path was
+added later and nobody put the gate on it, which is the mistake this rule looks
+for and the shape a real deployment reaches by bolting authorization onto one
+request path.
+
+`discovery-only` serves ONE era and gates nothing. It still answers
+`server/discover`, which every server must implement whatever era it serves, and
+its reply names only handshake-era versions. Any 2026-07-28 request gets a
+plain-text HTTP 400 saying the version is not served here. This is the posture a
+server built on the Go SDK has when StreamableHTTPOptions.Stateless is left
+false, and it is the negative control: taking the discovery answer as a modern
+wire made that 400 look like the refused half of an asymmetry, and the rule
+reported a critical authorization bypass against a server with no authorization
+at all.
+
+This is hand-rolled rather than built on the MCP SDK on purpose: the Python SDK
+serves both eras correctly and applies no authorization, so it cannot exhibit the
+asymmetry the `vulnerable` posture needs.
 
 Run:
-    python testdata/mcp_era_downgrade_server.py
+    python testdata/mcp_era_downgrade_server.py [vulnerable|discovery-only]
 
 Endpoint: http://127.0.0.1:7800/mcp
 
-Expect: mcp-era-downgrade-001 confirms, and the unauth rules stay silent on the
-legacy wire while reporting the modern one.
+Expect, `vulnerable`: mcp-era-downgrade-001 confirms, and the unauth rules stay
+silent on the legacy wire while reporting the modern one.
+
+Expect, `discovery-only`: mcp-era-downgrade-001 stays silent, and the unauth
+rules report the one wire that is there, unlabelled.
 """
 import json
+import sys
 
 import uvicorn
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import JSONResponse
+from starlette.responses import JSONResponse, PlainTextResponse
 from starlette.routing import Route
 
 PORT = 7800
 MODERN = "2026-07-28"
 VALID_TOKEN = "Bearer letmein"
 
+POSTURES = ("vulnerable", "discovery-only")
+POSTURE = sys.argv[1] if len(sys.argv) > 1 else "vulnerable"
+
 TOOLS = [{"name": "echo", "description": "Echoes input"}]
+
+# The versions a handshake-only server names in its DiscoverResult. The modern
+# revision is deliberately absent: the server does not serve it.
+HANDSHAKE_VERSIONS = ["2025-11-25", "2025-06-18", "2024-11-05"]
 
 
 def rpc_error(req_id, code, message):
@@ -51,6 +74,24 @@ async def mcp(request: Request) -> JSONResponse:
     req_id = body.get("id")
     modern = request.headers.get("mcp-protocol-version") == MODERN
     authorized = request.headers.get("authorization") == VALID_TOKEN
+
+    if POSTURE == "discovery-only":
+        # Discovery is answered on every version, and names only what is served.
+        if method == "server/discover":
+            return JSONResponse({"jsonrpc": "2.0", "id": req_id, "result": {
+                "resultType": "complete",
+                "supportedVersions": HANDSHAKE_VERSIONS,
+                "capabilities": {"tools": {"listChanged": False}},
+            }})
+        if modern:
+            # Not JSON-RPC and not an authorization refusal: the version simply
+            # is not served here. This is the Go SDK's wording.
+            return PlainTextResponse(
+                f'Bad Request: protocol version "{MODERN}" is only supported on '
+                "stateless HTTP servers (set StreamableHTTPOptions.Stateless = true)",
+                status_code=400,
+            )
+        return legacy_wire(method, req_id, authorized=True)
 
     # --- 2026-07-28: stateless, no handshake. The gate was never added here. ---
     if modern:
@@ -72,6 +113,12 @@ async def mcp(request: Request) -> JSONResponse:
         return JSONResponse({"jsonrpc": "2.0", "id": req_id, "result": envelope})
 
     # --- handshake era: the bearer check lives here, and only here. ---
+    return legacy_wire(method, req_id, authorized)
+
+
+def legacy_wire(method, req_id, authorized):
+    """The handshake wire. authorized is passed in so the discovery-only posture
+    can serve the same wire with nothing gated."""
     if method == "initialize":
         return JSONResponse(
             {"jsonrpc": "2.0", "id": req_id, "result": {
@@ -93,6 +140,12 @@ async def mcp(request: Request) -> JSONResponse:
 app = Starlette(routes=[Route("/mcp", mcp, methods=["POST"])])
 
 if __name__ == "__main__":
-    print(f"Starting MCP era-downgrade target on http://127.0.0.1:{PORT}/mcp")
-    print(json.dumps({"gated": "2025-06-18 wire", "open": f"{MODERN} wire"}))
+    if POSTURE not in POSTURES:
+        sys.exit(f"unknown posture {POSTURE!r}; expected one of {', '.join(POSTURES)}")
+    print(f"Starting MCP era-downgrade target ({POSTURE}) on http://127.0.0.1:{PORT}/mcp")
+    if POSTURE == "vulnerable":
+        print(json.dumps({"gated": "2025-06-18 wire", "open": f"{MODERN} wire"}))
+    else:
+        print(json.dumps({"served": "2025-06-18 wire", "gated": None,
+                          "discovery": HANDSHAKE_VERSIONS}))
     uvicorn.run(app, host="127.0.0.1", port=PORT, log_level="warning")


### PR DESCRIPTION
Era detection treated any answered `server/discover` as proof the 2026-07-28 wire was served. Every MCP server implements that RPC whatever era it serves, so a handshake-only server answers too, and its reply names only the versions it actually serves.

A server built on the Go SDK without `StreamableHTTPOptions.Stateless` is exactly that. `server/discover` returns 200 with `supportedVersions` of `["2025-11-25","2025-06-18","2025-03-26","2024-11-05"]`, then any 2026-07-28 request gets:

```
400 Bad Request: protocol version "2026-07-28" is only supported on stateless HTTP servers
```

`mcp-era-downgrade-001` read that 400 as the refused half of an authorization asymmetry and reported a critical bypass against a target enforcing no authorization at all. The dual-wire rules also probed a wire that answers 400 to everything.

## Fix

`detectEra` and `discoverModern` now require the reply to advertise the modern revision in `result.supportedVersions`. The field is required on a `DiscoverResult` in the specification and in the Python, TypeScript and Go SDKs, and the specification's own description of it, "the client should choose a version from this list for use in subsequent requests", is the semantics being relied on. The reserved-error-code path (-32020..-32099) is unchanged.

`mcp_era_downgrade_server.py` takes a posture argument; the new `discovery-only` posture is the negative control.

## Verification

Baseline vs patched against five live servers:

| Target | Before | After |
|---|---|---|
| Go SDK v1.7.0, non-stateless | 9 | **8** |
| Go SDK v1.7.0, stateless | 13 (5 modern) | 13 (5 modern) |
| Python SDK v2 | 10 (5 modern) | 10 (5 modern) |
| TypeScript SDK v2 | 11 (5 modern) | 11 (5 modern) |
| Go SDK v1.7.0 secured, FastMCP secured | 0 | 0 |

Only the false positive is gone. The `vulnerable` fixture posture still confirms; the `discovery-only` posture is silent. Reverting the discriminator fails the three new behavioural tests.

Also corrects `testdata/README.md`, which claimed no rule fires against `mcp_modern_era_server.py`. The SDK applies no authorization, so the unauth rules have reported against it on both wires since they started running per wire.
