### PR TITLE
fix(a2a): report declared auth for v0.3 agent cards in probe

### DIFF
--- a/internal/cli/probe.go
+++ b/internal/cli/probe.go
@@ -179,7 +179,7 @@ func cardToProbeResult(card *a2a.AgentCard, elapsed time.Duration) *report.Probe
 		Streaming:             card.Capabilities.Streaming,
 		PushNotifications:     card.Capabilities.PushNotifications,
 		ExtendedCardAvailable: card.Capabilities.ExtendedAgentCard,
-		AuthRequired:          len(card.SecurityRequirements) > 0,
+		AuthRequired:          card.RequiresAuth(),
 		Elapsed:               elapsed,
 	}
 

--- a/internal/cli/probe_test.go
+++ b/internal/cli/probe_test.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/calbebop/batesian/internal/protocol/a2a"
+)
+
+// The Authentication block probe prints is built here, so this is where a
+// regression in what it reads would show up. The unit tests on AgentCard cover
+// the card semantics; these cover that cardToProbeResult actually asks the card
+// rather than reaching for one version's field.
+func TestCardToProbeResult_AuthAcrossCardVersions(t *testing.T) {
+	tests := []struct {
+		name           string
+		security       string
+		wantAuth       bool
+		wantSchemeText string
+		why            string
+	}{
+		{
+			name: "v0.3 card, native shape",
+			security: `"security":[{"bearerAuth":["a2a:invoke"]}],` +
+				`"securitySchemes":{"bearerAuth":{"type":"http","scheme":"bearer","bearerFormat":"opaque"}}`,
+			wantAuth:       true,
+			wantSchemeText: "bearerAuth (http/bearer)",
+			why:            "this is what the official Go SDK serves, and probe reported it as unauthenticated",
+		},
+		{
+			name: "v1.0 card, native shape",
+			security: `"securityRequirements":[{"schemes":{"bearerAuth":{"list":["a2a:invoke"]}}}],` +
+				`"securitySchemes":{"bearerAuth":{"httpAuthSecurityScheme":{"scheme":"bearer"}}}`,
+			wantAuth:       true,
+			wantSchemeText: "bearerAuth (http/bearer)",
+			why:            "the v1.0 path must be unaffected",
+		},
+		{
+			name:     "no security declared",
+			security: `"description2":"none"`,
+			wantAuth: false,
+			why:      "an agent declaring nothing is reported as unauthenticated, which is accurate",
+		},
+		{
+			name:     "v0.3 card permitting anonymous access",
+			security: `"security":[{},{"bearerAuth":[]}]`,
+			wantAuth: false,
+			why:      "an empty requirement object explicitly permits anonymous access",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := `{"name":"Agent","description":"d","version":"1.0.0","url":"http://127.0.0.1:1/",` +
+				`"preferredTransport":"JSONRPC","capabilities":{},"skills":[],` + tt.security + `}`
+			var card a2a.AgentCard
+			if err := json.Unmarshal([]byte(body), &card); err != nil {
+				t.Fatalf("card must parse: %v", err)
+			}
+
+			got := cardToProbeResult(&card, time.Millisecond)
+			if got.AuthRequired != tt.wantAuth {
+				t.Errorf("AuthRequired = %v, want %v (%s)", got.AuthRequired, tt.wantAuth, tt.why)
+			}
+			if tt.wantSchemeText == "" {
+				return
+			}
+			joined := strings.Join(got.SecuritySchemes, ", ")
+			if joined != tt.wantSchemeText {
+				t.Errorf("SecuritySchemes = %q, want %q", joined, tt.wantSchemeText)
+			}
+		})
+	}
+}

--- a/internal/protocol/a2a/card.go
+++ b/internal/protocol/a2a/card.go
@@ -137,6 +137,39 @@ type AgentSkill struct {
 	SecurityRequirements []SecurityRequirement `json:"securityRequirements,omitempty"`
 }
 
+// DeclaredSecurity returns the requirements list the card actually declares,
+// preferring the v1.0 securityRequirements field and falling back to the v0.3
+// security field.
+//
+// The two spellings hold the same statement, so a caller asking "what auth does
+// this card require" must consult both. Reading only securityRequirements
+// reported every v0.3 agent as unauthenticated, including ones that reject
+// anonymous callers outright. The precedence lives here so callers do not each
+// reimplement it.
+func (c *AgentCard) DeclaredSecurity() []SecurityRequirement {
+	if len(c.SecurityRequirements) > 0 {
+		return c.SecurityRequirements
+	}
+	return c.Security
+}
+
+// RequiresAuth reports whether the card declares authentication with no
+// anonymous alternative. Per OpenAPI semantics an empty requirement object in the
+// list explicitly permits anonymous access, so its presence means auth is not
+// required whatever else the list holds.
+func (c *AgentCard) RequiresAuth() bool {
+	list := c.DeclaredSecurity()
+	if len(list) == 0 {
+		return false
+	}
+	for _, req := range list {
+		if len(req) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // SecurityRequirement maps scheme names to required OAuth scopes.
 // An empty slice means the scheme is required but no specific scopes are needed.
 type SecurityRequirement map[string][]string
@@ -220,14 +253,94 @@ func protoSchemeMap(entry map[string]json.RawMessage) (SecurityRequirement, bool
 }
 
 // SecurityScheme is a discriminated union - exactly one nested scheme object is populated.
-// The discriminant is the JSON key name itself (apiKeySecurityScheme, httpAuthSecurityScheme, etc.),
-// not a "type" field. This matches the A2A v1.0 specification.
+// In v1.0 the discriminant is the JSON key name itself (apiKeySecurityScheme,
+// httpAuthSecurityScheme, etc.). v0.3 cards instead use the OpenAPI form, a flat
+// object carrying a "type" field; UnmarshalJSON reads both into these fields.
 type SecurityScheme struct {
 	APIKey        *APIKeySecurityScheme        `json:"apiKeySecurityScheme,omitempty"`
 	HTTPAuth      *HTTPAuthSecurityScheme      `json:"httpAuthSecurityScheme,omitempty"`
 	OAuth2        *OAuth2SecurityScheme        `json:"oauth2SecurityScheme,omitempty"`
 	OpenIDConnect *OpenIDConnectSecurityScheme `json:"openIdConnectSecurityScheme,omitempty"`
 	MTLS          *MutualTLSSecurityScheme     `json:"mtlsSecurityScheme,omitempty"`
+}
+
+// UnmarshalJSON accepts the v1.0 nested form and the v0.3 OpenAPI flat form.
+//
+// v1.0 keys the union on the member name:
+//
+//	{"httpAuthSecurityScheme": {"scheme": "bearer"}}
+//
+// v0.3 follows OpenAPI, with a flat object and a "type" discriminant. The shapes
+// served by the official Go SDK, which is a native v0.3 implementation, are:
+//
+//	{"type": "http",          "scheme": "bearer", "bearerFormat": "opaque"}
+//	{"type": "apiKey",        "in": "header", "name": "X-API-Key"}
+//	{"type": "oauth2",        "flows": {...}}
+//	{"type": "openIdConnect", "openIdConnectUrl": "..."}
+//	{"type": "mutualTLS"}
+//
+// Without this, a v0.3 card left every member nil and Type() reported "unknown",
+// so probe could not name the scheme an agent declared. Note apiKey carries the
+// location under "in" here and under "location" in v1.0, so both are read.
+func (s *SecurityScheme) UnmarshalJSON(data []byte) error {
+	// The nested form first: it is unambiguous, since none of its keys collide
+	// with the flat form's.
+	type nested SecurityScheme
+	var n nested
+	if err := json.Unmarshal(data, &n); err == nil {
+		candidate := SecurityScheme(n)
+		if candidate.Type() != "unknown" {
+			*s = candidate
+			return nil
+		}
+	}
+
+	var flat struct {
+		Type              string            `json:"type"`
+		Description       string            `json:"description"`
+		Scheme            string            `json:"scheme"`
+		BearerFormat      string            `json:"bearerFormat"`
+		In                string            `json:"in"`
+		Location          string            `json:"location"`
+		Name              string            `json:"name"`
+		Flows             OAuthFlows        `json:"flows"`
+		OAuth2MetadataURL string            `json:"oauth2MetadataUrl"`
+		OpenIDConnectURL  string            `json:"openIdConnectUrl"`
+		Scopes            map[string]string `json:"scopes"`
+	}
+	if err := json.Unmarshal(data, &flat); err != nil {
+		// Not an object we can read. Leave the scheme empty rather than failing
+		// the card: Type() reports "unknown", which is the honest answer, and one
+		// unreadable scheme must not cost the operator the whole card.
+		*s = SecurityScheme{}
+		return nil
+	}
+
+	switch flat.Type {
+	case "http":
+		s.HTTPAuth = &HTTPAuthSecurityScheme{
+			Description: flat.Description, Scheme: flat.Scheme, BearerFormat: flat.BearerFormat,
+		}
+	case "apiKey":
+		location := flat.In
+		if location == "" {
+			location = flat.Location
+		}
+		s.APIKey = &APIKeySecurityScheme{
+			Description: flat.Description, Location: location, Name: flat.Name,
+		}
+	case "oauth2":
+		s.OAuth2 = &OAuth2SecurityScheme{
+			Description: flat.Description, Flows: flat.Flows, OAuth2MetadataURL: flat.OAuth2MetadataURL,
+		}
+	case "openIdConnect":
+		s.OpenIDConnect = &OpenIDConnectSecurityScheme{
+			Description: flat.Description, OpenIDConnectURL: flat.OpenIDConnectURL,
+		}
+	case "mutualTLS":
+		s.MTLS = &MutualTLSSecurityScheme{Description: flat.Description}
+	}
+	return nil
 }
 
 // Type returns a human-readable string describing the scheme type.

--- a/internal/protocol/a2a/card_test.go
+++ b/internal/protocol/a2a/card_test.go
@@ -419,6 +419,132 @@ func TestFetchAgentCard_RealV1SecuredCard(t *testing.T) {
 	}
 }
 
+// TestAgentCard_RequiresAuth covers what probe reports in its Authentication
+// block. Reading only the v1.0 securityRequirements field described every v0.3
+// agent as "no (unauthenticated access)", including ones that reject anonymous
+// callers with 401.
+func TestAgentCard_RequiresAuth(t *testing.T) {
+	tests := []struct {
+		name string
+		sec  string
+		want bool
+		why  string
+	}{
+		{
+			name: "v0.3 security field",
+			sec:  `"security":[{"bearerAuth":["a2a:invoke"]}]`,
+			want: true,
+			why:  "a native v0.3 implementation declares auth here and nowhere else",
+		},
+		{
+			name: "v1.0 securityRequirements, nested",
+			sec:  `"securityRequirements":[{"schemes":{"bearerAuth":{"list":["a2a:invoke"]}}}]`,
+			want: true,
+			why:  "the v1.0 spelling must keep working",
+		},
+		{
+			name: "both fields present",
+			sec:  `"securityRequirements":[{"schemes":{"bearerAuth":{"list":[]}}}],"security":[{}]`,
+			want: true,
+			why:  "v1.0 takes precedence when a card carries both",
+		},
+		{
+			name: "no declaration",
+			sec:  `"name2":"x"`,
+			want: false,
+			why:  "nothing declared means nothing required",
+		},
+		{
+			name: "v0.3 with an anonymous alternative",
+			sec:  `"security":[{},{"bearerAuth":[]}]`,
+			want: false,
+			why:  "an empty requirement object explicitly permits anonymous access",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := `{"name":"Agent","description":"d","version":"1.0.0","capabilities":{},"skills":[],` + tt.sec + `}`
+			var card AgentCard
+			if err := json.Unmarshal([]byte(body), &card); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got := card.RequiresAuth(); got != tt.want {
+				t.Errorf("RequiresAuth() = %v, want %v (%s)", got, tt.want, tt.why)
+			}
+		})
+	}
+}
+
+// TestSecurityScheme_V03FlatForm covers the OpenAPI flat form a v0.3 card serves.
+// The shapes are the ones the official Go SDK emits, which is a native v0.3
+// implementation. Before this, every member stayed nil and Type() reported
+// "unknown", so probe could not name the scheme an agent declared.
+func TestSecurityScheme_V03FlatForm(t *testing.T) {
+	tests := []struct {
+		name     string
+		scheme   string
+		wantType string
+	}{
+		{"http bearer", `{"type":"http","scheme":"bearer","bearerFormat":"opaque"}`, "http/bearer"},
+		{"http basic", `{"type":"http","scheme":"basic"}`, "http/basic"},
+		{"apiKey", `{"type":"apiKey","in":"header","name":"X-API-Key"}`, "apiKey"},
+		{"oauth2", `{"type":"oauth2","flows":{"clientCredentials":{"tokenUrl":"https://idp/token","scopes":{}}}}`, "oauth2"},
+		{"openIdConnect", `{"type":"openIdConnect","openIdConnectUrl":"https://idp/.well-known/openid-configuration"}`, "openIdConnect"},
+		{"mutualTLS", `{"type":"mutualTLS"}`, "mtls"},
+		// The v1.0 nested form must be unaffected.
+		{"v1.0 nested http", `{"httpAuthSecurityScheme":{"scheme":"bearer"}}`, "http/bearer"},
+		{"v1.0 nested apiKey", `{"apiKeySecurityScheme":{"location":"header","name":"X-API-Key"}}`, "apiKey"},
+		// An unreadable scheme must not fail the card.
+		{"unrecognized type", `{"type":"quantum"}`, "unknown"},
+		{"not an object", `"bearer"`, "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := `{"name":"Agent","description":"d","version":"1.0.0","capabilities":{},"skills":[],` +
+				`"securitySchemes":{"s":` + tt.scheme + `}}`
+			var card AgentCard
+			if err := json.Unmarshal([]byte(body), &card); err != nil {
+				t.Fatalf("card must parse: %v", err)
+			}
+			if card.Name != "Agent" {
+				t.Errorf("the rest of the card must survive, got name %q", card.Name)
+			}
+			scheme, ok := card.SecuritySchemes["s"]
+			if !ok {
+				t.Fatal("scheme missing from the map")
+			}
+			if got := scheme.Type(); got != tt.wantType {
+				t.Errorf("Type() = %q, want %q", got, tt.wantType)
+			}
+		})
+	}
+}
+
+// TestSecurityScheme_V03APIKeyLocation: v0.3 names the location "in", v1.0 names
+// it "location". Both must land in the same field, since that is what an operator
+// needs in order to know where the key goes.
+func TestSecurityScheme_V03APIKeyLocation(t *testing.T) {
+	for name, scheme := range map[string]string{
+		"v0.3 in":       `{"type":"apiKey","in":"cookie","name":"sid"}`,
+		"v1.0 location": `{"apiKeySecurityScheme":{"location":"cookie","name":"sid"}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			var s SecurityScheme
+			if err := json.Unmarshal([]byte(scheme), &s); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if s.APIKey == nil {
+				t.Fatal("APIKey member not populated")
+			}
+			if s.APIKey.Location != "cookie" {
+				t.Errorf("Location = %q, want cookie", s.APIKey.Location)
+			}
+		})
+	}
+}
+
 func TestAgentCard_RoundTrip(t *testing.T) {
 	var card AgentCard
 	if err := json.Unmarshal([]byte(fullV1CardJSON), &card); err != nil {


### PR DESCRIPTION
`probe` computed `AuthRequired` from `card.SecurityRequirements` alone, the v1.0 field, and ignored `Security`, the v0.3 one. The card type captures both, with a comment saying either version's declared auth can be read, but the reading half was never done.

Against the official `a2a-go` SDK, a native v0.3 implementation whose card carries `"security": [{"bearerAuth": ["a2a:invoke"]}]` and which answers an anonymous call with 401:

```
Authentication
  Auth required  no (unauthenticated access)
```

## Fix

`AgentCard` gains `DeclaredSecurity` (prefers `securityRequirements`, falls back to `security`) and `RequiresAuth` (applies the OpenAPI rule that an empty requirement object in the list permits anonymous access). The precedence now lives in one place, mirroring `cardSecurityList` on the scanner side.

**A second defect was masked by the first.** `SecurityScheme` only understood the v1.0 nested union keyed on the member name, while a v0.3 card uses the OpenAPI flat form with a `type` discriminant, so every member stayed nil and `Type()` reported `unknown`. Because the printer nests the `Schemes` row inside the `AuthRequired` branch, fixing only the first would have printed `bearerAuth (unknown)`. `UnmarshalJSON` now reads both forms, using the five shapes the Go SDK emits as the reference for the flat one. `apiKey` carries its location under `in` there and under `location` in v1.0, so both are read into the same field. An unrecognized type leaves the scheme empty rather than failing the card.

## Verification

| Target | Before | After |
|---|---|---|
| a2a-go secured (v0.3) | `Auth required no (unauthenticated access)` | `Auth required yes` / `Schemes bearerAuth (http/bearer)` |
| a2a-go open (v0.3) | — | byte-identical |
| a2a-sdk secured (v1.0) | `yes` / `bearerAuth (http/bearer)` | unchanged |

Scan findings unchanged across five live targets. Each of the three parts is covered by a test that fails when only that part is reverted, including at the `cardToProbeResult` call site, which had no coverage at all and is why reverting the probe line alone initially left the suite green. Full suite green, `golangci-lint` 0 issues.
