### PR TITLE
fix(mcp): stop reading a 404 as a rejected token in mcp-oauth-audience-002

### DIFF
--- a/internal/attack/mcp/oauth_audience.go
+++ b/internal/attack/mcp/oauth_audience.go
@@ -319,9 +319,17 @@ func fetchResourceFromMetadata(ctx context.Context, client *attack.HTTPClient, m
 }
 
 // runProbesAgainstEndpoint sends every probe to each candidate endpoint and
-// returns the outcomes for the first endpoint that produced any usable
-// response. Endpoints that error on every probe are skipped so a stray /api
-// path cannot hide a real /mcp finding.
+// returns the outcomes for the first endpoint that produced a usable response.
+//
+// "Usable" means the endpoint actually engaged with the token. A transport
+// failure does not count, and neither does a reply that only says the path is
+// not there: this loop used to accept any response that was not a transport
+// error, so an unrouted candidate answering 404 ended the walk immediately and
+// the real endpoint further down the list was never probed. Combined with 404
+// classifying as a rejection, that made the rule report a target secure on the
+// strength of four requests to a path that did not exist. A stray /api path must
+// not be able to hide a real /mcp finding, which is what the old comment here
+// claimed and the code did not do.
 func runProbesAgainstEndpoint(ctx context.Context, client *attack.HTTPClient, baseURL string, probes []audienceProbe) (string, []probeOutcome, error) {
 	for _, ep := range endpointCandidates(baseURL) {
 		outcomes := make([]probeOutcome, 0, len(probes))
@@ -349,7 +357,9 @@ func runProbesAgainstEndpoint(ctx context.Context, client *attack.HTTPClient, ba
 				})
 				continue
 			}
-			anyResponse = true
+			if !endpointAbsent(resp) {
+				anyResponse = true
+			}
 			outcomes = append(outcomes, probeOutcome{
 				probe:    p,
 				verdict:  classifyResponse(resp),
@@ -389,11 +399,27 @@ func classifyResponse(resp *attack.Response) audVerdict {
 		return verdictInconclusive
 	case resp.StatusCode == 401, resp.StatusCode == 403:
 		return verdictRejected
+	case endpointAbsent(resp):
+		// There is no MCP endpoint at this path, so nothing examined the token.
+		// Calling it a rejection read a 404 as evidence that audience matching
+		// worked, which is how this rule reported a whole target secure on the
+		// strength of paths that did not exist.
+		return verdictInconclusive
 	case resp.StatusCode >= 400 && resp.StatusCode < 500:
 		return verdictRejected
 	default:
 		return verdictInconclusive
 	}
+}
+
+// endpointAbsent reports whether a response says "there is nothing here to talk
+// to" rather than anything about the request that was made.
+//
+// 404 means the path is unrouted. 405 means it is routed but does not take the
+// POST an MCP call requires, so it is not an MCP endpoint either. Neither is a
+// verdict on the forged token, and neither should end the candidate walk.
+func endpointAbsent(resp *attack.Response) bool {
+	return resp.StatusCode == 404 || resp.StatusCode == 405
 }
 
 // isJSONRPCResult reports whether body parses as a JSON-RPC response with a

--- a/internal/attack/mcp/oauth_audience_test.go
+++ b/internal/attack/mcp/oauth_audience_test.go
@@ -400,3 +400,85 @@ func TestOAuthAudience_UnreachableHost(t *testing.T) {
 
 	assertInconclusive(t, mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC()), addr, optsWithAudience(testExpectedAud))
 }
+
+// unroutedThenVulnerableServer serves the vulnerable substring matcher at
+// /sub/mcp and 404s everything else, including /sub itself. Scanned at
+// srv.URL+"/sub", the first candidate is the base path, which is unrouted.
+//
+// The base is only a candidate when the target carries a path, which is why a
+// root-targeted test cannot reproduce this: there the walk starts at /mcp and
+// finds the endpoint immediately.
+//
+// The walk used to stop at the first path returning any response that was not a
+// transport error, so the 404 at /sub ended it and /sub/mcp was never probed.
+// Worse, a 404 classified as a rejected token, so four requests to a path that
+// did not exist read as evidence that audience matching worked.
+func unroutedThenVulnerableServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/sub/mcp" {
+			// Unrouted, exactly as a real server answers a path it does not serve.
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		aud := decodeJWTAud(t, r.Header.Get("Authorization"))
+		if str, ok := aud.(string); ok && strings.Contains(str, testExpectedAud) {
+			initializeOK(w)
+			return
+		}
+		challenge401(w)
+	}))
+}
+
+// A 404 at one candidate must not end the walk, and must not read as the server
+// rejecting the token.
+func TestOAuthAudience_UnroutedCandidateDoesNotHideFinding(t *testing.T) {
+	srv := unroutedThenVulnerableServer(t)
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC())
+	findings, err := exec.Execute(context.Background(), srv.URL+"/sub", optsWithAudience(testExpectedAud))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected the finding at /sub/mcp to survive the 404 at /sub, got %d", len(findings))
+	}
+	if !strings.Contains(findings[0].TargetURL, "/sub/mcp") {
+		t.Errorf("finding should name the endpoint that answered, got %q", findings[0].TargetURL)
+	}
+}
+
+// A target that 404s every candidate has said nothing about audience matching, so
+// the rule must report that it could not test rather than that the server is
+// secure. This is the shape that produced a false clean.
+func TestOAuthAudience_AllCandidatesUnroutedIsNotTested(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC())
+	findings, err := exec.Execute(context.Background(), srv.URL, optsWithAudience(testExpectedAud))
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Errorf("404s everywhere are not evidence of a secure audience check; want ErrInconclusive, got %v", err)
+	}
+}
+
+// 405 is the same class: the path exists but does not take the POST an MCP call
+// needs, so it is not an MCP endpoint and says nothing about the token.
+func TestOAuthAudience_MethodNotAllowedIsNotARejection(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC())
+	_, err := exec.Execute(context.Background(), srv.URL, optsWithAudience(testExpectedAud))
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Errorf("want ErrInconclusive for a target answering 405 everywhere, got %v", err)
+	}
+}

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -46,7 +46,7 @@ fixtures for live-validation / manual smoke testing.
 | `a2a_card_security_unenforced_server.py` | 3110 | `a2a-card-security-unenforced-001` |
 | `mcp_unauth_resources_server.py` | 7787 | `mcp-resources-unauth-001` |
 | `mcp_oauth_dcr_server.py` | 7788 | `mcp-oauth-dcr-001` |
-| `mcp_oauth_audience_server.py` | 7785 | `mcp-oauth-audience-002` |
+| `mcp_oauth_audience_server.py` | 7785 | `mcp-oauth-audience-002` (four sub-paths, one per bug class; target each, not the root) |
 | `mcp_new_rules_server.py` | 3100 | `mcp-prompt-unauth-001`, `mcp-tools-unauth-001`; `mcp-init-downgrade-001` needs the `downgrade` posture, see below |
 | `mcp_session_fixation_server.py` | 7786 | `mcp-session-fixation-001` |
 | `mcp_header_body_split_server.py` | 7789 | `mcp-header-body-split-001` |
@@ -78,8 +78,10 @@ when it is not, so check them before concluding a rule has regressed:
   specifically, not arbitrary names.
 - **Target.** The OAuth fixtures (`mcp_oauth_dcr_server.py`,
   `mcp_oauth_metadata_ssrf_server.py`, `mcp_confused_deputy_server.py`) are
-  scanned at the root, not at `/mcp`. `mcp_oauth_audience_server.py` also needs
-  `--audience-claim`.
+  scanned at the root, not at `/mcp`. `mcp_oauth_audience_server.py` is the
+  opposite: each bug class lives at its own sub-path, so the target must name the
+  endpoint (`http://127.0.0.1:7785/vulnerable-substring/mcp` and so on), and it
+  takes `--audience-claim`. Scanning its root correctly reports "not tested".
 - **Postures.** Several fixtures need a non-default argument, listed above.
 
 **`mcp_modern_era_server.py` is the one server here that is not deliberately

--- a/testdata/mcp_oauth_audience_server.py
+++ b/testdata/mcp_oauth_audience_server.py
@@ -42,7 +42,13 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
 
-EXPECTED_AUD = "https://api.example.com/mcp"
+# Deliberately mixed case. The case-canonicalization probe only produces a real
+# case variant when the expected value has something to vary: given an all
+# lowercase audience the rule falls back to a default-port variant
+# (https://api.example.com:443/mcp), which /vulnerable-casefold/mcp correctly
+# rejects because it compares aud.lower() to EXPECTED_AUD.lower(). That left the
+# casefold endpoint advertising a bug it could not demonstrate.
+EXPECTED_AUD = "https://API.example.com/mcp"
 PORT = 7785
 
 


### PR DESCRIPTION
Continuing the fixture sweep, `mcp-oauth-audience-002` reported clean against its own fixture. Unlike #147, **this one is the rule's fault**, and the result is a security-relevant false clean.

Two lines conspired:

- `runProbesAgainstEndpoint` set `anyResponse` on any reply that was not a **transport** error, so an unrouted candidate answering **404 ended the candidate walk** before the real endpoint was reached. Its comment claimed "a stray /api path cannot hide a real /mcp finding" — which is exactly what the code failed to do.
- `classifyResponse` mapped any 4xx to `verdictRejected`, so those 404s read as the server **refusing a forged token**.

Together the rule could call a target secure on the strength of four requests to a path that does not exist.

| target | before | after |
|---|---|---|
| `/vulnerable-substring` (parent path) | clean | **FIRED** |
| fixture root | clean | **not tested** |
| `/vulnerable-substring/mcp` | FIRED | FIRED |
| `/secure/mcp` | clean | clean |

## Fix

404 and 405 are inconclusive rather than rejected, and neither ends the walk. A parent path now finds the endpoint below it, and a target answering 404 everywhere reports *not tested* instead of *secure*.

## Why no one noticed

Two fixture problems hid it, both fixed here:

- The documented command scans the root, but each bug class lives at its own sub-path and those are unreachable from the root — the candidates are the base plus `/mcp`, `/api`, `/rpc`, none of which match `/vulnerable-substring/mcp`. The command now names each endpoint.
- `EXPECTED_AUD` was all lowercase, so the case-canonicalization probe fell back to a default-port variant (`:443`) that `/vulnerable-casefold/mcp` correctly rejects — leaving that endpoint advertising a bug it could not demonstrate. It now carries mixed case, and I checked the other three endpoints behave unchanged under that value.

## Verification

All three `vulnerable-*` endpoints report a finding and `/secure` does not. Isolated against a **current main** baseline across eight live targets — three MCP implementations, two secured postures, an A2A server — with no change to any. Disabling the new `endpointAbsent` check fails the three new cases.
