### PR TITLE
fix: stop truncating response bodies at 1 MB, and never truncate silently

### DIFF
--- a/internal/attack/http.go
+++ b/internal/attack/http.go
@@ -13,7 +13,20 @@ import (
 	"github.com/calbebop/batesian/internal/sse"
 )
 
-const maxBody = 1 << 20 // 1 MB
+// maxBody bounds how much of a response body is read into memory.
+//
+// It was 1 MB, which a real server exceeds without trying: a tools/list on a
+// server with a few hundred tools, or a resources/read of a config file, is
+// larger than that. The read truncated silently at the limit, the truncated JSON
+// failed to unmarshal, and rules that treat an unparseable probe the same as a
+// refused one reported those surfaces clean. A wide-open server was measured
+// producing 1 finding at 1.33 MB responses and 7 at 20 KB, with nothing else
+// changed.
+//
+// The engine runs rules sequentially, so the cost is one body at a time rather
+// than one per rule. Exceeding the limit is an explicit error (see the read in
+// do), never a quietly shortened body.
+const maxBody = 32 << 20 // 32 MB
 
 // Version is the build-time version string injected from main via attack.Version.
 // It is embedded in the User-Agent header on every outbound HTTP request.
@@ -240,9 +253,16 @@ func (c *HTTPClient) do(ctx context.Context, method, url string, body io.Reader,
 		// SSE streams never close; read only the first data event then stop.
 		respBody = readFirstSSEEvent(resp.Body)
 	} else {
-		respBody, err = io.ReadAll(io.LimitReader(resp.Body, maxBody))
+		// Read one byte past the limit so exceeding it is detectable. A plain
+		// LimitReader at maxBody returns a truncated body and no error, which
+		// reads downstream as malformed JSON from the server rather than as a
+		// body this scanner declined to finish reading.
+		respBody, err = io.ReadAll(io.LimitReader(resp.Body, maxBody+1))
 		if err != nil {
 			return nil, fmt.Errorf("reading response from %s: %w", url, err)
+		}
+		if len(respBody) > maxBody {
+			return nil, fmt.Errorf("response body from %s exceeds the %d byte read limit", url, maxBody)
 		}
 	}
 

--- a/internal/attack/http_test.go
+++ b/internal/attack/http_test.go
@@ -2,6 +2,7 @@ package attack_test
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -208,5 +209,55 @@ func TestHTTPClient_RedirectDoesNotForwardToken(t *testing.T) {
 		t.Fatalf("bearer token was forwarded to the redirect target (Authorization=%q); the client must not follow redirects", authz)
 	default:
 		// good: /sink was never reached, so the token stayed put
+	}
+}
+
+// A body that fits must arrive whole. The previous 1 MB cap truncated silently,
+// and a truncated JSON-RPC result is unparseable, which rules that treat an
+// unparseable probe the same as a refused one reported as a clean surface. A
+// wide-open MCP server was measured producing 1 finding with 1.33 MB responses
+// and 7 with 20 KB ones, with nothing else changed.
+func TestHTTPClient_LargeBodyIsNotTruncated(t *testing.T) {
+	// Comfortably past the old 1 MB limit, comfortably under the new one.
+	payload := `{"jsonrpc":"2.0","id":1,"result":{"pad":"` + strings.Repeat("x", 4<<20) + `"}}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, payload)
+	}))
+	defer srv.Close()
+
+	client := attack.NewUnauthHTTPClient(attack.Options{TimeoutSeconds: 30}, attack.NewVars(srv.URL, ""))
+	resp, err := client.POST(context.Background(), srv.URL, nil, map[string]interface{}{"jsonrpc": "2.0"})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	if len(resp.Body) != len(payload) {
+		t.Fatalf("body is %d bytes, want %d: a fitting body must not be shortened", len(resp.Body), len(payload))
+	}
+	// The point of not truncating: the result still parses, so the rule sees a
+	// success rather than what looks like a malformed reply.
+	if !resp.IsAccepted() {
+		t.Error("a large but valid JSON-RPC result must read as accepted")
+	}
+}
+
+// Over the limit is an explicit error, not a quietly shortened body. Returning a
+// truncated body would be indistinguishable from a server sending malformed JSON.
+func TestHTTPClient_OverLimitBodyIsAnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// 33 MB of payload, past the 32 MB ceiling.
+		_, _ = io.WriteString(w, `{"result":"`+strings.Repeat("x", 33<<20)+`"}`)
+	}))
+	defer srv.Close()
+
+	client := attack.NewUnauthHTTPClient(attack.Options{TimeoutSeconds: 60}, attack.NewVars(srv.URL, ""))
+	resp, err := client.POST(context.Background(), srv.URL, nil, map[string]interface{}{"jsonrpc": "2.0"})
+	if err == nil {
+		t.Fatalf("expected an error for an over-limit body, got a %d byte response", len(resp.Body))
+	}
+	if !strings.Contains(err.Error(), "read limit") {
+		t.Errorf("error should name the read limit, got: %v", err)
 	}
 }

--- a/internal/protocol/a2a/client.go
+++ b/internal/protocol/a2a/client.go
@@ -24,7 +24,7 @@ const (
 	ExtendedCardPath = "/extendedAgentCard"
 
 	defaultTimeout = 10 * time.Second
-	maxBodyBytes   = 1 << 20 // 1 MB
+	maxBodyBytes   = 32 << 20 // 32 MB; see internal/attack.maxBody
 )
 
 // Client fetches and validates A2A endpoints.

--- a/internal/protocol/mcp/client.go
+++ b/internal/protocol/mcp/client.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	defaultTimeout = 10 * time.Second
-	maxBodyBytes   = 1 << 20 // 1 MB
+	maxBodyBytes   = 32 << 20 // 32 MB; see internal/attack.maxBody
 )
 
 // candidatePaths are tried in order when discovering the MCP endpoint.

--- a/internal/sse/limits_test.go
+++ b/internal/sse/limits_test.go
@@ -1,0 +1,36 @@
+package sse
+
+import (
+	"strings"
+	"testing"
+)
+
+// A small SSE reply must not cost the ceiling in memory. NewReaderSize used to
+// allocate maxLine up front, so a large cap made every SSE read expensive.
+func TestFirstData_DoesNotAllocateTheCapUpFront(t *testing.T) {
+	body := "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n\n"
+	res := testing.Benchmark(func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_, _ = FirstData(strings.NewReader(body), 32<<20)
+		}
+	})
+	perOp := res.AllocedBytesPerOp()
+	t.Logf("allocated %d bytes per FirstData call with a 32 MB cap", perOp)
+	if perOp > 1<<20 {
+		t.Errorf("a small SSE reply allocated %d bytes; the cap must not be paid up front", perOp)
+	}
+}
+
+// A line larger than the initial buffer must still be readable, up to the cap.
+func TestFirstData_GrowsBeyondTheInitialBuffer(t *testing.T) {
+	big := strings.Repeat("x", 4<<20) // 4 MB, far past the 64 KB initial buffer
+	body := "data: " + big + "\n\n"
+	got, err := FirstData(strings.NewReader(body), 32<<20)
+	if err != nil {
+		t.Fatalf("FirstData: %v", err)
+	}
+	if len(got) != len(big) {
+		t.Errorf("got %d bytes, want %d: the scanner must grow to the cap", len(got), len(big))
+	}
+}

--- a/internal/sse/sse.go
+++ b/internal/sse/sse.go
@@ -16,10 +16,16 @@ import (
 )
 
 // MaxBytes is the default cap on how many bytes a reader will consume from a
-// stream, matching the 1 MB body cap used by the scan and recon clients.
-const MaxBytes int64 = 1 << 20
+// stream, matching the body cap used by the scan and recon clients.
+const MaxBytes int64 = 32 << 20
 
-const defaultLineBytes = 1 << 20
+// defaultLineBytes caps a single line when no limit is supplied. initialLineBytes
+// is what the scanner starts with; it grows from there on demand, so the cap
+// costs nothing until a line actually approaches it.
+const (
+	defaultLineBytes = 32 << 20
+	initialLineBytes = 64 << 10
+)
 
 // Event is one dispatched SSE event.
 type Event struct {
@@ -53,7 +59,15 @@ func NewReaderSize(r io.Reader, maxLine int) *Reader {
 		maxLine = defaultLineBytes
 	}
 	sc := bufio.NewScanner(r)
-	sc.Buffer(make([]byte, maxLine), maxLine)
+	// Start small and let the scanner grow to maxLine only if a line needs it.
+	// Allocating maxLine up front made the ceiling cost real on every read: an
+	// SSE reply is the normal case for MCP streamable HTTP, so a large ceiling
+	// would allocate that much per response even for a few hundred bytes of data.
+	initial := initialLineBytes
+	if maxLine < initial {
+		initial = maxLine
+	}
+	sc.Buffer(make([]byte, initial), maxLine)
 	return &Reader{sc: sc}
 }
 

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -61,6 +61,7 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_task_idor_server.py` | 7798 | `mcp-task-idor-001` (two principals; needs two `--principal`s) |
 | `mcp_modern_era_server.py` | 7799 | none, by design: an era-detection target, see below |
 | `mcp_era_downgrade_server.py` | 7800 | `mcp-era-downgrade-001` (two postures, see below) |
+| `mcp_large_body_server.py` | 7801 | the unauth family at responses past the body read limit, see below |
 
 **Coverage.** 35 of the 36 rules have a standalone Python fixture above. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
@@ -88,6 +89,24 @@ BATESIAN_LIVE_MCP_ENDPOINT=http://127.0.0.1:7799/mcp \
 Because the SDK serves both eras from one server, it also answers the 2025-era
 `initialize` handshake, which is why the existing rules still work against
 current deployments.
+
+**`mcp_large_body_server.py` is a size test, not a new vulnerability.** It has no
+authentication at all, so it should produce the same findings any open server
+does. What it varies is response size: every listing and read is padded past the
+scanner's body read limit, which is what a real server does without trying once it
+has a few hundred tools or a config file worth reading.
+
+```sh
+python testdata/mcp_large_body_server.py            # ~1.33 MB responses
+python testdata/mcp_large_body_server.py 7801 8     # ~20 KB, the control
+```
+
+Both invocations must produce the same findings. They did not: the read limit was
+1 MB and truncated silently, the truncated JSON-RPC result was unparseable, and
+rules that treat an unparseable probe the same as a refused one reported those
+surfaces clean. The large server gave 1 finding where the small one gave 7, so a
+server could hide every unauthenticated-access finding by being large. If the two
+invocations ever disagree again, a body is being truncated somewhere.
 
 **`mcp_era_downgrade_server.py` takes a posture argument**, defaulting to
 `vulnerable`:

--- a/testdata/mcp_large_body_server.py
+++ b/testdata/mcp_large_body_server.py
@@ -1,0 +1,110 @@
+"""
+Batesian MCP validation target: responses larger than the scanner's read limit.
+
+This server is deliberately vulnerable in the ordinary way: it has NO
+authentication, so every unauth rule should fire against it exactly as it would
+against any other open server. The only unusual thing about it is response size.
+Every listing and read is padded past the scanner's body read limit.
+
+That size is the whole point. The limit used to be 1 MB and the read truncated
+silently, so a truncated JSON-RPC result was unparseable, and rules that treat an
+unparseable probe the same as a refused one reported those surfaces clean. A
+server could hide every unauthenticated-access finding by being large.
+
+Measured against this fixture at 1.33 MB responses: 1 finding before, 7 after.
+The same server with small responses gives 7 either way, which is what makes size
+the only variable.
+
+1 MB is not a large response. A tools/list on a server with a few hundred tools,
+or a resources/read of a config file, exceeds it without trying.
+
+Run:
+    python testdata/mcp_large_body_server.py [port] [size_kb]
+
+Endpoint: http://127.0.0.1:7801/mcp
+
+Expect: the same findings a small open server produces, notably
+mcp-tools-unauth-001, mcp-prompt-unauth-001 and mcp-resources-unauth-001,
+including the critical credential read. Any of those going silent means a body
+was truncated somewhere.
+"""
+import json
+import sys
+
+import uvicorn
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 7801
+# Default comfortably past the old 1 MB limit and well under the current one.
+SIZE_KB = int(sys.argv[2]) if len(sys.argv) > 2 else 1200
+
+# The padding carries a credential, so the credential-detection path is exercised
+# at the same size as everything else.
+PAD = "postgresql://admin:hunter2@db.internal:5432/prod " + ("x" * 1024)
+FILLER = [{"name": f"pad_{i}", "description": PAD} for i in range(SIZE_KB)]
+
+TOOLS = [{"name": "echo", "description": "Echoes input",
+          "inputSchema": {"type": "object", "properties": {"text": {"type": "string"}}}}]
+PROMPTS = [{"name": "greet", "description": "A prompt template"}]
+RESOURCES = [{"uri": "config://database", "name": "database", "mimeType": "text/plain"}]
+
+
+async def mcp(request: Request) -> JSONResponse:
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"jsonrpc": "2.0", "id": None,
+                             "error": {"code": -32700, "message": "Parse error"}}, status_code=400)
+
+    method = body.get("method")
+    req_id = body.get("id")
+
+    if method == "initialize":
+        return JSONResponse(
+            {"jsonrpc": "2.0", "id": req_id, "result": {
+                "protocolVersion": "2025-06-18",
+                "serverInfo": {"name": "LargeBodyTarget", "version": "1.0"},
+                "capabilities": {"tools": {}, "prompts": {}, "resources": {}, "logging": {}},
+            }},
+            headers={"Mcp-Session-Id": "large-body-session"},
+        )
+    if method == "notifications/initialized":
+        return JSONResponse({}, status_code=202)
+
+    # No authorization check on any of these. The padding is the only trick.
+    if method == "tools/list":
+        return JSONResponse({"jsonrpc": "2.0", "id": req_id,
+                             "result": {"tools": TOOLS + FILLER}})
+    if method == "prompts/list":
+        return JSONResponse({"jsonrpc": "2.0", "id": req_id,
+                             "result": {"prompts": PROMPTS + FILLER}})
+    if method == "prompts/get":
+        return JSONResponse({"jsonrpc": "2.0", "id": req_id, "result": {
+            "messages": [{"role": "user", "content": {"type": "text", "text": PAD}}] * SIZE_KB}})
+    if method == "resources/list":
+        return JSONResponse({"jsonrpc": "2.0", "id": req_id,
+                             "result": {"resources": RESOURCES + FILLER}})
+    if method == "resources/read":
+        return JSONResponse({"jsonrpc": "2.0", "id": req_id, "result": {
+            "contents": [{"uri": "config://database", "mimeType": "text/plain",
+                          "text": PAD * SIZE_KB}]}})
+    if method == "tools/call":
+        return JSONResponse({"jsonrpc": "2.0", "id": req_id,
+                             "result": {"content": [{"type": "text", "text": PAD}]}})
+
+    return JSONResponse({"jsonrpc": "2.0", "id": req_id,
+                         "error": {"code": -32601, "message": "Method not found"}}, status_code=400)
+
+
+app = Starlette(routes=[Route("/mcp", mcp, methods=["POST"])])
+
+if __name__ == "__main__":
+    sample = len(json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"tools": TOOLS + FILLER}}))
+    print(f"Starting MCP large-body target on http://127.0.0.1:{PORT}/mcp")
+    print(json.dumps({"tools_list_bytes": sample,
+                      "tools_list_mb": round(sample / (1 << 20), 2),
+                      "auth": None}))
+    uvicorn.run(app, host="127.0.0.1", port=PORT, log_level="warning")


### PR DESCRIPTION
A wide-open MCP server hid every unauthenticated-access finding by returning large responses. One server, no authentication anywhere, response size the only variable:

| Response size | findings | tools-unauth | prompt-unauth | resources-unauth |
|---|---|---|---|---|
| ~20 KB | **7** | FIRED ×2 | FIRED ×2 | FIRED ×2 |
| 1.33 MB | **1** | CLEAN | CLEAN | CLEAN |

The rules reported those surfaces **clean**, not inconclusive, so the scan claimed they were secure. The losses included the critical credential read.

`io.ReadAll(io.LimitReader(body, maxBody))` truncates at the limit and returns no error, so a truncated JSON-RPC result is unparseable, and rules that treat an unparseable probe the same as a refused one report a clean surface. 1 MB is not a large response: a `tools/list` on a server with a few hundred tools, or a `resources/read` of a config file, exceeds it without trying.

## Fix

The limit is 32 MB, and the read takes `maxBody+1` bytes so exceeding it is an explicit error rather than a quietly shortened body. Memory stays bounded, and the engine runs rules sequentially, so the cost is one body at a time.

The recon clients carried the same 1 MB constant and are raised with it. A large valid agent card was being rejected there as "not valid JSON", the same class of problem as #142.

**Raising the cap alone would have made every SSE read expensive.** `sse.NewReaderSize` passed the ceiling to `bufio.Scanner.Buffer` as both the initial and the maximum size, allocating it up front, and an SSE reply is the normal case for MCP streamable HTTP. The scanner now starts at 64 KB and grows only when a line needs it: measured **65,880 bytes** per read with a 32 MB cap, with a 4 MB line still read whole.

## Verification

`testdata/mcp_large_body_server.py` (port 7801) is the regression and takes a size argument, so the large and small runs are directly comparable. Both must produce the same findings; that they did not is the bug.

| Target | Before | After |
|---|---|---|
| fixture, 1.33 MB | 1 | **7** |
| fixture, 20 KB (control) | 7 | 7 |

The recovered findings include `CRITICAL MCP resource "config://database" contains potential credentials`. Nine other live targets are unchanged: both A2A SDKs, three MCP implementations, and two secured postures. Full suite green, `golangci-lint` 0 issues.

## Not addressed here

A body over the new ceiling still reports clean, because 48 call sites across 20 rule files collapse "refused", "unreachable" and "unparseable" into one `return nil`. That is the S3 rubric never applied at the per-probe level, and it wants its own wave rather than being bolted on here. I also tried erroring at the transport layer without raising the cap, on the theory that existing `err != nil` paths would carry it to inconclusive — they do not, they `return nil`, so that cheaper shape does not work.
