### PR TITLE
test(mcp): give mcp-init-downgrade-001 a fixture that can actually fire

### DIFF
--- a/testdata/README.md
+++ b/testdata/README.md
@@ -47,7 +47,7 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_unauth_resources_server.py` | 7787 | `mcp-resources-unauth-001` |
 | `mcp_oauth_dcr_server.py` | 7788 | `mcp-oauth-dcr-001` |
 | `mcp_oauth_audience_server.py` | 7785 | `mcp-oauth-audience-002` |
-| `mcp_new_rules_server.py` | 3100 | `mcp-init-downgrade-001`, `mcp-prompt-unauth-001`, `mcp-tools-unauth-001` |
+| `mcp_new_rules_server.py` | 3100 | `mcp-prompt-unauth-001`, `mcp-tools-unauth-001`; `mcp-init-downgrade-001` needs the `downgrade` posture, see below |
 | `mcp_session_fixation_server.py` | 7786 | `mcp-session-fixation-001` |
 | `mcp_header_body_split_server.py` | 7789 | `mcp-header-body-split-001` |
 | `mcp_sse_resume_replay_server.py` | 7790 | `mcp-sse-resume-replay-001` |
@@ -64,11 +64,23 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_large_body_server.py` | 7801 | the unauth family at responses past the body read limit, see below |
 | `mcp_transient_failure_server.py` | 7802 | the unauth family when a probe fails without refusing, see below |
 
-**Coverage.** 35 of the 36 rules have a standalone Python fixture above. The
+**Coverage.** 35 of the 36 rules have a standalone Python fixture above, and each
+of those was checked by actually running it rather than by reading this table. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
 (`internal/attack/mcp/token_replay_test.go`); the same is true of the per-rule
 edge-case harnesses for every other rule. `mockserver.go` is a Go helper used by
 unit tests via `net/http/httptest`; it is not a standalone server.
+
+A registry row is a claim, and claims rot. Three things make a fixture look broken
+when it is not, so check them before concluding a rule has regressed:
+
+- **Tokens.** The multi-principal fixtures expect `tok-a` and `tok-b`
+  specifically, not arbitrary names.
+- **Target.** The OAuth fixtures (`mcp_oauth_dcr_server.py`,
+  `mcp_oauth_metadata_ssrf_server.py`, `mcp_confused_deputy_server.py`) are
+  scanned at the root, not at `/mcp`. `mcp_oauth_audience_server.py` also needs
+  `--audience-claim`.
+- **Postures.** Several fixtures need a non-default argument, listed above.
 
 **`mcp_modern_era_server.py` is the one server here that is not deliberately
 vulnerable.** It is built on the official MCP Python SDK and speaks the
@@ -108,6 +120,26 @@ rules that treat an unparseable probe the same as a refused one reported those
 surfaces clean. The large server gave 1 finding where the small one gave 7, so a
 server could hide every unauthenticated-access finding by being large. If the two
 invocations ever disagree again, a body is being truncated somewhere.
+
+**`mcp_new_rules_server.py` takes a posture argument**, defaulting to `open`:
+
+```sh
+python testdata/mcp_new_rules_server.py            # prompt-unauth + tools-unauth
+python testdata/mcp_new_rules_server.py downgrade  # mcp-init-downgrade-001
+```
+
+`mcp-init-downgrade-001` needs its own posture because accepting an old protocol
+version is not the bug. Version negotiation permits a server to honour a supported
+older revision, so the rule requires an asymmetry: resources/list REJECTED under
+the modern version but GRANTED under the pre-auth 2024-11-05. The `open` posture
+enforces nothing and therefore grants both, which is
+`mcp-resources-unauth-001`'s finding rather than a downgrade, and the rule
+correctly stays silent.
+
+This row claimed `mcp-init-downgrade-001` for a long time while the rule could not
+possibly fire against the fixture, so a critical-severity rule had no standalone
+fixture at all and nobody could tell from the table. That is the failure the note
+below about confirming a rule actually fires is warning about.
 
 **`mcp_transient_failure_server.py` separates a failure from a refusal.** It has
 no authentication, and selects how its listing methods answer:

--- a/testdata/mcp_new_rules_server.py
+++ b/testdata/mcp_new_rules_server.py
@@ -1,13 +1,25 @@
 """
-Deliberately vulnerable MCP test server for validating:
-  - mcp-init-downgrade-001: accepts legacy protocol version 2024-11-05
+Deliberately vulnerable MCP test server. Two postures, selected by the first
+argument.
+
+`open` (the default) enforces nothing, and validates:
   - mcp-prompt-unauth-001: exposes prompt templates without auth
   - mcp-tools-unauth-001: exposes tools/list and tools/call dispatch without auth
 
-(May still carry a legacy CORS route from a pruned rule; only the rules listed
-above are part of the current rule set.)
+`downgrade` validates mcp-init-downgrade-001, and needs its own posture because
+accepting an old protocol version is NOT the bug. Version negotiation permits a
+server to honour a supported older revision, so the rule requires a
+discriminator: resources/list REJECTED under the modern version (authorization
+enforced) but GRANTED under the pre-auth 2024-11-05. A server with no
+authorization at all grants both, which is mcp-resources-unauth-001's finding
+rather than a downgrade, and the rule correctly stays silent.
 
-Run: python testdata/mcp_new_rules_server.py
+The `open` posture grants both, so it can never exhibit the downgrade bypass. It
+was listed in the registry as covering mcp-init-downgrade-001 for a long time
+while the rule could not possibly fire against it, which left the rule with no
+standalone fixture at all.
+
+Run: python testdata/mcp_new_rules_server.py [open|downgrade]
 """
 import json
 import sys
@@ -19,6 +31,14 @@ from starlette.routing import Route
 import uvicorn
 
 PORT = 3100
+
+POSTURES = ("open", "downgrade")
+POSTURE = sys.argv[1] if len(sys.argv) > 1 else "open"
+
+# The pre-authorization revision. Under `downgrade`, negotiating this version is
+# what skips the authorization check.
+LEGACY_VERSION = "2024-11-05"
+VALID_TOKEN = "Bearer letmein"
 
 TOOLS = [
     {"name": "echo", "description": "Echo the input", "inputSchema": {"type": "object", "properties": {"text": {"type": "string"}}}},
@@ -95,6 +115,19 @@ async def mcp_endpoint(request: Request) -> Response:
     if method == "notifications/initialized":
         return Response(status_code=202, headers=cors)
 
+    # Under `downgrade`, resources/list is gated unless the session negotiated the
+    # pre-auth revision. The scanner echoes the negotiated version back in
+    # MCP-Protocol-Version on every follow-up, which is what makes the two paths
+    # distinguishable without tracking sessions here.
+    if POSTURE == "downgrade" and method == "resources/list":
+        negotiated = request.headers.get("mcp-protocol-version", "")
+        authorized = request.headers.get("authorization", "") == VALID_TOKEN
+        if negotiated != LEGACY_VERSION and not authorized:
+            return Response(json.dumps({"jsonrpc": "2.0", "id": req_id,
+                                        "error": {"code": -32001, "message": "Unauthorized"}}),
+                            status_code=401, media_type="application/json",
+                            headers={**cors, "Content-Type": "application/json"})
+
     # All subsequent methods: no auth check (vulnerable)
     if method == "tools/list":
         result = {"tools": TOOLS}
@@ -136,6 +169,8 @@ app = Starlette(routes=[
 ])
 
 if __name__ == "__main__":
-    print(f"[*] MCP new-rules vulnerable server on port {PORT}", flush=True)
+    if POSTURE not in POSTURES:
+        sys.exit(f"unknown posture {POSTURE!r}; expected one of {', '.join(POSTURES)}")
+    print(f"[*] MCP new-rules vulnerable server ({POSTURE}) on port {PORT}", flush=True)
     print("[*] Vulnerabilities: protocol downgrade, CORS origin reflection, unauthenticated prompts and tools", flush=True)
     uvicorn.run(app, host="127.0.0.1", port=PORT)


### PR DESCRIPTION
A sweep of every fixture against the rules the registry claims for it found `mcp-init-downgrade-001` (CRITICAL) reporting clean against its only listed fixture. **The rule is not at fault and neither is its Go harness.**

`mcp_new_rules_server.py` enforces no authorization at all, so an unauthenticated `resources/list` is granted under both the modern version and the legacy `2024-11-05`:

```
2024-11-05  resources/list -> HTTP 200 granted=True
2025-06-18  resources/list -> HTTP 200 granted=True
```

The rule requires an asymmetry — modern REJECTED, legacy GRANTED — because honouring a supported older revision is permitted by version negotiation and is not a vulnerability on its own. Both granted is `mcp-resources-unauth-001`'s finding, and suppressing it there is exactly what the rule's doc comment and `TestInitDowngrade_NoAuthAtAll` describe.

So the fixture could never exhibit the bug, and because it was the only one listed, **a critical-severity rule had no standalone fixture at all while the table said otherwise.**

## Fix

The fixture takes a posture argument. `open` is unchanged and still covers prompt-unauth and tools-unauth. `downgrade` gates `resources/list` unless the session negotiated `2024-11-05`, which the scanner echoes back in `MCP-Protocol-Version` on every follow-up, so the two paths are distinguishable without tracking sessions in the fixture.

## Verification

| posture | legacy | modern | rule |
|---|---|---|---|
| `downgrade` | granted | **401** | **CRITICAL fires** |
| `open` | granted | granted | correctly silent |

The `open` posture is byte-identical to a pre-change binary: same 7 findings. No Go changes, so the suite and lint are untouched.

The registry row and coverage note are corrected. The note now also records the three things that made fixtures look broken during the sweep when they were not: the multi-principal fixtures want `tok-a`/`tok-b` specifically, the OAuth fixtures are scanned at the root rather than `/mcp`, and several need a non-default posture. All three produced false misses.
