### PR TITLE
fix(mcp): stop reporting a failed logging/setLevel probe as a secure surface

### DIFF
--- a/internal/attack/mcp/logging_unauth.go
+++ b/internal/attack/mcp/logging_unauth.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/calbebop/batesian/internal/attack"
@@ -66,13 +65,17 @@ func (e *LoggingUnauthExecutor) Execute(ctx context.Context, target string, opts
 		"method":  "logging/setLevel",
 		"params":  map[string]interface{}{"level": bogusLevel},
 	})
-	if err != nil || !resp.IsSuccess() {
-		return nil, nil // auth gate (401/403) or unreachable
-	}
-
-	var body map[string]interface{}
-	if err := json.Unmarshal(resp.Body, &body); err != nil {
-		return nil, nil
+	verdict, body := classifyProbe(resp, err)
+	if verdict != probeAnswered {
+		if verdict == probeRejected {
+			// An auth status, or a JSON-RPC error at a non-2xx: the surface is
+			// closed or absent, which is a genuine clean result.
+			return nil, nil
+		}
+		// Nothing was established. The request failed, or the reply carried no
+		// protocol-level verdict, so reporting this surface clean would claim it
+		// is secure when it was never tested.
+		return nil, attack.ErrInconclusive
 	}
 
 	reachable, reason := setLevelDispatchReachable(body)

--- a/internal/attack/mcp/unauth_honesty_test.go
+++ b/internal/attack/mcp/unauth_honesty_test.go
@@ -34,6 +34,10 @@ func listingServer(t *testing.T, mode string) *httptest.Server {
 		"prompts/list":        {"prompts": []interface{}{map[string]interface{}{"name": "greet"}}},
 		"resources/list":      {"resources": []interface{}{map[string]interface{}{"uri": "config://db"}}},
 		"completion/complete": {"completion": map[string]interface{}{"values": []interface{}{"alpha", "beta"}}},
+		// logging/setLevel is included for the same reason: left to fall through it
+		// answers -32601, which correctly reads as the method being absent, so the
+		// mode would never reach logging-unauth's gate.
+		"logging/setLevel": {},
 	}
 
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -115,6 +119,7 @@ func unauthFamily() map[string]func(attack.RuleContext) attack.Executor {
 		"mcp-prompt-unauth-001":     func(rc attack.RuleContext) attack.Executor { return mcpattack.NewPromptUnauthExecutor(rc) },
 		"mcp-resources-unauth-001":  func(rc attack.RuleContext) attack.Executor { return mcpattack.NewResourcesUnauthExecutor(rc) },
 		"mcp-completion-unauth-001": func(rc attack.RuleContext) attack.Executor { return mcpattack.NewCompletionUnauthExecutor(rc) },
+		"mcp-logging-unauth-001":    func(rc attack.RuleContext) attack.Executor { return mcpattack.NewLoggingUnauthExecutor(rc) },
 	}
 }
 
@@ -163,7 +168,8 @@ func TestUnauthFamily_OpenServerStillFires(t *testing.T) {
 	srv := listingServer(t, "open")
 	defer srv.Close()
 
-	for _, id := range []string{"mcp-tools-unauth-001", "mcp-prompt-unauth-001", "mcp-resources-unauth-001"} {
+	for _, id := range []string{"mcp-tools-unauth-001", "mcp-prompt-unauth-001",
+		"mcp-resources-unauth-001", "mcp-logging-unauth-001"} {
 		t.Run(id, func(t *testing.T) {
 			exec := unauthFamily()[id](attack.RuleContext{ID: id, Name: id, Severity: "high"})
 			findings, err := exec.Execute(context.Background(), srv.URL, testOpts())

--- a/testdata/mcp_transient_failure_server.py
+++ b/testdata/mcp_transient_failure_server.py
@@ -19,7 +19,7 @@ Run:
 
 Endpoint: http://127.0.0.1:7802/mcp
 
-Expect: 502 reports the tools, prompts and resources rules as not tested; 401
+Expect: 502 reports the tools, prompts, resources and logging rules as not tested; 401
 reports them clean; ok reports findings. The three must differ from each other.
 """
 
@@ -41,9 +41,13 @@ TOOLS = [{"name": "echo", "description": "Echoes input",
 PROMPTS = [{"name": "greet", "description": "A prompt template"}]
 RESOURCES = [{"uri": "config://database", "name": "database", "mimeType": "text/plain"}]
 
+# logging/setLevel is in here so mcp-logging-unauth-001 is exercised too. Left to
+# fall through it answers -32601, which correctly reads as the method being absent,
+# so the mode would never reach that rule's gate.
 LISTING = {"tools/list": {"tools": TOOLS},
            "prompts/list": {"prompts": PROMPTS},
-           "resources/list": {"resources": RESOURCES}}
+           "resources/list": {"resources": RESOURCES},
+           "logging/setLevel": {}}
 
 
 async def mcp(request: Request):


### PR DESCRIPTION
Increment 2 of the probe-honesty wave, and **smaller than planned on purpose**.

`logging_unauth` carried the same gate the rest of the family did, collapsing a refusal, an unreachable endpoint and an unparseable body into a clean result. It was left out of #146 only because it does not route through `runOnEachWire`, so the conversion is a direct `classifyProbe` call: an auth status or a JSON-RPC error at a non-2xx stays clean, anything that established nothing is inconclusive.

The transient-failure fixture could not see this — `logging/setLevel` fell through to `-32601`, which correctly reads as the method being absent, so the 502 mode never reached the rule's gate. The fixture and the Go harness now both drive `logging/setLevel` through the mode:

| posture | before | after |
|---|---|---|
| 502 | clean | **not tested** |
| 401 | clean | clean |
| open | FIRED | FIRED |

## Three rules deliberately not converted

The other increment-2 candidates are left alone, because the conflation is not demonstrable in them and converting on the strength of a shared-looking shape is how a fixture ends up vouching for an assumption:

- **`jsonrpc_batch_bypass`** already threads a `reached` flag and returns false on a transport failure. Its `!isAuthRejection(ctrl) → continue` is correct: a method that is not gated has no gate to bypass.
- **`task_idor`**'s `listTasks` already returns a bool, and its failure means the task surface is absent on a *secondary* probe rather than a verdict on the primary one.
- **`sse_resume_replay`** collects events in a time window, where an empty result is the ordinary case rather than an error signal, so it needs different reasoning than a request/response gate.

Each would need a fixture that exhibits the conflation first. If one cannot be built, that is the answer.

## Verification

Full suite and lint clean. Isolated against a current main baseline across eight live targets — three MCP implementations, two secured postures, an A2A server — none of which change. Forcing the rejected branch fails the new logging case.
