### PR TITLE
fix(cli): accept a principal's routing headers from --principal

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ batesian scan --target https://agent.example.com \
   --principal name=tenant-a,token="$TOKEN_A",tenant=A \
   --principal name=tenant-b,token="$TOKEN_B",tenant=B
 
+# When the target resolves the tenant from a routing header rather than the token,
+# give each identity its header, or the multi-tenant rules compare two identities
+# the server cannot tell apart. header= repeats per principal.
+batesian scan --target https://agent.example.com \
+  --principal name=tenant-a,token="$TOKEN_A",tenant=A,header=X-Tenant-Id:A \
+  --principal name=tenant-b,token="$TOKEN_B",tenant=B,header=X-Tenant-Id:B
+
 batesian scan --target https://agent.example.com --dry-run
 
 batesian scan --target https://mcp.example.com --proxy 127.0.0.1:8080 --skip-tls

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -73,7 +73,7 @@ func init() {
 	scanCmd.Flags().String("audience-claim", "", "Expected JWT aud value for the target MCP server (used by mcp-oauth-audience-002)")
 	// Multi-principal identities for cross-tenant / handoff chained rules.
 	// Repeatable; appended to any principals defined in the config file.
-	scanCmd.Flags().StringArray("principal", nil, "Extra identity as name=...,token=...,tenant=... (repeatable; for multi-tenant rules)")
+	scanCmd.Flags().StringArray("principal", nil, "Extra identity as name=...,token=...,tenant=...,header=Name:Value (repeatable, and header= repeats per identity; for multi-tenant rules)")
 	scanCmd.Flags().Bool("no-coalesce", false, "Do not coalesce overlapping findings from rules in the same vulnerability class")
 	scanCmd.Flags().Bool("dry-run", false, "Print the requests each rule would send and exit without sending any traffic")
 	rootCmd.AddCommand(scanCmd)
@@ -365,8 +365,25 @@ func buildPrincipals(cfgPrincipals []config.PrincipalConfig, flags []string) ([]
 }
 
 // parsePrincipalFlag parses a --principal value of the form
-// "name=tenant-a,token=eyJ...,tenant=A" into an attackpkg.Principal. Recognized
-// keys are name, token, and tenant; an unknown key is an error.
+// "name=tenant-a,token=eyJ...,tenant=A,header=X-Tenant-Id:A" into an
+// attackpkg.Principal. Recognized keys are name, token, tenant and header; an
+// unknown key is an error.
+//
+// header= is repeatable and each occurrence adds one entry, so a routing header
+// does not need a second level of delimiters inside a comma-separated value. The
+// value keeps everything after the first colon, which is what lets a header carry
+// a URL.
+//
+// A principal's headers were reachable from the config file but not from this
+// flag, even though five multi-principal A2A rules send them. Multi-tenant
+// deployments commonly resolve the tenant at a gateway and pass it downstream in a
+// header, so without this the CLI could not describe the identities it was asked
+// to compare. Measured against an agent that scopes tasks by X-Tenant-Id and
+// isolates them correctly: two false-positive cross-tenant findings from the flag
+// form, none from the equivalent config file.
+//
+// One shape still needs the config file: a header value containing a comma, since
+// the comma separates segments here.
 func parsePrincipalFlag(raw string) (attackpkg.Principal, error) {
 	var p attackpkg.Principal
 	for _, part := range strings.Split(raw, ",") {
@@ -387,8 +404,22 @@ func parsePrincipalFlag(raw string) (attackpkg.Principal, error) {
 			p.Token = v
 		case "tenant":
 			p.Tenant = v
+		case "header":
+			hk, hv, found := strings.Cut(v, ":")
+			hk = strings.TrimSpace(hk)
+			if !found || hk == "" {
+				return p, fmt.Errorf("invalid --principal header %q; expected header=Name:Value", v)
+			}
+			if p.Headers == nil {
+				p.Headers = map[string]string{}
+			}
+			p.Headers[hk] = strings.TrimSpace(hv)
+		case "headers":
+			// The config file spells this as a `headers:` map, so it is the first
+			// thing an operator tries here.
+			return p, fmt.Errorf("use header=Name:Value (repeatable) rather than headers= in --principal")
 		default:
-			return p, fmt.Errorf("unknown --principal key %q (valid: name, token, tenant)", k)
+			return p, fmt.Errorf("unknown --principal key %q (valid: name, token, tenant, header)", k)
 		}
 	}
 	if p.Name == "" {

--- a/internal/cli/scan_test.go
+++ b/internal/cli/scan_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/calbebop/batesian/internal/config"
@@ -31,6 +32,59 @@ func TestParsePrincipalFlag_UnknownKey(t *testing.T) {
 func TestParsePrincipalFlag_InvalidSegment(t *testing.T) {
 	if _, err := parsePrincipalFlag("name=a,justakey"); err == nil {
 		t.Error("expected error for key without =, got nil")
+	}
+}
+
+// Five multi-principal A2A rules send Principal.Headers. Multi-tenant deployments
+// commonly resolve the tenant at a gateway and pass it downstream in a header, so a
+// flag that cannot express one cannot describe the identities it is comparing.
+// Against a header-scoped agent that isolates correctly, the headerless form
+// produced two false-positive cross-tenant findings.
+func TestParsePrincipalFlag_HeadersAreRepeatable(t *testing.T) {
+	p, err := parsePrincipalFlag("name=a,token=t,tenant=A,header=X-Tenant-Id:A,header=X-Env:prod")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(p.Headers) != 2 {
+		t.Fatalf("expected both headers, got %+v", p.Headers)
+	}
+	if p.Headers["X-Tenant-Id"] != "A" || p.Headers["X-Env"] != "prod" {
+		t.Errorf("header values mismatch: %+v", p.Headers)
+	}
+	// The other fields must still parse alongside.
+	if p.Name != "a" || p.Token != "t" || p.Tenant != "A" {
+		t.Errorf("non-header fields mismatch: %+v", p)
+	}
+}
+
+// A header value may itself contain colons, e.g. a URL, so only the first splits.
+func TestParsePrincipalFlag_HeaderValueKeepsLaterColons(t *testing.T) {
+	p, err := parsePrincipalFlag("name=a,header=X-Origin:https://tenant-a.example.test:8443")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := p.Headers["X-Origin"]; got != "https://tenant-a.example.test:8443" {
+		t.Errorf("value should keep everything after the first colon, got %q", got)
+	}
+}
+
+func TestParsePrincipalFlag_HeaderNeedsNameAndValue(t *testing.T) {
+	for _, bad := range []string{"name=a,header=NoColon", "name=a,header=:justvalue"} {
+		if _, err := parsePrincipalFlag(bad); err == nil {
+			t.Errorf("expected an error for %q, got nil", bad)
+		}
+	}
+}
+
+// The config file spells this as a `headers:` map, so it is the first thing an
+// operator reaches for here. The error has to point at the form that works.
+func TestParsePrincipalFlag_PluralHeadersIsGuided(t *testing.T) {
+	_, err := parsePrincipalFlag("name=a,headers=X-Tenant-Id:A")
+	if err == nil {
+		t.Fatal("expected an error for headers=, got nil")
+	}
+	if !strings.Contains(err.Error(), "header=Name:Value") {
+		t.Errorf("error should name the working form, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Five multi-principal A2A rules send `Principal.Headers`, and [the config path carries them](internal/cli/scan.go:351), but `--principal` parsed only `name`, `token` and `tenant` and rejected anything else. A multi-tenant deployment that resolves the tenant at a gateway and passes it downstream in a header could not be described on the command line at all.

That is not just a missing convenience. Against an agent that scopes tasks by `X-Tenant-Id` and isolates them **correctly**, the flag form put both identities in the same tenant, so each read the other's task:

| principals supplied via | findings |
|---|---|
| `--principal` without headers | **2 false-positive cross-tenant findings** |
| equivalent config file | 0 |
| `--principal` with `header=` (this PR) | 0 |

## The form

`--principal name=a,token=t,tenant=A,header=X-Tenant-Id:A` — `header=` repeats per identity, so no second level of delimiters is needed inside a comma-separated value. The value keeps everything after the first colon, which is what lets a header carry a URL.

`headers=` is the config spelling and the first thing an operator reaches for, so it now errors with the form that works rather than "unknown key".

One shape still needs the config file: a header value containing a comma, since the comma separates segments here. Noted in the doc comment.

## Verification

Demonstrated live against a header-scoped agent, confirming by hand first that it isolates correctly when the header is sent (tenant B denied, no-header denied). The legacy flag form still parses unchanged. Four unit tests added covering repeats, colons in values, malformed `header=`, and the `headers=` guidance. Full suite green uncached, `go vet` and `gofmt` clean.
