### PR TITLE
fix: never send the operator's token to a host the target chose

### DIFF
--- a/internal/attack/http.go
+++ b/internal/attack/http.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -37,7 +38,50 @@ var Version = "dev"
 type HTTPClient struct {
 	inner *http.Client
 	vars  Vars
-	token string // bearer token injected into every request when set
+	token string // bearer token injected into requests to targetHost when set
+	// targetHost is the host:port of the scan target. The auto-injected token is
+	// withheld from any other host; see tokenAllowedFor.
+	targetHost string
+}
+
+// tokenAllowedFor reports whether the auto-injected bearer token may be sent to
+// this URL. It may not leave the scan target's host.
+//
+// The operator supplies one credential, for one target. Several rules follow URLs
+// the TARGET chooses: the resource_metadata parameter of its own WWW-Authenticate
+// challenge, a registration_endpoint out of its OAuth metadata, a push-notification
+// callback. A target that names another host and receives the operator's token has
+// harvested a credential it was never issued, and it does so by answering a normal
+// discovery request. Demonstrated against a server whose WWW-Authenticate pointed
+// resource_metadata at a collector on another port: the collector received
+// "Authorization: Bearer <operator token>".
+//
+// This guard is deliberately at the transport, not at the call sites. The call
+// sites are the thing that keeps getting this wrong, and one of them shipped.
+// An explicit per-request Authorization header still wins, because that is an
+// author stating intent (principal tokens, forged tokens) rather than ambient
+// injection.
+//
+// When the target host is unknown the token is sent, preserving the previous
+// behaviour rather than silently dropping credentials.
+func (c *HTTPClient) tokenAllowedFor(rawURL string) bool {
+	if c.targetHost == "" {
+		return true
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return true
+	}
+	return strings.EqualFold(u.Host, c.targetHost)
+}
+
+// hostOf returns the host:port of a URL, or "" when it cannot be determined.
+func hostOf(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return u.Host
 }
 
 // NewUnauthHTTPClient creates an attack HTTP client with no bearer token.
@@ -72,8 +116,9 @@ func NewHTTPClient(opts Options, vars Vars) *HTTPClient {
 			// redirects during the authorization-code flow.
 			CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
 		},
-		vars:  vars,
-		token: opts.Token,
+		vars:       vars,
+		token:      opts.Token,
+		targetHost: hostOf(vars.BaseURL),
 	}
 }
 
@@ -224,8 +269,9 @@ func (c *HTTPClient) do(ctx context.Context, method, url string, body io.Reader,
 	req.Header.Set("User-Agent", "batesian/"+Version+" (https://github.com/calbebop/batesian)")
 	// MCP streamable HTTP requires text/event-stream in Accept; A2A servers ignore it.
 	req.Header.Set("Accept", "application/json, text/event-stream")
-	// Inject the bearer token unless the caller overrides Authorization explicitly.
-	if c.token != "" {
+	// Inject the bearer token unless the caller overrides Authorization explicitly,
+	// and never to a host other than the scan target: see tokenAllowedFor.
+	if c.token != "" && c.tokenAllowedFor(url) {
 		req.Header.Set("Authorization", "Bearer "+c.token)
 	}
 	for k, v := range headers {

--- a/internal/attack/mcp/metadata_token_leak_test.go
+++ b/internal/attack/mcp/metadata_token_leak_test.go
@@ -1,0 +1,64 @@
+package mcp_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+// mcp-oauth-audience-002 follows the resource_metadata URL out of the target's own
+// WWW-Authenticate challenge. The target chooses that URL, so it can name any host,
+// and the rule fetched it with the operator's bearer token attached. A malicious or
+// compromised server harvested the credential by answering a discovery request with
+// a pointer to a collector it controlled.
+//
+// Verified against a live pair before the fix: the collector logged
+// "Authorization: Bearer <operator token>".
+func TestOAuthAudience_DoesNotSendOperatorTokenToTargetChosenHost(t *testing.T) {
+	var mu sync.Mutex
+	var collected []string
+
+	collector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		collected = append(collected, r.Header.Get("Authorization"))
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"resource":"https://api.example.test/mcp"}`))
+	}))
+	defer collector.Close()
+
+	// The target refuses the handshake and points resource_metadata off-host.
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate",
+			fmt.Sprintf(`Bearer realm="mcp", resource_metadata="%s/meta"`, collector.URL))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32001,"message":"Unauthorized"}}`))
+	}))
+	defer target.Close()
+
+	exec := mcpattack.NewOAuthAudienceExecutor(attack.RuleContext{ID: "mcp-oauth-audience-002"})
+	_, _ = exec.Execute(context.Background(), target.URL, attack.Options{
+		Token:          "operator-secret-token",
+		TimeoutSeconds: 5,
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(collected) == 0 {
+		t.Skip("the rule did not follow the advertised metadata URL; nothing to assert")
+	}
+	for i, auth := range collected {
+		if auth != "" {
+			t.Errorf("request %d to a target-chosen host carried a credential (%q); a scanned server "+
+				"must not be able to harvest the operator's token by advertising its own metadata URL",
+				i, auth)
+		}
+	}
+}

--- a/internal/attack/mcp/oauth_audience.go
+++ b/internal/attack/mcp/oauth_audience.go
@@ -81,7 +81,7 @@ func (e *OAuthAudienceExecutor) Execute(ctx context.Context, target string, opts
 
 	expected := strings.TrimSpace(opts.AudienceClaim)
 	if expected == "" {
-		discovered, mcpReached := discoverExpectedAudience(ctx, client, vars.BaseURL)
+		discovered, mcpReached := discoverExpectedAudience(ctx, client, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
 		if discovered == "" {
 			// Precondition not met: no operator input and no discoverable
 			// resource metadata. Operators who want this rule to run should pass
@@ -235,15 +235,16 @@ func hasUpper(s string) bool {
 //
 // Returns the resource URI on success, or an empty string if nothing
 // usable was found (caller treats that as "skip").
-func discoverExpectedAudience(ctx context.Context, client *attack.HTTPClient, baseURL string) (audience string, mcpReached bool) {
+// metaClient is unauthenticated because step 2 follows a URL the target chose.
+func discoverExpectedAudience(ctx context.Context, client, metaClient *attack.HTTPClient, baseURL string) (audience string, mcpReached bool) {
 	metaURL, mcpReached := probeWWWAuthenticateResourceMetadata(ctx, client, baseURL)
 	if metaURL != "" {
-		if resource := fetchResourceFromMetadata(ctx, client, metaURL); resource != "" {
+		if resource := fetchResourceFromMetadata(ctx, metaClient, metaURL); resource != "" {
 			return resource, mcpReached
 		}
 	}
 	wellKnown := baseURL + "/.well-known/oauth-protected-resource"
-	return fetchResourceFromMetadata(ctx, client, wellKnown), mcpReached
+	return fetchResourceFromMetadata(ctx, metaClient, wellKnown), mcpReached
 }
 
 // probeWWWAuthenticateResourceMetadata sends an unauth initialize request to
@@ -302,6 +303,13 @@ func parseResourceMetadataURL(header string) string {
 
 // fetchResourceFromMetadata GETs the metadata document and returns the
 // `resource` field if present and absolute.
+//
+// metaURL may come from the target's own WWW-Authenticate challenge, so it can
+// name any host. Protected-resource metadata is public per RFC 9728 and needs no
+// credential, and the caller therefore passes an unauthenticated client: a target
+// that points resource_metadata at a host it controls must not be handed the
+// operator's bearer token. The transport enforces this as well, so this is
+// defence in depth plus a statement of intent at the call site.
 func fetchResourceFromMetadata(ctx context.Context, client *attack.HTTPClient, metaURL string) string {
 	resp, err := client.GET(ctx, metaURL, nil)
 	if err != nil || !resp.IsSuccess() {

--- a/internal/attack/token_scope_test.go
+++ b/internal/attack/token_scope_test.go
@@ -1,0 +1,102 @@
+package attack_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// authRecorder is a server that records the Authorization header of every request.
+func authRecorder(t *testing.T) (*httptest.Server, func() []string) {
+	t.Helper()
+	var mu sync.Mutex
+	var seen []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seen = append(seen, r.Header.Get("Authorization"))
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"resource":"https://example.test/mcp"}`))
+	}))
+	return srv, func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]string, len(seen))
+		copy(out, seen)
+		return out
+	}
+}
+
+// The operator's credential is issued for one target. Several rules follow URLs the
+// TARGET supplies: the resource_metadata parameter of its own WWW-Authenticate
+// challenge, a registration_endpoint from its OAuth metadata. A target that names
+// another host must not receive the token by asking for it.
+func TestHTTPClient_TokenNotSentOffHost(t *testing.T) {
+	thirdParty, thirdPartyAuths := authRecorder(t)
+	defer thirdParty.Close()
+	target, targetAuths := authRecorder(t)
+	defer target.Close()
+
+	opts := attack.Options{Token: "operator-secret", TimeoutSeconds: 5}
+	client := attack.NewHTTPClient(opts, attack.NewVars(target.URL, ""))
+
+	if _, err := client.GET(context.Background(), target.URL+"/mcp", nil); err != nil {
+		t.Fatalf("GET target: %v", err)
+	}
+	if _, err := client.GET(context.Background(), thirdParty.URL+"/meta", nil); err != nil {
+		t.Fatalf("GET third party: %v", err)
+	}
+
+	got := targetAuths()
+	if len(got) != 1 || got[0] != "Bearer operator-secret" {
+		t.Errorf("the target should receive the operator token, got %q", got)
+	}
+	if off := thirdPartyAuths(); len(off) != 1 || off[0] != "" {
+		t.Errorf("a host other than the scan target must not receive the operator token, got %q", off)
+	}
+}
+
+// An explicit Authorization header is an author stating intent (a principal token,
+// a deliberately forged token), not ambient injection, so the guard leaves it
+// alone. Rules like a2a-peer-impersonation depend on this.
+func TestHTTPClient_ExplicitAuthorizationSurvivesOffHost(t *testing.T) {
+	thirdParty, auths := authRecorder(t)
+	defer thirdParty.Close()
+
+	opts := attack.Options{Token: "operator-secret", TimeoutSeconds: 5}
+	client := attack.NewHTTPClient(opts, attack.NewVars("http://target.invalid", ""))
+
+	_, err := client.GET(context.Background(), thirdParty.URL+"/x",
+		map[string]string{"Authorization": "Bearer deliberate-choice"})
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if got := auths(); len(got) != 1 || got[0] != "Bearer deliberate-choice" {
+		t.Errorf("an explicitly set Authorization header must be sent as written, got %q", got)
+	}
+}
+
+// Sub-paths and differing paths on the target host are still the target.
+func TestHTTPClient_TokenSentAcrossPathsOnTargetHost(t *testing.T) {
+	target, auths := authRecorder(t)
+	defer target.Close()
+
+	opts := attack.Options{Token: "operator-secret", TimeoutSeconds: 5}
+	// Target given as a sub-path, which is how the OAuth fixtures are scanned.
+	client := attack.NewHTTPClient(opts, attack.NewVars(target.URL+"/vulnerable/mcp", ""))
+
+	for _, p := range []string{"/mcp", "/.well-known/oauth-protected-resource", "/api"} {
+		if _, err := client.GET(context.Background(), target.URL+p, nil); err != nil {
+			t.Fatalf("GET %s: %v", p, err)
+		}
+	}
+	for i, a := range auths() {
+		if a != "Bearer operator-secret" {
+			t.Errorf("request %d to the target host should carry the token, got %q", i, a)
+		}
+	}
+}


### PR DESCRIPTION
A scanned server could harvest the credential the operator supplied, just by answering a discovery request.

`mcp-oauth-audience-002` follows the `resource_metadata` URL out of the target's own `WWW-Authenticate` challenge. [parseResourceMetadataURL](internal/attack/mcp/oauth_audience.go:288) accepts any absolute URL with no host check, and [fetchResourceFromMetadata](internal/attack/mcp/oauth_audience.go:305) used the authenticated client. A target that points `resource_metadata` at a host it controls is handed `Authorization: Bearer <operator token>`. No redirect is involved, so the existing redirect protection does not apply.

Demonstrated against a target whose challenge named a collector on another port:

| binary | requests to third-party host | carrying operator token |
|---|---|---|
| before | 1 | **1** |
| after | 1 | 0 |

## The fix

The metadata fetch uses an unauthenticated client — protected-resource metadata is public per RFC 9728 and needs no credential.

The shared client also withholds the auto-injected token from any host other than the scan target. The guard sits at the transport because the call sites are what keep getting this wrong, and one of them shipped. An explicit `Authorization` header still goes out as written: that is an author stating intent, not ambient injection, and the principal and forged-token rules depend on it.

Either change alone closes this instance; the transport guard also closes the class.

## Verification

I audited **all 36 rules** against a recording target with a sentinel token before writing anything, to find out which rules transmit it. Every other transmission is legitimate by design — `artifact_tamper` and `push_ssrf` need credentials to create a task, `dns_rebind_origin` deliberately pairs a valid token with a hostile Origin — and the whole unauth family correctly sends nothing. I also suspected `confused_deputy` and `oauth_dcr`, but their server-named endpoints arrive clean: `registerDCRClient` takes the client as a parameter and the callers pass the unauth one.

Non-vacuity checked per half: reverting the transport guard fails the unit test, reverting the call-site fix leaves the guard covering it, and with both reverted the end-to-end test fails.

**No behaviour change anywhere else.** The 39-case fixture sweep against the previous build shows no finding and no skip differing, so no rule relies on the token reaching another host. Full suite green uncached, `go vet` and `gofmt` clean.
