### PR TITLE
fix(a2a): stop probe rejecting every correctly secured v1.0 agent card

### DIFF
--- a/internal/protocol/a2a/card.go
+++ b/internal/protocol/a2a/card.go
@@ -3,6 +3,7 @@
 package a2a
 
 import (
+	"encoding/json"
 	"net/url"
 	"strings"
 )
@@ -139,6 +140,84 @@ type AgentSkill struct {
 // SecurityRequirement maps scheme names to required OAuth scopes.
 // An empty slice means the scheme is required but no specific scopes are needed.
 type SecurityRequirement map[string][]string
+
+// UnmarshalJSON accepts both wire shapes a requirement entry appears in.
+//
+// v1.0 is proto-derived: SecurityRequirement is a message holding a single map
+// field named schemes, whose values are StringList messages, so an entry
+// serializes with the names one level down:
+//
+//	{"schemes": {"bearerAuth": {"list": ["a2a:invoke"]}}}
+//
+// v0.3 and OpenAPI put the names at the top level with scope arrays as values:
+//
+//	{"bearerAuth": ["a2a:invoke"]}
+//
+// Both official SDKs emit the first. Decoding straight into map[string][]string
+// accepted only the second, so json.Unmarshal failed on every real v1.0 card
+// that declared security, and because FetchAgentCard treats an unmarshal error
+// as fatal, probe reported those agents as not serving valid JSON. Agents that
+// declared nothing probed fine, so the failure landed only on the ones
+// configured correctly.
+//
+// The two are told apart by structure, not by which card field they came from: an
+// entry whose sole key is "schemes" mapping to an object is the proto shape. A
+// v0.3 card may declare a scheme actually named "schemes", but then its value is
+// a scope array rather than an object, so that card still reads correctly.
+//
+// A value that is neither a scope array nor a StringList map records the scheme
+// name with no scopes rather than failing. Refusing to decode would sink the
+// whole card over one optional field, which is the bug this method exists to
+// fix; a recon parser should show the operator what is there.
+func (s *SecurityRequirement) UnmarshalJSON(data []byte) error {
+	var entry map[string]json.RawMessage
+	if err := json.Unmarshal(data, &entry); err != nil {
+		// Not an object at all. Leave the requirement empty rather than failing
+		// the card: an entry that names no scheme requires nothing, which is
+		// also what an empty object means.
+		*s = SecurityRequirement{}
+		return nil
+	}
+
+	if inner, ok := protoSchemeMap(entry); ok {
+		*s = inner
+		return nil
+	}
+
+	out := make(SecurityRequirement, len(entry))
+	for name, raw := range entry {
+		var scopes []string
+		if err := json.Unmarshal(raw, &scopes); err != nil {
+			scopes = nil
+		}
+		out[name] = scopes
+	}
+	*s = out
+	return nil
+}
+
+// protoSchemeMap reads the v1.0 nested shape, returning ok false when entry is
+// not that shape and should be read as a flat OpenAPI-style requirement.
+func protoSchemeMap(entry map[string]json.RawMessage) (SecurityRequirement, bool) {
+	if len(entry) != 1 {
+		return nil, false
+	}
+	raw, present := entry["schemes"]
+	if !present {
+		return nil, false
+	}
+	var schemes map[string]struct {
+		List []string `json:"list"`
+	}
+	if err := json.Unmarshal(raw, &schemes); err != nil {
+		return nil, false
+	}
+	out := make(SecurityRequirement, len(schemes))
+	for name, list := range schemes {
+		out[name] = list.List
+	}
+	return out, true
+}
 
 // SecurityScheme is a discriminated union - exactly one nested scheme object is populated.
 // The discriminant is the JSON key name itself (apiKeySecurityScheme, httpAuthSecurityScheme, etc.),

--- a/internal/protocol/a2a/card_test.go
+++ b/internal/protocol/a2a/card_test.go
@@ -1,6 +1,7 @@
 package a2a
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -269,6 +270,152 @@ func TestAgentCard_V03SecurityField(t *testing.T) {
 	}
 	if len(card.SecurityRequirements) != 0 {
 		t.Errorf("SecurityRequirements should be empty for a v0.3 card, got %d", len(card.SecurityRequirements))
+	}
+}
+
+// TestAgentCard_V1SecurityRequirementShapes covers the requirement entry shapes a
+// card can arrive in. The nested one is what both official SDKs serve, and
+// decoding straight into map[string][]string rejected it, which failed the whole
+// card because FetchAgentCard treats an unmarshal error as fatal.
+func TestAgentCard_V1SecurityRequirementShapes(t *testing.T) {
+	tests := []struct {
+		name       string
+		entry      string
+		wantScheme string
+		wantScopes []string
+		wantEmpty  bool
+		why        string
+	}{
+		{
+			name:       "v1.0 nested proto shape",
+			entry:      `{"schemes":{"bearerAuth":{"list":["a2a:invoke"]}}}`,
+			wantScheme: "bearerAuth",
+			wantScopes: []string{"a2a:invoke"},
+			why:        "SecurityRequirement is a proto message holding a schemes map of StringList",
+		},
+		{
+			name:       "v1.0 nested, no scopes",
+			entry:      `{"schemes":{"bearerAuth":{"list":[]}}}`,
+			wantScheme: "bearerAuth",
+			why:        "a required scheme need not demand any scope",
+		},
+		{
+			name:       "OpenAPI-flat shape",
+			entry:      `{"bearerAuth":["a2a:invoke"]}`,
+			wantScheme: "bearerAuth",
+			wantScopes: []string{"a2a:invoke"},
+			why:        "v0.3 cards and hand-rolled v1.0 cards use the flat shape",
+		},
+		{
+			name:      "empty entry",
+			entry:     `{}`,
+			wantEmpty: true,
+			why:       "an entry naming no scheme requires nothing",
+		},
+		{
+			name:      "empty schemes map",
+			entry:     `{"schemes":{}}`,
+			wantEmpty: true,
+			why:       "the v1.0 spelling of the same statement",
+		},
+		{
+			// A v0.3 card may name a scheme "schemes". Its value is a scope array
+			// rather than an object, which is what tells the shapes apart.
+			name:       "flat scheme literally named schemes",
+			entry:      `{"schemes":["read"]}`,
+			wantScheme: "schemes",
+			wantScopes: []string{"read"},
+			why:        "the shapes are distinguished by structure, not by the key name",
+		},
+		{
+			name:      "entry is not an object",
+			entry:     `"bearerAuth"`,
+			wantEmpty: true,
+			why:       "one malformed optional field must not sink an otherwise valid card",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := `{"name":"Agent","description":"d","version":"1.0.0","capabilities":{},"skills":[],` +
+				`"securityRequirements":[` + tt.entry + `]}`
+			var card AgentCard
+			if err := json.Unmarshal([]byte(body), &card); err != nil {
+				t.Fatalf("card must parse (%s): %v", tt.why, err)
+			}
+			if card.Name != "Agent" {
+				t.Errorf("the rest of the card must survive, got name %q", card.Name)
+			}
+			if len(card.SecurityRequirements) != 1 {
+				t.Fatalf("SecurityRequirements len = %d, want 1", len(card.SecurityRequirements))
+			}
+			got := card.SecurityRequirements[0]
+			if tt.wantEmpty {
+				if len(got) != 0 {
+					t.Errorf("requirement = %v, want empty (%s)", got, tt.why)
+				}
+				return
+			}
+			scopes, present := got[tt.wantScheme]
+			if !present {
+				t.Fatalf("requirement %v does not name %q (%s)", got, tt.wantScheme, tt.why)
+			}
+			if len(scopes) != len(tt.wantScopes) {
+				t.Errorf("scopes = %v, want %v", scopes, tt.wantScopes)
+			}
+			for i := range tt.wantScopes {
+				if i < len(scopes) && scopes[i] != tt.wantScopes[i] {
+					t.Errorf("scopes = %v, want %v", scopes, tt.wantScopes)
+					break
+				}
+			}
+		})
+	}
+}
+
+// TestFetchAgentCard_RealV1SecuredCard is the regression at the level the bug was
+// reported: probe fetching a real secured agent's card. It previously failed with
+// "is not valid JSON", so probe told the operator a correctly configured agent
+// was not an A2A agent.
+func TestFetchAgentCard_RealV1SecuredCard(t *testing.T) {
+	const securedCard = `{
+		"name": "Secured Echo Agent",
+		"description": "Agent that enforces bearer authorization",
+		"version": "1.0.0",
+		"capabilities": {"streaming": true},
+		"skills": [{"id": "echo", "name": "Echo", "description": "Echoes", "tags": ["echo"]}],
+		"supportedInterfaces": [{"url": "https://agent.example.com/", "protocolBinding": "JSONRPC", "protocolVersion": "1.0"}],
+		"securitySchemes": {"bearerAuth": {"httpAuthSecurityScheme": {"scheme": "bearer"}}},
+		"securityRequirements": [{"schemes": {"bearerAuth": {"list": ["a2a:invoke"]}}}]
+	}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != WellKnownPath {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(securedCard))
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(srv.URL)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	card, _, err := client.FetchAgentCard(context.Background())
+	if err != nil {
+		t.Fatalf("a real v1.0 secured card must be fetchable: %v", err)
+	}
+	if card.Name != "Secured Echo Agent" {
+		t.Errorf("Name = %q", card.Name)
+	}
+	// This is what probe reports as "auth required".
+	if len(card.SecurityRequirements) == 0 {
+		t.Error("SecurityRequirements is empty, so probe would report the agent as unauthenticated")
+	}
+	if _, ok := card.SecurityRequirements[0]["bearerAuth"]; !ok {
+		t.Errorf("requirement should name bearerAuth, got %v", card.SecurityRequirements[0])
 	}
 }
 


### PR DESCRIPTION
`SecurityRequirement` decoded into `map[string][]string`, the OpenAPI-flat shape. A v1.0 `SecurityRequirement` is a proto message holding a `schemes` map of `StringList`, so a real card serves:

```json
"securityRequirements": [{"schemes": {"bearerAuth": {"list": ["a2a:invoke"]}}}]
```

`json.Unmarshal` failed on that, and `FetchAgentCard` treats any unmarshal error as fatal, so `probe` reported the target as not serving valid JSON and therefore not an A2A agent. An agent declaring no security parsed fine, so this landed **only on agents configured correctly**.

Against a live a2a-sdk 1.1.2 agent whose card declares `bearerAuth`:

| | `probe` output |
|---|---|
| before | `error: could not fetch Agent Card: ... is not valid JSON: json: cannot unmarshal object into Go struct field AgentCard.securityRequirements of type []string` |
| after | card printed, `Auth required yes`, `Schemes bearerAuth (http/bearer)` |

## Fix

`SecurityRequirement` gains an `UnmarshalJSON` reading both shapes, chosen by structure rather than by which card field the entry came from, matching the discriminator #141 established for the scanner-side parser. One method covers all three uses of the type: `AgentCard.SecurityRequirements`, `AgentCard.Security` and `AgentSkill.SecurityRequirements`. A v0.3 card declaring a scheme actually named `schemes` still reads correctly, because its value is a scope array rather than an object.

An entry that is neither shape records no scheme instead of failing. Refusing to decode is what sank the card in the first place, and a recon parser should show the operator what is there rather than withhold an otherwise valid card over one optional field. Genuinely malformed JSON is still an error.

## Scope

The scan path was never affected: `internal/attack/a2a` parses cards into a map, which is why every scan against these agents worked. Verified unchanged across six live targets.

## Verification

`probe` now parses the four previously-rejected targets (live a2a-sdk agent in three postures, plus `testdata/a2a_card_security_unenforced_server.py`); output on an agent declaring no security is byte-identical. Reverting the method fails five of the new cases with the original error text. Full suite green, `golangci-lint` 0 issues.
