### PR TITLE
fix(a2a): run probe's extended-card checks against v0.3 agents

### DIFF
--- a/internal/cli/probe.go
+++ b/internal/cli/probe.go
@@ -128,7 +128,7 @@ func probeA2A(target, token string, timeoutSecs int, skipTLS bool, format report
 
 	result := cardToProbeResult(card, cardResult.Elapsed)
 
-	if card.Capabilities.ExtendedAgentCard {
+	if card.SupportsExtendedCard() {
 		printer.Verbose("Probing extended agent card (unauthenticated)...")
 		extResult, err := client.ProbeExtendedCard(ctx)
 		if err == nil && extResult.IsSuccess() {
@@ -176,9 +176,10 @@ func cardToProbeResult(card *a2a.AgentCard, elapsed time.Duration) *report.Probe
 		Description:           card.Description,
 		URL:                   card.GetServiceURL(),
 		Version:               card.Version,
+		ProtocolVersion:       card.ProtocolVersion,
 		Streaming:             card.Capabilities.Streaming,
 		PushNotifications:     card.Capabilities.PushNotifications,
-		ExtendedCardAvailable: card.Capabilities.ExtendedAgentCard,
+		ExtendedCardAvailable: card.SupportsExtendedCard(),
 		AuthRequired:          card.RequiresAuth(),
 		Elapsed:               elapsed,
 	}

--- a/internal/cli/probe_test.go
+++ b/internal/cli/probe_test.go
@@ -9,6 +9,68 @@ import (
 	"github.com/calbebop/batesian/internal/protocol/a2a"
 )
 
+// TestCardToProbeResult_ExtendedCardAndProtocol covers the two card fields whose
+// v0.3 spellings probe could not see. ExtendedCardAvailable is not merely a
+// printed row: probe gates two live checks of /extendedAgentCard on it, one of
+// which fetches the endpoint with a fabricated Bearer token, so a v0.3 agent got
+// neither.
+func TestCardToProbeResult_ExtendedCardAndProtocol(t *testing.T) {
+	tests := []struct {
+		name         string
+		fields       string
+		wantExtended bool
+		wantProtocol string
+		why          string
+	}{
+		{
+			name:         "v0.3 card",
+			fields:       `"protocolVersion":"0.3.0","supportsAuthenticatedExtendedCard":true`,
+			wantExtended: true,
+			wantProtocol: "0.3.0",
+			why:          "this is what a2a-go serves, and probe skipped both extended-card checks",
+		},
+		{
+			name:         "v1.0 card",
+			fields:       `"protocolVersion":"1.0","capabilities":{"extendedAgentCard":true}`,
+			wantExtended: true,
+			wantProtocol: "1.0",
+			why:          "the v1.0 path must be unaffected",
+		},
+		{
+			name:         "no extended card, no protocol declared",
+			fields:       `"capabilities":{"streaming":true}`,
+			wantExtended: false,
+			wantProtocol: "",
+			why:          "probe must not claim an extended card that was never advertised",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := `{"name":"Agent","description":"d","version":"9.9.9","url":"http://127.0.0.1:1/",` +
+				`"preferredTransport":"JSONRPC","skills":[],` + tt.fields + `}`
+			var card a2a.AgentCard
+			if err := json.Unmarshal([]byte(body), &card); err != nil {
+				t.Fatalf("card must parse: %v", err)
+			}
+
+			got := cardToProbeResult(&card, time.Millisecond)
+			if got.ExtendedCardAvailable != tt.wantExtended {
+				t.Errorf("ExtendedCardAvailable = %v, want %v (%s)",
+					got.ExtendedCardAvailable, tt.wantExtended, tt.why)
+			}
+			if got.ProtocolVersion != tt.wantProtocol {
+				t.Errorf("ProtocolVersion = %q, want %q", got.ProtocolVersion, tt.wantProtocol)
+			}
+			// The agent version and the protocol version are different things and
+			// must not be conflated in the output.
+			if got.Version != "9.9.9" {
+				t.Errorf("Version = %q, want the agent version 9.9.9", got.Version)
+			}
+		})
+	}
+}
+
 // The Authentication block probe prints is built here, so this is where a
 // regression in what it reads would show up. The unit tests on AgentCard cover
 // the card semantics; these cover that cardToProbeResult actually asks the card

--- a/internal/protocol/a2a/card.go
+++ b/internal/protocol/a2a/card.go
@@ -31,6 +31,17 @@ type AgentCard struct {
 	// (e.g. "JSONRPC", "GRPC").
 	PreferredTransport string `json:"preferredTransport,omitempty"`
 
+	// ProtocolVersion is the A2A revision the agent speaks ("0.3.0", "1.0"). It is
+	// the field that distinguishes the two card dialects from each other, so it is
+	// worth surfacing: every version-specific field below has a different name or
+	// shape depending on it.
+	ProtocolVersion string `json:"protocolVersion,omitempty"`
+
+	// SupportsAuthenticatedExtendedCard is the v0.3 spelling of the extended-card
+	// advertisement, at the card top level. v1.0 moved it to
+	// capabilities.extendedAgentCard. Read both via SupportsExtendedCard.
+	SupportsAuthenticatedExtendedCard bool `json:"supportsAuthenticatedExtendedCard,omitempty"`
+
 	// URL is the v0.3 top-level service URL field. Still present in many deployed
 	// agents; usable as the JSON-RPC endpoint only when PreferredTransport is JSONRPC.
 	URL string `json:"url,omitempty"`
@@ -168,6 +179,20 @@ func (c *AgentCard) RequiresAuth() bool {
 		}
 	}
 	return true
+}
+
+// SupportsExtendedCard reports whether the card advertises an authenticated
+// extended Agent Card, in either dialect's spelling.
+//
+// v1.0 nests the flag as capabilities.extendedAgentCard; v0.3 puts it at the card
+// top level as supportsAuthenticatedExtendedCard. Reading only the v1.0 spelling
+// meant probe skipped both of its extended-card checks against every v0.3 agent,
+// including the one that fetches the endpoint with a fabricated Bearer token, so
+// an agent serving its extended card to anonymous callers was reported as having
+// no extended card at all. The scan rule probes the path unconditionally and was
+// unaffected.
+func (c *AgentCard) SupportsExtendedCard() bool {
+	return c.Capabilities.ExtendedAgentCard || c.SupportsAuthenticatedExtendedCard
 }
 
 // SecurityRequirement maps scheme names to required OAuth scopes.

--- a/internal/protocol/a2a/card_test.go
+++ b/internal/protocol/a2a/card_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -542,6 +543,86 @@ func TestSecurityScheme_V03APIKeyLocation(t *testing.T) {
 				t.Errorf("Location = %q, want cookie", s.APIKey.Location)
 			}
 		})
+	}
+}
+
+// TestAgentCard_SupportsExtendedCard covers both dialects' spelling of the
+// extended-card advertisement. probe gates two of its own checks on this, one of
+// them the fabricated-Bearer-token fetch, so reading only the v1.0 spelling meant
+// neither ran against a v0.3 agent.
+func TestAgentCard_SupportsExtendedCard(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+		why  string
+	}{
+		{
+			name: "v0.3 top-level flag",
+			body: `"supportsAuthenticatedExtendedCard":true`,
+			want: true,
+			why:  "v0.3 advertises it at the card top level, which is what a2a-go serves",
+		},
+		{
+			name: "v1.0 nested flag",
+			body: `"capabilities":{"extendedAgentCard":true}`,
+			want: true,
+			why:  "v1.0 moved it under capabilities",
+		},
+		{
+			name: "both spellings",
+			body: `"supportsAuthenticatedExtendedCard":true,"capabilities":{"extendedAgentCard":true}`,
+			want: true,
+			why:  "a card carrying both still advertises one extended card",
+		},
+		{
+			name: "neither",
+			body: `"capabilities":{"streaming":true}`,
+			want: false,
+			why:  "no advertisement means probe must not claim one",
+		},
+		{
+			name: "v0.3 flag explicitly false",
+			body: `"supportsAuthenticatedExtendedCard":false`,
+			want: false,
+			why:  "an explicit false is still no advertisement",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := `{"name":"Agent","description":"d","version":"1.0.0","skills":[],` + tt.body + `}`
+			var card AgentCard
+			if err := json.Unmarshal([]byte(body), &card); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got := card.SupportsExtendedCard(); got != tt.want {
+				t.Errorf("SupportsExtendedCard() = %v, want %v (%s)", got, tt.want, tt.why)
+			}
+		})
+	}
+}
+
+// TestAgentCard_ProtocolVersionCaptured guards the field being read at all.
+// buildJSONOutput re-marshals the parsed card, so a field the struct does not
+// capture is dropped from probe's JSON output as well as its table.
+func TestAgentCard_ProtocolVersionCaptured(t *testing.T) {
+	const v03 = `{"name":"Agent","description":"d","version":"1.0.0","protocolVersion":"0.3.0",
+		"url":"http://127.0.0.1:1/","preferredTransport":"JSONRPC","capabilities":{},"skills":[]}`
+	var card AgentCard
+	if err := json.Unmarshal([]byte(v03), &card); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if card.ProtocolVersion != "0.3.0" {
+		t.Errorf("ProtocolVersion = %q, want %q", card.ProtocolVersion, "0.3.0")
+	}
+	// The JSON output path round-trips the card, so the field must survive that.
+	raw, err := json.Marshal(&card)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(raw), `"protocolVersion":"0.3.0"`) {
+		t.Errorf("protocolVersion did not survive the round trip: %s", raw)
 	}
 }
 

--- a/internal/report/printer.go
+++ b/internal/report/printer.go
@@ -90,6 +90,11 @@ type ProbeResult struct {
 	Version     string
 	Provider    string
 
+	// ProtocolVersion is the A2A revision the card declares. It is what
+	// distinguishes the two card dialects, and several card fields differ in name
+	// or shape between them, so it is worth showing rather than inferring.
+	ProtocolVersion string
+
 	// Capabilities
 	Streaming             bool
 	PushNotifications     bool
@@ -131,6 +136,9 @@ func (p *Printer) PrintProbeTable(r *ProbeResult) {
 	tw := tabwriter.NewWriter(p.w, 0, 0, 2, ' ', 0)
 	p.kvRow(tw, "Name", r.Name)
 	p.kvRow(tw, "Version", r.Version)
+	if r.ProtocolVersion != "" {
+		p.kvRow(tw, "Protocol", r.ProtocolVersion)
+	}
 	if r.Description != "" {
 		p.kvRow(tw, "Description", truncate(r.Description, 80))
 	}


### PR DESCRIPTION
`probe` read the extended-card advertisement only from `capabilities.extendedAgentCard`, the v1.0 spelling. v0.3 puts it at the card top level as `supportsAuthenticatedExtendedCard`, so the flag was always false for a v0.3 agent.

That is not only a wrong row in the Capabilities table. `probe` gates two live checks on the flag, an unauthenticated fetch of `/extendedAgentCard` and a fetch with a fabricated Bearer token, and neither ran.

Against an agent on the official `a2a-go` SDK that advertises the extended card and serves it with **HTTP 200 to an anonymous caller**:

| | Attack Surface |
|---|---|
| before | `Extended agent card no`, no extcard entry |
| after | `HIGH /extendedAgentCard returned HTTP 200 without authentication`<br>`CRITICAL /extendedAgentCard returned HTTP 200 with a fabricated invalid Bearer token` |

The critical entry is what `scan` already reported against the same target. **The scan rule was never affected** — it probes the path unconditionally rather than trusting the card, so only `probe` was blind.

## Changes

`AgentCard` gains `SupportsExtendedCard`, reading either spelling, alongside the `DeclaredSecurity` and `RequiresAuth` accessors added for the same class of problem.

`protocolVersion` is now captured and shown as a `Protocol` row. It is the field that says which dialect a card is written in, and every version-specific field differs by name or shape according to it. It also fixes a quiet loss in the JSON output: `buildJSONOutput` re-marshals the parsed card, so fields the struct did not capture were dropped from `probe -o json` entirely.

## Audit

I diffed every key a live card serves against what the type captures. Exactly two gaps on v0.3, none on v1.0:

| Card | Served but not captured |
|---|---|
| v0.3 (a2a-go v0.3.15) | `supportsAuthenticatedExtendedCard`, `protocolVersion` |
| v1.0 (a2a-sdk 1.1.2) | none |
| v1.0 (repo fixture) | none |

Both are fixed here, so the recon path now reads everything both dialects serve.

## Verification

The v0.3 agent gains a `Protocol` row, the correct extended-card row, and both flags. The **secured** v0.3 agent gains the two rows and no flags, with verbose output confirming both checks ran and saw `HTTP 401 (auth enforced)` — so silence there means tested, not skipped. Probe output on two v1.0 agents is byte-identical, scan findings unchanged across five live targets, and each of the three parts fails a test when reverted on its own.
