### PR TITLE
fix(a2a): read v1.0 security requirements from the shape cards actually use

### DIFF
--- a/internal/attack/a2a/card_security_shapes_test.go
+++ b/internal/attack/a2a/card_security_shapes_test.go
@@ -1,0 +1,106 @@
+package a2a
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// The AgentCard's requirements list has two wire shapes, and every finding this
+// rule produces names the scheme it read out of one of them. These cover the
+// parser directly, because the interesting cases are all in how a card is shaped
+// rather than in the HTTP exchange around it.
+func TestDeclaredAuthRequirement_Shapes(t *testing.T) {
+	tests := []struct {
+		name         string
+		card         string
+		wantSchemes  []string
+		wantRequired bool
+		why          string
+	}{
+		{
+			name:         "v1.0 proto shape",
+			card:         `{"securityRequirements":[{"schemes":{"bearerAuth":{"list":["a2a:invoke"]}}}]}`,
+			wantSchemes:  []string{"bearerAuth"},
+			wantRequired: true,
+			why:          "both official SDKs nest the names under schemes; this is what every real v1.0 card serves",
+		},
+		{
+			name:         "v1.0 proto shape, several schemes",
+			card:         `{"securityRequirements":[{"schemes":{"bearerAuth":{"list":[]},"apiKey":{"list":[]}}}]}`,
+			wantSchemes:  []string{"apiKey", "bearerAuth"},
+			wantRequired: true,
+			why:          "every name in the map is required, and the result is sorted",
+		},
+		{
+			name:         "v1.0 field with the OpenAPI-flat shape",
+			card:         `{"securityRequirements":[{"bearerAuth":["a2a:invoke"]}]}`,
+			wantSchemes:  []string{"bearerAuth"},
+			wantRequired: true,
+			why:          "a hand-rolled card may use the flat shape under the v1.0 field name",
+		},
+		{
+			name:         "v0.3 security field",
+			card:         `{"security":[{"bearerAuth":[]}]}`,
+			wantSchemes:  []string{"bearerAuth"},
+			wantRequired: true,
+			why:          "the v0.3 spelling must still be read",
+		},
+		{
+			name:         "v1.0 entry with an empty schemes map",
+			card:         `{"securityRequirements":[{"schemes":{}}]}`,
+			wantRequired: false,
+			why:          "a proto message always carries its map field, so this is how v1.0 says anonymous is permitted",
+		},
+		{
+			name:         "empty entry in the list",
+			card:         `{"securityRequirements":[{},{"schemes":{"bearerAuth":{"list":[]}}}]}`,
+			wantRequired: false,
+			why:          "an empty requirement object permits anonymous access whatever else the list holds",
+		},
+		{
+			name:         "no security declaration",
+			card:         `{"name":"agent"}`,
+			wantRequired: false,
+			why:          "nothing was promised, so nothing can be unenforced",
+		},
+		{
+			name:         "empty requirements list",
+			card:         `{"securityRequirements":[]}`,
+			wantRequired: false,
+			why:          "an empty list declares no requirement",
+		},
+		{
+			name:         "malformed entry",
+			card:         `{"securityRequirements":["bearerAuth"]}`,
+			wantRequired: false,
+			why:          "a non-object entry is not a requirement to assert a violation against",
+		},
+		{
+			// A v0.3 card may legitimately name a scheme "schemes". Its value is a
+			// scope array rather than an object, which is what tells the two
+			// shapes apart, so the nested branch must not claim this one.
+			name:         "v0.3 scheme literally named schemes",
+			card:         `{"security":[{"schemes":["read"]}]}`,
+			wantSchemes:  []string{"schemes"},
+			wantRequired: true,
+			why:          "the shapes are distinguished by structure, not by the name of the key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var card map[string]interface{}
+			if err := json.Unmarshal([]byte(tt.card), &card); err != nil {
+				t.Fatalf("bad test card: %v", err)
+			}
+			schemes, required := declaredAuthRequirement(card)
+			if required != tt.wantRequired {
+				t.Errorf("required = %v, want %v (%s)", required, tt.wantRequired, tt.why)
+			}
+			if tt.wantRequired && !reflect.DeepEqual(schemes, tt.wantSchemes) {
+				t.Errorf("schemes = %v, want %v (%s)", schemes, tt.wantSchemes, tt.why)
+			}
+		})
+	}
+}

--- a/internal/attack/a2a/card_security_unenforced.go
+++ b/internal/attack/a2a/card_security_unenforced.go
@@ -256,10 +256,11 @@ func declaredAuthRequirement(card map[string]interface{}) (schemes []string, req
 		if !ok {
 			return nil, false // malformed requirement entry: do not assert a violation
 		}
-		if len(obj) == 0 {
-			return nil, false // empty requirement object: anonymous access is allowed
+		names, ok := requirementSchemeNames(obj)
+		if !ok {
+			return nil, false // anonymous access is allowed by this entry
 		}
-		for name := range obj {
+		for _, name := range names {
 			if !seen[name] {
 				seen[name] = true
 				schemes = append(schemes, name)
@@ -268,6 +269,55 @@ func declaredAuthRequirement(card map[string]interface{}) (schemes []string, req
 	}
 	sort.Strings(schemes)
 	return schemes, true
+}
+
+// requirementSchemeNames returns the scheme names one requirement entry demands.
+// ok is false when the entry permits anonymous access, which is what an entry
+// carrying no scheme at all means.
+//
+// Two wire shapes exist and both are read here, because the field name alone does
+// not tell them apart.
+//
+// v1.0 is proto-derived: SecurityRequirement holds a single map field named
+// schemes, so an entry serializes as
+//
+//	{"schemes": {"bearerAuth": {"list": ["a2a:invoke"]}}}
+//
+// and the scheme names are one level down. Both official SDKs define it this way
+// (a2a-sdk's proto descriptor and @a2a-js/sdk's SecurityRequirement interface),
+// so this is the shape every real v1.0 card serves. Reading the entry's own keys
+// yielded the literal "schemes" as the scheme name on every one of them.
+//
+// v0.3 and OpenAPI put the names at the top level:
+//
+//	{"bearerAuth": ["a2a:invoke"]}
+//
+// The two are told apart by structure rather than by which card field they came
+// from: an entry whose only key is "schemes" mapping to an object is the proto
+// shape. A v0.3 card could in principle declare a scheme actually named
+// "schemes", but then its value is a scope array, not an object, so the check
+// does not misfire on it.
+func requirementSchemeNames(entry map[string]interface{}) (names []string, ok bool) {
+	if len(entry) == 0 {
+		return nil, false
+	}
+	if len(entry) == 1 {
+		if inner, isObject := entry["schemes"].(map[string]interface{}); isObject {
+			if len(inner) == 0 {
+				// An explicit empty scheme map requires nothing, the same
+				// statement {} makes in the v0.3 shape.
+				return nil, false
+			}
+			for name := range inner {
+				names = append(names, name)
+			}
+			return names, true
+		}
+	}
+	for name := range entry {
+		names = append(names, name)
+	}
+	return names, true
 }
 
 // cardSecurityList returns the requirements list, preferring the v1.0

--- a/internal/attack/a2a/card_security_unenforced_test.go
+++ b/internal/attack/a2a/card_security_unenforced_test.go
@@ -18,8 +18,11 @@ import (
 
 // cardSecServer builds a mock A2A server whose AgentCard security declaration and
 // JSON-RPC auth behavior depend on mode:
-//   - "vuln-v1":      card declares securityRequirements (v1.0 field) requiring a
-//     scheme, but message/send is served unauthenticated => finding.
+//   - "vuln-v1":      card declares securityRequirements in the real v1.0 wire
+//     shape (names nested under "schemes"), but message/send is served
+//     unauthenticated => finding.
+//   - "vuln-v1-flat":  the same field carrying the OpenAPI-flat shape, which a
+//     server that hand-rolls its card may serve => finding.
 //   - "vuln-v03":     same, but the card uses the v0.3 "security" field => finding
 //     (proves both field spellings are read).
 //   - "secure":       card declares required auth and the server enforces it
@@ -27,6 +30,8 @@ import (
 //   - "anon-allowed": card requirement list includes an empty {} object, so
 //     anonymous access is explicitly permitted; even though the endpoint is open,
 //     it must not be flagged => silent.
+//   - "anon-allowed-v1": the v1.0 spelling of the same statement, an entry whose
+//     "schemes" map is empty => silent.
 //   - "no-security":  card declares no security requirement; the open endpoint is
 //     not a broken promise => silent.
 //   - "not-a2a":      no card, everything 404 => inconclusive.
@@ -40,12 +45,19 @@ func cardSecServer(mode string) *httptest.Server {
 		switch mode {
 		case "vuln-v03":
 			sec = `"security":[{"bearerAuth":[]}],`
+		case "vuln-v1-flat":
+			sec = `"securityRequirements":[{"bearerAuth":[]}],`
 		case "anon-allowed":
 			sec = `"securityRequirements":[{},{"bearerAuth":[]}],`
+		case "anon-allowed-v1":
+			sec = `"securityRequirements":[{"schemes":{}}],`
 		case "no-security":
 			sec = ``
 		default: // vuln-v1, secure
-			sec = `"securityRequirements":[{"bearerAuth":[]}],`
+			// The shape both official SDKs serve: SecurityRequirement is a
+			// proto message holding one map field, so the scheme names sit a
+			// level below the entry.
+			sec = `"securityRequirements":[{"schemes":{"bearerAuth":{"list":["a2a:invoke"]}}}],`
 		}
 		return `{
 			"name": "Card Security Test Agent",
@@ -158,6 +170,35 @@ func TestCardSecurity_VulnV1(t *testing.T) {
 	if !strings.Contains(f.Title, "declares required authentication") {
 		t.Errorf("unexpected title %q", f.Title)
 	}
+	// The scheme name is the actionable part of the finding: it tells an operator
+	// which scheme their server failed to enforce. On the real v1.0 shape the
+	// names sit under "schemes", and reading the entry's own keys reported the
+	// literal "schemes" on every v1.0 card in existence.
+	if !strings.Contains(f.Evidence, "bearerAuth") {
+		t.Errorf("evidence must name the declared scheme, got:\n%s", f.Evidence)
+	}
+	if strings.Contains(f.Evidence, "scheme(s): schemes") {
+		t.Errorf("evidence named the proto field instead of the scheme:\n%s", f.Evidence)
+	}
+}
+
+// TestCardSecurity_VulnV1FlatShape: a server that hand-rolls its card may put the
+// names at the top level under the v1.0 field name. Both shapes must be read, so
+// fixing the nested shape must not lose this one.
+func TestCardSecurity_VulnV1FlatShape(t *testing.T) {
+	srv := cardSecServer("vuln-v1-flat")
+	defer srv.Close()
+
+	findings, err := runCardSec(t, srv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %+v", len(findings), findings)
+	}
+	if !strings.Contains(findings[0].Evidence, "bearerAuth") {
+		t.Errorf("evidence must name the declared scheme, got:\n%s", findings[0].Evidence)
+	}
 }
 
 // TestCardSecurity_VulnV03: the v0.3 "security" field must be read, not only the
@@ -193,6 +234,21 @@ func TestCardSecurity_AnonymousAllowed(t *testing.T) {
 
 	if findings, err := runCardSec(t, srv); err != nil || len(findings) != 0 {
 		t.Errorf("expected 0 findings / nil err when the card permits anonymous access, got %d findings, err=%v", len(findings), err)
+	}
+}
+
+// TestCardSecurity_AnonymousAllowedV1: the v1.0 spelling of "anonymous is
+// permitted" is an entry whose schemes map is empty, since a proto message
+// always carries its map field. Reading the entry's own keys saw one key and
+// called auth required, which would flag an open endpoint the card never
+// promised to protect.
+func TestCardSecurity_AnonymousAllowedV1(t *testing.T) {
+	srv := cardSecServer("anon-allowed-v1")
+	defer srv.Close()
+
+	if findings, err := runCardSec(t, srv); err != nil || len(findings) != 0 {
+		t.Errorf("expected 0 findings / nil err when the v1.0 card permits anonymous access, got %d findings, err=%v",
+			len(findings), err)
 	}
 }
 

--- a/testdata/a2a_card_security_unenforced_server.py
+++ b/testdata/a2a_card_security_unenforced_server.py
@@ -37,7 +37,13 @@ AGENT_CARD = {
     "securitySchemes": {
         "bearerAuth": {"httpAuthSecurityScheme": {"scheme": "Bearer", "bearerFormat": "JWT"}},
     },
-    "securityRequirements": [{"bearerAuth": []}],
+    # SecurityRequirement is a proto message holding one map field, so a v1.0
+    # card nests the scheme names under "schemes" and each maps to a StringList.
+    # This fixture previously served [{"bearerAuth": []}], the v0.3 body shape
+    # under the v1.0 field name, which no real implementation emits: it was
+    # vouching for how the rule happened to parse rather than for the protocol,
+    # and it hid the rule naming the proto field as the scheme.
+    "securityRequirements": [{"schemes": {"bearerAuth": {"list": ["a2a:invoke"]}}}],
 }
 
 tasks = {}


### PR DESCRIPTION
`declaredAuthRequirement` read each `securityRequirements` entry's top-level keys as scheme names. A v1.0 `SecurityRequirement` is a proto message holding a single map field, so the names sit one level below the entry:

```json
[{"schemes": {"bearerAuth": {"list": ["a2a:invoke"]}}}]
```

Both official SDKs define it that way (`a2a-sdk`'s proto descriptor, `@a2a-js/sdk`'s `SecurityRequirement` interface), so this is the shape every real v1.0 card serves. The rule named the literal proto field on all of them:

```
card-declared security scheme(s): schemes
```

The verdict was unaffected, since auth genuinely is required, but the scheme name is the actionable part of the finding: it tells an operator which scheme their server failed to enforce. One narrow verdict case was also wrong. A proto message always carries its map field, so a v1.0 card says "anonymous is permitted" with an empty `schemes` map, and reading the entry's own keys saw one key and called auth required.

## Fix

Entries are matched by structure rather than by which card field they came from, so the OpenAPI-flat shape keeps working for v0.3 cards and for servers that hand-roll a v1.0 card. A v0.3 card declaring a scheme actually named `schemes` is unaffected, because its value is a scope array rather than an object.

## Why no test caught it

The `vuln-v1` case and `testdata/a2a_card_security_unenforced_server.py` both used `"securityRequirements":[{"bearerAuth":[]}]`, the v1.0 field name with the v0.3 body shape, which no implementation emits. Neither had ever exercised a real v1.0 card. Both now serve the proto shape, the flat shape is kept as its own case, and `vuln-v1` asserts the scheme name instead of only the finding count.

## Verification

| Target | Before | After |
|---|---|---|
| `testdata/a2a_card_security_unenforced_server.py` | `scheme(s): schemes` | `scheme(s): bearerAuth` |
| live a2a-sdk 1.1.2 agent declaring bearerAuth | `scheme(s): schemes` | `scheme(s): bearerAuth` |

Finding counts unchanged across seven live configurations of that agent, which is expected because only the evidence was wrong. Reverting the structural branch fails five of the new cases. Full suite green, `golangci-lint` 0 issues.
