### PR TITLE
fix: make the reachability oracles actually establish reachability

### DIFF
--- a/internal/attack/a2a/endpoint.go
+++ b/internal/attack/a2a/endpoint.go
@@ -81,7 +81,27 @@ func resolveHTTPJSONBase(ctx context.Context, client *attack.HTTPClient, baseURL
 func resolveA2AEndpoint(ctx context.Context, client *attack.HTTPClient, baseURL string) (endpoint string, ok bool) {
 	if card, found := fetchDiscoveryCard(ctx, client, baseURL); found {
 		if cardURL := selectJSONRPCURL(card); cardURL != "" {
-			return pinToTargetHost(cardURL, baseURL), true
+			// The card's path has to answer before it is returned as reachable.
+			//
+			// It used to be returned on trust, which broke the contract this
+			// function's own doc comment states. A card advertises the URL clients
+			// reach the agent on, which for anything behind a proxy is not the path
+			// the operator is scanning: an agent published at
+			// https://public.example/a2a/v1 may be mounted at / on the origin. The
+			// card URL then 404s, the candidate walk that would have found / was
+			// skipped, and ok=true told a dozen rules their failed probes were a
+			// tested-clean result. Measured against a wide-open agent in exactly
+			// that shape: two POSTs to the dead path, nothing reached the handler,
+			// and a-task-idor reported clean.
+			//
+			// probeJSONRPCEndpoint accepts a 401/403, so an auth-gated card path is
+			// still recognized and this does not narrow what counts as reachable.
+			pinned := pinToTargetHost(cardURL, baseURL)
+			if probeJSONRPCEndpoint(ctx, client, pinned) {
+				return pinned, true
+			}
+			// Fall through: the card's claim did not hold at this host, so try the
+			// conventional paths rather than reporting an unreachable endpoint.
 		}
 	}
 	for _, ep := range candidateEndpoints(baseURL) {

--- a/internal/attack/a2a/endpoint_test.go
+++ b/internal/attack/a2a/endpoint_test.go
@@ -109,6 +109,13 @@ func TestResolveA2AEndpoint_FromCard(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(strings.ReplaceAll(referenceCard, "HOST", host)))
 	})
+	// The declared interface has to answer. Serving only the card made this test
+	// assert the defect it was written before: discovery returned the card's path
+	// as reachable without ever contacting it.
+	mux.HandleFunc("/a2a/jsonrpc", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32001,"message":"Task not found"}}`))
+	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 	host = strings.TrimPrefix(srv.URL, "http://")
@@ -261,5 +268,70 @@ func TestResolveA2AEndpoint_OriginTargetUnchanged(t *testing.T) {
 	ep, ok := resolveA2AEndpoint(context.Background(), newClient(srv.URL), srv.URL)
 	if !ok || ep != srv.URL+"/a2a/jsonrpc" {
 		t.Errorf("endpoint = %q ok = %v, want %s/a2a/jsonrpc true", ep, ok, srv.URL)
+	}
+}
+
+// A card advertises the URL clients reach the agent on, which for anything behind
+// a proxy is not the path the operator is scanning: an agent published at
+// https://public.example/a2a/v1 may be mounted at / on the origin. The card URL
+// was returned as reachable without ever being contacted, so the candidate walk
+// that would have found / was skipped and ok=true told a dozen rules their failed
+// probes were a tested-clean result.
+func TestResolveA2AEndpoint_CardPathThatDoesNotAnswerFallsBack(t *testing.T) {
+	var hits []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/agent-card.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Declares an external path that is not mounted at this origin.
+		_, _ = w.Write([]byte(`{"name":"proxied","version":"1.0",` +
+			`"url":"https://public.example.test/a2a/v1","preferredTransport":"JSONRPC"}`))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// "/" is a catch-all in ServeMux, so the declared /a2a/v1 must be refused
+		// explicitly or it would appear to answer and the test would prove nothing.
+		if r.URL.Path != "/" || r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		hits = append(hits, r.Method+" "+r.URL.Path)
+		// The real handler, answering a task-shaped probe.
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32001,"message":"Task not found"}}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ep, ok := resolveA2AEndpoint(context.Background(), newClient(srv.URL), srv.URL)
+	if !ok {
+		t.Fatal("expected discovery to fall back to the conventional paths and find the handler")
+	}
+	if ep != srv.URL+"/" {
+		t.Errorf("endpoint = %q, want the path that actually answered (%s/)", ep, srv.URL)
+	}
+	if len(hits) == 0 {
+		t.Error("the real handler was never contacted; the card's claim was taken on trust")
+	}
+}
+
+// An auth-gated card path must still be accepted, or securing an agent would make
+// it look undiscoverable. probeJSONRPCEndpoint treats 401/403 as found.
+func TestResolveA2AEndpoint_CardPathBehindAuthIsAccepted(t *testing.T) {
+	var host string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/agent-card.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"secured","version":"1.0","url":"http://` + host +
+			`/a2a/v1","preferredTransport":"JSONRPC"}`))
+	})
+	mux.HandleFunc("/a2a/v1", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	host = strings.TrimPrefix(srv.URL, "http://")
+
+	ep, ok := resolveA2AEndpoint(context.Background(), newClient(srv.URL), srv.URL)
+	if !ok || ep != srv.URL+"/a2a/v1" {
+		t.Errorf("endpoint = %q ok = %v, want %s/a2a/v1 true (a 401 proves the endpoint exists)", ep, ok, srv.URL)
 	}
 }

--- a/internal/attack/mcp/init_downgrade.go
+++ b/internal/attack/mcp/init_downgrade.go
@@ -133,7 +133,90 @@ func responsiveMCP(ctx context.Context, client *attack.HTTPClient, ep string) bo
 	if err != nil || !resp.IsSuccess() {
 		return false
 	}
-	return looksJSONRPC(resp.BodyString())
+	return answersMCPInitialize(resp.Body)
+}
+
+// answersMCPInitialize reports whether a reply to an MCP initialize came from
+// something that actually implements MCP.
+//
+// This used to be looksJSONRPC, which matches any body containing "jsonrpc",
+// "result", "error" or "protocolVersion" — that is every JSON-RPC service in
+// existence. Since this oracle decides clean-versus-skipped for five rules, an A2A
+// agent answering `-32601 Method not found` to initialize was accepted as an MCP
+// server and mcp-oauth-dcr-001, mcp-confused-deputy-001,
+// mcp-oauth-metadata-ssrf-001, mcp-token-replay-001 and mcp-init-downgrade-001 all
+// reported it clean, with nothing skipped. The A2A side already guards the mirror
+// of this with answersMCPInitialize in a2a/endpoint.go; the MCP side never did.
+//
+// A version rejection still counts, deliberately: the endpoint speaks MCP and only
+// declined the offered revision, which is a reachable endpoint rather than an
+// untestable one. That is why this cannot simply require a result envelope.
+//
+// Uncertain cases resolve to false, so the rule reports not-tested rather than
+// clean. That is the direction this project errs in.
+// mcpMethodNotFound is the JSON-RPC code a server returns for a method it does
+// not implement. Real SDKs return it at HTTP 200.
+const mcpMethodNotFound = -32601
+
+func answersMCPInitialize(body []byte) bool {
+	// A successful handshake names the negotiated revision. This reads
+	// result.protocolVersion directly rather than calling negotiatedVersion, which
+	// falls back to latestStable when the server echoed nothing and so never
+	// reports absence. That fallback is correct for choosing a header value and
+	// wrong for detecting whether this is an MCP server at all.
+	var envelope struct {
+		Result *struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		} `json:"result"`
+	}
+	if json.Unmarshal(body, &envelope) == nil && envelope.Result != nil &&
+		envelope.Result.ProtocolVersion != "" {
+		return true
+	}
+	code, hasErr := jsonRPCErrorCode(body)
+	if !hasErr {
+		return false
+	}
+	// Method not found is the answer from something that does not implement
+	// initialize at all, which is what an A2A agent or any other JSON-RPC service
+	// returns. It is not an MCP server.
+	if code == mcpMethodNotFound {
+		return false
+	}
+	// An error in the range the modern revision reserves is MCP-specific.
+	if code >= modernErrCodeMin && code <= modernErrCodeMax {
+		return true
+	}
+	// An auth rejection also proves an endpoint is listening and processing the
+	// request, which is what this oracle asks. Excluding it would give every
+	// credential-gated MCP server a spurious "not tested" on all five OAuth rules
+	// when the honest answer is that it publishes no OAuth metadata and there is
+	// nothing for them to test. Measured against
+	// testdata/mcp_secret_canary_server.py, which answers initialize with
+	// -32000 "authentication failed for token".
+	if authFlavoredError(code, jsonRPCErrorMessage(body)) {
+		return true
+	}
+	// Otherwise require the error to be about the protocol version, which is what
+	// a legacy server rejecting the offered revision says.
+	lower := strings.ToLower(string(body))
+	return strings.Contains(lower, "protocolversion") ||
+		strings.Contains(lower, "protocol version") ||
+		strings.Contains(lower, "unsupported protocol")
+}
+
+// jsonRPCErrorMessage extracts the error message from a JSON-RPC envelope, or ""
+// when there is none.
+func jsonRPCErrorMessage(body []byte) string {
+	var envelope struct {
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(body, &envelope) != nil || envelope.Error == nil {
+		return ""
+	}
+	return envelope.Error.Message
 }
 
 // initAndList performs an MCP initialize with the given protocol version, sends

--- a/internal/attack/mcp/reachability_test.go
+++ b/internal/attack/mcp/reachability_test.go
@@ -1,0 +1,133 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// answersMCPInitialize decides clean-versus-skipped for five rules, so what it
+// accepts is load-bearing. It replaced looksJSONRPC, which matched any body
+// containing "jsonrpc", "result", "error" or "protocolVersion" and therefore
+// accepted every JSON-RPC service in existence as an MCP server.
+func TestAnswersMCPInitialize(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			// The case that caused the defect: an A2A agent, or any other JSON-RPC
+			// service, answers a method it does not implement with -32601 at HTTP 200.
+			name: "method not found is not an MCP server",
+			body: `{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}`,
+			want: false,
+		},
+		{
+			name: "completed handshake names the revision",
+			body: `{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","serverInfo":{"name":"s"}}}`,
+			want: true,
+		},
+		{
+			// A version rejection still means the endpoint speaks MCP; it declined
+			// the offered revision. This is why the oracle cannot demand a result.
+			name: "version rejection counts",
+			body: `{"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"Unsupported protocol version"}}`,
+			want: true,
+		},
+		{
+			name: "modern reserved error code counts",
+			body: `{"jsonrpc":"2.0","id":1,"error":{"code":-32022,"message":"whatever"}}`,
+			want: true,
+		},
+		{
+			// A credential-gated MCP server refuses the handshake. Treating that as
+			// not-MCP would give every secured server five spurious not-tested
+			// entries when the honest answer is that it publishes no OAuth metadata.
+			name: "auth rejection counts",
+			body: `{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"authentication failed for token: "}}`,
+			want: true,
+		},
+		{
+			name: "unrelated error does not count",
+			body: `{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"Bad Request"}}`,
+			want: false,
+		},
+		{
+			// looksJSONRPC accepted this. A result of any shape is not a handshake.
+			name: "arbitrary result does not count",
+			body: `{"jsonrpc":"2.0","id":1,"result":"pong"}`,
+			want: false,
+		},
+		{
+			name: "empty body does not count",
+			body: ``,
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := answersMCPInitialize([]byte(tc.body)); got != tc.want {
+				t.Errorf("answersMCPInitialize(%s) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+// negotiatedVersion falls back to latestStable when the server echoed nothing, so
+// it never reports absence. answersMCPInitialize must not be built on it; an
+// earlier version of this fix was, and accepted every body as an MCP handshake.
+func TestNegotiatedVersion_NeverReportsAbsence(t *testing.T) {
+	if got := negotiatedVersion([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32601}}`)); got == "" {
+		t.Skip("negotiatedVersion now reports absence; answersMCPInitialize may be simplified")
+	}
+	if answersMCPInitialize([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32601}}`)) {
+		t.Error("answersMCPInitialize must not treat negotiatedVersion's fallback as a handshake")
+	}
+}
+
+// This pins the WIRING, not just the oracle. A unit test on
+// answersMCPInitialize alone stays green when responsiveMCP is reverted to
+// looksJSONRPC, so it does not protect the behaviour that matters.
+//
+// The five OAuth-gated rules use responsiveMCP to decide clean-versus-skipped.
+// Pointed at a JSON-RPC service that is not an MCP server, they reported it clean
+// with nothing skipped, which claims the OAuth handling is sound about a host that
+// speaks no MCP.
+func TestOAuthGatedRules_NotMCPServerIsInconclusive(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// No OAuth metadata anywhere.
+		if r.Method == http.MethodGet {
+			http.NotFound(w, r)
+			return
+		}
+		// A JSON-RPC service that does not implement initialize: exactly what an
+		// A2A agent answers, at HTTP 200.
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}`))
+	}))
+	defer srv.Close()
+
+	rules := map[string]attack.Executor{
+		"mcp-oauth-dcr-001":           NewOAuthDCRExecutor(attack.RuleContext{ID: "mcp-oauth-dcr-001"}),
+		"mcp-confused-deputy-001":     NewConfusedDeputyExecutor(attack.RuleContext{ID: "mcp-confused-deputy-001"}),
+		"mcp-oauth-metadata-ssrf-001": NewOAuthMetadataSSRFExecutor(attack.RuleContext{ID: "mcp-oauth-metadata-ssrf-001"}),
+		"mcp-token-replay-001":        NewTokenReplayExecutor(attack.RuleContext{ID: "mcp-token-replay-001"}),
+	}
+	for id, exec := range rules {
+		t.Run(id, func(t *testing.T) {
+			findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+			if len(findings) != 0 {
+				t.Fatalf("expected no findings, got %d", len(findings))
+			}
+			if !errors.Is(err, attack.ErrInconclusive) {
+				t.Errorf("a server that does not implement MCP must be not-tested, not clean; got err=%v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Two shared helpers decide whether a rule was exercised. Neither established what it claimed, so rules reported targets clean that they had never tested.

## MCP: any JSON-RPC service counted as an MCP server

`responsiveMCP` settles clean-versus-skipped for five rules, using `looksJSONRPC` — which matches any body containing `"jsonrpc"`, `"result"`, `"error"` or `"protocolVersion"`. An A2A agent answering `initialize` with `-32601` at HTTP 200 was accepted as an MCP server.

Measured against an A2A-only fixture:

| | findings | skipped |
|---|---|---|
| before | 0 | **0** — all five reported clean |
| after | 0 | 5 |

The A2A side already guards the mirror of this with its own `answersMCPInitialize`; the MCP side never did.

The new oracle accepts a completed handshake, a version rejection, a modern-reserved error code, or an auth rejection — and rejects method-not-found and arbitrary JSON-RPC. **Auth rejections have to count**, or every credential-gated MCP server gets five spurious not-tested entries when the honest answer is that it publishes no OAuth metadata. `testdata/mcp_secret_canary_server.py` is exactly that case and the sweep caught my first version over-rejecting it.

## A2A: the card's declared URL was never contacted

`resolveA2AEndpoint` returned the card-declared URL on trust and skipped the candidate walk — while its own doc comment says `ok=false` means no endpoint responded, implying `ok=true` means one did. A card advertises the URL *clients* reach the agent on, so anything behind a proxy declares a path not mounted at the origin being scanned.

Measured against a wide-open agent published at one path and mounted at another: **two POSTs to the dead path, nothing reached the handler, and `a2a-task-idor-001` reported clean.** The card path is now probed, with fallback to the conventional paths. A 401 still counts, so securing an agent does not make it look undiscoverable.

## Verification

Full fixture sweep against the previous build: **no finding gained or lost anywhere**; the only skip changes are the five MCP rules correctly declining to assess A2A fixtures.

Non-vacuity checked per half. The MCP half needed a second attempt: a unit test on the oracle alone stayed green when the *wiring* was reverted, so it did not protect the behaviour that matters. There is now an end-to-end test driving all four OAuth rules against a non-MCP server, and that one does fail on revert. This is the #143 lesson — revert each part separately.

Two of my own mistakes worth recording: my first oracle was built on `negotiatedVersion`, which falls back to `latestStable` and therefore never reports absence, so it accepted every body as a handshake; and my first fallback test used `ServeMux`'s `/` catch-all, which also served the "unreachable" path and proved nothing.

One existing test asserted the A2A defect — it declared an endpoint nothing served and expected discovery to call it reachable. Its real subject is interface selection, so the declared interface now answers.

Full suite green across 17 packages, `golangci-lint` clean.
