### PR TITLE
fix(a2a): forge the peer-impersonation JWT with the issuer the target trusts

### DIFF
--- a/internal/attack/a2a/peer_impersonation.go
+++ b/internal/attack/a2a/peer_impersonation.go
@@ -8,10 +8,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
 	"github.com/calbebop/batesian/internal/attack"
+	protoa2a "github.com/calbebop/batesian/internal/protocol/a2a"
 )
 
 // PeerImpersonationExecutor tests whether an A2A server validates the
@@ -21,13 +23,28 @@ import (
 // Attack sequence:
 //  1. Fetch /.well-known/agent-card.json to extract the agent name for use as
 //     the JWT subject. Falls back to "trusted-orchestrator" if unavailable.
-//  2. Build a forged HS256 JWT signed with a random key the server cannot know.
-//     Claims: sub=<agent-name>, iss=legitimate-orchestrator.example.com,
-//     role=orchestrator, aud=<target>.
+//  2. Discover the issuer and audience the target actually trusts, and build a
+//     forged HS256 JWT carrying them, signed with a random key the server cannot
+//     know. Claims: sub=<agent-name>, iss=<discovered>, role=orchestrator,
+//     aud=<discovered>.
 //  3. Send a SendMessage request with the forged token in Authorization: Bearer.
 //  4. Send a baseline SendMessage with no Authorization header.
 //  5. Compare: forged accepted + baseline rejected => server trusts claims
 //     without signature verification; both accepted => no auth enforced.
+//
+// The issuer must be discovered rather than invented. This rule asks one
+// question: does the server verify the signature? A server that checks the
+// issuer against an allowlist before (or instead of) verifying the signature
+// answers a token bearing an unknown issuer with a 401, which is
+// indistinguishable from a server that verified the signature and found it
+// invalid. Issuer allowlisting is ordinary practice, so a fabricated issuer made
+// this rule report those servers clean. Measured against a server that trusts a
+// published issuer and never verifies signatures: reported clean with a
+// fabricated issuer, HIGH with the real one, same server both times.
+//
+// When no issuer can be discovered and the forged probe is refused, the rule
+// says so rather than reporting clean, because the refusal cannot be attributed
+// to signature verification.
 type PeerImpersonationExecutor struct {
 	rule attack.RuleContext
 }
@@ -53,20 +70,25 @@ func (e *PeerImpersonationExecutor) Execute(ctx context.Context, target string, 
 		return nil, attack.ErrInconclusive
 	}
 
-	// Step 1: Probe the agent card to find a plausible agent name to impersonate.
+	// Step 1: Probe the agent card for a plausible agent name to impersonate, and
+	// keep the parsed card: its security schemes are where the trusted issuer is
+	// published, and its service URL is the audience the server expects.
 	agentName := "trusted-orchestrator"
-	cardResp, err := client.GET(ctx, vars.BaseURL+"/.well-known/agent-card.json", nil)
-	if err == nil && cardResp.IsSuccess() {
-		var card struct {
-			Name string `json:"name"`
-		}
-		if jsonErr := json.Unmarshal(cardResp.Body, &card); jsonErr == nil && card.Name != "" {
-			agentName = card.Name
+	var card *protoa2a.AgentCard
+	if body, ok := fetchAgentCardBody(ctx, client, vars.BaseURL); ok {
+		var parsed protoa2a.AgentCard
+		if json.Unmarshal(body, &parsed) == nil {
+			card = &parsed
+			if parsed.Name != "" {
+				agentName = parsed.Name
+			}
 		}
 	}
 
-	// Step 2: Build the forged JWT using a random signing key.
-	forgedToken, err := buildForgedJWT(agentName, target)
+	// Step 2: Build the forged JWT using a random signing key, carrying the issuer
+	// and audience the target actually trusts.
+	claims := deriveForgedClaims(ctx, client, vars.BaseURL, target, card)
+	forgedToken, err := buildForgedJWT(agentName, claims.iss, claims.aud)
 	if err != nil {
 		return nil, fmt.Errorf("building forged JWT: %w", err)
 	}
@@ -126,11 +148,13 @@ func (e *PeerImpersonationExecutor) Execute(ctx context.Context, target string, 
 					"key was accepted by the A2A server (HTTP %d), while an unauthenticated "+
 					"baseline request was rejected (HTTP %d). The server is granting access based "+
 					"on JWT claims alone without verifying the token signature.",
-				agentName, "https://legitimate-orchestrator.example.com",
+				agentName, claims.iss,
 				forgedResp.StatusCode, baselineResp.StatusCode),
 			Evidence: fmt.Sprintf(
-				"Forged JWT (redacted): %s...[signature omitted]\nForged response: HTTP %d\nBaseline response: HTTP %d\n%s",
-				jwtHeader(forgedToken), forgedResp.StatusCode, baselineResp.StatusCode,
+				"Forged JWT (redacted): %s...[signature omitted]\niss: %s\nissuer source: %s\naud: %s\n"+
+					"Forged response: HTTP %d\nBaseline response: HTTP %d\n%s",
+				jwtHeader(forgedToken), claims.iss, claims.source, claims.aud,
+				forgedResp.StatusCode, baselineResp.StatusCode,
 				snippet(forgedResp.Body, 400)),
 			Remediation: e.rule.Remediation,
 			TargetURL:   endpoint,
@@ -156,14 +180,154 @@ func (e *PeerImpersonationExecutor) Execute(ctx context.Context, target string, 
 			Remediation: e.rule.Remediation,
 			TargetURL:   endpoint,
 		})
+
+	case !forgedOK && !claims.discovered():
+		// The forged token was refused, but it carried an invented issuer, so the
+		// refusal is equally consistent with the server filtering unknown issuers
+		// and with the server verifying the signature. Reporting clean here is the
+		// false negative this rule shipped with: a server that trusts a published
+		// issuer and never checks signatures looks identical from the outside.
+		return nil, fmt.Errorf("%w: the target publishes no trusted issuer, so a forged token "+
+			"carrying an invented issuer (%s) cannot distinguish signature verification from "+
+			"issuer filtering; publish RFC 9728 protected-resource metadata or an "+
+			"openIdConnect/oauth2 securityScheme in the agent card to make this testable",
+			attack.ErrInconclusive, claims.iss)
 	}
 
 	return findings, nil
 }
 
+// fallbackForgedIssuer is used only when the target publishes no issuer anywhere.
+// A token carrying it proves nothing about signature verification on a server
+// that filters issuers, which is why discovery is attempted first and why a
+// refusal under this fallback is reported as inconclusive.
+const fallbackForgedIssuer = "https://legitimate-orchestrator.example.com"
+
+// forgedClaims are the issuer and audience the forged token will carry, and
+// whether they came from the target or had to be invented.
+type forgedClaims struct {
+	iss    string
+	aud    string
+	source string // where iss came from, for the finding's evidence
+}
+
+// discovered reports whether the issuer came from the target rather than being
+// fabricated, which is what makes a refusal meaningful.
+func (c forgedClaims) discovered() bool { return c.iss != fallbackForgedIssuer }
+
+// deriveForgedClaims finds the issuer and audience the target actually trusts.
+//
+// Two sources, in order of authority:
+//  1. RFC 9728 protected-resource metadata, which names the authorization
+//     servers and the canonical resource identifier outright.
+//  2. The agent card's security schemes: an openIdConnect scheme's issuer is its
+//     configuration URL minus the well-known suffix, and an OAuth2 flow's issuer
+//     is the origin of its authorization or token endpoint.
+//
+// The audience falls back to the card's service URL and then to the target,
+// since an audience mismatch confounds the probe the same way an issuer
+// mismatch does.
+func deriveForgedClaims(ctx context.Context, client *attack.HTTPClient, baseURL, target string, card *protoa2a.AgentCard) forgedClaims {
+	out := forgedClaims{iss: fallbackForgedIssuer, aud: target, source: "fabricated (target published no issuer)"}
+
+	if card != nil {
+		if u := card.GetServiceURL(); u != "" {
+			out.aud = u
+		}
+	}
+
+	// Source 1: protected-resource metadata.
+	if resp, err := client.GET(ctx, baseURL+"/.well-known/oauth-protected-resource", nil); err == nil && resp.IsSuccess() {
+		var meta struct {
+			Resource             string   `json:"resource"`
+			AuthorizationServers []string `json:"authorization_servers"`
+		}
+		if json.Unmarshal(resp.Body, &meta) == nil {
+			if len(meta.AuthorizationServers) > 0 && meta.AuthorizationServers[0] != "" {
+				out.iss = strings.TrimSuffix(meta.AuthorizationServers[0], "/")
+				out.source = "protected-resource metadata (authorization_servers)"
+			}
+			if meta.Resource != "" {
+				out.aud = meta.Resource
+			}
+			if out.discovered() {
+				return out
+			}
+		}
+	}
+
+	// Source 2: the agent card's security schemes.
+	if card == nil {
+		return out
+	}
+	for name, scheme := range card.SecuritySchemes {
+		if iss := issuerFromScheme(scheme); iss != "" {
+			out.iss = iss
+			out.source = fmt.Sprintf("agent card securityScheme %q", name)
+			return out
+		}
+	}
+	return out
+}
+
+// issuerFromScheme extracts an issuer from one declared security scheme, or ""
+// when the scheme carries no issuer (an apiKey or plain bearer scheme does not).
+func issuerFromScheme(s protoa2a.SecurityScheme) string {
+	if s.OpenIDConnect != nil && s.OpenIDConnect.OpenIDConnectURL != "" {
+		u := s.OpenIDConnect.OpenIDConnectURL
+		// An OIDC issuer is its configuration URL without the well-known suffix.
+		u = strings.TrimSuffix(u, "/.well-known/openid-configuration")
+		return strings.TrimSuffix(u, "/")
+	}
+	if s.OAuth2 != nil {
+		for _, endpoint := range oauthFlowEndpoints(s.OAuth2.Flows) {
+			if origin := urlOrigin(endpoint); origin != "" {
+				return origin
+			}
+		}
+	}
+	return ""
+}
+
+// oauthFlowEndpoints lists the authorization and token endpoints declared across
+// an OAuth2 scheme's flows, in a stable order so the derived issuer does not
+// depend on which flows a card happens to declare first.
+func oauthFlowEndpoints(f protoa2a.OAuthFlows) []string {
+	var out []string
+	if f.AuthorizationCode != nil {
+		out = append(out, f.AuthorizationCode.AuthorizationURL, f.AuthorizationCode.TokenURL)
+	}
+	if f.ClientCredentials != nil {
+		out = append(out, f.ClientCredentials.TokenURL)
+	}
+	if f.DeviceCode != nil {
+		out = append(out, f.DeviceCode.DeviceAuthorizationURL, f.DeviceCode.TokenURL)
+	}
+	if f.Implicit != nil {
+		out = append(out, f.Implicit.AuthorizationURL)
+	}
+	if f.Password != nil {
+		out = append(out, f.Password.TokenURL)
+	}
+	return out
+}
+
+// urlOrigin reduces an endpoint URL to scheme://host, which is the closest an
+// OAuth2 flow URL gets to naming its issuer.
+func urlOrigin(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return ""
+	}
+	return u.Scheme + "://" + u.Host
+}
+
 // buildForgedJWT constructs a HS256 JWT signed with a random key.
 // It uses only stdlib: encoding/base64, encoding/json, crypto/hmac, crypto/sha256, crypto/rand.
-func buildForgedJWT(sub, aud string) (string, error) {
+func buildForgedJWT(sub, iss, aud string) (string, error) {
 	headerJSON, err := json.Marshal(map[string]string{
 		"alg": "HS256",
 		"typ": "JWT",
@@ -175,7 +339,7 @@ func buildForgedJWT(sub, aud string) (string, error) {
 	now := time.Now().Unix()
 	payloadJSON, err := json.Marshal(map[string]interface{}{
 		"sub":  sub,
-		"iss":  "https://legitimate-orchestrator.example.com",
+		"iss":  iss,
 		"aud":  aud,
 		"role": "orchestrator",
 		"iat":  now,

--- a/internal/attack/a2a/peer_impersonation_test.go
+++ b/internal/attack/a2a/peer_impersonation_test.go
@@ -2,6 +2,8 @@ package a2a_test
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -71,17 +73,101 @@ func unauthAllowedServer(t *testing.T) *httptest.Server {
 	}))
 }
 
-// properJWTServer rejects all bearer tokens (simulating real signature validation
-// where the random key used to forge the JWT is unknown to the server).
+// testIssuer is the issuer the fixtures below publish in their agent card. The
+// rule must send it in the forged token, or an issuer-filtering server refuses on
+// the wrong claim and the missing signature check is never reached.
+const testIssuer = "https://sso.example.test/realms/agents"
+
+// cardWithIssuer is an agent card that publishes testIssuer the way a real
+// OIDC-protected agent does.
+func cardWithIssuer(name string) map[string]interface{} {
+	return map[string]interface{}{
+		"name":    name,
+		"version": "1.0",
+		"securitySchemes": map[string]interface{}{
+			"sso": map[string]interface{}{
+				"type":             "openIdConnect",
+				"openIdConnectUrl": testIssuer + "/.well-known/openid-configuration",
+			},
+		},
+	}
+}
+
+// properJWTServer publishes its issuer and still rejects every bearer token, which
+// is what real signature validation looks like: the forged token carries the right
+// issuer and is refused anyway, because the random signing key is unknown.
+//
+// It has to publish the issuer for the test to mean anything. A server that
+// publishes nothing and refuses everything is indistinguishable from one that
+// filters unknown issuers without checking signatures, which is what
+// TestPeerImpersonation_NoPublishedIssuerIsInconclusive covers.
 func properJWTServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "agent-card.json") {
+			writeJSON(w, cardWithIssuer("secure-agent"))
+			return
+		}
+		// Any bearer token is rejected; the forged token (random key) will fail.
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+}
+
+// opaqueServer publishes no card and no issuer, and refuses everything. Whether it
+// verifies signatures cannot be determined from outside.
+func opaqueServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "agent-card.json") {
 			http.NotFound(w, r)
 			return
 		}
-		// Any bearer token is rejected; the forged token (random key) will fail.
 		w.WriteHeader(http.StatusUnauthorized)
+	}))
+}
+
+// issuerAllowlistServer is the failure this rule exists to catch, in the shape
+// that used to escape it: the issuer is checked against the published value and
+// the signature is never verified at all. Unauthenticated callers are refused, so
+// the baseline probe behaves exactly as it does on a secure server.
+func issuerAllowlistServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "agent-card.json") {
+			writeJSON(w, cardWithIssuer("billing-orchestrator"))
+			return
+		}
+		auth := r.Header.Get("Authorization")
+		if !strings.HasPrefix(auth, "Bearer ") {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		// Decode the claims without verifying anything, and trust the issuer.
+		parts := strings.Split(strings.TrimPrefix(auth, "Bearer "), ".")
+		if len(parts) != 3 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+		if err != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		var claims struct {
+			Iss string `json:"iss"`
+		}
+		if json.Unmarshal(raw, &claims) != nil || claims.Iss != testIssuer {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		writeJSON(w, map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"result": map[string]interface{}{
+				"id":     "task-003",
+				"status": map[string]interface{}{"state": "completed"},
+			},
+		})
 	}))
 }
 
@@ -190,6 +276,58 @@ func TestPeerImpersonation_ProperValidation(t *testing.T) {
 	}
 	if len(findings) != 0 {
 		t.Errorf("expected zero findings on secure server, got %d: %v", len(findings), findings)
+	}
+}
+
+// TestPeerImpersonation_IssuerAllowlistOnly is the regression test for the false
+// negative this rule shipped with. The server trusts the issuer it publishes and
+// never verifies a signature, so any caller can mint a token for any subject. With
+// a fabricated issuer the forged probe was refused on the wrong claim and the rule
+// reported the server clean.
+func TestPeerImpersonation_IssuerAllowlistOnly(t *testing.T) {
+	ts := issuerAllowlistServer(t)
+	defer ts.Close()
+
+	exec := a2aattack.NewPeerImpersonationExecutor(peerImpersonationRC())
+	findings, err := exec.Execute(context.Background(), ts.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) == 0 {
+		t.Fatal("expected a finding: the server accepts a randomly signed token bearing its published issuer")
+	}
+	if findings[0].Severity != "high" {
+		t.Errorf("expected high severity, got %q", findings[0].Severity)
+	}
+	// The evidence must show the issuer was taken from the target, not invented,
+	// because that is what makes the acceptance meaningful.
+	if !strings.Contains(findings[0].Evidence, testIssuer) {
+		t.Errorf("evidence should record the discovered issuer, got: %s", findings[0].Evidence)
+	}
+	if !strings.Contains(findings[0].Evidence, "securityScheme") {
+		t.Errorf("evidence should name where the issuer came from, got: %s", findings[0].Evidence)
+	}
+}
+
+// TestPeerImpersonation_NoPublishedIssuerIsInconclusive: a server that publishes no
+// issuer and refuses everything cannot be assessed. Reporting it clean would claim
+// signature verification that was never demonstrated, since refusing a token with
+// an invented issuer is what an issuer filter does too.
+func TestPeerImpersonation_NoPublishedIssuerIsInconclusive(t *testing.T) {
+	ts := opaqueServer(t)
+	defer ts.Close()
+
+	exec := a2aattack.NewPeerImpersonationExecutor(peerImpersonationRC())
+	findings, err := exec.Execute(context.Background(), ts.URL, testOpts())
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive when no issuer is discoverable, got err=%v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings, got %d", len(findings))
+	}
+	// The reason must name the actual obstacle, not a network problem.
+	if !strings.Contains(err.Error(), "no trusted issuer") {
+		t.Errorf("inconclusive reason should explain the missing issuer, got: %v", err)
 	}
 }
 

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -215,6 +215,19 @@ does not exhibit what they test for:
 - `a2a-jws-algconf-001` analyses JWS signatures on the agent card. This fixture
   deliberately serves an unsigned card, so there is nothing to analyse.
 
+**`a2a-peer-impersonation-001` reports "not tested" against most fixtures here, and
+that is correct.** The rule forges a JWT and asks whether the server accepts it. To
+mean anything, the forged token has to carry the issuer the target actually trusts:
+a server that checks the issuer against an allowlist before verifying the signature
+refuses an unknown issuer with a 401, which looks exactly like a server that
+verified the signature and rejected it. The rule therefore discovers the issuer from
+RFC 9728 protected-resource metadata or from an `openIdConnect` / `oauth2`
+securityScheme in the agent card. Six of the eleven A2A fixtures publish neither and
+refuse the forged token, so the rule cannot attribute the refusal and says so
+instead of reporting clean. Only `a2a_card_security_unenforced_server.py` publishes
+security schemes; the four fixtures where the rule fires do so because they accept
+the token, which needs no issuer at all.
+
 When adding a fixture, confirm the rule actually fires against it rather than
 assuming coverage from the registry table. `a2a-session-smuggle-001` was listed
 here for a long time while the fixture returned a hardcoded task history that


### PR DESCRIPTION
`a2a-peer-impersonation-001` asks one question: does the server verify the JWT signature? It forged a token carrying a fixed invented issuer, `legitimate-orchestrator.example.com`, and read a refusal as evidence of signature verification.

A server that checks the issuer against an allowlist before verifying the signature refuses an unknown issuer with a 401 — indistinguishable from a server that verified the signature and found it invalid. Issuer allowlisting is ordinary practice for OIDC-protected agents, so the rule reported those servers clean.

Isolated on one server that trusts a published issuer and never verifies signatures. Only the issuer string differs between the two runs:

| server's trusted issuer | verdict |
|---|---|
| its real published issuer | **clean** (false negative) |
| the rule's hardcoded value | HIGH finding |

The fix discovers the issuer from RFC 9728 protected-resource metadata or from an `openIdConnect` / `oauth2` securityScheme in the agent card, reusing the card parsing added in #142–#144, and derives the audience from the card's service URL rather than the raw scan target, which confounds the probe the same way. The finding records the issuer used and its source.

When no issuer is discoverable and the forged token is refused, the rule now reports inconclusive rather than clean, since the refusal cannot be attributed to signature verification.

## Verification

Live, against a server that trusts its published issuer and never checks signatures (confirmed vulnerable first by hand: a random-signature token with the correct issuer returns 200):

- before: 0 findings, 0 skipped, reported clean
- after: HIGH, evidence `issuer source: protected-resource metadata (authorization_servers)`

Three unit tests added: the issuer-allowlist server must be caught, an opaque server must be inconclusive with a reason naming the missing issuer, and the secure fixture now publishes an issuer so that "rejects a correctly-issued forged token" is what it actually asserts. Without the derivation, both the allowlist test and the secure test fail, so neither is vacuous.

**Output-breadth change, measured across all 11 A2A fixtures:** 6 move from `clean` to `INCONCLUSIVE` (they publish no security metadata and refuse the token). All 4 findings are preserved and 1 was already inconclusive. `testdata/README.md` documents why, next to the existing note on rules that are silent by design.

Full suite green uncached, `go vet` and `gofmt` clean.
