### PR TITLE
feat: route requests through an intercepting proxy with --proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,16 @@ batesian scan --target https://agent.example.com \
 
 batesian scan --target https://agent.example.com --dry-run
 
+batesian scan --target https://mcp.example.com --proxy 127.0.0.1:8080 --skip-tls
+
 batesian init
 ```
+
+`--proxy` routes every request through an intercepting proxy so a whole scan can be
+reviewed in Burp or ZAP, and pairs with `--skip-tls` because such proxies present
+their own CA. With no flag, `HTTPS_PROXY`, `HTTP_PROXY` and `NO_PROXY` are honoured;
+note that Go does not send loopback targets through an environment proxy, so a scan
+against `127.0.0.1` needs the explicit flag.
 
 `probe` is reconnaissance (table or JSON). It does not emit SARIF. `batesian init` writes an annotated `batesian.yaml` to the current directory (it will not overwrite an existing one) so targets, tokens, and rule selections can live in version-controlled config. For flags, filters, config files, OAuth, and extra rule paths: `batesian scan --help`.
 

--- a/internal/attack/dryrun.go
+++ b/internal/attack/dryrun.go
@@ -5,8 +5,11 @@ import (
 	"crypto/tls"
 	"io"
 	"net/http"
+
 	"strings"
 	"sync"
+
+	"github.com/calbebop/batesian/internal/httpx"
 )
 
 // DryRunOOBPlaceholderURL is the base callback URL substituted for a real OOB
@@ -125,8 +128,14 @@ func syntheticResponse(req *http.Request) *http.Response {
 
 // Transport returns the RoundTripper for a scan-path HTTP client. In a dry run it
 // returns a recording transport that sends nothing; otherwise a real
-// *http.Transport honoring opts.SkipTLS. Routing every scan-path client through
-// this one function is what makes the dry-run "send nothing" guarantee total.
+// *http.Transport honoring opts.SkipTLS and opts.Proxy. Routing every scan-path
+// client through this one function is what makes the dry-run "send nothing"
+// guarantee total, and it is why one change here reaches the shared client plus
+// the two rules that keep their own (confused-deputy and sse-resume-replay).
+//
+// A bare &http.Transport{} does not consult the environment, so before this every
+// scan ignored HTTPS_PROXY while the OAuth clients honoured it. See
+// httpx.ProxyFunc.
 func Transport(opts Options) http.RoundTripper {
 	if opts.DryRun {
 		return &dryRunRoundTripper{rec: opts.Recorder}
@@ -135,5 +144,22 @@ func Transport(opts Options) http.RoundTripper {
 	if opts.SkipTLS {
 		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
 	}
+	proxy, err := httpx.ProxyFunc(opts.Proxy)
+	if err != nil {
+		// Fail every request rather than fall back to a direct connection: a
+		// mistyped proxy that silently bypasses the operator's interception is
+		// precisely the outcome this option exists to prevent.
+		return &erroringRoundTripper{err: err}
+	}
+	tr.Proxy = proxy
 	return tr
+}
+
+// erroringRoundTripper fails every request with a fixed error. It reports a
+// misconfigured proxy at the point of use, so the failure is attributable instead
+// of appearing as a scan that mysteriously reached nothing.
+type erroringRoundTripper struct{ err error }
+
+func (e *erroringRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, e.err
 }

--- a/internal/attack/executor.go
+++ b/internal/attack/executor.go
@@ -46,6 +46,16 @@ type Options struct {
 	// SkipTLS disables TLS certificate verification.
 	SkipTLS bool
 
+	// Proxy routes every request through an intercepting proxy, which is how a
+	// scan gets reviewed in Burp or ZAP. Empty means consult the environment
+	// (HTTPS_PROXY, HTTP_PROXY, NO_PROXY).
+	//
+	// An intercepting proxy presents its own CA, so this is normally paired with
+	// SkipTLS. It is deliberately not implied: quietly dropping certificate
+	// verification because a proxy was requested is the kind of surprise this
+	// tool should not spring.
+	Proxy string
+
 	// Verbose enables debug logging.
 	Verbose bool
 

--- a/internal/attack/http_test.go
+++ b/internal/attack/http_test.go
@@ -261,3 +261,52 @@ func TestHTTPClient_OverLimitBodyIsAnError(t *testing.T) {
 		t.Errorf("error should name the read limit, got: %v", err)
 	}
 }
+
+// The scan client must route through the configured proxy. Every transport here
+// used to be a bare &http.Transport{}, which ignores even HTTPS_PROXY, while the
+// OAuth clients left Transport nil and so honoured it. An operator who set
+// HTTPS_PROXY captured the OAuth traffic and nothing else, and a capture that
+// looks complete but is not is worse than no proxy support.
+func TestTransport_RoutesThroughProxy(t *testing.T) {
+	var proxied []string
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxied = append(proxied, r.Host)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"jsonrpc":"2.0","id":1,"result":{}}`)
+	}))
+	defer proxy.Close()
+
+	client := attack.NewUnauthHTTPClient(
+		attack.Options{TimeoutSeconds: 5, Proxy: strings.TrimPrefix(proxy.URL, "http://")},
+		attack.NewVars("http://target.invalid", ""))
+
+	// target.invalid does not resolve, so a response can only have come via the proxy.
+	resp, err := client.POST(context.Background(), "http://target.invalid/mcp", nil,
+		map[string]interface{}{"jsonrpc": "2.0"})
+	if err != nil {
+		t.Fatalf("request should have gone through the proxy: %v", err)
+	}
+	if !resp.IsAccepted() {
+		t.Errorf("expected the proxy's response, got HTTP %d %s", resp.StatusCode, resp.BodyString())
+	}
+	if len(proxied) != 1 || proxied[0] != "target.invalid" {
+		t.Errorf("proxy should have seen one request for target.invalid, saw %v", proxied)
+	}
+}
+
+// A mistyped proxy must fail loudly. Falling back to a direct connection would let
+// the operator believe they were intercepting when they were not.
+func TestTransport_UnusableProxyFailsRequests(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"result":{}}`)
+	}))
+	defer srv.Close()
+
+	client := attack.NewUnauthHTTPClient(
+		attack.Options{TimeoutSeconds: 5, Proxy: "ftp://nope:21"},
+		attack.NewVars(srv.URL, ""))
+
+	if _, err := client.POST(context.Background(), srv.URL, nil, map[string]interface{}{}); err == nil {
+		t.Error("an unusable proxy must fail the request, not silently connect directly")
+	}
+}

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -13,9 +13,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/calbebop/batesian/internal/httpx"
 )
 
 // TokenResponse holds the fields returned by an OAuth 2.0 token endpoint.
@@ -40,6 +43,12 @@ type ClientCredentialsConfig struct {
 	Audience string
 	// Timeout is the HTTP timeout for the token request (default: 15s).
 	Timeout time.Duration
+
+	// Proxy routes the token exchange through an intercepting proxy. Empty means
+	// consult the environment, which these clients already did by leaving
+	// Transport nil; the field is what lets an explicit --proxy win over it, so
+	// the OAuth leg and the scan leg agree on where traffic goes.
+	Proxy string
 }
 
 // FetchClientCredentialsToken performs an OAuth 2.0 client credentials grant
@@ -79,7 +88,14 @@ func fetchClientCredentialsTokenWithClient(ctx context.Context, cfg ClientCreden
 
 	httpClient := client
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: cfg.Timeout}
+		proxy, err := httpx.ProxyFunc(cfg.Proxy)
+		if err != nil {
+			return nil, err
+		}
+		httpClient = &http.Client{
+			Timeout:   cfg.Timeout,
+			Transport: &http.Transport{Proxy: proxy},
+		}
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.TokenURL,
 		strings.NewReader(form.Encode()))
@@ -152,6 +168,12 @@ type AuthCodeConfig struct {
 	PKCEVerifier string
 	// Timeout is the HTTP timeout for the token request.
 	Timeout time.Duration
+
+	// Proxy routes the token exchange through an intercepting proxy. Empty means
+	// consult the environment, which these clients already did by leaving
+	// Transport nil; the field is what lets an explicit --proxy win over it, so
+	// the OAuth leg and the scan leg agree on where traffic goes.
+	Proxy string
 }
 
 // ExchangeAuthCode exchanges an authorization code (plus PKCE verifier) for tokens.
@@ -183,7 +205,14 @@ func exchangeAuthCodeWithClient(ctx context.Context, cfg AuthCodeConfig, client 
 
 	httpClient := client
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: cfg.Timeout}
+		proxy, err := httpx.ProxyFunc(cfg.Proxy)
+		if err != nil {
+			return nil, err
+		}
+		httpClient = &http.Client{
+			Timeout:   cfg.Timeout,
+			Transport: &http.Transport{Proxy: proxy},
+		}
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.TokenURL,
 		strings.NewReader(form.Encode()))

--- a/internal/cli/probe.go
+++ b/internal/cli/probe.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/calbebop/batesian/internal/httpx"
 	"github.com/calbebop/batesian/internal/protocol/a2a"
 	"github.com/calbebop/batesian/internal/protocol/mcp"
 	"github.com/calbebop/batesian/internal/report"
@@ -50,6 +51,7 @@ func init() {
 	probeCmd.Flags().String("token", "", "Bearer token for authenticated requests")
 	probeCmd.Flags().Int("timeout", 10, "Request timeout in seconds")
 	probeCmd.Flags().Bool("skip-tls", false, "Skip TLS certificate verification")
+	probeCmd.Flags().String("proxy", "", "Route all requests through an intercepting proxy, e.g. 127.0.0.1:8080 (default: honor HTTPS_PROXY/HTTP_PROXY/NO_PROXY); usually paired with --skip-tls")
 	rootCmd.AddCommand(probeCmd)
 }
 
@@ -61,6 +63,12 @@ func runProbe(cmd *cobra.Command, args []string) error {
 	token, _ := cmd.Flags().GetString("token")
 	timeoutSecs, _ := cmd.Flags().GetInt("timeout")
 	skipTLS, _ := cmd.Flags().GetBool("skip-tls")
+	proxy, _ := cmd.Flags().GetString("proxy")
+	// Validate once, up front: a broken proxy should not look like an unreachable
+	// target.
+	if _, err := httpx.ProxyFunc(proxy); err != nil {
+		return err
+	}
 
 	if target == "" {
 		return fmt.Errorf("--target is required")
@@ -83,15 +91,15 @@ func runProbe(cmd *cobra.Command, args []string) error {
 
 	switch strings.ToLower(protocol) {
 	case "a2a":
-		return probeA2A(target, token, timeoutSecs, skipTLS, format, printer)
+		return probeA2A(target, token, timeoutSecs, skipTLS, proxy, format, printer)
 	case "mcp":
-		return probeMCP(target, token, timeoutSecs, skipTLS, format, printer)
+		return probeMCP(target, token, timeoutSecs, skipTLS, proxy, format, printer)
 	default:
 		return fmt.Errorf("unknown protocol %q; supported: a2a, mcp", protocol)
 	}
 }
 
-func probeA2A(target, token string, timeoutSecs int, skipTLS bool, format report.Format, printer *report.Printer) error { //nolint:cyclop
+func probeA2A(target, token string, timeoutSecs int, skipTLS bool, proxy string, format report.Format, printer *report.Printer) error { //nolint:cyclop
 	if timeoutSecs <= 0 {
 		timeoutSecs = 10
 	}
@@ -103,6 +111,9 @@ func probeA2A(target, token string, timeoutSecs int, skipTLS bool, format report
 	}
 	if skipTLS {
 		opts = append(opts, a2a.WithSkipTLSVerify())
+	}
+	if proxy != "" {
+		opts = append(opts, a2a.WithProxy(proxy))
 	}
 
 	client, err := a2a.NewClient(target, opts...)
@@ -208,7 +219,7 @@ func cardToProbeResult(card *a2a.AgentCard, elapsed time.Duration) *report.Probe
 	return r
 }
 
-func probeMCP(target, token string, timeoutSecs int, skipTLS bool, format report.Format, printer *report.Printer) error {
+func probeMCP(target, token string, timeoutSecs int, skipTLS bool, proxy string, format report.Format, printer *report.Printer) error {
 	if timeoutSecs <= 0 {
 		timeoutSecs = 10
 	}
@@ -220,6 +231,9 @@ func probeMCP(target, token string, timeoutSecs int, skipTLS bool, format report
 	}
 	if skipTLS {
 		opts = append(opts, mcp.WithSkipTLSVerify())
+	}
+	if proxy != "" {
+		opts = append(opts, mcp.WithProxy(proxy))
 	}
 
 	client, err := mcp.NewClient(target, opts...)

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -14,6 +14,7 @@ import (
 	"github.com/calbebop/batesian/internal/auth"
 	"github.com/calbebop/batesian/internal/config"
 	"github.com/calbebop/batesian/internal/engine"
+	"github.com/calbebop/batesian/internal/httpx"
 	"github.com/calbebop/batesian/internal/report"
 	"github.com/calbebop/batesian/internal/rules"
 	"github.com/spf13/cobra"
@@ -53,6 +54,7 @@ func init() {
 	scanCmd.Flags().String("token", "", "Bearer token for authenticated requests")
 	scanCmd.Flags().Int("timeout", 10, "Request timeout in seconds")
 	scanCmd.Flags().Bool("skip-tls", false, "Skip TLS certificate verification")
+	scanCmd.Flags().String("proxy", "", "Route all requests through an intercepting proxy, e.g. 127.0.0.1:8080 (default: honor HTTPS_PROXY/HTTP_PROXY/NO_PROXY); usually paired with --skip-tls")
 	scanCmd.Flags().String("oob-url", "", "External OOB server URL (default: start a local listener automatically)")
 	scanCmd.Flags().String("config", "", "Path to batesian.yaml config file (default: auto-discover)")
 	// OAuth 2.0 flags for automatic token acquisition.
@@ -96,6 +98,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 	token, _ := cmd.Flags().GetString("token")
 	timeoutSecs, _ := cmd.Flags().GetInt("timeout")
 	skipTLS, _ := cmd.Flags().GetBool("skip-tls")
+	proxy, _ := cmd.Flags().GetString("proxy")
 	oobURL, _ := cmd.Flags().GetString("oob-url")
 	audienceClaim, _ := cmd.Flags().GetString("audience-claim")
 	principalFlags, _ := cmd.Flags().GetStringArray("principal")
@@ -127,6 +130,18 @@ func runScan(cmd *cobra.Command, args []string) error {
 	}
 	timeoutSecs = effectiveTimeout(cmd.Flags().Changed("timeout"), timeoutSecs, cfg.TimeoutSeconds)
 	skipTLS = effectiveSkipTLS(cmd.Flags().Changed("skip-tls"), skipTLS, cfg.SkipTLS)
+	// Same sentinel problem as skip-tls: an empty string is indistinguishable from
+	// "not passed", so the flag only wins when it was actually set. That lets
+	// --proxy="" force a direct connection over a config proxy.
+	if !cmd.Flags().Changed("proxy") {
+		proxy = cfg.Proxy
+	}
+	// Validate here rather than letting each rule fail its own requests. A broken
+	// proxy is one configuration mistake, and surfacing it as "31 of 36 rules could
+	// not reach a testable endpoint" reads as an unreachable target instead.
+	if _, err := httpx.ProxyFunc(proxy); err != nil {
+		return err
+	}
 	if oobURL == "" {
 		oobURL = cfg.OOBURL
 	}
@@ -226,6 +241,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 		Token:          token,
 		TimeoutSeconds: timeoutSecs,
 		SkipTLS:        skipTLS,
+		Proxy:          proxy,
 		Verbose:        verbose,
 		AudienceClaim:  audienceClaim,
 		Principals:     principals,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,11 @@ type Config struct {
 	// SkipTLS disables TLS certificate verification.
 	SkipTLS bool `yaml:"skip_tls"`
 
+	// Proxy routes every request through an intercepting proxy, so a scan can be
+	// reviewed in Burp or ZAP. Empty leaves the environment in charge
+	// (HTTPS_PROXY, HTTP_PROXY, NO_PROXY).
+	Proxy string `yaml:"proxy"`
+
 	// RuleIDs is an explicit list of rule IDs to run.
 	RuleIDs []string `yaml:"rule_ids"`
 
@@ -191,6 +196,13 @@ func Example() string {
 
 # Disable TLS certificate verification (not recommended for production).
 # skip_tls: false
+
+# Route every request through an intercepting proxy, so a whole scan can be
+# reviewed in Burp or ZAP. A bare host:port is fine. Usually paired with skip_tls,
+# since such proxies present their own CA. Omit to honour HTTPS_PROXY/HTTP_PROXY/
+# NO_PROXY instead; note that Go does not send loopback targets through an
+# environment proxy, so a scan against 127.0.0.1 needs this set explicitly.
+# proxy: 127.0.0.1:8080
 
 # Run only these specific rule IDs (comma-separated in CLI, list here).
 # rule_ids:

--- a/internal/httpx/proxy.go
+++ b/internal/httpx/proxy.go
@@ -1,0 +1,61 @@
+// Package httpx holds HTTP transport wiring shared by the scan path, the recon
+// clients and the OAuth flows. It exists so those three can agree on proxy
+// behaviour without importing each other.
+package httpx
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// ProxyFunc returns the Proxy function for an http.Transport.
+//
+// raw is the operator's explicit choice (--proxy or the config file). When it is
+// empty the environment is consulted, so HTTPS_PROXY, HTTP_PROXY and NO_PROXY work
+// with no flag, matching what any Go program using http.DefaultTransport does.
+//
+// This is not a nicety. Every transport in this repository was constructed as a
+// bare &http.Transport{}, which ignores the environment, while the OAuth clients
+// left Transport nil and so picked up http.DefaultTransport. An operator who set
+// HTTPS_PROXY captured the OAuth traffic and nothing else, and a capture that
+// looks complete but is not is worse than no proxy support at all.
+//
+// An unparseable value is an error rather than a silent fallback to the
+// environment: a mistyped proxy that quietly sends traffic direct is exactly the
+// failure this is meant to remove.
+func ProxyFunc(raw string) (func(*http.Request) (*url.URL, error), error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return http.ProxyFromEnvironment, nil
+	}
+	u, err := normalizeProxyURL(raw)
+	if err != nil {
+		return nil, err
+	}
+	return http.ProxyURL(u), nil
+}
+
+// normalizeProxyURL accepts the forms an operator actually types. A bare
+// host:port is the common one (Burp and ZAP both present themselves that way),
+// and url.Parse reads it as a path rather than a host, so the scheme is supplied.
+func normalizeProxyURL(raw string) (*url.URL, error) {
+	candidate := raw
+	if !strings.Contains(candidate, "://") {
+		candidate = "http://" + candidate
+	}
+	u, err := url.Parse(candidate)
+	if err != nil {
+		return nil, fmt.Errorf("invalid proxy %q: %w", raw, err)
+	}
+	if u.Host == "" {
+		return nil, fmt.Errorf("invalid proxy %q: no host", raw)
+	}
+	switch u.Scheme {
+	case "http", "https", "socks5", "socks5h":
+	default:
+		return nil, fmt.Errorf("invalid proxy %q: unsupported scheme %q", raw, u.Scheme)
+	}
+	return u, nil
+}

--- a/internal/httpx/proxy_test.go
+++ b/internal/httpx/proxy_test.go
@@ -1,0 +1,105 @@
+package httpx
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// The forms an operator actually types. A bare host:port is the common one, since
+// Burp and ZAP both present themselves that way, and url.Parse reads it as a path
+// rather than a host unless a scheme is supplied.
+func TestProxyFunc_AcceptedForms(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"bare host and port", "127.0.0.1:8080", "http://127.0.0.1:8080"},
+		{"explicit http", "http://127.0.0.1:8080", "http://127.0.0.1:8080"},
+		{"https proxy", "https://proxy.internal:3128", "https://proxy.internal:3128"},
+		{"socks5", "socks5://127.0.0.1:1080", "socks5://127.0.0.1:1080"},
+		{"hostname without port", "proxy.internal", "http://proxy.internal"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fn, err := ProxyFunc(tt.raw)
+			if err != nil {
+				t.Fatalf("ProxyFunc(%q): %v", tt.raw, err)
+			}
+			req := httptest.NewRequest(http.MethodGet, "https://target.example/mcp", nil)
+			got, err := fn(req)
+			if err != nil {
+				t.Fatalf("resolving proxy: %v", err)
+			}
+			if got == nil {
+				t.Fatal("expected a proxy URL, got nil (traffic would go direct)")
+			}
+			if got.String() != tt.want {
+				t.Errorf("proxy = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// An unusable value must be an error, not a silent fallback. A mistyped proxy that
+// quietly sends traffic direct is the failure this option exists to prevent: the
+// operator would believe they were intercepting when they were not.
+func TestProxyFunc_RejectsUnusableValues(t *testing.T) {
+	for _, raw := range []string{"://nope", "ftp://proxy:21", "http://"} {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := ProxyFunc(raw); err == nil {
+				t.Errorf("ProxyFunc(%q) should fail rather than fall back to a direct connection", raw)
+			}
+		})
+	}
+}
+
+// An empty value hands control to the environment, which is what makes
+// HTTPS_PROXY work with no flag and NO_PROXY carve-outs keep working.
+func TestProxyFunc_EmptyUsesEnvironment(t *testing.T) {
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:9999")
+	t.Setenv("NO_PROXY", "excluded.example")
+
+	fn, err := ProxyFunc("")
+	if err != nil {
+		t.Fatalf("ProxyFunc(\"\"): %v", err)
+	}
+
+	proxied := httptest.NewRequest(http.MethodGet, "https://target.example/mcp", nil)
+	got, err := fn(proxied)
+	if err != nil {
+		t.Fatalf("resolving proxy: %v", err)
+	}
+	if got == nil || got.String() != "http://127.0.0.1:9999" {
+		t.Errorf("HTTPS_PROXY should apply when no proxy is configured, got %v", got)
+	}
+
+	excluded := httptest.NewRequest(http.MethodGet, "https://excluded.example/mcp", nil)
+	got, err = fn(excluded)
+	if err != nil {
+		t.Fatalf("resolving proxy: %v", err)
+	}
+	if got != nil {
+		t.Errorf("NO_PROXY host should bypass the proxy, got %v", got)
+	}
+}
+
+// An explicit value must beat the environment, so --proxy is authoritative when
+// the operator sets both.
+func TestProxyFunc_ExplicitBeatsEnvironment(t *testing.T) {
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:1111")
+
+	fn, err := ProxyFunc("127.0.0.1:2222")
+	if err != nil {
+		t.Fatalf("ProxyFunc: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "https://target.example/mcp", nil)
+	got, err := fn(req)
+	if err != nil {
+		t.Fatalf("resolving proxy: %v", err)
+	}
+	if got == nil || got.String() != "http://127.0.0.1:2222" {
+		t.Errorf("explicit proxy should win over HTTPS_PROXY, got %v", got)
+	}
+}

--- a/internal/protocol/a2a/client.go
+++ b/internal/protocol/a2a/client.go
@@ -8,8 +8,11 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+
 	"strings"
 	"time"
+
+	"github.com/calbebop/batesian/internal/httpx"
 )
 
 const (
@@ -32,6 +35,10 @@ type Client struct {
 	http    *http.Client
 	baseURL string
 	headers map[string]string
+
+	// proxyErr records an unusable --proxy value so NewClient can report it
+	// rather than let the scan run with interception silently bypassed.
+	proxyErr error
 }
 
 // ClientOption configures a Client.
@@ -54,6 +61,26 @@ func WithHeader(key, value string) ClientOption {
 // WithBearerToken adds an Authorization: Bearer header.
 func WithBearerToken(token string) ClientOption {
 	return WithHeader("Authorization", "Bearer "+token)
+}
+
+// WithProxy routes requests through an intercepting proxy. An empty value leaves
+// the environment in charge (HTTPS_PROXY, HTTP_PROXY, NO_PROXY), which is also the
+// default: a bare &http.Transport{} ignores the environment, so before this the
+// recon path proxied nothing even when the operator had set HTTPS_PROXY.
+//
+// An unusable value is reported at construction rather than dropped, so a mistyped
+// proxy cannot silently bypass interception.
+func WithProxy(raw string) ClientOption {
+	return func(c *Client) {
+		proxy, err := httpx.ProxyFunc(raw)
+		if err != nil {
+			c.proxyErr = err
+			return
+		}
+		if t, ok := c.http.Transport.(*http.Transport); ok {
+			t.Proxy = proxy
+		}
+	}
 }
 
 // WithSkipTLSVerify disables TLS certificate verification.
@@ -85,7 +112,7 @@ func NewClient(baseURL string, opts ...ClientOption) (*Client, error) {
 	c := &Client{
 		http: &http.Client{
 			Timeout:   defaultTimeout,
-			Transport: &http.Transport{TLSClientConfig: &tls.Config{}}, //nolint:gosec
+			Transport: &http.Transport{TLSClientConfig: &tls.Config{}, Proxy: http.ProxyFromEnvironment}, //nolint:gosec
 		},
 		baseURL: base,
 		headers: map[string]string{
@@ -96,6 +123,10 @@ func NewClient(baseURL string, opts ...ClientOption) (*Client, error) {
 	for _, o := range opts {
 		o(c)
 	}
+	if c.proxyErr != nil {
+		return nil, c.proxyErr
+	}
+
 	return c, nil
 }
 

--- a/internal/protocol/mcp/client.go
+++ b/internal/protocol/mcp/client.go
@@ -12,8 +12,11 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+
 	"strings"
 	"time"
+
+	"github.com/calbebop/batesian/internal/httpx"
 
 	"github.com/calbebop/batesian/internal/endpoint"
 	"github.com/calbebop/batesian/internal/sse"
@@ -32,6 +35,10 @@ type Client struct {
 	http        *http.Client
 	baseURL     string
 	bearerToken string
+
+	// proxyErr records an unusable --proxy value so NewClient can report it
+	// rather than let the scan run with interception silently bypassed.
+	proxyErr error
 }
 
 // ClientOption configures a Client.
@@ -45,6 +52,26 @@ func WithTimeout(d time.Duration) ClientOption {
 // WithBearerToken attaches an Authorization: Bearer header to every request.
 func WithBearerToken(token string) ClientOption {
 	return func(c *Client) { c.bearerToken = token }
+}
+
+// WithProxy routes requests through an intercepting proxy. An empty value leaves
+// the environment in charge (HTTPS_PROXY, HTTP_PROXY, NO_PROXY), which is also the
+// default: a bare &http.Transport{} ignores the environment, so before this the
+// recon path proxied nothing even when the operator had set HTTPS_PROXY.
+//
+// An unusable value is reported at construction rather than dropped, so a mistyped
+// proxy cannot silently bypass interception.
+func WithProxy(raw string) ClientOption {
+	return func(c *Client) {
+		proxy, err := httpx.ProxyFunc(raw)
+		if err != nil {
+			c.proxyErr = err
+			return
+		}
+		if t, ok := c.http.Transport.(*http.Transport); ok {
+			t.Proxy = proxy
+		}
+	}
 }
 
 // WithSkipTLSVerify disables TLS certificate verification.
@@ -71,13 +98,17 @@ func NewClient(baseURL string, opts ...ClientOption) (*Client, error) {
 	c := &Client{
 		http: &http.Client{
 			Timeout:   defaultTimeout,
-			Transport: &http.Transport{TLSClientConfig: &tls.Config{}}, //nolint:gosec
+			Transport: &http.Transport{TLSClientConfig: &tls.Config{}, Proxy: http.ProxyFromEnvironment}, //nolint:gosec
 		},
 		baseURL: strings.TrimRight(u.String(), "/"),
 	}
 	for _, o := range opts {
 		o(c)
 	}
+	if c.proxyErr != nil {
+		return nil, c.proxyErr
+	}
+
 	return c, nil
 }
 


### PR DESCRIPTION
A scanner that cannot be pointed at Burp or ZAP is hard to adopt, and the state before this was **worse than simply missing the feature**:

| Client | Proxy before |
|---|---|
| shared scan transport (all 36 rules, plus confused-deputy and sse-resume-replay) | none |
| both recon clients | none |
| three OAuth clients (nil Transport → `http.DefaultTransport`) | **honoured `HTTPS_PROXY`** |

Not one transport set `Proxy`, and a bare `&http.Transport{}` ignores the environment. So an operator who set `HTTPS_PROXY` captured the OAuth traffic and **nothing else** — a capture that looks complete but is not.

## Change

`Options.Proxy` plus a `--proxy` flag on `scan` and `probe`, honoured at every construction site. An empty value leaves the environment in charge, so `HTTPS_PROXY`, `HTTP_PROXY` and `NO_PROXY` keep working with no flag. A bare `host:port` is accepted, since that is how Burp and ZAP present themselves. Also a `proxy` key in `batesian.yaml`, using the `Flags().Changed` precedence pattern rather than the truthiness check that bit `skipTLS`.

## Two deliberate choices

- **TLS verification is not weakened implicitly.** An intercepting proxy presents its own CA, so `--proxy` is normally paired with `--skip-tls`. Quietly dropping verification because a proxy was requested is the kind of surprise this tool should not spring, so it is documented instead.
- **An unusable value is rejected before any request goes out.** My first implementation reported a bad proxy as `0 findings, 31 of 36 rules could not reach a testable endpoint` — which reads as an unreachable target rather than a configuration mistake. It now fails immediately with `invalid proxy "ftp://bad:21": unsupported scheme "ftp"`.

## Verification

With a counting forward proxy:

| Scenario | Requests captured |
|---|---|
| no proxy configured | **0** |
| `scan --proxy` | **221** (target plus the SSRF canary host) |
| `probe --proxy` | **5** (recon client) |
| `HTTP_PROXY` env, no flag, non-loopback target | **350** |

Findings are identical proxied and direct (8/12 on the same fixture). Worth knowing and now documented: **Go never sends loopback targets through an environment proxy**, so a scan against `127.0.0.1` needs the explicit flag — my first env test looked like a failure until I found that rule.

The dry-run path is untouched: `Transport` returns the recording transport before any of this and sends nothing either way.

Unrelated observation while regression-testing: `a2a-wellknown-hostinject-001` emits 4 or 5 findings non-deterministically against `a2a_new_rules_server.py`, on the pre-change binary too. Not from this change, but it makes finding counts on that fixture unreliable as a regression signal.
