### PR TITLE
fix(mcp): keep reporting a task IDOR when only task reads are authenticated

### DIFF
--- a/internal/attack/mcp/task_idor.go
+++ b/internal/attack/mcp/task_idor.go
@@ -56,6 +56,16 @@ type safeTool struct {
 	args map[string]interface{}
 }
 
+// authEvidence records what the discriminator established about the target's
+// authentication, so a finding describes the boundary it actually measured rather
+// than the one the rule originally assumed. enforcedOn names the surface a
+// credential is required for; anonProbe is the single anonymous request that
+// demonstrated it.
+type authEvidence struct {
+	enforcedOn string
+	anonProbe  string
+}
+
 func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
 	vars := attack.NewVars(target, opts.OOBListenerURL)
 	// One transport, with credentials attached per request, so each session can
@@ -92,12 +102,37 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 		return nil, nil
 	}
 
-	// Step 2: discriminator. If an anonymous caller can create a task too, the
-	// server enforces no authentication at all, which is a different (and more
-	// obvious) failure owned by mcp-tools-unauth-001. Do not call that an IDOR.
+	// Step 2: discriminator. This rule claims task reads are not bound to the
+	// creating authorization context, which presupposes there is an authorization
+	// context at all. A server that authenticates nothing is a different and more
+	// obvious failure, owned by mcp-tools-unauth-001, and must not be called an IDOR.
+	//
+	// "Authenticates nothing" has to be measured on the read surface too, not on
+	// creation alone. A server can leave a task-augmented tools/call open while
+	// gating tasks/get and tasks/result, and that gate is a real authorization
+	// boundary: an anonymous caller is refused, an authenticated one is not, and
+	// which tasks the authenticated one may read is exactly this rule's question.
+	// Suppressing on open creation alone hid that server completely.
+	// Each branch below records only what it actually observed, so no finding
+	// claims a probe that was skipped. The read probe runs only when creation was
+	// open, because a refused creation already proves a credential is required.
+	auth := authEvidence{
+		enforcedOn: "the MCP endpoint",
+		anonProbe:  "anonymous initialize: refused",
+	}
 	if anonSess, anonOK := e.initSession(ctx, client, vars.BaseURL, ""); anonOK {
+		auth = authEvidence{
+			enforcedOn: "task creation and reads",
+			anonProbe:  "anonymous task creation: refused",
+		}
 		if e.createTask(ctx, client, anonSess, "", tool) != "" {
-			return nil, nil
+			if _, anonCanRead := e.getTask(ctx, client, anonSess, "", taskID); anonCanRead {
+				return nil, nil // no credential is required anywhere
+			}
+			auth = authEvidence{
+				enforcedOn: "task reads only (anonymous task creation was accepted)",
+				anonProbe:  "anonymous tasks/get: refused",
+			}
 		}
 	}
 
@@ -111,13 +146,13 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 
 	// Step 4: can B read A's task by id? A correctly-scoped server answers -32602.
 	if meta, ok := e.getTask(ctx, client, sessB, tokenB, taskID); ok {
-		findings = append(findings, e.metadataFinding(sessA.Endpoint, taskID, meta, crossPrincipal))
+		findings = append(findings, e.metadataFinding(sessA.Endpoint, taskID, meta, crossPrincipal, auth))
 
 		// Escalate if B can also read the result. tasks/result blocks until the
 		// task is terminal, so poll tasks/get first and stay inside the budget.
 		if e.pollTerminal(ctx, client, sessB, tokenB, taskID) {
 			if content, ok := e.getResult(ctx, client, sessB, tokenB, taskID); ok {
-				findings = append(findings, e.resultFinding(sessA.Endpoint, taskID, tool.name, content, crossPrincipal))
+				findings = append(findings, e.resultFinding(sessA.Endpoint, taskID, tool.name, content, crossPrincipal, auth))
 			}
 		}
 	}
@@ -129,7 +164,7 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 	// prior knowledge of the task id at all.
 	if tasksSupportsList(sessA.RawInit) {
 		if ids, ok := e.listTasks(ctx, client, sessB, tokenB); ok && containsTaskID(ids, taskID) {
-			findings = append(findings, e.enumerationFinding(sessA.Endpoint, taskID, len(ids), crossPrincipal))
+			findings = append(findings, e.enumerationFinding(sessA.Endpoint, taskID, len(ids), crossPrincipal, auth))
 		}
 	}
 
@@ -472,7 +507,7 @@ func requestorLabel(crossPrincipal bool) string {
 	return "a separate authenticated session"
 }
 
-func (e *TaskIDORExecutor) metadataFinding(endpoint, taskID string, st taskState, crossPrincipal bool) attack.Finding {
+func (e *TaskIDORExecutor) metadataFinding(endpoint, taskID string, st taskState, crossPrincipal bool, auth authEvidence) attack.Finding {
 	return attack.Finding{
 		RuleID:     e.rule.ID,
 		RuleName:   e.rule.Name,
@@ -480,21 +515,23 @@ func (e *TaskIDORExecutor) metadataFinding(endpoint, taskID string, st taskState
 		Confidence: attack.ConfirmedExploit,
 		Title:      "MCP task readable by another authorization context (tasks/get IDOR)",
 		Description: fmt.Sprintf(
-			"tasks/get at %s returned task %s to %s that did not create it. The server rejected "+
-				"anonymous task creation, so authentication is enforced, yet task lookup is not bound to "+
-				"the creating context. The MCP spec requires receivers to reject tasks/get for tasks "+
-				"outside the requestor's authorization context, so any caller who learns or guesses a "+
-				"task id can track another context's work.", endpoint, taskID, requestorLabel(crossPrincipal)),
+			"tasks/get at %s returned task %s to %s that did not create it. Authentication is enforced "+
+				"on %s, so a credential is required, yet task lookup is not bound to the creating "+
+				"context. The MCP spec requires receivers to reject tasks/get for tasks outside the "+
+				"requestor's authorization context, so any caller who learns or guesses a task id can "+
+				"track another context's work.",
+			endpoint, taskID, requestorLabel(crossPrincipal), auth.enforcedOn),
 		Evidence: fmt.Sprintf(
-			"endpoint: %s\ntask: %s\nanonymous task creation: rejected (auth enforced)\n"+
-				"cross-context tasks/get: accepted\ndisclosed status: %s\nstatusMessage: %s\ncreatedAt: %s",
-			endpoint, taskID, st.Status, st.StatusMessage, st.CreatedAt),
+			"endpoint: %s\ntask: %s\nauthentication enforced on: %s\n%s\n"+
+				"cross-context tasks/get: accepted\n"+
+				"disclosed status: %s\nstatusMessage: %s\ncreatedAt: %s",
+			endpoint, taskID, auth.enforcedOn, auth.anonProbe, st.Status, st.StatusMessage, st.CreatedAt),
 		Remediation: e.rule.Remediation,
 		TargetURL:   endpoint,
 	}
 }
 
-func (e *TaskIDORExecutor) enumerationFinding(endpoint, taskID string, total int, crossPrincipal bool) attack.Finding {
+func (e *TaskIDORExecutor) enumerationFinding(endpoint, taskID string, total int, crossPrincipal bool, auth authEvidence) attack.Finding {
 	return attack.Finding{
 		RuleID:     e.rule.ID,
 		RuleName:   e.rule.Name,
@@ -509,15 +546,15 @@ func (e *TaskIDORExecutor) enumerationFinding(endpoint, taskID string, total int
 				"context, and to not advertise the tasks.list capability at all when requestors cannot be "+
 				"identified.", endpoint, taskID, requestorLabel(crossPrincipal), total),
 		Evidence: fmt.Sprintf(
-			"endpoint: %s\nanonymous task creation: rejected (auth enforced)\n"+
+			"endpoint: %s\nauthentication enforced on: %s\n%s\n"+
 				"cross-context tasks/list: accepted\ntasks returned: %d\nincludes another context's task: %s",
-			endpoint, total, taskID),
+			endpoint, auth.enforcedOn, auth.anonProbe, total, taskID),
 		Remediation: e.rule.Remediation,
 		TargetURL:   endpoint,
 	}
 }
 
-func (e *TaskIDORExecutor) resultFinding(endpoint, taskID, toolName, content string, crossPrincipal bool) attack.Finding {
+func (e *TaskIDORExecutor) resultFinding(endpoint, taskID, toolName, content string, crossPrincipal bool, auth authEvidence) attack.Finding {
 	return attack.Finding{
 		RuleID:     e.rule.ID,
 		RuleName:   e.rule.Name,
@@ -531,9 +568,9 @@ func (e *TaskIDORExecutor) resultFinding(endpoint, taskID, toolName, content str
 				"receivers to reject tasks/result for tasks outside the requestor's authorization context.",
 			endpoint, taskID, requestorLabel(crossPrincipal), toolName),
 		Evidence: fmt.Sprintf(
-			"endpoint: %s\ntask: %s\ntool: %s\nanonymous task creation: rejected (auth enforced)\n"+
+			"endpoint: %s\ntask: %s\ntool: %s\nauthentication enforced on: %s\n%s\n"+
 				"cross-context tasks/result: accepted\ndisclosed result: %s",
-			endpoint, taskID, toolName, snippetMCP([]byte(content))),
+			endpoint, taskID, toolName, auth.enforcedOn, auth.anonProbe, snippetMCP([]byte(content))),
 		Remediation: e.rule.Remediation,
 		TargetURL:   endpoint,
 	}

--- a/internal/attack/mcp/task_idor_test.go
+++ b/internal/attack/mcp/task_idor_test.go
@@ -22,8 +22,11 @@ import (
 //   - "metadata-only": tasks/get leaks across sessions but tasks/result is
 //     scoped => only the tasks/get finding.
 //   - "secure":        tasks are bound to the creating session => silent.
-//   - "no-auth":       task creation succeeds with no credentials, so the
-//     discriminator suppresses the finding => silent.
+//   - "no-auth":       nothing requires credentials, on creation or on reads, so
+//     the discriminator suppresses the finding => silent.
+//   - "create-open":   task creation needs no credentials but reads do, and reads
+//     are not scoped. Authentication really is enforced on the surface this rule
+//     tests, so the boundary B crosses is real => both findings.
 //   - "no-tasks-cap":  the tasks capability is absent => skip.
 //   - "unsafe-tool":   the only task-capable tool carries no safety annotations,
 //     so the rule refuses to invoke it => skip.
@@ -105,8 +108,8 @@ func taskIDORServer(mode string) *httptest.Server {
 				rpcErr(-32600, "task augmentation required")
 				return
 			}
-			// Every mode except no-auth requires credentials to create a task.
-			if mode != "no-auth" && !authed {
+			// Only no-auth and create-open let an anonymous caller create a task.
+			if mode != "no-auth" && mode != "create-open" && !authed {
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			}
@@ -121,6 +124,11 @@ func taskIDORServer(mode string) *httptest.Server {
 			}})
 
 		case "tasks/get":
+			// create-open gates the read surface even though creation is open.
+			if mode == "create-open" && !authed {
+				rpcErr(-32001, "Unauthorized")
+				return
+			}
 			tid, _ := params["taskId"].(string)
 			mu.Lock()
 			own, exists := owner[tid]
@@ -137,6 +145,10 @@ func taskIDORServer(mode string) *httptest.Server {
 			})
 
 		case "tasks/result":
+			if mode == "create-open" && !authed {
+				rpcErr(-32001, "Unauthorized")
+				return
+			}
 			tid, _ := params["taskId"].(string)
 			mu.Lock()
 			own, exists := owner[tid]
@@ -151,6 +163,10 @@ func taskIDORServer(mode string) *httptest.Server {
 			})
 
 		case "tasks/list":
+			if mode == "create-open" && !authed {
+				rpcErr(-32001, "Unauthorized")
+				return
+			}
 			mu.Lock()
 			var listed []interface{}
 			for tid, own := range owner {
@@ -298,6 +314,61 @@ func TestTaskIDOR_NoAuthSuppressed(t *testing.T) {
 
 	if findings := runTaskIDOR(t, srv); len(findings) != 0 {
 		t.Errorf("expected 0 findings when the server enforces no auth at all, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestTaskIDOR_CreateOpenButReadsGated: task creation needs no credentials, but
+// tasks/get, tasks/result and tasks/list all refuse an anonymous caller and none
+// of them are scoped to the creator.
+//
+// Open creation alone used to suppress the whole rule, which lost this server. The
+// suppression exists to avoid reporting an IDOR against a server that authenticates
+// nothing, and this server does authenticate the surface the rule tests: anonymous
+// reads are refused, authenticated reads are not, and any authenticated principal
+// can read every other principal's task. That is the boundary the spec requires
+// receivers to enforce, so it is reportable.
+func TestTaskIDOR_CreateOpenButReadsGated(t *testing.T) {
+	srv := taskIDORServer("create-open")
+	defer srv.Close()
+
+	findings := runTaskIDOR(t, srv)
+	if len(findings) == 0 {
+		t.Fatal("expected findings: reads are gated and unscoped, so an authorization boundary was crossed")
+	}
+
+	// The evidence must describe the boundary that was actually measured. Here that
+	// is the refused anonymous read, not a refused creation, which did not happen.
+	for _, f := range findings {
+		if strings.Contains(f.Evidence, "anonymous task creation: refused") {
+			t.Errorf("evidence claims anonymous creation was refused, but this server accepts it: %s", f.Evidence)
+		}
+		if !strings.Contains(f.Evidence, "anonymous tasks/get: refused") {
+			t.Errorf("evidence should cite the anonymous read that was refused, got: %s", f.Evidence)
+		}
+		if !strings.Contains(f.Evidence, "task reads only (anonymous task creation was accepted)") {
+			t.Errorf("evidence should record that only reads are authenticated, got: %s", f.Evidence)
+		}
+	}
+}
+
+// The default posture refuses anonymous task creation, so the discriminator stops
+// there and never issues an anonymous read. The evidence must cite the refused
+// creation rather than a read it did not attempt.
+func TestTaskIDOR_EvidenceCitesTheProbeThatRan(t *testing.T) {
+	srv := taskIDORServer("vuln")
+	defer srv.Close()
+
+	findings := runTaskIDOR(t, srv)
+	if len(findings) == 0 {
+		t.Fatal("expected findings against the unscoped server")
+	}
+	for _, f := range findings {
+		if !strings.Contains(f.Evidence, "anonymous task creation: refused") {
+			t.Errorf("evidence should cite the refused creation, got: %s", f.Evidence)
+		}
+		if strings.Contains(f.Evidence, "anonymous tasks/get: refused") {
+			t.Errorf("no anonymous read was attempted, so the evidence must not cite one: %s", f.Evidence)
+		}
 	}
 }
 

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -58,7 +58,7 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_batch_bypass_server.py` | 7795 | `mcp-jsonrpc-batch-bypass-001` |
 | `mcp_completion_unauth_server.py` | 7796 | `mcp-completion-unauth-001` |
 | `mcp_logging_unauth_server.py` | 7797 | `mcp-logging-unauth-001` |
-| `mcp_task_idor_server.py` | 7798 | `mcp-task-idor-001` (two principals; needs two `--principal`s) |
+| `mcp_task_idor_server.py` | 7798 | `mcp-task-idor-001` (two principals; needs two `--principal`s; two postures, see below) |
 | `mcp_modern_era_server.py` | 7799 | none, by design: an era-detection target, see below |
 | `mcp_era_downgrade_server.py` | 7800 | `mcp-era-downgrade-001` (two postures, see below) |
 | `mcp_large_body_server.py` | 7801 | the unauth family at responses past the body read limit, see below |
@@ -122,6 +122,22 @@ rules that treat an unparseable probe the same as a refused one reported those
 surfaces clean. The large server gave 1 finding where the small one gave 7, so a
 server could hide every unauthenticated-access finding by being large. If the two
 invocations ever disagree again, a body is being truncated somewhere.
+
+**`mcp_task_idor_server.py` takes a posture argument**, defaulting to `vulnerable`:
+
+```sh
+python testdata/mcp_task_idor_server.py              # creation and reads authenticated
+python testdata/mcp_task_idor_server.py create-open  # only reads authenticated
+```
+
+Both postures must produce the same three findings. The rule suppresses itself when
+a server authenticates nothing, because that is `mcp-tools-unauth-001`'s failure
+rather than an IDOR, but it used to decide that from task creation alone. The
+`create-open` posture leaves a task-augmented `tools/call` open while `tasks/get`,
+`tasks/result` and `tasks/list` all require a Bearer token and none of them are
+scoped to the creator. That is a real authorization boundary on the exact surface
+the rule tests, and the scanner reported the server clean. Run both postures when
+touching the discriminator: agreement is the property under test.
 
 **`mcp_new_rules_server.py` takes a posture argument**, defaulting to `open`:
 

--- a/testdata/mcp_task_idor_server.py
+++ b/testdata/mcp_task_idor_server.py
@@ -3,13 +3,19 @@ Deliberately vulnerable MCP test server for validating:
   - mcp-task-idor-001: MCP 2025-11-25 tasks are not bound to the authorization
     context that created them.
 
-The server enforces authentication on task creation (so the rule's
-discriminator passes) but applies no scoping to tasks/get or tasks/result, so
-any authenticated session can read another session's task and its result.
+Postures:
+  - "vulnerable" (default): authentication is enforced on task creation, but no
+    scoping is applied to tasks/get, tasks/result or tasks/list, so any
+    authenticated session can read another session's task and its result.
+  - "create-open": task creation needs no credentials, while the read methods
+    still require a Bearer token and are still unscoped. Authentication is
+    enforced on the surface the rule tests, so the cross-context read is still
+    an authorization failure and must still be reported.
 
-Run: python testdata/mcp_task_idor_server.py
+Run: python testdata/mcp_task_idor_server.py [posture]
 """
 import json
+import sys
 import uuid
 from starlette.applications import Starlette
 from starlette.requests import Request
@@ -18,6 +24,9 @@ from starlette.routing import Route
 import uvicorn
 
 PORT = 7798
+
+POSTURES = ("vulnerable", "create-open")
+POSTURE = sys.argv[1] if len(sys.argv) > 1 else "vulnerable"
 
 # taskId -> {"owner": session_id, "topic": str}
 TASKS = {}
@@ -76,9 +85,9 @@ async def mcp_endpoint(request: Request) -> Response:
     if method == "tools/call":
         if "task" not in params:
             return error(-32600, "Task augmentation required for this tool")
-        # Authentication IS enforced here, so this is an authorization failure
-        # rather than a missing-authentication one.
-        if not authed:
+        # Under the default posture authentication is enforced here. Under
+        # create-open it is not, and the read methods below carry the boundary.
+        if POSTURE != "create-open" and not authed:
             return Response(status_code=401)
         tid = uuid.uuid4().hex
         TASKS[tid] = {"owner": sid, "topic": params.get("arguments", {}).get("topic", "")}
@@ -87,6 +96,11 @@ async def mcp_endpoint(request: Request) -> Response:
             "createdAt": "2026-07-20T07:00:00Z", "lastUpdatedAt": "2026-07-20T07:00:00Z",
             "ttl": 60000, "pollInterval": 500,
         }})
+
+    # Under create-open the read methods are the only authenticated surface, so
+    # an anonymous caller must be refused here even though creation was open.
+    if POSTURE == "create-open" and method in ("tasks/get", "tasks/result", "tasks/list") and not authed:
+        return error(-32001, "Unauthorized")
 
     # Vulnerable: neither of the following checks the requesting session against
     # the task's owner, so any caller holding a task id can read it.
@@ -127,6 +141,10 @@ app = Starlette(routes=[
 ])
 
 if __name__ == "__main__":
-    print(f"[*] MCP task-IDOR vulnerable server on port {PORT}", flush=True)
+    if POSTURE not in POSTURES:
+        sys.exit(f"unknown posture {POSTURE!r}; expected one of {', '.join(POSTURES)}")
+    print(f"[*] MCP task-IDOR vulnerable server ({POSTURE}) on port {PORT}", flush=True)
     print("[*] Vulnerability: tasks/get and tasks/result are not scoped to the creating session", flush=True)
+    if POSTURE == "create-open":
+        print("[*] Task creation is open; the read methods require a Bearer token", flush=True)
     uvicorn.run(app, host="127.0.0.1", port=PORT)


### PR DESCRIPTION
`mcp-task-idor-001` suppressed itself whenever an anonymous caller could create a task, on the reasoning that a server authenticating nothing is `mcp-tools-unauth-001`'s failure rather than an IDOR. But creation being open says nothing about the read surface. A server can leave a task-augmented `tools/call` open while `tasks/get`, `tasks/result` and `tasks/list` all require a Bearer token and none are scoped to the creator. That token check is a real authorization boundary on the exact surface this rule tests, and the scanner reported such a server clean.

The discriminator now measures both surfaces and suppresses only when an anonymous caller can create a task *and* read another context's task. The read probe is only issued when creation was open, so the common path costs no extra request.

The findings also hardcoded `anonymous task creation: rejected (auth enforced)` as evidence, which was false on these servers. Each path now names the surface a credential is required for and cites the one anonymous probe that established it.

## Verification

`testdata/mcp_task_idor_server.py` gained a `create-open` posture, verified at the wire before use (anonymous create 200, anonymous `tasks/get` refused). Against it:

| | default posture | create-open |
|---|---|---|
| `origin/main` | 3 findings | **0 findings, "Target appears clean"** |
| this branch | 3 findings | 3 findings |

Two unit tests added, one per posture. The new create-open test fails on `origin/main`'s discriminator and is the only failure, so it is not vacuous. The other posture's test pins the inverse property: the default path never issues an anonymous read, so its evidence must not cite one.

Full suite green uncached, `go vet` and `gofmt` clean, and the package passes under `-race`.
