### PR TITLE
chore(ci): add a manual trigger and stop running CI twice per push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,23 @@ on:
     branches:
       - main
       - dev
-      # Same-repo feature work: CI on push without widening to arbitrary branch names.
-      - 'fix/**'
-      - 'feat/**'
-      - 'chore/**'
-      - 'docs/**'
     tags: ['v*']
   pull_request:
     branches: [main, dev]
+  # Manual trigger, for a branch with no open pull request yet and as the way in
+  # when event delivery is unavailable. During the 2026-08-06 Actions incident,
+  # webhooks were throttled to roughly 15% and neither a push nor a
+  # close/reopen produced a run, while the re-run endpoints deadlocked
+  # ("already running" against "has not yet queued"). workflow_dispatch is a
+  # direct API call and does not depend on webhook delivery.
+  workflow_dispatch:
+
+# One run per branch or pull request. A superseded run is cancelled rather than
+# left competing for a runner, which is what made the incident above worse.
+# Tag runs are never cancelled: that is the release path.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
 jobs:
   build:
@@ -85,7 +94,9 @@ jobs:
   release:
     name: Release (goreleaser)
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Tag PUSH only. workflow_dispatch accepts any ref, including a tag, so a
+    # ref test alone would let a manual run re-publish an existing release.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: [build, lint, vuln]
     permissions:
       contents: write      # create GitHub releases and upload assets

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,9 +16,16 @@ on:
     # Weekly, Monday 06:15 UTC. Catches newly published CodeQL queries against
     # code that has not otherwise changed.
     - cron: '15 6 * * 1'
+  # Manual trigger, for the reason given in ci.yml: it does not depend on
+  # webhook delivery, so it still works when event delivery is degraded.
+  workflow_dispatch:
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analyze:


### PR DESCRIPTION
During the 2026-08-06 Actions incident there was no way to start a run. Webhook delivery was throttled to roughly 15%, so neither a push nor a close/reopen of #139 produced one, and the re-run endpoints deadlocked:

| Endpoint | Response |
|---|---|
| `cancel` / `force-cancel` | 409 "Cannot cancel a workflow re-run that has not yet queued" |
| `rerun` / `rerun-failed-jobs` | 403 "This workflow is already running" |

Three runs sat queued for over two hours and could not be cleared.

## Fix

`workflow_dispatch` on CI and CodeQL is a direct API call and does not depend on webhook delivery, so it works when event delivery does not. `mcp-era-watch.yml` already had one.

It also covers what the feature-branch push triggers existed for, a branch with no PR open yet, so those are removed: a push to a branch with an open PR was starting two identical runs of Build & Test, Lint and Vulnerability Scan. Pushes to `main` and `dev`, tag pushes and `pull_request` are unchanged.

## Two guards that come with it

- The release job now requires `github.event_name == 'push'` as well as a v-prefixed ref. `workflow_dispatch` accepts any ref including a tag, so a ref test alone would let a manual run re-publish an existing release.
- Both workflows gain a concurrency group keyed on the ref, so a superseded run is cancelled instead of competing for a runner. Tag runs are exempt via `cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}` so a release is never cancelled mid-publish.

## Verification

`actionlint` clean across all four workflows. Parsing both files confirms CI exposes `push`, `pull_request` and `workflow_dispatch`, and that `release` is the only job carrying a condition. This PR is its own test of the dedupe: it should produce one CI run, not two.
