### PR TITLE
fix(mcp): stop reporting a failed probe as a secure surface

### DIFF
--- a/internal/attack/mcp/completion_unauth.go
+++ b/internal/attack/mcp/completion_unauth.go
@@ -73,18 +73,20 @@ func (e *CompletionUnauthExecutor) Execute(ctx context.Context, target string, o
 
 	// A server may expose completion on both protocol wires, and need not gate it
 	// the same way on each, so every wire it serves is probed.
-	return runOnEachWire(ctx, client, vars.BaseURL, func(session mcpSession) []attack.Finding {
+	return runOnEachWire(ctx, client, vars.BaseURL, func(session mcpSession) ([]attack.Finding, bool) {
 		return e.probeSession(ctx, client, session, vars.RandID)
 	})
 }
 
-// probeSession runs the rule against one already-opened wire.
-func (e *CompletionUnauthExecutor) probeSession(ctx context.Context, client *attack.HTTPClient, session mcpSession, randID string) []attack.Finding {
+// probeSession runs the rule against one already-opened wire. determined reports
+// whether the wire established anything; see classifyProbe.
+func (e *CompletionUnauthExecutor) probeSession(ctx context.Context, client *attack.HTTPClient, session mcpSession, randID string) (findings []attack.Finding, determined bool) {
 	// Skip servers that do not advertise the completions capability; probing them
 	// would produce meaningless noise. Read from the captured handshake object
-	// rather than substring-matching the body.
+	// rather than substring-matching the body. Determined: the server says it has
+	// no completion surface, so none can be open.
 	if !session.ServerSupports("completions") {
-		return nil
+		return nil, true
 	}
 
 	// Probe real refs discovered from the live server first, preferring one that
@@ -92,7 +94,10 @@ func (e *CompletionUnauthExecutor) probeSession(ctx context.Context, client *att
 	// reachable probe so reachability is reported even when no ref discloses.
 	var firstReachable, disclosure *completionOutcome
 	for _, ref := range e.discoverRefs(ctx, client, session) {
-		out := e.probe(ctx, client, session, ref)
+		out, probed := e.probe(ctx, client, session, ref)
+		if probed {
+			determined = true
+		}
 		if out == nil {
 			continue
 		}
@@ -116,11 +121,17 @@ func (e *CompletionUnauthExecutor) probeSession(ctx context.Context, client *att
 			real:    false,
 			label:   "synthetic probe ref",
 		}
-		firstReachable = e.probe(ctx, client, session, synth)
+		var probed bool
+		firstReachable, probed = e.probe(ctx, client, session, synth)
+		if probed {
+			determined = true
+		}
 	}
 
 	if firstReachable == nil {
-		return nil
+		// Nothing was reachable. Whether that means the surface is closed or that
+		// no probe ever got an answer is the difference determined carries.
+		return nil, determined
 	}
 
 	// Base the reachability finding on the disclosure probe when one was found, so
@@ -130,7 +141,7 @@ func (e *CompletionUnauthExecutor) probeSession(ctx context.Context, client *att
 		base = disclosure
 	}
 
-	findings := []attack.Finding{{
+	findings = []attack.Finding{{
 		RuleID:     e.rule.ID,
 		RuleName:   e.rule.Name,
 		Severity:   "medium",
@@ -167,14 +178,17 @@ func (e *CompletionUnauthExecutor) probeSession(ctx context.Context, client *att
 		})
 	}
 
-	return findings
+	return findings, true
 }
 
 // probe sends a single unauthenticated completion/complete request for ref and
 // returns the outcome if the handler was reached, or nil on an HTTP auth gate,
 // transport error, or a non-dispatching JSON-RPC error. Suggestion values are
 // captured only for real refs (synthetic refs never disclose real data).
-func (e *CompletionUnauthExecutor) probe(ctx context.Context, client *attack.HTTPClient, session mcpSession, ref completionRef) *completionOutcome {
+// probe returns the outcome for one reference. determined reports whether the
+// server answered at all: a nil outcome with determined false means the probe
+// established nothing, which must not be reported as a closed surface.
+func (e *CompletionUnauthExecutor) probe(ctx context.Context, client *attack.HTTPClient, session mcpSession, ref completionRef) (out *completionOutcome, determined bool) {
 	// An empty value asks the server to enumerate all suggestions for the
 	// argument. Fuzzy/prefix matchers (the common implementation) return their
 	// full candidate set for the empty prefix, which is exactly the
@@ -185,22 +199,19 @@ func (e *CompletionUnauthExecutor) probe(ctx context.Context, client *attack.HTT
 		"ref":      ref.params,
 		"argument": map[string]interface{}{"name": ref.argName, "value": ""},
 	})
-	if err != nil || !resp.IsSuccess() {
-		return nil
-	}
-	var body map[string]interface{}
-	if err := json.Unmarshal(resp.Body, &body); err != nil {
-		return nil
+	verdict, body := classifyProbe(resp, err)
+	if verdict != probeAnswered {
+		return nil, verdict == probeRejected
 	}
 	reachable, reason := completionDispatchReachable(body)
 	if !reachable {
-		return nil
+		return nil, true
 	}
-	out := &completionOutcome{ref: ref, status: resp.StatusCode, reason: reason}
+	out = &completionOutcome{ref: ref, status: resp.StatusCode, reason: reason}
 	if ref.real {
 		out.values = completionValues(body)
 	}
-	return out
+	return out, true
 }
 
 // discoverRefs returns real completion references built from the server's live

--- a/internal/attack/mcp/dispatch.go
+++ b/internal/attack/mcp/dispatch.go
@@ -1,6 +1,79 @@
 package mcp
 
-import "strings"
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// probeVerdict says what a probe attempt established, before its body is
+// interpreted. The distinction the rules were missing is the first one: a probe
+// that failed to produce an answer is not the same as a server that refused.
+type probeVerdict int
+
+const (
+	// probeInconclusive means nothing was established. The request failed in
+	// transport, or the server answered in a way that carries no protocol-level
+	// verdict (a gateway 502, an HTML 500, an empty 400), or the body would not
+	// parse. Reporting a surface clean on this basis claims it is secure when it
+	// was never tested.
+	probeInconclusive probeVerdict = iota
+	// probeRejected means the server answered and the answer was not a usable
+	// result: an auth status, or a JSON-RPC error. Whether that is authorization
+	// being enforced or the method being absent, the surface is closed and a
+	// clean result is correct.
+	probeRejected
+	// probeAnswered means an HTTP 2xx carrying a parseable JSON object, which the
+	// caller can interpret.
+	probeAnswered
+)
+
+// classifyProbe decides what a probe established.
+//
+// The gate this replaces was `if err != nil || !resp.IsSuccess() { return nil }`
+// followed by `if json.Unmarshal(...) != nil { return nil }`, which collapsed
+// "refused", "unreachable" and "unparseable" into a clean result. Measured
+// against a wide-open server whose listings answered 502, the unauth rules
+// reported all three surfaces clean, indistinguishably from the same server
+// answering 401.
+//
+// Every non-2xx that carries a JSON-RPC error stays rejected rather than
+// inconclusive, deliberately. A -32601 says the method is absent and a -32001
+// says access was denied; both mean the surface is closed, which is what the
+// rules concluded before. Only a non-2xx with no protocol-level answer in it
+// changes meaning. Keeping that case out of probeAnswered also matters because
+// classifyDispatch is documented for 2xx bodies only: a 500 carrying -32603
+// would otherwise read as "the handler ran" and invent a finding.
+func classifyProbe(resp *attack.Response, err error) (probeVerdict, map[string]interface{}) {
+	if err != nil || resp == nil {
+		return probeInconclusive, nil
+	}
+
+	var body map[string]interface{}
+	parsed := json.Unmarshal(resp.Body, &body) == nil && body != nil
+
+	if resp.IsSuccess() {
+		if !parsed {
+			return probeInconclusive, nil
+		}
+		return probeAnswered, body
+	}
+
+	// An auth status is an answer on its own, whatever the body looks like.
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return probeRejected, nil
+	}
+	// Otherwise the server must have said something in JSON-RPC terms for this to
+	// count as an answer.
+	if parsed {
+		if _, hasErr := body["error"]; hasErr {
+			return probeRejected, nil
+		}
+	}
+	return probeInconclusive, nil
+}
 
 // authFlavoredError reports whether a JSON-RPC error signals an authentication
 // or authorization rejection rather than a request-processing or validation

--- a/internal/attack/mcp/probe_verdict_test.go
+++ b/internal/attack/mcp/probe_verdict_test.go
@@ -1,0 +1,126 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// classifyProbe is the seam the unauth family hangs on, so the interesting cases
+// are all in what a server can answer with. The gate it replaced treated a
+// gateway failure, an auth rejection and an unparseable body identically, which
+// let a wide-open server whose listings answered 502 report every surface clean.
+func TestClassifyProbe(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   probeVerdict
+		why    string
+	}{
+		{
+			name: "2xx with a result", status: 200,
+			body: `{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}`,
+			want: probeAnswered,
+			why:  "a parseable 2xx is the only case the caller can interpret",
+		},
+		{
+			name: "2xx with a JSON-RPC error", status: 200,
+			body: `{"jsonrpc":"2.0","id":1,"error":{"code":-32001,"message":"Unauthorized"}}`,
+			want: probeAnswered,
+			why:  "the caller decides what a 2xx error means; it is still an answer",
+		},
+		{
+			name: "401", status: 401, body: `{"error":"unauthenticated"}`,
+			want: probeRejected,
+			why:  "auth enforced, so a clean report is correct",
+		},
+		{
+			name: "403 with an empty body", status: 403, body: ``,
+			want: probeRejected,
+			why:  "an auth status is an answer whatever the body looks like",
+		},
+		{
+			name: "400 carrying an auth error", status: 400,
+			body: `{"jsonrpc":"2.0","id":1,"error":{"code":-32001,"message":"Unauthorized"}}`,
+			want: probeRejected,
+			why:  "some servers signal auth with 400 plus a JSON-RPC error",
+		},
+		{
+			name: "400 carrying method not found", status: 400,
+			body: `{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}`,
+			want: probeRejected,
+			why:  "the method is absent, so the surface is closed; this must stay clean, not become untested",
+		},
+		{
+			// The case that motivated all of this.
+			name: "502 from a gateway", status: 502, body: `Bad Gateway`,
+			want: probeInconclusive,
+			why:  "a gateway failure says nothing about authorization",
+		},
+		{
+			name: "500 with an HTML body", status: 500, body: `<html><body>oops</body></html>`,
+			want: probeInconclusive,
+			why:  "a server error is not evidence of a closed surface",
+		},
+		{
+			name: "empty 400", status: 400, body: ``,
+			want: probeInconclusive,
+			why:  "nothing was said in protocol terms",
+		},
+		{
+			name: "2xx that will not parse", status: 200, body: `{"result":{"tools":[`,
+			want: probeInconclusive,
+			why:  "a truncated or malformed body establishes nothing; this is what the 1 MB read limit produced",
+		},
+		{
+			name: "2xx carrying JSON null", status: 200, body: `null`,
+			want: probeInconclusive,
+			why:  "null unmarshals without error but is not an object the caller can read",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			client := attack.NewUnauthHTTPClient(attack.Options{TimeoutSeconds: 5}, attack.NewVars(srv.URL, ""))
+			resp, err := client.POST(context.Background(), srv.URL, nil, map[string]interface{}{"jsonrpc": "2.0"})
+
+			got, body := classifyProbe(resp, err)
+			if got != tt.want {
+				t.Errorf("classifyProbe() = %v, want %v (%s)", got, tt.want, tt.why)
+			}
+			if tt.want == probeAnswered && body == nil {
+				t.Error("an answered probe must hand back the parsed body")
+			}
+			if tt.want != probeAnswered && body != nil {
+				t.Error("only an answered probe may hand back a body")
+			}
+		})
+	}
+}
+
+// A transport failure establishes nothing. This is the path a connection reset,
+// a timeout or an over-limit body takes.
+func TestClassifyProbe_TransportFailure(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	srv.Close() // closed before use, so the connection fails
+
+	client := attack.NewUnauthHTTPClient(attack.Options{TimeoutSeconds: 5}, attack.NewVars(srv.URL, ""))
+	resp, err := client.POST(context.Background(), srv.URL, nil, map[string]interface{}{"jsonrpc": "2.0"})
+	if err == nil {
+		t.Skip("expected the closed server to fail the request")
+	}
+	if got, _ := classifyProbe(resp, err); got != probeInconclusive {
+		t.Errorf("classifyProbe() = %v, want probeInconclusive for a transport failure", got)
+	}
+}

--- a/internal/attack/mcp/prompt_unauth.go
+++ b/internal/attack/mcp/prompt_unauth.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/calbebop/batesian/internal/attack"
@@ -31,42 +30,40 @@ func (e *PromptUnauthExecutor) Execute(ctx context.Context, target string, opts 
 
 	// A server may expose prompts on both protocol wires, and need not gate them
 	// the same way on each, so every wire it serves is probed.
-	return runOnEachWire(ctx, client, vars.BaseURL, func(session mcpSession) []attack.Finding {
+	return runOnEachWire(ctx, client, vars.BaseURL, func(session mcpSession) ([]attack.Finding, bool) {
 		return e.probeSession(ctx, client, session)
 	})
 }
 
-// probeSession runs the rule against one already-opened wire.
-func (e *PromptUnauthExecutor) probeSession(ctx context.Context, client *attack.HTTPClient, session mcpSession) []attack.Finding {
+// probeSession runs the rule against one already-opened wire. determined reports
+// whether the wire established anything; see classifyProbe.
+func (e *PromptUnauthExecutor) probeSession(ctx context.Context, client *attack.HTTPClient, session mcpSession) (findings []attack.Finding, determined bool) {
 	// Skip servers that do not advertise the prompts capability - probing them
 	// would produce meaningless noise. This reads the server capabilities from
 	// the handshake captured by initializeMCP (no redundant second initialize),
 	// and parses the structured capabilities object rather than substring-matching
 	// the whole body (which could false-match "prompts" in serverInfo/instructions).
 	if !session.ServerSupports("prompts") {
-		return nil
+		// Determined: the server says it has none, so none can be open.
+		return nil, true
 	}
 
 	// Call prompts/list without any auth token.
 	listResp, err := session.post(ctx, client, 3, "prompts/list", nil)
-	if err != nil || !listResp.IsSuccess() {
-		return nil
-	}
-
-	var listBody map[string]interface{}
-	if err := json.Unmarshal(listResp.Body, &listBody); err != nil {
-		return nil
+	verdict, listBody := classifyProbe(listResp, err)
+	if verdict != probeAnswered {
+		return nil, verdict == probeRejected
 	}
 
 	// JSON-RPC error means auth is enforced - not vulnerable.
 	if _, hasErr := listBody["error"]; hasErr {
-		return nil
+		return nil, true
 	}
 
 	result, _ := listBody["result"].(map[string]interface{})
 	promptsRaw, _ := result["prompts"].([]interface{})
 	if len(promptsRaw) == 0 {
-		return nil
+		return nil, true
 	}
 
 	// Collect prompt names for evidence.
@@ -78,8 +75,6 @@ func (e *PromptUnauthExecutor) probeSession(ctx context.Context, client *attack.
 			}
 		}
 	}
-
-	var findings []attack.Finding
 
 	findings = append(findings, attack.Finding{
 		RuleID:     e.rule.ID,
@@ -101,20 +96,17 @@ func (e *PromptUnauthExecutor) probeSession(ctx context.Context, client *attack.
 
 	// Attempt to retrieve content of the first prompt via prompts/get.
 	if len(names) == 0 {
-		return findings
+		return findings, true
 	}
 
 	getResp, err := session.post(ctx, client, 4, "prompts/get", map[string]interface{}{"name": names[0]})
-	if err != nil || !getResp.IsSuccess() {
-		return findings
-	}
-
-	var getBody map[string]interface{}
-	if err := json.Unmarshal(getResp.Body, &getBody); err != nil {
-		return findings
+	getVerdict, getBody := classifyProbe(getResp, err)
+	if getVerdict != probeAnswered {
+		// The list finding stands: it was confirmed before this probe.
+		return findings, true
 	}
 	if _, hasErr := getBody["error"]; hasErr {
-		return findings
+		return findings, true
 	}
 
 	content := string(getResp.Body)
@@ -134,5 +126,5 @@ func (e *PromptUnauthExecutor) probeSession(ctx context.Context, client *attack.
 		TargetURL:   session.Endpoint,
 	})
 
-	return findings
+	return findings, true
 }

--- a/internal/attack/mcp/resources_unauth.go
+++ b/internal/attack/mcp/resources_unauth.go
@@ -74,35 +74,34 @@ func (e *ResourcesUnauthExecutor) Execute(ctx context.Context, target string, op
 
 	// A server may expose resources on both protocol wires, and need not gate them
 	// the same way on each, so every wire it serves is probed.
-	return runOnEachWire(ctx, client, vars.BaseURL, func(session mcpSession) []attack.Finding {
+	return runOnEachWire(ctx, client, vars.BaseURL, func(session mcpSession) ([]attack.Finding, bool) {
 		return e.probeSession(ctx, client, session)
 	})
 }
 
-// probeSession runs the rule against one already-opened wire.
-func (e *ResourcesUnauthExecutor) probeSession(ctx context.Context, client *attack.HTTPClient, session mcpSession) []attack.Finding {
-	var findings []attack.Finding
-
+// probeSession runs the rule against one already-opened wire. determined reports
+// whether the wire established anything; see classifyProbe.
+//
+// Only the listing decides that. The per-resource reads below feed the credential
+// escalation, and they run after the listing finding is already confirmed, so a
+// read that fails cannot turn a confirmed finding into "not tested".
+func (e *ResourcesUnauthExecutor) probeSession(ctx context.Context, client *attack.HTTPClient, session mcpSession) (findings []attack.Finding, determined bool) {
 	// Step 1: resources/list - enumerate available resources
 	listResp, err := session.post(ctx, client, 3, "resources/list", nil)
-	if err != nil || !listResp.IsSuccess() {
-		return nil
-	}
-
-	var listBody map[string]interface{}
-	if err := json.Unmarshal(listResp.Body, &listBody); err != nil {
-		return nil
+	verdict, listBody := classifyProbe(listResp, err)
+	if verdict != probeAnswered {
+		return nil, verdict == probeRejected
 	}
 
 	// JSON-RPC error means the endpoint exists but rejected the call - not vulnerable.
 	if _, hasErr := listBody["error"]; hasErr {
-		return nil
+		return nil, true
 	}
 
 	result, _ := listBody["result"].(map[string]interface{})
 	resourcesRaw, _ := result["resources"].([]interface{})
 	if len(resourcesRaw) == 0 {
-		return nil
+		return nil, true
 	}
 
 	// Build a display list of resource URIs
@@ -138,7 +137,7 @@ func (e *ResourcesUnauthExecutor) probeSession(ctx context.Context, client *atta
 	// server's choice, so the rule cannot let it decide the severity.
 	read, examined := e.readResources(ctx, client, session, uris)
 	if read == nil {
-		return findings
+		return findings, true
 	}
 
 	// Baseline: unauthenticated read of resource content is high. Escalate to
@@ -174,7 +173,7 @@ func (e *ResourcesUnauthExecutor) probeSession(ctx context.Context, client *atta
 		TargetURL:   session.Endpoint,
 	})
 
-	return findings
+	return findings, true
 }
 
 // resourceRead is one successfully read resource.

--- a/internal/attack/mcp/tools_unauth.go
+++ b/internal/attack/mcp/tools_unauth.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/calbebop/batesian/internal/attack"
@@ -43,40 +42,40 @@ func (e *ToolsUnauthExecutor) Execute(ctx context.Context, target string, opts a
 
 	// A server may expose tools on both protocol wires, and need not gate them the
 	// same way on each, so every wire it serves is probed.
-	return runOnEachWire(ctx, client, vars.BaseURL, func(session mcpSession) []attack.Finding {
+	return runOnEachWire(ctx, client, vars.BaseURL, func(session mcpSession) ([]attack.Finding, bool) {
 		return e.probeSession(ctx, client, session, vars.RandID)
 	})
 }
 
-// probeSession runs the rule against one already-opened wire.
-func (e *ToolsUnauthExecutor) probeSession(ctx context.Context, client *attack.HTTPClient, session mcpSession, randID string) []attack.Finding {
+// probeSession runs the rule against one already-opened wire. determined reports
+// whether the wire established anything: a probe that failed in transport, or
+// whose answer carried no protocol-level verdict, proves nothing either way and
+// must not be reported as a clean surface.
+func (e *ToolsUnauthExecutor) probeSession(ctx context.Context, client *attack.HTTPClient, session mcpSession, randID string) (findings []attack.Finding, determined bool) {
 	// Skip servers that do not advertise the tools capability; probing them would
 	// produce meaningless noise. Read from the captured handshake capabilities
-	// rather than substring-matching the body.
+	// rather than substring-matching the body. This IS determined: the server said
+	// it has no tools, so there is nothing here to be open.
 	if !session.ServerSupports("tools") {
-		return nil
+		return nil, true
 	}
 
 	// Step 1: tools/list without any auth token.
 	listResp, err := session.post(ctx, client, 3, "tools/list", nil)
-	if err != nil || !listResp.IsSuccess() {
-		return nil
-	}
-
-	var listBody map[string]interface{}
-	if err := json.Unmarshal(listResp.Body, &listBody); err != nil {
-		return nil
+	verdict, listBody := classifyProbe(listResp, err)
+	if verdict != probeAnswered {
+		return nil, verdict == probeRejected
 	}
 
 	// A JSON-RPC error means auth is enforced on tool methods - not vulnerable.
 	if _, hasErr := listBody["error"]; hasErr {
-		return nil
+		return nil, true
 	}
 
 	result, _ := listBody["result"].(map[string]interface{})
 	toolsRaw, _ := result["tools"].([]interface{})
 	if len(toolsRaw) == 0 {
-		return nil
+		return nil, true
 	}
 
 	// Collect tool names for evidence.
@@ -89,7 +88,7 @@ func (e *ToolsUnauthExecutor) probeSession(ctx context.Context, client *attack.H
 		}
 	}
 
-	findings := []attack.Finding{{
+	findings = []attack.Finding{{
 		RuleID:     e.rule.ID,
 		RuleName:   e.rule.Name,
 		Severity:   "medium",
@@ -114,18 +113,15 @@ func (e *ToolsUnauthExecutor) probeSession(ctx context.Context, client *attack.H
 	bogusTool := "batesian-nonexistent-" + randID
 	callResp, err := session.post(ctx, client, 4, "tools/call",
 		map[string]interface{}{"name": bogusTool, "arguments": map[string]interface{}{}})
-	if err != nil || !callResp.IsSuccess() {
-		return findings // auth gate (401/403) or unreachable; the list finding stands
-	}
-
-	var callBody map[string]interface{}
-	if err := json.Unmarshal(callResp.Body, &callBody); err != nil {
-		return findings
+	callVerdict, callBody := classifyProbe(callResp, err)
+	if callVerdict != probeAnswered {
+		// The list finding stands either way: it was confirmed before this probe.
+		return findings, true
 	}
 
 	reachable, reason := callDispatchReachable(callBody)
 	if !reachable {
-		return findings
+		return findings, true
 	}
 
 	findings = append(findings, attack.Finding{
@@ -143,7 +139,7 @@ func (e *ToolsUnauthExecutor) probeSession(ctx context.Context, client *attack.H
 		TargetURL:   session.Endpoint,
 	})
 
-	return findings
+	return findings, true
 }
 
 // callDispatchReachable reports whether a tools/call response for a non-existent

--- a/internal/attack/mcp/unauth_honesty_test.go
+++ b/internal/attack/mcp/unauth_honesty_test.go
@@ -1,0 +1,178 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+// listingServer is a wide-open MCP server whose listing methods answer according
+// to mode. Nothing is ever authorization-checked, so what the unauth rules should
+// report depends only on whether they could establish anything.
+//
+//	"open" every listing returns a result       => findings
+//	"401"  every listing returns 401            => clean, auth is enforced
+//	"502"  every listing returns a gateway 502  => inconclusive, nothing was established
+//
+// The 401 and 502 cases used to be indistinguishable: both gates were
+// `if err != nil || !resp.IsSuccess() { return nil }`, so a scan claimed the
+// surfaces were secure when it had merely failed to reach them.
+func listingServer(t *testing.T, mode string) *httptest.Server {
+	t.Helper()
+	// completion/complete is included because it is completion-unauth's own probe.
+	// With only the listings affected, that rule reaches completion/complete, gets a
+	// -32601, and correctly concludes the surface is absent, so the mode would
+	// never exercise what this test is about.
+	listings := map[string]map[string]interface{}{
+		"tools/list":          {"tools": []interface{}{map[string]interface{}{"name": "echo"}}},
+		"prompts/list":        {"prompts": []interface{}{map[string]interface{}{"name": "greet"}}},
+		"resources/list":      {"resources": []interface{}{map[string]interface{}{"uri": "config://db"}}},
+		"completion/complete": {"completion": map[string]interface{}{"values": []interface{}{"alpha", "beta"}}},
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mcp" {
+			http.NotFound(w, r)
+			return
+		}
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method, _ := body["method"].(string)
+		id := body["id"]
+		w.Header().Set("Content-Type", "application/json")
+
+		result := func(v map[string]interface{}) {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id, "result": v})
+		}
+
+		switch method {
+		case "initialize":
+			w.Header().Set("Mcp-Session-Id", "listing-session")
+			result(map[string]interface{}{
+				"protocolVersion": "2025-06-18",
+				"serverInfo":      map[string]interface{}{"name": "listing", "version": "1"},
+				"capabilities": map[string]interface{}{
+					"tools": map[string]interface{}{}, "prompts": map[string]interface{}{},
+					"resources": map[string]interface{}{}, "logging": map[string]interface{}{},
+					"completions": map[string]interface{}{},
+				},
+			})
+			return
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+
+		if listing, isListing := listings[method]; isListing {
+			switch mode {
+			case "502":
+				// A gateway failure. It says nothing about authorization.
+				w.Header().Set("Content-Type", "text/plain")
+				w.WriteHeader(http.StatusBadGateway)
+				_, _ = w.Write([]byte("Bad Gateway"))
+			case "401":
+				w.WriteHeader(http.StatusUnauthorized)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"jsonrpc": "2.0", "id": id,
+					"error": map[string]interface{}{"code": -32001, "message": "Unauthorized"},
+				})
+			default:
+				result(listing)
+			}
+			return
+		}
+
+		switch method {
+		case "resources/read":
+			result(map[string]interface{}{"contents": []interface{}{
+				map[string]interface{}{"uri": "config://db", "text": "plain content"}}})
+		case "prompts/get":
+			result(map[string]interface{}{"messages": []interface{}{
+				map[string]interface{}{"role": "user", "content": map[string]interface{}{"type": "text", "text": "Hello"}}}})
+		case "tools/call":
+			result(map[string]interface{}{"content": []interface{}{
+				map[string]interface{}{"type": "text", "text": "ok"}}})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": -32601, "message": "Method not found"},
+			})
+		}
+	}))
+}
+
+// unauthFamily is the set converted in this increment. Each is driven through the
+// same three server postures, because the defect and the fix are shared.
+func unauthFamily() map[string]func(attack.RuleContext) attack.Executor {
+	return map[string]func(attack.RuleContext) attack.Executor{
+		"mcp-tools-unauth-001":      func(rc attack.RuleContext) attack.Executor { return mcpattack.NewToolsUnauthExecutor(rc) },
+		"mcp-prompt-unauth-001":     func(rc attack.RuleContext) attack.Executor { return mcpattack.NewPromptUnauthExecutor(rc) },
+		"mcp-resources-unauth-001":  func(rc attack.RuleContext) attack.Executor { return mcpattack.NewResourcesUnauthExecutor(rc) },
+		"mcp-completion-unauth-001": func(rc attack.RuleContext) attack.Executor { return mcpattack.NewCompletionUnauthExecutor(rc) },
+	}
+}
+
+// A gateway failure on the listing is not evidence of a closed surface, so the
+// rule must report that it could not test rather than that the server is secure.
+func TestUnauthFamily_GatewayFailureIsInconclusive(t *testing.T) {
+	srv := listingServer(t, "502")
+	defer srv.Close()
+
+	for id, mk := range unauthFamily() {
+		t.Run(id, func(t *testing.T) {
+			exec := mk(attack.RuleContext{ID: id, Name: id, Severity: "high"})
+			findings, err := exec.Execute(context.Background(), srv.URL, testOpts())
+			if len(findings) != 0 {
+				t.Fatalf("expected no findings against a 502, got %d", len(findings))
+			}
+			if !errors.Is(err, attack.ErrInconclusive) {
+				t.Errorf("a 502 established nothing, so this must be inconclusive, got err=%v", err)
+			}
+		})
+	}
+}
+
+// Auth genuinely enforced. A clean report is correct here, and must not be
+// collateral damage from the fix.
+func TestUnauthFamily_AuthEnforcedStaysClean(t *testing.T) {
+	srv := listingServer(t, "401")
+	defer srv.Close()
+
+	for id, mk := range unauthFamily() {
+		t.Run(id, func(t *testing.T) {
+			exec := mk(attack.RuleContext{ID: id, Name: id, Severity: "high"})
+			findings, err := exec.Execute(context.Background(), srv.URL, testOpts())
+			if err != nil {
+				t.Fatalf("auth enforced is a tested, clean result, not an error: %v", err)
+			}
+			if len(findings) != 0 {
+				t.Errorf("expected no findings when auth is enforced, got %d", len(findings))
+			}
+		})
+	}
+}
+
+// The positive direction, so the conversion is not silently suppressing findings.
+func TestUnauthFamily_OpenServerStillFires(t *testing.T) {
+	srv := listingServer(t, "open")
+	defer srv.Close()
+
+	for _, id := range []string{"mcp-tools-unauth-001", "mcp-prompt-unauth-001", "mcp-resources-unauth-001"} {
+		t.Run(id, func(t *testing.T) {
+			exec := unauthFamily()[id](attack.RuleContext{ID: id, Name: id, Severity: "high"})
+			findings, err := exec.Execute(context.Background(), srv.URL, testOpts())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(findings) == 0 {
+				t.Error("an open server must still produce findings")
+			}
+		})
+	}
+}

--- a/internal/attack/mcp/wire.go
+++ b/internal/attack/mcp/wire.go
@@ -192,15 +192,34 @@ func discoverModern(ctx context.Context, client *attack.HTTPClient, ep string) (
 // A server that serves both eras is exposed on both, and the two need not behave
 // alike, so each is exercised. Findings from the modern wire are labelled; see
 // labelEra.
+//
+// probe reports whether it established anything on that wire, which is separate
+// from whether it found something: a probe whose request failed in transport, or
+// whose answer carried no protocol-level verdict, has tested nothing. When no
+// wire established anything and nothing was found, the result is ErrInconclusive
+// rather than a clean report, because "the scanner could not tell" and "the
+// server is secure" are different claims and the engine records them differently.
+//
+// Findings survive an undetermined wire. A rule that confirmed an open listing
+// and then failed to complete a follow-up probe still found the listing, and the
+// honest report is that finding rather than a blanket "not tested".
 func runOnEachWire(ctx context.Context, client *attack.HTTPClient, baseURL string,
-	probe func(mcpSession) []attack.Finding) ([]attack.Finding, error) {
+	probe func(mcpSession) ([]attack.Finding, bool)) ([]attack.Finding, error) {
 	sessions, err := openSessions(ctx, client, baseURL)
 	if err != nil {
 		return nil, err
 	}
 	var out []attack.Finding
+	anyDetermined := false
 	for _, s := range sessions {
-		out = append(out, labelEra(s, probe(s))...)
+		findings, determined := probe(s)
+		if determined {
+			anyDetermined = true
+		}
+		out = append(out, labelEra(s, findings)...)
+	}
+	if len(out) == 0 && !anyDetermined {
+		return nil, attack.ErrInconclusive
 	}
 	return out, nil
 }

--- a/internal/attack/mcp/wire_test.go
+++ b/internal/attack/mcp/wire_test.go
@@ -406,9 +406,9 @@ func TestRunOnEachWire_LabelsModernFindingsOnly(t *testing.T) {
 
 	var eras []Era
 	findings, err := runOnEachWire(context.Background(), wireClient(), srv.URL,
-		func(s mcpSession) []attack.Finding {
+		func(s mcpSession) ([]attack.Finding, bool) {
 			eras = append(eras, s.Era)
-			return []attack.Finding{{Title: "surface exposed", Evidence: "body"}}
+			return []attack.Finding{{Title: "surface exposed", Evidence: "body"}}, true
 		})
 	if err != nil {
 		t.Fatalf("runOnEachWire: %v", err)
@@ -437,8 +437,8 @@ func TestRunOnEachWire_LegacyOnlyIsUnchanged(t *testing.T) {
 	defer srv.Close()
 
 	findings, err := runOnEachWire(context.Background(), wireClient(), srv.URL,
-		func(mcpSession) []attack.Finding {
-			return []attack.Finding{{Title: "surface exposed", Evidence: "body"}}
+		func(mcpSession) ([]attack.Finding, bool) {
+			return []attack.Finding{{Title: "surface exposed", Evidence: "body"}}, true
 		})
 	if err != nil {
 		t.Fatalf("runOnEachWire: %v", err)
@@ -478,5 +478,77 @@ func TestSessionPost_ModernMirrorsMcpName(t *testing.T) {
 	}
 	if got := (*seen)[len(*seen)-1].headers.Get("Mcp-Name"); got != "" {
 		t.Errorf("tools/call is name-bearing but tools/list is not; sent Mcp-Name=%q", got)
+	}
+}
+
+// A wire that establishes nothing must not read as a clean pass. This is what
+// carries the per-probe verdict up to the engine, which records ErrInconclusive
+// as skipped rather than as a secure result.
+func TestRunOnEachWire_UndeterminedWithNoFindingsIsInconclusive(t *testing.T) {
+	srv, _ := wireServer(t, true, false)
+	defer srv.Close()
+
+	_, err := runOnEachWire(context.Background(), wireClient(), srv.URL,
+		func(mcpSession) ([]attack.Finding, bool) {
+			return nil, false
+		})
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive when no wire established anything, got %v", err)
+	}
+}
+
+// A determined wire that found nothing is a genuine clean pass and must stay one.
+func TestRunOnEachWire_DeterminedWithNoFindingsIsClean(t *testing.T) {
+	srv, _ := wireServer(t, true, false)
+	defer srv.Close()
+
+	findings, err := runOnEachWire(context.Background(), wireClient(), srv.URL,
+		func(mcpSession) ([]attack.Finding, bool) {
+			return nil, true
+		})
+	if err != nil {
+		t.Fatalf("a determined wire must not be inconclusive: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+// Findings survive an undetermined wire. A rule that confirmed something and then
+// failed a follow-up probe still found it, and reporting "not tested" would throw
+// away a real result.
+func TestRunOnEachWire_FindingsSurviveAnUndeterminedWire(t *testing.T) {
+	srv, _ := wireServer(t, true, false)
+	defer srv.Close()
+
+	findings, err := runOnEachWire(context.Background(), wireClient(), srv.URL,
+		func(mcpSession) ([]attack.Finding, bool) {
+			return []attack.Finding{{Title: "surface exposed"}}, false
+		})
+	if err != nil {
+		t.Fatalf("findings must not be discarded as inconclusive: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected the finding to survive, got %d", len(findings))
+	}
+}
+
+// On a dual-era server one wire establishing something is enough: the other may
+// legitimately not serve the surface.
+func TestRunOnEachWire_OneDeterminedWireIsEnough(t *testing.T) {
+	srv, _ := wireServer(t, true, true)
+	defer srv.Close()
+
+	calls := 0
+	_, err := runOnEachWire(context.Background(), wireClient(), srv.URL,
+		func(mcpSession) ([]attack.Finding, bool) {
+			calls++
+			return nil, calls == 1 // legacy determined, modern not
+		})
+	if err != nil {
+		t.Fatalf("one determined wire must be enough, got %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("both wires should be probed, got %d calls", calls)
 	}
 }

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -62,6 +62,7 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_modern_era_server.py` | 7799 | none, by design: an era-detection target, see below |
 | `mcp_era_downgrade_server.py` | 7800 | `mcp-era-downgrade-001` (two postures, see below) |
 | `mcp_large_body_server.py` | 7801 | the unauth family at responses past the body read limit, see below |
+| `mcp_transient_failure_server.py` | 7802 | the unauth family when a probe fails without refusing, see below |
 
 **Coverage.** 35 of the 36 rules have a standalone Python fixture above. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
@@ -107,6 +108,21 @@ rules that treat an unparseable probe the same as a refused one reported those
 surfaces clean. The large server gave 1 finding where the small one gave 7, so a
 server could hide every unauthenticated-access finding by being large. If the two
 invocations ever disagree again, a body is being truncated somewhere.
+
+**`mcp_transient_failure_server.py` separates a failure from a refusal.** It has
+no authentication, and selects how its listing methods answer:
+
+```sh
+python testdata/mcp_transient_failure_server.py 7802 ok    # findings
+python testdata/mcp_transient_failure_server.py 7802 401   # clean, auth enforced
+python testdata/mcp_transient_failure_server.py 7802 502   # not tested
+```
+
+All three must differ. They did not: the rules gated on
+`if err != nil || !resp.IsSuccess() { return nil }`, so a gateway 502 was
+indistinguishable from a 401 and both reported the surfaces clean. An operator
+could not tell "this server enforces auth" from "the scanner could not tell". If
+the 401 and 502 runs ever agree again, that conflation is back.
 
 **`mcp_era_downgrade_server.py` takes a posture argument**, defaulting to
 `vulnerable`:

--- a/testdata/mcp_transient_failure_server.py
+++ b/testdata/mcp_transient_failure_server.py
@@ -1,0 +1,102 @@
+"""
+Batesian MCP validation target: a failure that is not a refusal.
+
+This server has NO authentication, so every unauth rule should fire against it.
+What it varies is how its listing methods fail, selected by the second argument:
+
+    ok    every listing returns a result   -> findings, as any open server
+    401   every listing returns 401        -> clean, authorization is enforced
+    502   every listing returns 502        -> INCONCLUSIVE, nothing was established
+
+The 502 mode is the point. A gateway failure says nothing about authorization, but
+the unauth rules gated on `if err != nil || !resp.IsSuccess() { return nil }`,
+which lumped 502 in with 401 and reported the surfaces clean. The 401 and 502 runs
+produced identical output, so an operator could not tell "this server enforces
+auth" from "the scanner could not tell".
+
+Run:
+    python testdata/mcp_transient_failure_server.py [port] [ok|401|502]
+
+Endpoint: http://127.0.0.1:7802/mcp
+
+Expect: 502 reports the tools, prompts and resources rules as not tested; 401
+reports them clean; ok reports findings. The three must differ from each other.
+"""
+
+
+import sys
+
+import uvicorn
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, PlainTextResponse
+from starlette.routing import Route
+
+PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 7802
+MODE = sys.argv[2] if len(sys.argv) > 2 else "502"
+MODES = ("ok", "401", "502")
+
+TOOLS = [{"name": "echo", "description": "Echoes input",
+          "inputSchema": {"type": "object", "properties": {"text": {"type": "string"}}}}]
+PROMPTS = [{"name": "greet", "description": "A prompt template"}]
+RESOURCES = [{"uri": "config://database", "name": "database", "mimeType": "text/plain"}]
+
+LISTING = {"tools/list": {"tools": TOOLS},
+           "prompts/list": {"prompts": PROMPTS},
+           "resources/list": {"resources": RESOURCES}}
+
+
+async def mcp(request: Request):
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"jsonrpc": "2.0", "id": None,
+                             "error": {"code": -32700, "message": "Parse error"}}, status_code=400)
+
+    method = body.get("method")
+    req_id = body.get("id")
+
+    if method == "initialize":
+        return JSONResponse(
+            {"jsonrpc": "2.0", "id": req_id, "result": {
+                "protocolVersion": "2025-06-18",
+                "serverInfo": {"name": "FlakyTarget", "version": "1.0"},
+                "capabilities": {"tools": {}, "prompts": {}, "resources": {}, "logging": {}},
+            }},
+            headers={"Mcp-Session-Id": "flaky-session"},
+        )
+    if method == "notifications/initialized":
+        return JSONResponse({}, status_code=202)
+
+    if method in LISTING:
+        if MODE == "502":
+            # A gateway failure. Says nothing about authorization.
+            return PlainTextResponse("Bad Gateway", status_code=502)
+        if MODE == "401":
+            # Auth genuinely enforced. Reporting clean here is correct.
+            return JSONResponse({"jsonrpc": "2.0", "id": req_id,
+                                 "error": {"code": -32001, "message": "Unauthorized"}}, status_code=401)
+        return JSONResponse({"jsonrpc": "2.0", "id": req_id, "result": LISTING[method]})
+
+    if method == "resources/read":
+        return JSONResponse({"jsonrpc": "2.0", "id": req_id, "result": {
+            "contents": [{"uri": "config://database", "mimeType": "text/plain",
+                          "text": "postgresql://admin:hunter2@db.internal:5432/prod"}]}})
+    if method == "prompts/get":
+        return JSONResponse({"jsonrpc": "2.0", "id": req_id, "result": {
+            "messages": [{"role": "user", "content": {"type": "text", "text": "Hello"}}]}})
+    if method == "tools/call":
+        return JSONResponse({"jsonrpc": "2.0", "id": req_id,
+                             "result": {"content": [{"type": "text", "text": "ok"}]}})
+
+    return JSONResponse({"jsonrpc": "2.0", "id": req_id,
+                         "error": {"code": -32601, "message": "Method not found"}}, status_code=400)
+
+
+app = Starlette(routes=[Route("/mcp", mcp, methods=["POST"])])
+
+if __name__ == "__main__":
+    if MODE not in MODES:
+        sys.exit(f"unknown mode {MODE!r}; expected one of {', '.join(MODES)}")
+    print(f"Starting MCP transient-failure target ({MODE}) on http://127.0.0.1:{PORT}/mcp")
+    uvicorn.run(app, host="127.0.0.1", port=PORT, log_level="warning")


### PR DESCRIPTION
Every probe in the unauth family was gated on:

```go
if err != nil || !resp.IsSuccess() { return nil }
if err := json.Unmarshal(resp.Body, &body); err != nil { return nil }
```

That collapses three different outcomes into a clean result: the server refused, the request never got an answer, and the answer could not be parsed.

Against a server with **no authorization anywhere** whose listing methods answered 502:

| Posture | findings | tools | prompts | resources |
|---|---|---|---|---|
| all open | 7 | FIRED | FIRED | FIRED |
| **502** | 1 | CLEAN | CLEAN | CLEAN |
| **401** | 1 | CLEAN | CLEAN | CLEAN |

The 401 and 502 rows were identical, so an operator could not tell "this server enforces auth" from "the scanner could not tell". This is the rubric S3 established for *reaching* an endpoint, never applied to a probe inside a session that was reached.

## Fix

`classifyProbe` returns one of three verdicts:

- **answered** — 2xx with a parseable JSON object; the caller interprets it as before.
- **rejected** — an auth status, or any non-2xx carrying a JSON-RPC error. A `-32601` says the method is absent and a `-32001` says access was denied; both mean the surface is closed, which is what these rules concluded before.
- **inconclusive** — transport failure, gateway 502, HTML 500, empty 400, or a body that will not parse.

Keeping non-2xx-with-an-error as *rejected* rather than *answered* is deliberate: `classifyDispatch` is documented for 2xx bodies only, and a 500 carrying `-32603` would otherwise read as "the handler ran" and invent a finding.

`runOnEachWire` now takes a probe that also reports whether it established anything, and returns `ErrInconclusive` when no wire established anything and nothing was found. **Findings survive an undetermined wire** — a rule that confirmed an open listing and then failed a follow-up still found the listing, and `tools_unauth` returning it when the `tools/call` probe fails was already correct.

Four rules move onto it: tools, prompts, resources, completion. A capability the handshake does not advertise stays *determined*, because the server saying it has no tools is an answer.

## Verification

`testdata/mcp_transient_failure_server.py` (port 7802) selects `ok`, `401` or `502` on its listings. All three must differ; that 401 and 502 did not is the bug.

Against a true main baseline across **thirteen live targets, exactly one changes** — the 502 posture, where the three rules move from clean to not tested (1 finding / 12 skipped → 1 / 15). Findings are identical everywhere else, covering both A2A SDKs, four MCP implementations and three secured postures. Reverting `classifyProbe` to the old semantics fails seven of the new cases.

## Scope

Increment 1 of the wave. Still conflating the same three outcomes: `logging_unauth`, and outside this family `task_idor`, `sse_resume_replay`, `jsonrpc_batch_bypass` and the A2A rules. Those do not share this idiom and want reading individually rather than a mechanical pass, so they are not bundled here.
