### PR TITLE
fix: report why a rule was not exercised instead of blaming reachability

### DIFF
--- a/internal/attack/a2a/artifact_tamper.go
+++ b/internal/attack/a2a/artifact_tamper.go
@@ -64,7 +64,9 @@ func (e *ArtifactTamperExecutor) Execute(ctx context.Context, target string, opt
 		// path used to return clean with the comment "not an A2A server", which
 		// resolveA2AEndpoint has already ruled out, and which meant a stale v0.2-only
 		// method name reported every real agent secure.
-		return nil, attack.ErrInconclusive
+		return nil, fmt.Errorf("%w: the agent at %s accepted no task-creating request "+
+			"(SendMessage, message/send or tasks/send), so there was no task whose immutability "+
+			"could be tested", attack.ErrInconclusive, endpoint)
 	}
 
 	// Step 2: re-submit against the SAME task ID with different content, on the
@@ -81,7 +83,9 @@ func (e *ArtifactTamperExecutor) Execute(ctx context.Context, target string, opt
 	if !ok {
 		// The re-submission was accepted but the stored content is unknown, so
 		// whether the artifact changed cannot be established either way.
-		return nil, attack.ErrInconclusive
+		return nil, fmt.Errorf("%w: task %s was re-submitted and accepted, but reading it back "+
+			"returned no task history, so whether the stored artifact changed could not be "+
+			"established", attack.ErrInconclusive, taskID)
 	}
 
 	stored := string(getBody)
@@ -120,7 +124,9 @@ func (e *ArtifactTamperExecutor) Execute(ctx context.Context, target string, opt
 	default:
 		// Neither marker is visible, so the server does not surface message text and
 		// the read-back can neither confirm nor refute an overwrite.
-		return nil, attack.ErrInconclusive
+		return nil, fmt.Errorf("%w: task %s read back without either the original or the "+
+			"tampered marker, so this agent does not surface message text and an overwrite can "+
+			"be neither confirmed nor refuted", attack.ErrInconclusive, taskID)
 	}
 }
 

--- a/internal/attack/a2a/card_security_unenforced.go
+++ b/internal/attack/a2a/card_security_unenforced.go
@@ -64,11 +64,14 @@ func (e *CardSecurityUnenforcedExecutor) Execute(ctx context.Context, target str
 	// Fetch the card. Without it there is no declared contract to test against.
 	cardBody, ok := fetchAgentCardBody(ctx, client, vars.BaseURL)
 	if !ok {
-		return nil, attack.ErrInconclusive
+		return nil, fmt.Errorf("%w: no agent card was served under %s, and this rule tests the "+
+			"card's declared security against what the endpoint actually enforces",
+			attack.ErrInconclusive, vars.BaseURL)
 	}
 	card, ok := parseCard(cardBody)
 	if !ok {
-		return nil, attack.ErrInconclusive
+		return nil, fmt.Errorf("%w: the agent card served by %s is not parseable JSON, so its "+
+			"declared security contract could not be read", attack.ErrInconclusive, vars.BaseURL)
 	}
 
 	// Only proceed when the card declares required auth with no anonymous option.

--- a/internal/attack/a2a/card_trust.go
+++ b/internal/attack/a2a/card_trust.go
@@ -54,7 +54,8 @@ func (e *CardTrustExecutor) Execute(ctx context.Context, target string, opts att
 		// This rule analyses the card, so no card means it was not exercised.
 		// It used to return clean here, which reads as "the card is fine" for a
 		// target that served none.
-		return nil, attack.ErrInconclusive
+		return nil, fmt.Errorf("%w: no agent card was served at %s or %s, and this rule analyses "+
+			"the card's transport and caching headers", attack.ErrInconclusive, primaryURL, legacyURL)
 	}
 
 	// Use whichever path actually served a card as the basis for the cache and

--- a/internal/attack/a2a/inconclusive_reason_test.go
+++ b/internal/attack/a2a/inconclusive_reason_test.go
@@ -1,0 +1,79 @@
+package a2a_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	a2aattack "github.com/calbebop/batesian/internal/attack/a2a"
+)
+
+// reachableNoCardServer answers JSON-RPC normally but serves no agent card. The
+// endpoint is plainly reachable, so a rule that gives up here has not failed to
+// reach anything: it has failed to find the card it analyses.
+//
+// This distinction is the point of the test. Every one of these rules reported
+// "could not reach a testable endpoint", which is what an operator reads as a
+// network or address problem, when the target was answering the whole time.
+func reachableNoCardServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, ".well-known") {
+			http.NotFound(w, r)
+			return
+		}
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": body["id"],
+			"result": map[string]interface{}{
+				"id": "task-1", "contextId": "ctx-1",
+				"status": map[string]interface{}{"state": "completed"},
+			},
+		})
+	}))
+}
+
+// The card-analysing rules must attribute their skip to the missing card rather
+// than to reachability, and must name the card so the operator knows what to fix.
+func TestCardRules_InconclusiveReasonNamesTheMissingCard(t *testing.T) {
+	srv := reachableNoCardServer(t)
+	defer srv.Close()
+
+	cases := map[string]func(attack.RuleContext) attack.Executor{
+		"a2a-card-trust-001": func(rc attack.RuleContext) attack.Executor {
+			return a2aattack.NewCardTrustExecutor(rc)
+		},
+		"a2a-jws-algconf-001": func(rc attack.RuleContext) attack.Executor {
+			return a2aattack.NewJWSAlgConfExecutor(rc)
+		},
+		"a2a-card-security-unenforced-001": func(rc attack.RuleContext) attack.Executor {
+			return a2aattack.NewCardSecurityUnenforcedExecutor(rc)
+		},
+		"a2a-wellknown-hostinject-001": func(rc attack.RuleContext) attack.Executor {
+			return a2aattack.NewWellKnownHostInjectExecutor(rc)
+		},
+	}
+
+	for id, mk := range cases {
+		t.Run(id, func(t *testing.T) {
+			exec := mk(attack.RuleContext{ID: id, Name: id, Severity: "medium"})
+			findings, err := exec.Execute(context.Background(), srv.URL, testOpts())
+			if len(findings) != 0 {
+				t.Fatalf("expected no findings against a server serving no card, got %d", len(findings))
+			}
+			if !errors.Is(err, attack.ErrInconclusive) {
+				t.Fatalf("no card means the rule was not exercised; want ErrInconclusive, got %v", err)
+			}
+			if !strings.Contains(err.Error(), "agent card") {
+				t.Errorf("reason should name the missing agent card, got: %v", err)
+			}
+		})
+	}
+}

--- a/internal/attack/a2a/jws_algconf.go
+++ b/internal/attack/a2a/jws_algconf.go
@@ -55,12 +55,14 @@ func (e *JWSAlgConfExecutor) Execute(ctx context.Context, target string, opts at
 		// sound" for a target that served no card at all. This holds even when
 		// the target is plainly an A2A agent by other evidence: a card rule with
 		// no card has nothing to say either way.
-		return nil, attack.ErrInconclusive
+		return nil, fmt.Errorf("%w: no agent card was served at %s, and this rule analyses the "+
+			"JWS signatures on the card", attack.ErrInconclusive, cardURL)
 	}
 
 	var card map[string]interface{}
 	if err := json.Unmarshal(resp.Body, &card); err != nil {
-		return nil, attack.ErrInconclusive
+		return nil, fmt.Errorf("%w: the agent card at %s is not parseable JSON, so its JWS "+
+			"signatures could not be analysed", attack.ErrInconclusive, cardURL)
 	}
 
 	var findings []attack.Finding

--- a/internal/attack/a2a/wellknown_hostinject.go
+++ b/internal/attack/a2a/wellknown_hostinject.go
@@ -139,7 +139,9 @@ func (e *WellKnownHostInjectExecutor) Execute(ctx context.Context, target string
 	}
 
 	if len(findings) == 0 && !cardParsed {
-		return nil, attack.ErrInconclusive
+		return nil, fmt.Errorf("%w: no parseable agent card was served under %s for any injected "+
+			"host header, so there was no card body in which to look for a reflection",
+			attack.ErrInconclusive, vars.BaseURL)
 	}
 	return findings, nil
 }

--- a/internal/attack/mcp/logging_unauth.go
+++ b/internal/attack/mcp/logging_unauth.go
@@ -74,8 +74,11 @@ func (e *LoggingUnauthExecutor) Execute(ctx context.Context, target string, opts
 		}
 		// Nothing was established. The request failed, or the reply carried no
 		// protocol-level verdict, so reporting this surface clean would claim it
-		// is secure when it was never tested.
-		return nil, attack.ErrInconclusive
+		// is secure when it was never tested. The handshake already succeeded, so
+		// this is not a reachability failure and must not be reported as one.
+		return nil, fmt.Errorf("%w: the MCP handshake succeeded at %s but the logging/setLevel "+
+			"probe returned no protocol-level verdict, so whether the surface is authenticated "+
+			"was never established", attack.ErrInconclusive, session.Endpoint)
 	}
 
 	reachable, reason := setLevelDispatchReachable(body)

--- a/internal/attack/mcp/unauth_honesty_test.go
+++ b/internal/attack/mcp/unauth_honesty_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/calbebop/batesian/internal/attack"
@@ -138,6 +139,13 @@ func TestUnauthFamily_GatewayFailureIsInconclusive(t *testing.T) {
 			}
 			if !errors.Is(err, attack.ErrInconclusive) {
 				t.Errorf("a 502 established nothing, so this must be inconclusive, got err=%v", err)
+			}
+			// The handshake succeeded here, so the reason must say what actually
+			// happened. Reported as bare unreachability, this sends the operator
+			// looking for a network fault when the server is answering fine.
+			if !strings.Contains(err.Error(), "handshake succeeded") {
+				t.Errorf("inconclusive reason should record that the handshake succeeded and the "+
+					"probe returned no verdict, got: %v", err)
 			}
 		})
 	}

--- a/internal/attack/mcp/wire.go
+++ b/internal/attack/mcp/wire.go
@@ -219,7 +219,12 @@ func runOnEachWire(ctx context.Context, client *attack.HTTPClient, baseURL strin
 		out = append(out, labelEra(s, findings)...)
 	}
 	if len(out) == 0 && !anyDetermined {
-		return nil, attack.ErrInconclusive
+		// The handshake succeeded on at least one wire, so this is not a
+		// reachability failure. Every probe either failed in transport or answered
+		// without a protocol-level verdict.
+		return nil, fmt.Errorf("%w: the MCP handshake succeeded on %d wire(s) at %s but no probe "+
+			"returned a protocol-level verdict, so the surface was never actually assessed",
+			attack.ErrInconclusive, len(sessions), baseURL)
 	}
 	return out, nil
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -122,14 +122,20 @@ func (e *Engine) runOne(ctx context.Context, target string, entry planEntry, bb 
 	// as a (misleading) clean result and not as an error.
 	if errors.Is(err, attackpkg.ErrInconclusive) {
 		// Executors may wrap ErrInconclusive with the reason the rule could not
-		// run (for example, the target speaks a protocol era these rules do not
-		// support). Surface that detail rather than discarding it: "not tested
-		// because your server speaks MCP 2026-07-28" is actionable, while a bare
-		// "could not reach a testable endpoint" invites the operator to assume a
-		// network problem. The generic prefix is preserved either way.
+		// run. Surface that detail rather than discarding it: "not tested because
+		// your server speaks MCP 2026-07-28" is actionable, while a bare "could
+		// not reach a testable endpoint" invites the operator to assume a network
+		// problem.
+		//
+		// When a reason is supplied it REPLACES the generic sentence instead of
+		// being appended to it. Most reasons describe a target that was reached
+		// and then could not be assessed (an unsupported protocol revision, an
+		// absent agent card, a probe that established nothing after a successful
+		// handshake), so prefixing them with a reachability claim produced a
+		// message that contradicted itself.
 		msg := "could not reach a testable endpoint"
 		if detail := inconclusiveDetail(err); detail != "" {
-			msg += ": " + detail
+			msg = "not tested: " + detail
 		}
 		return RunResult{
 			Rule:    r,

--- a/internal/engine/inconclusive_test.go
+++ b/internal/engine/inconclusive_test.go
@@ -73,9 +73,11 @@ func TestRun_ModernEraServerReportsUnsupportedProtocol(t *testing.T) {
 	if !res.Skipped {
 		t.Fatalf("expected a skipped result, got skipped=%v err=%v findings=%d", res.Skipped, res.Err, len(res.Findings))
 	}
-	// The generic prefix is preserved so existing reporting keeps working.
-	if !strings.Contains(res.SkipMsg, "could not reach") {
-		t.Errorf("skip message lost its generic prefix: %q", res.SkipMsg)
+	// A supplied reason replaces the generic sentence rather than being appended to
+	// it. This server was reached and answered; claiming it could not be reached is
+	// the network-fault misdirection this test's premise is about.
+	if strings.Contains(res.SkipMsg, "could not reach") {
+		t.Errorf("skip message claims the target was unreachable, but it answered the era probe: %q", res.SkipMsg)
 	}
 	// And the actionable detail is present.
 	if !strings.Contains(res.SkipMsg, "2026-07-28") {

--- a/internal/report/inconclusive_test.go
+++ b/internal/report/inconclusive_test.go
@@ -10,21 +10,59 @@ import (
 	"github.com/calbebop/batesian/internal/rules"
 )
 
-// TestPrintScanSummary_InconclusiveNotClean: when rules were skipped because no
-// endpoint was reachable and there are no findings, the summary must NOT claim
-// the target "appears clean".
+// TestPrintScanSummary_InconclusiveNotClean: when rules were skipped and there are
+// no findings, the summary must NOT claim the target "appears clean".
 func TestPrintScanSummary_InconclusiveNotClean(t *testing.T) {
 	var buf bytes.Buffer
 	report.New(&buf, false).PrintScanSummary([]engine.RunResult{
 		{Rule: &rules.Rule{ID: "a2a-x"}, Skipped: true, SkipMsg: "could not reach a testable endpoint"},
-		{Rule: &rules.Rule{ID: "a2a-y"}, Skipped: true, SkipMsg: "could not reach a testable endpoint"},
+		{Rule: &rules.Rule{ID: "a2a-y"}, Skipped: true, SkipMsg: "not tested: no agent card was served"},
 	})
 	out := buf.String()
 	if strings.Contains(out, "appears clean") {
 		t.Errorf("must not claim 'appears clean' when no rule was exercised:\n%s", out)
 	}
-	if !strings.Contains(out, "could not reach a testable endpoint") {
+	if !strings.Contains(out, "were not exercised") {
 		t.Errorf("expected an inconclusive note, got:\n%s", out)
+	}
+}
+
+// The zero-findings branch used to return before printing any per-rule skip
+// reason, so on a scan that found nothing, which is exactly when an operator needs
+// to know what went untested, the reasons were unreachable even in verbose mode.
+// The summary points at -v, so -v has to actually show them.
+func TestPrintScanSummary_VerboseShowsSkipReasonsWithNoFindings(t *testing.T) {
+	var buf bytes.Buffer
+	report.New(&buf, true).PrintScanSummary([]engine.RunResult{
+		{Rule: &rules.Rule{ID: "mcp-tools-unauth-001"}, Skipped: true,
+			SkipMsg: "not tested: the MCP handshake succeeded but no probe returned a verdict"},
+	})
+	out := buf.String()
+	if !strings.Contains(out, "mcp-tools-unauth-001") {
+		t.Errorf("verbose output should name each skipped rule, got:\n%s", out)
+	}
+	if !strings.Contains(out, "no probe returned a verdict") {
+		t.Errorf("verbose output should carry the per-rule skip reason, got:\n%s", out)
+	}
+}
+
+// The summary aggregates rules skipped for unrelated reasons, so it must not
+// attribute them all to unreachability. Here one rule was genuinely unreachable
+// and the other served no agent card; a summary claiming both could not be reached
+// sends the operator looking for a network fault that does not exist.
+func TestPrintScanSummary_DoesNotAttributeAllSkipsToReachability(t *testing.T) {
+	var buf bytes.Buffer
+	report.New(&buf, false).PrintScanSummary([]engine.RunResult{
+		{Rule: &rules.Rule{ID: "a2a-x"}, Skipped: true, SkipMsg: "could not reach a testable endpoint"},
+		{Rule: &rules.Rule{ID: "a2a-y"}, Skipped: true,
+			SkipMsg: "not tested: the MCP handshake succeeded but no probe returned a verdict"},
+	})
+	out := buf.String()
+	if strings.Contains(out, "could not reach a testable endpoint and were not exercised") {
+		t.Errorf("summary must not attribute every skip to unreachability:\n%s", out)
+	}
+	if !strings.Contains(out, "-v") {
+		t.Errorf("summary should point at the per-rule reasons, got:\n%s", out)
 	}
 }
 

--- a/internal/report/printer.go
+++ b/internal/report/printer.go
@@ -289,11 +289,22 @@ func (p *Printer) PrintScanSummary(results []engine.RunResult) {
 		}
 	}
 
+	// The summary counts rules that were not exercised but does not say why. Rules
+	// go unexercised for reasons that have nothing to do with reachability: an
+	// unsupported protocol revision, an agent card the target does not serve, a
+	// probe that established nothing after a successful handshake. Asserting
+	// "could not reach a testable endpoint" for all of them sent operators looking
+	// for a network fault. The per-rule reason is on each SKIP line, which -v shows.
 	if total == 0 {
 		if notExercised > 0 {
 			fmt.Fprintf(p.w, "  %s\n\n", Yellow(fmt.Sprintf(
-				"No findings, but %d of %d rule(s) could not reach a testable endpoint and were not exercised. The target was not fully tested.",
+				"No findings, but %d of %d rule(s) were not exercised, so the target was not fully tested. Run with -v to see why each was skipped.",
 				notExercised, len(results))))
+			// The per-rule reasons have to print here too. This branch used to
+			// return before reaching the loop below, so on a scan with no findings,
+			// which is exactly when an operator needs to know what went untested,
+			// the reasons were unreachable even with -v.
+			p.printSkipsAndErrors(results)
 		} else {
 			fmt.Fprintf(p.w, "  %s\n\n", Green("No findings. Target appears clean for the tested rules."))
 		}
@@ -312,7 +323,18 @@ func (p *Printer) PrintScanSummary(results []engine.RunResult) {
 		}
 	}
 
-	// Print rules that were skipped or errored.
+	p.printSkipsAndErrors(results)
+
+	if notExercised > 0 {
+		fmt.Fprintf(p.w, "\n  %s\n", Yellow(fmt.Sprintf(
+			"Note: %d of %d rule(s) were not exercised. Run with -v to see why each was skipped.",
+			notExercised, len(results))))
+	}
+}
+
+// printSkipsAndErrors reports, per rule, why it did not run. The skip reason is
+// the only place the actual cause appears, so both summary branches must reach it.
+func (p *Printer) printSkipsAndErrors(results []engine.RunResult) {
 	for _, r := range results {
 		if r.Skipped {
 			p.Verbose(fmt.Sprintf("SKIP %s: %s", r.Rule.ID, r.SkipMsg))
@@ -320,12 +342,6 @@ func (p *Printer) PrintScanSummary(results []engine.RunResult) {
 		if r.Err != nil {
 			p.Warn(fmt.Sprintf("ERROR running %s: %v", r.Rule.ID, r.Err))
 		}
-	}
-
-	if notExercised > 0 {
-		fmt.Fprintf(p.w, "\n  %s\n", Yellow(fmt.Sprintf(
-			"Note: %d of %d rule(s) could not reach a testable endpoint and were not exercised.",
-			notExercised, len(results))))
 	}
 }
 


### PR DESCRIPTION
Every inconclusive result rendered as `could not reach a testable endpoint`, which sends an operator looking for a network fault. Of the 36 sites returning `ErrInconclusive`, **11 describe a target that was reached and then could not be assessed**: no agent card was served, no task could be created, a probe returned no protocol-level verdict after a successful handshake. Two were introduced by the artifact-tamper rewrite in #150.

The mechanism to carry a reason already existed but was used exactly once, and the engine *appended* the reason to the generic sentence rather than replacing it — so even that one site contradicted itself. A server that answered the era probe was reported as unreachable:

```
before: could not reach a testable endpoint: ... speaks MCP 2026-07-28 ...
after:  not tested: server implements a protocol era these rules do not support: ...
```

Wrapped the 11 sites with the actual cause. The other 25 genuinely are reachability failures and keep the existing message.

Live, against `mcp_transient_failure_server.py 7802 502` (a server that handshakes fine and then 502s its listings):

```
before: could not reach a testable endpoint
after:  not tested: the MCP handshake succeeded on 1 wire(s) at http://127.0.0.1:7802/mcp
        but no probe returned a protocol-level verdict, so the surface was never actually assessed
```

## Two further defects found while doing this

**The scan summary had the same problem**, at the point an operator is most likely to read it: it asserted unreachability for every unexercised rule regardless of cause. It now reports the count and points at the per-rule reasons.

**Those reasons were unreachable in the case that matters most.** `PrintScanSummary` returned in the zero-findings branch before printing any skip reason, so on a scan that found nothing — exactly when you need to know what went untested — `-v` showed nothing at all. Both branches now print them. I only caught this because the new summary text promises `-v` works, and I checked.

## Verification

Three unit tests added and two corrected. The engine test had asserted the generic prefix was preserved while its own doc comment said the operator "would otherwise assume a network fault" — the assertion contradicted its stated intent, so it now asserts the message does *not* claim unreachability.

Non-vacuity checked on each part **separately**, since a combined revert gave a false all-clear in #143: reverting the engine prefix fails only the engine test; reverting the two MCP site reasons fails all five subtests of the unauth-family test; reverting `card_trust`'s reason alone fails only its own subtest; reverting the early-return fix fails only the new verbose test.

No finding changes: the transient-failure fixture in `ok` mode reports the same 8 findings and 13 skips before and after. Full suite green uncached, `go vet` and `gofmt` clean.
