### PR TITLE
fix(a2a): report each host-injection reflection once, not once per field ordering

### DIFF
--- a/internal/attack/a2a/wellknown_hostinject.go
+++ b/internal/attack/a2a/wellknown_hostinject.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/calbebop/batesian/internal/attack"
@@ -150,10 +151,23 @@ type reflection struct {
 }
 
 // findReflections recursively walks a JSON object and returns the dot-paths and
-// values of any string field whose value contains the canary substring.
+// values of any string field whose value contains the canary substring, sorted by
+// path.
+//
+// The sort is load-bearing, not cosmetic. walkJSON ranges a
+// map[string]interface{}, and Go randomizes map iteration order, so without it the
+// reflection order changed between runs. Everything downstream inherits that
+// order: the caller joins the paths into the dedup key that collapses the same
+// reflection across the two well-known paths, so the key differed run to run and
+// the dedup hit or missed at random. The same header was reported twice, once as
+// "provider.url, url" and once as "url, provider.url", and one fixture yielded 3,
+// 4 or 5 findings on identical input. The finding title, description and evidence
+// list the fields too, so a stable order also makes two scans of an unchanged
+// target diffable.
 func findReflections(v interface{}, canary string) []reflection {
 	var out []reflection
 	walkJSON(v, "", canary, &out)
+	sort.Slice(out, func(i, j int) bool { return out[i].path < out[j].path })
 	return out
 }
 

--- a/internal/attack/a2a/wellknown_hostinject_test.go
+++ b/internal/attack/a2a/wellknown_hostinject_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/calbebop/batesian/internal/attack"
@@ -163,5 +164,94 @@ func TestWellKnownHostInject_ReflectsInProviderField(t *testing.T) {
 	}
 	if len(findings) == 0 {
 		t.Fatal("expected findings for server that reflects X-Original-Host")
+	}
+}
+
+// multiFieldReflectingServer reflects the injected host into TWO url-ish fields and
+// serves both well-known paths, which is what makes the ordering matter: the same
+// header is probed twice, once per path, and the dedup key is built by joining the
+// reflected field names.
+func multiFieldReflectingServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/agent-card.json" && r.URL.Path != "/.well-known/agent.json" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		host := r.Header.Get("X-Forwarded-Host")
+		if host == "" {
+			host = r.Host
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"name":         "Reflector",
+			"description":  "d",
+			"version":      "1.0.0",
+			"url":          "https://" + host + "/a2a",
+			"provider":     map[string]interface{}{"organization": "Org", "url": "https://" + host + "/org"},
+			"capabilities": map[string]interface{}{},
+			"skills":       []interface{}{},
+		})
+	}))
+}
+
+// Two scans of an unchanged target must agree, and each header must be reported
+// once rather than once per field ordering.
+//
+// findReflections walks the card with a map range, and Go randomizes map iteration
+// order. The reflected field names flow into the dedup key that collapses the same
+// reflection across the two well-known paths, so before the paths were sorted the
+// key differed between runs: the same header was reported twice, once as
+// "provider.url, url" and once as "url, provider.url", and this server yielded 3, 4
+// or 5 findings on identical input. Repeating the scan is what makes the failure
+// reliable instead of a coin flip.
+func TestWellKnownHostInject_ResultIsDeterministic(t *testing.T) {
+	srv := multiFieldReflectingServer(t)
+	defer srv.Close()
+
+	exec := a2aattack.NewWellKnownHostInjectExecutor(attack.RuleContext{ID: "a2a-wellknown-hostinject-001"})
+
+	var first []string
+	for run := 0; run < 12; run++ {
+		findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+		if err != nil {
+			t.Fatalf("run %d: unexpected error: %v", run, err)
+		}
+
+		titles := make([]string, 0, len(findings))
+		for _, f := range findings {
+			titles = append(titles, f.Title)
+		}
+
+		// No header may appear twice: two findings differing only in field order
+		// are the same reflection reported once per ordering.
+		perHeader := map[string]int{}
+		for _, f := range findings {
+			for _, h := range []string{"Host", "X-Forwarded-Host", "X-Original-Host", "X-Forwarded-For"} {
+				if strings.Contains(f.Title, `"`+h+`"`) {
+					perHeader[h]++
+				}
+			}
+		}
+		for h, n := range perHeader {
+			if n > 1 {
+				t.Fatalf("run %d: header %s reported %d times; the same reflection must dedupe across both well-known paths: %v",
+					run, h, n, titles)
+			}
+		}
+
+		if run == 0 {
+			first = titles
+			continue
+		}
+		if len(titles) != len(first) {
+			t.Fatalf("run %d produced %d finding(s), run 0 produced %d: identical input must give identical output; first=%v now=%v",
+				run, len(titles), len(first), first, titles)
+		}
+		for i := range titles {
+			if titles[i] != first[i] {
+				t.Fatalf("run %d finding %d differs from run 0: first=%q now=%q", run, i, first[i], titles[i])
+			}
+		}
 	}
 }


### PR DESCRIPTION
`a2a-wellknown-hostinject-001` returned a different number of findings on identical input — 3, 4 or 5 against the same fixture. The count was the visible symptom; the real defect is that it emitted **duplicate findings for the same reflection**:

```
run1: 4  Host -> provider.url, url | X-Forwarded-Host -> url, provider.url
         X-Original-Host -> url, provider.url | Host -> url, provider.url
run2: 3  Host -> url, provider.url | X-Forwarded-Host -> ... | X-Original-Host -> ...
run3: 5  ... Host twice, X-Forwarded-Host twice
```

`findReflections` walks the agent card with a **map range**, and Go randomizes map iteration order, so the reflected field paths came back in a different order each run. The caller joins those paths into the key that dedupes a reflection across the two well-known paths (`agent-card.json` and `agent.json`). A different order meant a different key, so the dedupe hit or missed at random and the same header was reported twice — once as `provider.url, url`, once as `url, provider.url`. Both are high-severity findings describing one reflection.

## Fix

Sort the paths where they are produced. That fixes the key, and also stabilizes the title, description and evidence, all of which list the fields — so two scans of an unchanged target are now diffable, which they were not.

The correct answer for that fixture is **3**: three of the four probed headers reflect, each reported once.

| | before | after |
|---|---|---|
| 6 consecutive full scans of port 3101 | 5, 6, 5, … | **5 every time** |
| `hostinject` findings | 3, 4 or 5 | **3** |

## Test

Twelve repetitions per run, asserting both that no header appears twice and that every run matches the first. Repetition is the point: a single-run assertion passes whenever the coin lands right. Removing the sort fails it on **five consecutive attempts**.

Found while regression-testing #151, where this fixture produced two false CHANGED rows before I compared rule sets instead of counts.
