### PR TITLE
docs(testdata): name both fixtures that need the MCP Python SDK v2

### DIFF
--- a/testdata/README.md
+++ b/testdata/README.md
@@ -14,12 +14,18 @@ They are intentionally misconfigured to be exploitable.
 pip install starlette uvicorn httpx "mcp>=2"
 ```
 
-Only `mcp_unauth_resources_server.py` uses the MCP Python SDK; the rest are plain
-Starlette. The SDK's v2 line is what `pip install mcp` now gives you, and it
-renamed `FastMCP` to `MCPServer` with no compatibility alias, so that fixture
-does not run on 1.x. The version is pinned above rather than left bare so a
-future major bump is a deliberate change here instead of a fixture that stops
-starting.
+Two fixtures use the MCP Python SDK, `mcp_unauth_resources_server.py` and
+`mcp_modern_era_server.py`; the rest are plain Starlette. Both import
+`mcp.server.mcpserver.MCPServer`, so both need the v2 line: it renamed `FastMCP`
+to `MCPServer` with no compatibility alias and neither fixture runs on 1.x. The
+version is pinned above rather than left bare so a future major bump is a
+deliberate change here instead of a fixture that stops starting.
+
+If either fails to start with `ModuleNotFoundError: No module named
+'mcp.server.mcpserver'`, the installed `mcp` is 1.x. Check with
+`python -c "import importlib.metadata as m; print(m.version('mcp'))"`. This is
+worth knowing before a sweep: a fixture that does not bind measures nothing, and
+a run that treats it as a clean result is reporting coverage it does not have.
 
 ---
 


### PR DESCRIPTION
The prerequisites section said only `mcp_unauth_resources_server.py` uses the MCP Python SDK. `mcp_modern_era_server.py` imports `mcp.server.mcpserver.MCPServer` too, so both fail to start on the 1.x line.

This cost real time during the last registry sweep: both fixtures failed to bind, and the first version of my sweep script would have read that as a clean result. The note now names the symptom (`ModuleNotFoundError: No module named 'mcp.server.mcpserver'`), gives the version check, and says why it matters — a fixture that does not bind measures nothing.

Docs only; no code change.
