### PR TITLE
fix(cli): print probe's security schemes in a stable order

### DIFF
--- a/internal/cli/probe.go
+++ b/internal/cli/probe.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -203,9 +204,15 @@ func cardToProbeResult(card *a2a.AgentCard, elapsed time.Duration) *report.Probe
 		}
 	}
 
+	// Sorted because SecuritySchemes is a map and Go randomizes map iteration, so
+	// without this the Schemes row printed a different order between runs and two
+	// probes of an unchanged agent were not comparable. Measured over 20 runs on a
+	// four-scheme card: three distinct orderings. The JSON output is unaffected,
+	// since encoding/json sorts map keys itself.
 	for name, scheme := range card.SecuritySchemes {
 		r.SecuritySchemes = append(r.SecuritySchemes, name+" ("+scheme.Type()+")")
 	}
+	sort.Strings(r.SecuritySchemes)
 
 	for _, sk := range card.Skills {
 		r.Skills = append(r.Skills, report.SkillSummary{

--- a/internal/cli/probe_test.go
+++ b/internal/cli/probe_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -134,5 +135,51 @@ func TestCardToProbeResult_AuthAcrossCardVersions(t *testing.T) {
 				t.Errorf("SecuritySchemes = %q, want %q", joined, tt.wantSchemeText)
 			}
 		})
+	}
+}
+
+// Two probes of an unchanged agent must print the same Schemes row.
+//
+// SecuritySchemes is a map and Go randomizes map iteration, so the row order used
+// to vary between runs. Repetition is what makes this reliable: the first six live
+// runs against a four-scheme card all agreed by chance, and only at twenty did
+// three distinct orderings appear. Go shuffles the start offset within a bucket, so
+// a small map yields rotations of one sequence and a short sample easily misses it.
+func TestCardToProbeResult_SchemeOrderIsDeterministic(t *testing.T) {
+	const card = `{
+		"name": "Multi-Scheme Agent", "description": "d", "version": "1.0.0",
+		"capabilities": {}, "skills": [],
+		"securitySchemes": {
+			"bearerAuth": {"httpAuthSecurityScheme": {"scheme": "bearer"}},
+			"apiKeyAuth": {"apiKeySecurityScheme": {"location": "header", "name": "X-API-Key"}},
+			"oauth2Auth": {"oauth2SecurityScheme": {"flows": {}}},
+			"mtlsAuth": {"mtlsSecurityScheme": {}},
+			"oidcAuth": {"openIdConnectSecurityScheme": {"openIdConnectUrl": "https://idp/.well-known/openid-configuration"}}
+		}
+	}`
+
+	var first []string
+	for run := 0; run < 50; run++ {
+		var c a2a.AgentCard
+		if err := json.Unmarshal([]byte(card), &c); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		got := cardToProbeResult(&c, time.Millisecond).SecuritySchemes
+		if len(got) != 5 {
+			t.Fatalf("run %d: expected 5 schemes, got %d: %v", run, len(got), got)
+		}
+		if run == 0 {
+			first = got
+			continue
+		}
+		for i := range got {
+			if got[i] != first[i] {
+				t.Fatalf("run %d printed a different scheme order than run 0; two probes of an unchanged agent must match: first=%v now=%v",
+					run, first, got)
+			}
+		}
+	}
+	if !sort.StringsAreSorted(first) {
+		t.Errorf("schemes should be in a stable, predictable order, got %v", first)
 	}
 }


### PR DESCRIPTION
Follow-through on #152. That fix was one instance of a class, so I swept every map iteration that can reach a dedupe key, an output string, or an ordering decision. **One more real instance, and two that only look like it.**

## The instance

`probe` built its Schemes row by ranging `card.SecuritySchemes`, a map, so the row order varied between runs and two probes of an unchanged agent were not comparable. Live against a four-scheme card, 20 runs:

```
  14  bearerAuth (http/bearer), apiKeyAuth (apiKey), oauth2Auth (oauth2), mtlsAuth (mtls)
   4  mtlsAuth (mtls), bearerAuth (http/bearer), apiKeyAuth (apiKey), oauth2Auth (oauth2)
   2  apiKeyAuth (apiKey), oauth2Auth (oauth2), mtlsAuth (mtls), bearerAuth (http/bearer)
```

The JSON output was never affected — `encoding/json` sorts map keys itself — so this is the human-readable table only. After the fix: 20/20 identical.

## Deliberately not changed

- **`engine.go` `orderPlan`** ranges `requires[j]` to build the dependency graph, but the result is order-independent: the drain always picks the lowest-index ready node, and `indegree` is a count, so the number of increments and decrements is the same whatever order edges are appended in.
- **`registry.RegisteredTypes`**, **`sarif.go`**'s rule list and **`scan.go`**'s `significantHeaderKeys` all range a map and all already sort — SARIF with a comment saying why.

`card_security_unenforced`'s scheme names were already sorted, in #141.

## The measurement is the interesting part

The **first six** live runs all agreed, which looks like determinism and isn't. Go randomizes the start offset within a bucket, so a small map yields rotations of one sequence and a short sample misses the variation. Only at twenty runs did the other two orderings appear.

So the test repeats **fifty** times and compares every run to the first. It fails on five consecutive attempts with the sort removed; a single-run assertion would have passed most of the time — which is the same trap I nearly fell into when the six-run sample looked clean.
