### PR TITLE
fix(cli): stop the dry-run plan asserting a request count it cannot know

### DIFF
--- a/internal/cli/dryrun_plan_test.go
+++ b/internal/cli/dryrun_plan_test.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	attackpkg "github.com/calbebop/batesian/internal/attack"
+)
+
+// req is a compact constructor for a recorded request.
+func req(rule, method, url, body string) attackpkg.RecordedRequest {
+	return attackpkg.RecordedRequest{RuleID: rule, Method: method, URL: url, Body: body}
+}
+
+// The first attempt in an endpoint walk must NOT be marked, because it is the one a
+// real scan sends. Marking the whole group flagged 97% of a real plan and implied
+// all of it was skipped.
+func TestEndpointCandidateProbes_MarksOnlyFallbacks(t *testing.T) {
+	reqs := []attackpkg.RecordedRequest{
+		req("r1", "POST", "http://t/mcp", `{"m":"initialize"}`),     // 0: sent
+		req("r1", "POST", "http://t/mcp/mcp", `{"m":"initialize"}`), // 1: fallback
+		req("r1", "POST", "http://t/mcp/api", `{"m":"initialize"}`), // 2: fallback
+		req("r1", "POST", "http://t/mcp", `{"m":"tools/list"}`),     // 3: single URL, not a walk
+		req("r2", "POST", "http://t/mcp", `{"m":"initialize"}`),     // 4: different rule, its own first
+		req("r2", "POST", "http://t/mcp/api", `{"m":"initialize"}`), // 5: fallback
+	}
+
+	marked := endpointCandidateProbes(reqs)
+
+	for _, i := range []int{1, 2, 5} {
+		if !marked[i] {
+			t.Errorf("request %d is a fallback attempt and should be marked", i)
+		}
+	}
+	for _, i := range []int{0, 3, 4} {
+		if marked[i] {
+			t.Errorf("request %d must not be marked: index 0 and 4 are the first attempt of their walk and 3 is not a walk at all", i)
+		}
+	}
+}
+
+// A probe sent to exactly one URL is not a walk, however many times it repeats.
+func TestEndpointCandidateProbes_SingleURLIsNotAWalk(t *testing.T) {
+	reqs := []attackpkg.RecordedRequest{
+		req("r1", "POST", "http://t/mcp", `{"m":"a"}`),
+		req("r1", "POST", "http://t/mcp", `{"m":"a"}`),
+	}
+	if len(endpointCandidateProbes(reqs)) != 0 {
+		t.Error("repeats at the same URL are not an endpoint walk and must not be marked")
+	}
+}
+
+// The plan must not assert a request count as fact, and must state both directions
+// in which it diverges from a real scan. It over-states endpoint fan-out, because no
+// candidate can answer in a dry run, and under-states chained follow-ups.
+func TestPrintDryRunPlan_StatesBothDivergences(t *testing.T) {
+	rec := &attackpkg.Recorder{}
+	rec.SetCurrentRule("r1")
+
+	var buf bytes.Buffer
+	printDryRunPlan(&buf, "http://t/mcp", rec)
+	out := buf.String()
+
+	if strings.Contains(out, "would be issued") {
+		t.Error("the plan must not assert the recorded requests as the ones that would be issued; it is wrong in both directions")
+	}
+	for _, want := range []string{
+		"Nothing was sent",
+		"The host list above is exact",
+		"cannot be expanded here",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("plan summary is missing %q; got: %s", want, out)
+		}
+	}
+}
+
+// The method is part of the grouping key, so a GET walk and a POST walk over the
+// same URLs are separate walks and each keeps its own first attempt. The plan
+// contains both: well-known card fetches are GETs, JSON-RPC probes are POSTs.
+func TestEndpointCandidateProbes_MethodIsPartOfTheKey(t *testing.T) {
+	reqs := []attackpkg.RecordedRequest{
+		req("r1", "GET", "http://t/a/.well-known/agent-card.json", ""),  // 0: first GET
+		req("r1", "GET", "http://t/b/.well-known/agent-card.json", ""),  // 1: fallback GET
+		req("r1", "POST", "http://t/a/.well-known/agent-card.json", ""), // 2: first POST, own walk
+		req("r1", "POST", "http://t/b/.well-known/agent-card.json", ""), // 3: fallback POST
+	}
+
+	marked := endpointCandidateProbes(reqs)
+
+	if marked[0] || marked[2] {
+		t.Error("each method's first attempt is sent and must not be marked")
+	}
+	if !marked[1] || !marked[3] {
+		t.Error("each method's later attempts are fallbacks and must be marked")
+	}
+}

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -470,20 +470,53 @@ func fetchOAuthTokenPKCE(ctx context.Context, authURL, tokenURL, clientID string
 // printDryRunPlan writes the request plan captured during a dry run. Nothing was
 // sent; this is the preview an operator reviews before authorizing a real scan.
 // Requests are grouped by the rule that issued them, in execution order.
+//
+// The plan is an approximation, and it diverges in both directions, so it says so
+// rather than presenting a count as fact. Measured against
+// testdata/mcp_unauth_resources_server.py, 344 recorded against 221 actually sent:
+//
+//   - Too many endpoint probes. No candidate endpoint can answer in a dry run, so
+//     every endpoint-discovery walk runs to exhaustion. The real scan stops at the
+//     first endpoint that responds, so it contacted /mcp and never touched /mcp/api
+//     or /mcp/mcp at all. The fallback attempts are marked, since those are the
+//     ones a real scan mostly skips; the first attempt in each walk is not marked
+//     because it is the one that goes out.
+//   - Too few follow-ups. A rule that branches on response content cannot proceed
+//     past that branch, so its later requests never appear. The real scan sent 92
+//     POSTs to /mcp where the plan records 58.
+//
+// The exhaustive recording is deliberately kept: over-showing endpoint probes is
+// the safe bias for a review, and the alternative was measured. Making the
+// synthetic response a valid JSON-RPC result envelope, so acceptance-gated walks
+// short-circuit like they do live, brought the total closer (202 against 221) but
+// silently dropped 32 requests to /mcp/a2a and /mcp/a2a/jsonrpc that a real scan
+// does send. A plan used to authorize a scan must not hide traffic.
+//
+// The host list is exact, which is the part an operator authorizes on. Only the
+// counts are approximate.
 func printDryRunPlan(out io.Writer, target string, rec *attackpkg.Recorder) {
 	reqs := rec.Requests()
-	fmt.Fprintf(out, "\nDry run: nothing was sent. The following %d request(s) would be issued against %s:\n\n", len(reqs), target)
+	fmt.Fprintf(out, "\nDry run: nothing was sent. Planned requests against %s (%d recorded, see the notes below):\n\n",
+		target, len(reqs))
+
+	candidates := endpointCandidateProbes(reqs)
 
 	hosts := map[string]bool{}
 	rulesSeen := map[string]bool{}
+	marked := 0
 	lastRule := "\x00" // sentinel so the first rule (even "") prints a header
-	for _, r := range reqs {
+	for i, r := range reqs {
 		if r.RuleID != lastRule {
 			fmt.Fprintf(out, "[%s]\n", dryRunRuleLabel(r.RuleID))
 			lastRule = r.RuleID
 		}
 		rulesSeen[r.RuleID] = true
-		fmt.Fprintf(out, "  %s %s\n", r.Method, r.URL)
+		suffix := ""
+		if candidates[i] {
+			suffix = "   [fallback endpoint]"
+			marked++
+		}
+		fmt.Fprintf(out, "  %s %s%s\n", r.Method, r.URL, suffix)
 		if u, err := url.Parse(r.URL); err == nil && u.Host != "" {
 			hosts[u.Host] = true
 		}
@@ -495,8 +528,54 @@ func printDryRunPlan(out io.Writer, target string, rec *attackpkg.Recorder) {
 		}
 	}
 
-	fmt.Fprintf(out, "\n%d request(s) across %d rule(s) to %d host(s). Nothing was sent.\n", len(reqs), len(rulesSeen), len(hosts))
-	fmt.Fprintln(out, "Note: requests built from live responses (chained follow-ups, acquired tokens, OOB callbacks) are not expanded in a dry run.")
+	fmt.Fprintf(out, "\n%d request(s) recorded across %d rule(s) to %d host(s). Nothing was sent.\n",
+		len(reqs), len(rulesSeen), len(hosts))
+	fmt.Fprintln(out, "The host list above is exact. The counts are not, in both directions:")
+	if marked > 0 {
+		fmt.Fprintf(out, "  - %d marked [fallback endpoint]: a repeat of an earlier probe at another path.\n", marked)
+		fmt.Fprintln(out, "    A real scan stops at the first path that answers, so most of these are not sent.")
+	}
+	fmt.Fprintln(out, "  - Requests built from live responses (chained follow-ups, acquired tokens, OOB")
+	fmt.Fprintln(out, "    callbacks) cannot be expanded here, so a real scan sends more than this.")
+}
+
+// endpointCandidateProbes marks the recorded requests that are FALLBACK attempts in
+// an endpoint-discovery walk: the same rule sending the same method and body to a
+// further URL after an earlier one.
+//
+// Only the attempts after the first are marked, because the first is the one a real
+// scan sends. Marking the whole group would flag 97% of a typical plan and imply
+// that all of it is skipped, when in fact one probe per group goes out.
+//
+// This is derived from what was recorded rather than from any change in behaviour,
+// so the plan still lists every candidate. It exists because these entries are the
+// ones a real scan mostly does not send, and an unmarked plan invites an operator to
+// authorize traffic to paths that will never be contacted.
+func endpointCandidateProbes(reqs []attackpkg.RecordedRequest) map[int]bool {
+	type probeKey struct{ rule, method, body string }
+	urlsFor := map[probeKey]map[string]bool{}
+	for _, r := range reqs {
+		k := probeKey{r.RuleID, r.Method, r.Body}
+		if urlsFor[k] == nil {
+			urlsFor[k] = map[string]bool{}
+		}
+		urlsFor[k][r.URL] = true
+	}
+
+	marked := map[int]bool{}
+	seenFirst := map[probeKey]bool{}
+	for i, r := range reqs {
+		k := probeKey{r.RuleID, r.Method, r.Body}
+		if len(urlsFor[k]) < 2 {
+			continue // a single URL is not a walk
+		}
+		if !seenFirst[k] {
+			seenFirst[k] = true
+			continue // the first attempt is the one that is actually sent
+		}
+		marked[i] = true
+	}
+	return marked
 }
 
 // dryRunRuleLabel labels a recorded request's rule, naming the pre-rule setup


### PR DESCRIPTION
**S9.** The plan claimed `The following 344 request(s) would be issued`, as fact. It is wrong in both directions, and the note under it admitted only one of them.

Measured by running the same scan through a counting proxy — **344 recorded, 221 actually sent**:

| | planned | actual |
|---|---|---|
| `POST /mcp/api` | 42 | **0** |
| `POST /mcp/mcp` | 42 | **0** |
| `POST /mcp/` | 66 | 24 |
| `POST /mcp` | 58 | **92** |

- **Too many endpoint probes.** No candidate endpoint can answer in a dry run, because the synthetic response fails `IsAccepted`, so every endpoint-discovery walk runs to exhaustion. The real scan stopped at `/mcp` and never touched `/mcp/api` or `/mcp/mcp` — 84 planned, 0 sent. This half was undocumented.
- **Too few follow-ups.** A rule that branches on response content cannot proceed past that branch. This half was already noted.

## Change

Fallback attempts in a walk are marked `[fallback endpoint]`, and the summary states both directions plus the fact that **the host list is exact while the counts are not** — the host list being what an operator actually authorizes on.

Only attempts *after the first* are marked, because the first is the one that goes out. Marking whole groups flagged 334 of 344 lines and implied all of it was skipped.

## The alternative was measured, not assumed

Making the synthetic response a valid JSON-RPC result envelope, so acceptance-gated walks short-circuit as they do live, brings the total closer (202 vs 221) — but:

| | old | new | actual |
|---|---|---|---|
| `POST /mcp/a2a` | 16 | **0** | 16 |
| `POST /mcp/a2a/jsonrpc` | 16 | **0** | 16 |

It silently drops 32 requests a real scan does send, because one synthetic response cannot model a target whose MCP endpoints answer and whose A2A endpoints do not. A plan used to authorize a scan must not hide traffic, so over-showing is the right bias. The numbers are recorded in the code comment so the next person does not retry it.

## Verification

No behaviour change — this reads what the recorder already captured. A real scan is byte-identical: 8 findings, 12 skipped, before and after. Reverting the fallback-only marking fails two tests; restoring the old headline fails the third.
