### PR TITLE
fix: stop losing findings whose severity is not one of the known values

### DIFF
--- a/internal/engine/coalesce.go
+++ b/internal/engine/coalesce.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	attackpkg "github.com/calbebop/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/severity"
 )
 
 // vulnClass maps a rule ID to a coalescing class. Two rules in the SAME class
@@ -128,17 +129,8 @@ func confidenceLabel(c attackpkg.Confidence) string {
 	return string(c)
 }
 
-func severityRank(s string) int {
-	switch strings.ToLower(s) {
-	case "critical":
-		return 4
-	case "high":
-		return 3
-	case "medium":
-		return 2
-	case "low":
-		return 1
-	default:
-		return 0
-	}
-}
+// severityRank defers to internal/severity so ranking, SARIF scoring and the
+// report's grouping order cannot disagree. This copy lowercased its input while
+// the SARIF copy did not, so "Critical" ranked as the worst severity here and as
+// the least severe there.
+func severityRank(s string) int { return severity.Rank(s) }

--- a/internal/report/inconclusive_test.go
+++ b/internal/report/inconclusive_test.go
@@ -2,10 +2,10 @@ package report_test
 
 import (
 	"bytes"
-	attackpkg "github.com/calbebop/batesian/internal/attack"
 	"strings"
 	"testing"
 
+	attackpkg "github.com/calbebop/batesian/internal/attack"
 	"github.com/calbebop/batesian/internal/engine"
 	"github.com/calbebop/batesian/internal/report"
 	"github.com/calbebop/batesian/internal/rules"

--- a/internal/report/inconclusive_test.go
+++ b/internal/report/inconclusive_test.go
@@ -2,6 +2,7 @@ package report_test
 
 import (
 	"bytes"
+	attackpkg "github.com/calbebop/batesian/internal/attack"
 	"strings"
 	"testing"
 
@@ -75,5 +76,55 @@ func TestPrintScanSummary_CleanWhenAllRan(t *testing.T) {
 	})
 	if !strings.Contains(buf.String(), "appears clean") {
 		t.Errorf("expected 'appears clean' when rules ran with no findings, got:\n%s", buf.String())
+	}
+}
+
+// A finding whose severity is not one of the recognized values used to be counted
+// in the header and then never printed: the loop iterated a hardcoded list and
+// skipped every other key. Rule YAML can no longer express one, but an executor
+// sets its finding's severity as a plain string, so the report must not rely on
+// that being correct.
+func TestPrintScanSummary_UnknownSeverityIsStillPrinted(t *testing.T) {
+	var buf bytes.Buffer
+	report.New(&buf, false).PrintScanSummary([]engine.RunResult{
+		{Rule: &rules.Rule{ID: "custom-001"}, Findings: []attackpkg.Finding{
+			{RuleID: "custom-001", Severity: "Critical", Title: "typo-cased severity"},
+			{RuleID: "custom-001", Severity: "sev1", Title: "wholly unknown severity"},
+		}},
+	})
+	out := buf.String()
+	if !strings.Contains(out, "typo-cased severity") {
+		t.Errorf("a severity differing only in case must still print:\n%s", out)
+	}
+	if !strings.Contains(out, "wholly unknown severity") {
+		t.Errorf("an unrecognized severity must still print rather than vanish:\n%s", out)
+	}
+	// And it must not be relabelled as the least severe.
+	if strings.Contains(out, "INFO") {
+		t.Errorf("an unplaceable severity must not be shown as INFO:\n%s", out)
+	}
+}
+
+// Two severities that fold to the same canonical value must print in a stable
+// order. Grouping walks a map, and map order is randomized, which is what made
+// scans undiffable in the host-injection rule.
+func TestPrintScanSummary_GroupingIsDeterministic(t *testing.T) {
+	build := func() string {
+		var buf bytes.Buffer
+		report.New(&buf, false).PrintScanSummary([]engine.RunResult{
+			{Rule: &rules.Rule{ID: "r"}, Findings: []attackpkg.Finding{
+				{RuleID: "r", Severity: "high", Title: "lower-high"},
+				{RuleID: "r", Severity: "High", Title: "upper-high"},
+				{RuleID: "r", Severity: "zzz", Title: "unknown-one"},
+				{RuleID: "r", Severity: "aaa", Title: "unknown-two"},
+			}},
+		})
+		return buf.String()
+	}
+	first := build()
+	for i := 0; i < 40; i++ {
+		if got := build(); got != first {
+			t.Fatalf("output differed between runs (iteration %d); grouping is not deterministic", i)
+		}
 	}
 }

--- a/internal/report/printer.go
+++ b/internal/report/printer.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"text/tabwriter"
 	"time"
 
 	attackpkg "github.com/calbebop/batesian/internal/attack"
 	"github.com/calbebop/batesian/internal/engine"
+	"github.com/calbebop/batesian/internal/severity"
 	"github.com/fatih/color"
 )
 
@@ -257,7 +259,8 @@ func boolDisplay(b bool) string {
 }
 
 func severityDisplay(sev string) (icon, label string) {
-	switch strings.ToLower(sev) {
+	canonical := severity.Canonical(sev)
+	switch canonical {
 	case "critical":
 		return BoldRed("[!]"), BoldRed("CRITICAL")
 	case "high":
@@ -266,9 +269,17 @@ func severityDisplay(sev string) (icon, label string) {
 		return Yellow("[~]"), Yellow("MEDIUM")
 	case "low":
 		return Cyan("[~]"), Cyan("LOW")
-	default:
+	case "info":
 		return Dim("[-]"), Dim("INFO")
 	}
+	// A severity we cannot place is shown as itself. Labelling it INFO would
+	// understate a finding whose real severity is simply misspelled, and the
+	// report now prints these rather than dropping them.
+	shown := strings.ToUpper(strings.TrimSpace(sev))
+	if shown == "" {
+		shown = "UNSPECIFIED"
+	}
+	return Yellow("[?]"), Yellow(shown)
 }
 
 // PrintScanSummary renders the scan results as a terminal table.
@@ -311,15 +322,44 @@ func (p *Printer) PrintScanSummary(results []engine.RunResult) {
 		return
 	}
 
-	// Print findings grouped by severity (critical first).
+	// Print findings grouped by severity, worst first, then anything whose severity
+	// is not one we recognize.
+	//
+	// This loop used to iterate a hardcoded list and skip every other key, so a
+	// finding carrying an unexpected severity was counted in the header above and
+	// then never printed: "Scan Results (1 finding(s))" followed by no finding.
+	// Rule YAML can no longer express one (rules.Validate rejects it), but an
+	// executor sets its finding's severity as a plain string, so the report must not
+	// depend on that being right. A severity we cannot place is printed last rather
+	// than dropped.
+	// Keys are walked in sorted order, not map order: two severities that fold to
+	// the same canonical value (say "high" and "High") would otherwise print in a
+	// different order on every run, which is the nondeterminism that made scans
+	// undiffable in the host-injection rule.
 	bySev := engine.FindingsBySeverity(results)
-	for _, sev := range []string{"critical", "high", "medium", "low", "info"} {
-		findings, ok := bySev[sev]
-		if !ok {
-			continue
-		}
-		for _, f := range findings {
+	keys := make([]string, 0, len(bySev))
+	for k := range bySev {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	printed := map[string]bool{}
+	printKey := func(key string) {
+		printed[key] = true
+		for _, f := range bySev[key] {
 			p.printFinding(f)
+		}
+	}
+	for _, sev := range severity.Ordered() {
+		for _, key := range keys {
+			if !printed[key] && severity.Canonical(key) == sev {
+				printKey(key)
+			}
+		}
+	}
+	for _, key := range keys {
+		if !printed[key] {
+			printKey(key)
 		}
 	}
 

--- a/internal/report/sarif.go
+++ b/internal/report/sarif.go
@@ -8,6 +8,7 @@ import (
 
 	attackpkg "github.com/calbebop/batesian/internal/attack"
 	"github.com/calbebop/batesian/internal/engine"
+	"github.com/calbebop/batesian/internal/severity"
 )
 
 // SARIF v2.1.0 output for SARIF consumers (DAST viewers, dashboards) and CI.
@@ -198,7 +199,10 @@ func findingToSARIF(f attackpkg.Finding) sarifResult {
 //	warning -> Medium
 //	note    -> Low/Info
 func severityLevel(sev string) string {
-	switch sev {
+	// Canonicalize first. This switch compared the raw string, so a severity that
+	// differed only in case was demoted to "note" here while the engine ranked it
+	// as the worst severity there.
+	switch severity.Canonical(sev) {
 	case "critical", "high":
 		return "error"
 	case "medium":
@@ -208,19 +212,10 @@ func severityLevel(sev string) string {
 	}
 }
 
-// severityScore maps severity to a CVSS-like numeric string for GitHub's security-severity tag.
-// GitHub uses this to categorize findings as Critical/High/Medium/Low.
-func severityScore(sev string) string {
-	switch sev {
-	case "critical":
-		return "9.5"
-	case "high":
-		return "7.5"
-	case "medium":
-		return "5.0"
-	case "low":
-		return "3.0"
-	default:
-		return "1.0"
-	}
-}
+// severityScore maps severity to a CVSS-like numeric string for GitHub's
+// security-severity tag, which GitHub uses to categorize findings.
+//
+// It defers to internal/severity. This copy compared the raw string while the
+// engine's rank lowercased first, so a severity that differed only in case scored
+// as the least severe here and ranked as the worst there.
+func severityScore(sev string) string { return severity.SARIFScore(sev) }

--- a/internal/rules/rule.go
+++ b/internal/rules/rule.go
@@ -1,6 +1,12 @@
 // Package rules loads, validates, and provides attack rules from YAML files.
 package rules
 
+import (
+	"fmt"
+
+	"github.com/calbebop/batesian/internal/severity"
+)
+
 // Rule is the catalog entry for a Batesian attack. Rules live in rules/a2a/ or
 // rules/mcp/ as YAML files and carry metadata only: the executor logic lives in
 // Go (internal/attack/...), and attack.Type is the key that binds a rule to its
@@ -46,8 +52,15 @@ func (r *Rule) Validate() error {
 	if r.Info.Name == "" {
 		errs = append(errs, "missing info.name")
 	}
+	// An unrecognized severity has to fail here. Downstream, findings are grouped
+	// by severity against a fixed set, so a value outside it was counted in the
+	// report header and then never printed. Failing at load names the rule and the
+	// bad value instead of losing its findings silently at output time.
 	if r.Info.Severity == "" {
 		errs = append(errs, "missing info.severity")
+	} else if !severity.Valid(r.Info.Severity) {
+		errs = append(errs, fmt.Sprintf("info.severity %q is not a severity (want one of: %s)",
+			r.Info.Severity, severity.List()))
 	}
 	if r.Attack.Protocol == "" {
 		errs = append(errs, "missing attack.protocol")
@@ -61,21 +74,10 @@ func (r *Rule) Validate() error {
 	return nil
 }
 
-// SeverityRank returns a numeric rank for sorting (higher = more severe).
-func (r *Rule) SeverityRank() int {
-	switch r.Info.Severity {
-	case "critical":
-		return 4
-	case "high":
-		return 3
-	case "medium":
-		return 2
-	case "low":
-		return 1
-	default:
-		return 0
-	}
-}
+// SeverityRank was a fifth independent copy of the severity ordering, keyed on the
+// raw string so it disagreed with the engine's rank on case, and it had no callers
+// at all. Removed rather than rewired: internal/severity.Rank is the one ranking
+// function, and a duplicate with no consumers is how these drift apart.
 
 // ValidationError is returned when a rule fails validation.
 type ValidationError struct {

--- a/internal/rules/severity_validate_test.go
+++ b/internal/rules/severity_validate_test.go
@@ -1,0 +1,59 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+)
+
+// A severity outside the recognized set has to fail at load. Downstream, findings
+// are grouped against a fixed set, so such a value was counted in the report
+// header and then never printed. Failing here names the rule and the value.
+func TestValidate_RejectsUnknownSeverity(t *testing.T) {
+	for _, bad := range []string{"sev1", "urgent", "criticalish", "P1"} {
+		r := &Rule{ID: "x-001"}
+		r.Info.Name = "n"
+		r.Info.Severity = bad
+		r.Attack.Protocol = "mcp"
+		r.Attack.Type = "t"
+
+		err := r.Validate()
+		if err == nil {
+			t.Errorf("severity %q should be rejected at load", bad)
+			continue
+		}
+		if !strings.Contains(err.Error(), "severity") {
+			t.Errorf("error for %q should name the field, got: %v", bad, err)
+		}
+	}
+}
+
+func TestValidate_AcceptsEveryCanonicalSeverity(t *testing.T) {
+	for _, ok := range []string{"critical", "high", "medium", "low", "info"} {
+		r := &Rule{ID: "x-001"}
+		r.Info.Name = "n"
+		r.Info.Severity = ok
+		r.Attack.Protocol = "mcp"
+		r.Attack.Type = "t"
+		if err := r.Validate(); err != nil {
+			t.Errorf("severity %q must be accepted, got: %v", ok, err)
+		}
+	}
+}
+
+// A case variant is accepted deliberately. Severity filtering already compares
+// with strings.EqualFold, and ranking, scoring and report grouping now all
+// canonicalize, so "Critical" behaves identically to "critical" everywhere. What
+// used to make case dangerous was the disagreement between those copies, not the
+// spelling, and rejecting it here would fail rule files that work correctly.
+func TestValidate_AcceptsCaseVariants(t *testing.T) {
+	for _, ok := range []string{"Critical", "HIGH", " medium "} {
+		r := &Rule{ID: "x-001"}
+		r.Info.Name = "n"
+		r.Info.Severity = ok
+		r.Attack.Protocol = "mcp"
+		r.Attack.Type = "t"
+		if err := r.Validate(); err != nil {
+			t.Errorf("severity %q should be accepted (filtering is case-insensitive), got: %v", ok, err)
+		}
+	}
+}

--- a/internal/severity/severity.go
+++ b/internal/severity/severity.go
@@ -1,0 +1,79 @@
+// Package severity is the single source of truth for finding severities: which
+// values are legal, how they order, and how they map onto the numbers other
+// formats want.
+//
+// It exists because three places encoded that knowledge independently and had
+// already drifted. internal/engine ranked severities for coalescing and
+// lowercased its input; internal/report scored them for SARIF and did not; the
+// table printer carried its own inline ordering. So "Critical" ranked as the worst
+// severity when two findings were merged, scored 1.0 (the value meaning "least
+// severe") in SARIF, and was omitted from the table entirely while still being
+// counted in its header.
+package severity
+
+import "strings"
+
+// ordered lists every legal severity, worst first. This order is the report's
+// grouping order and the basis of Rank.
+var ordered = []string{"critical", "high", "medium", "low", "info"}
+
+// sarifScore maps a severity onto GitHub's security-severity tag, a CVSS-like
+// number it uses to bucket findings.
+var sarifScore = map[string]string{
+	"critical": "9.5",
+	"high":     "7.5",
+	"medium":   "5.0",
+	"low":      "3.0",
+	"info":     "1.0",
+}
+
+// Ordered returns the legal severities, worst first.
+func Ordered() []string {
+	out := make([]string, len(ordered))
+	copy(out, ordered)
+	return out
+}
+
+// Canonical folds a severity to its legal spelling, or returns "" when the value
+// is not a severity at all. Callers that must not lose data check for "".
+func Canonical(s string) string {
+	folded := strings.ToLower(strings.TrimSpace(s))
+	for _, k := range ordered {
+		if folded == k {
+			return k
+		}
+	}
+	return ""
+}
+
+// Valid reports whether s names a severity, ignoring case and surrounding space.
+func Valid(s string) bool { return Canonical(s) != "" }
+
+// Rank orders severities for comparison, higher being worse. An unrecognized
+// value ranks below every legal one rather than tying with "info", so a typo can
+// never win a coalescing contest against a real severity.
+func Rank(s string) int {
+	c := Canonical(s)
+	if c == "" {
+		return 0
+	}
+	for i, k := range ordered {
+		if k == c {
+			return len(ordered) - i
+		}
+	}
+	return 0
+}
+
+// SARIFScore returns the security-severity value for s. An unrecognized severity
+// gets the lowest score, because inventing a high one for a value we do not
+// understand would overstate it.
+func SARIFScore(s string) string {
+	if v, ok := sarifScore[Canonical(s)]; ok {
+		return v
+	}
+	return "1.0"
+}
+
+// List renders the legal severities for an error message.
+func List() string { return strings.Join(ordered, ", ") }

--- a/internal/severity/severity_test.go
+++ b/internal/severity/severity_test.go
@@ -1,0 +1,62 @@
+package severity_test
+
+import (
+	"testing"
+
+	"github.com/calbebop/batesian/internal/severity"
+)
+
+// The three copies this package replaced disagreed on case: one lowercased its
+// input, the others compared raw. So "Critical" ranked as the worst severity when
+// coalescing and simultaneously scored as the least severe in SARIF.
+func TestCanonical_FoldsCaseAndSpace(t *testing.T) {
+	for _, in := range []string{"critical", "Critical", "CRITICAL", "  critical  "} {
+		if got := severity.Canonical(in); got != "critical" {
+			t.Errorf("Canonical(%q) = %q, want %q", in, got, "critical")
+		}
+	}
+	for _, in := range []string{"", "sev1", "urgent", "criticalish"} {
+		if got := severity.Canonical(in); got != "" {
+			t.Errorf("Canonical(%q) = %q, want \"\" for a non-severity", in, got)
+		}
+	}
+}
+
+// Rank is only ever compared, so the absolute numbers do not matter, but the
+// ordering and the treatment of an unknown value do.
+func TestRank_OrdersWorstFirstAndSinksUnknown(t *testing.T) {
+	ordered := severity.Ordered()
+	for i := 1; i < len(ordered); i++ {
+		if severity.Rank(ordered[i-1]) <= severity.Rank(ordered[i]) {
+			t.Errorf("%q should rank above %q", ordered[i-1], ordered[i])
+		}
+	}
+	// A typo must not beat a real severity when coalescing picks a winner.
+	if severity.Rank("sev1") >= severity.Rank("info") {
+		t.Error("an unrecognized severity must rank below every real one, including info")
+	}
+	// Case must not change the rank.
+	if severity.Rank("Critical") != severity.Rank("critical") {
+		t.Error("Rank must not depend on case")
+	}
+}
+
+func TestSARIFScore_MatchesCanonicalAndCase(t *testing.T) {
+	if severity.SARIFScore("Critical") != severity.SARIFScore("critical") {
+		t.Error("SARIFScore must not depend on case; this was the drift against the engine's rank")
+	}
+	if severity.SARIFScore("critical") == severity.SARIFScore("info") {
+		t.Error("critical and info must not score the same")
+	}
+	if severity.SARIFScore("sev1") != severity.SARIFScore("info") {
+		t.Error("an unrecognized severity should score lowest rather than inventing a high one")
+	}
+}
+
+func TestOrdered_IsACopy(t *testing.T) {
+	a := severity.Ordered()
+	a[0] = "tampered"
+	if severity.Ordered()[0] != "critical" {
+		t.Error("Ordered must return a copy so a caller cannot reorder the canonical list")
+	}
+}


### PR DESCRIPTION
The report grouped findings by iterating a hardcoded severity list and skipping every other key, while the header counted all of them. A finding carrying any other severity printed like this:

```
header says: "Scan Results (1 finding(s))"
finding printed? false
```

`Validate()` only checked that `info.severity` was non-empty, so a rule file — including one from `--rules-dir` — could express such a value freely.

## Six places encoded severity, and they had already drifted

| site | behaviour |
|---|---|
| `engine.severityRank` | lowercased its input |
| `report.severityScore` | compared the raw string |
| `report.severityLevel` | compared the raw string |
| `report.severityDisplay` | lowercased, unknown → `INFO` |
| printer's grouping loop | inline hardcoded list |
| `rules.SeverityRank` | fifth copy, raw string, **no callers** |

So `"Critical"` ranked as the worst severity when coalescing picked a winner, scored 1.0 (least severe) in SARIF, was demoted to `note` there, and never appeared in the table.

`internal/severity` is now the single source for the legal values, their order, ranking and the SARIF score. `rules.SeverityRank` is deleted rather than rewired — a duplicate with no consumers is how these drift apart.

## Decisions worth flagging

**Case variants stay legal.** Severity filtering already compares with `strings.EqualFold`, and every consumer now canonicalizes, so `"Critical"` behaves exactly like `"critical"`. Rejecting it would fail rule files that work correctly. My first test asserted the opposite and the code was right, so I changed the test and recorded the reasoning next to it.

**The report still prints a severity it cannot place** — last, and labelled with its own value rather than as `INFO`. Rule YAML can no longer express one, but an executor sets its finding's severity as a plain string, so the report must not depend on that being correct. Labelling it `INFO` would understate a finding whose severity is merely misspelled.

**Grouping walks sorted keys.** Two spellings of one severity would otherwise reorder between runs, the nondeterminism that made scans undiffable in #152. Pinned by a 40-iteration test.

## Verification

A bad custom rule is now named and rejected at load:

```
[!] Skipping malformed rule bad.yaml: rule custom-bad-001 validation failed:
    info.severity "Sev1" is not a severity (want one of: critical, high, medium, low, info)
```

All 36 shipped rules load unchanged. Non-vacuity checked per part: reverting the printer grouping fails the vanished-finding test, reverting the `Validate` check fails the rejection test. Full suite green uncached across 17 packages, `go vet` and `gofmt` clean.
