### PR TITLE
fix(a2a): test v0.3 agents for forged JWTs, and stop reporting a new task as a hijacked one

### DIFF
--- a/internal/attack/a2a/delegation_integrity.go
+++ b/internal/attack/a2a/delegation_integrity.go
@@ -187,8 +187,10 @@ func (e *DelegationIntegrityExecutor) continueTask(ctx context.Context, c *attac
 	if err != nil || !resp.IsAccepted() {
 		return false
 	}
-	// The continuation landed on A's task only if the result still references it.
-	return resp.ContainsAny(taskID, contextID, `"contextId"`)
+	// The continuation landed on A's task only if the result identifies it. See
+	// resultReferencesTask: the previous check also accepted the bare key name
+	// "contextId", which any Task envelope contains.
+	return resultReferencesTask(resp.Body, taskID, contextID)
 }
 
 // finding builds the confirmed delegation chain-of-custody break.

--- a/internal/attack/a2a/delegation_integrity_test.go
+++ b/internal/attack/a2a/delegation_integrity_test.go
@@ -2,6 +2,9 @@ package a2a_test
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -214,5 +217,63 @@ func TestDelegation_ConsumesBlackboardTaskID(t *testing.T) {
 	}
 	if c := findings[0].Chain; len(c) != 2 || !strings.Contains(c[0].Action, preTask) || !strings.Contains(c[0].Action, "consumed from blackboard") {
 		t.Errorf("expected hop 1 to cite the consumed blackboard task, got %+v", c)
+	}
+}
+
+// A server with tenant-scoped task stores. Principal B's continuation names A's
+// taskId, which B's store does not contain, so the server treats the message as a
+// NEW conversation and answers with a new task. It has correctly refused to expose
+// A's task, and there is no chain-of-custody break to report.
+//
+// This used to fire high/ConfirmedExploit: the acceptance oracle accepted the bare
+// key name "contextId", which the new task's envelope contains.
+func TestDelegationIntegrity_NewTaskForUnknownIDIsNotAContinuation(t *testing.T) {
+	var created int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, ".well-known") {
+			writeJSON(w, map[string]interface{}{"name": "scoped", "version": "1.0"})
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Method string `json:"method"`
+			Params struct {
+				Message struct {
+					TaskID string `json:"taskId"`
+				} `json:"message"`
+			} `json:"params"`
+		}
+		_ = json.Unmarshal(body, &req)
+
+		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if token == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		// Every send yields a task in the CALLER's own tenant namespace. A taskId
+		// the caller does not own is simply not continued.
+		created++
+		writeJSON(w, map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": map[string]interface{}{
+			"id":        fmt.Sprintf("task-%s-%d", token, created),
+			"contextId": "ctx-" + token,
+			"status":    map[string]interface{}{"state": "working"},
+		}})
+	}))
+	defer srv.Close()
+
+	exec := a2a.NewDelegationIntegrityExecutor(testRuleCtx())
+	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{
+		TimeoutSeconds: 5,
+		Principals: []attack.Principal{
+			{Name: "a", Token: "tok-a"},
+			{Name: "b", Token: "tok-b"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("FALSE POSITIVE: B got its own new task, not A's; got %d finding(s): %s",
+			len(findings), findings[0].Title)
 	}
 }

--- a/internal/attack/a2a/multitenant_isolation.go
+++ b/internal/attack/a2a/multitenant_isolation.go
@@ -168,7 +168,9 @@ func (e *MultiTenantIsolationExecutor) readTask(ctx context.Context, c *attack.H
 	if err != nil || !resp.IsAccepted() {
 		return false
 	}
-	return resp.ContainsAny(`"history"`, `"contextId"`, taskID, contextID)
+	// Identifiers, not key names: "history" and "contextId" appear in every Task
+	// envelope. See resultReferencesTask.
+	return resultReferencesTask(resp.Body, taskID, contextID)
 }
 
 // finding builds the confirmed cross-tenant isolation breach finding. reader is

--- a/internal/attack/a2a/peer_impersonation.go
+++ b/internal/attack/a2a/peer_impersonation.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -93,33 +94,14 @@ func (e *PeerImpersonationExecutor) Execute(ctx context.Context, target string, 
 		return nil, fmt.Errorf("building forged JWT: %w", err)
 	}
 
-	msgBody := map[string]interface{}{
-		"jsonrpc": "2.0",
-		"id":      1,
-		"method":  "SendMessage",
-		"params": map[string]interface{}{
-			"message": map[string]interface{}{
-				"role":  1,
-				"parts": []interface{}{map[string]string{"text": "ping"}},
-			},
-			"configuration": map[string]interface{}{},
-		},
-	}
-
-	// Step 3: Forged-token probe.
-	forgedHeaders := map[string]string{
-		"A2A-Version":   "1.0",
-		"Authorization": "Bearer " + forgedToken,
-	}
-	forgedResp, err := client.POST(ctx, endpoint, forgedHeaders, msgBody)
-	if err != nil {
-		return nil, nil
-	}
-
-	// Step 4: Unauthenticated baseline - use unauthClient so opts.Token is not injected.
-	baselineResp, err := unauthClient.POST(ctx, endpoint, map[string]string{"A2A-Version": "1.0"}, msgBody)
-	if err != nil {
-		return nil, nil
+	// Steps 3 and 4: on each revision the agent might speak, send the forged probe
+	// and the unauthenticated baseline, and keep the first pair where the send
+	// method exists. The baseline uses unauthClient so opts.Token is not injected.
+	forgedResp, baselineResp, wire, ok := e.probeWires(ctx, client, unauthClient, endpoint, forgedToken, vars.RandID)
+	if !ok {
+		return nil, fmt.Errorf("%w: no revision's send method is implemented at %s "+
+			"(tried v1.0 SendMessage and v0.3 message/send), so credential handling was never exercised",
+			attack.ErrInconclusive, endpoint)
 	}
 
 	// Acceptance = a 2xx carrying a JSON-RPC result envelope (IsAccepted).
@@ -152,8 +134,8 @@ func (e *PeerImpersonationExecutor) Execute(ctx context.Context, target string, 
 				forgedResp.StatusCode, baselineResp.StatusCode),
 			Evidence: fmt.Sprintf(
 				"Forged JWT (redacted): %s...[signature omitted]\niss: %s\nissuer source: %s\naud: %s\n"+
-					"Forged response: HTTP %d\nBaseline response: HTTP %d\n%s",
-				jwtHeader(forgedToken), claims.iss, claims.source, claims.aud,
+					"wire: %s\nForged response: HTTP %d\nBaseline response: HTTP %d\n%s",
+				jwtHeader(forgedToken), claims.iss, claims.source, claims.aud, wire,
 				forgedResp.StatusCode, baselineResp.StatusCode,
 				snippet(forgedResp.Body, 400)),
 			Remediation: e.rule.Remediation,
@@ -174,8 +156,8 @@ func (e *PeerImpersonationExecutor) Execute(ctx context.Context, target string, 
 					"making peer agent impersonation trivial for any caller.",
 				forgedResp.StatusCode, baselineResp.StatusCode),
 			Evidence: fmt.Sprintf(
-				"Forged response: HTTP %d\nBaseline response: HTTP %d\n%s",
-				forgedResp.StatusCode, baselineResp.StatusCode,
+				"wire: %s\nForged response: HTTP %d\nBaseline response: HTTP %d\n%s",
+				wire, forgedResp.StatusCode, baselineResp.StatusCode,
 				snippet(forgedResp.Body, 400)),
 			Remediation: e.rule.Remediation,
 			TargetURL:   endpoint,
@@ -195,6 +177,83 @@ func (e *PeerImpersonationExecutor) Execute(ctx context.Context, target string, 
 	}
 
 	return findings, nil
+}
+
+// impersonationWire is one revision's send request, in the shape that revision
+// defines.
+type impersonationWire struct {
+	name    string
+	headers map[string]string
+	body    map[string]interface{}
+}
+
+// impersonationWires lists the send methods to try, newest first.
+//
+// The rule sent only v1.0 SendMessage and had no fallback, alone among the A2A
+// rules. A v0.3 agent answers that with -32601 at HTTP 200 for BOTH the forged and
+// the baseline probe, so neither was accepted, no switch case matched, and the rule
+// returned clean: a server that trusts a published issuer and never verifies a
+// signature was reported secure because the scanner spoke the wrong revision at it.
+// The rejection it saw came from the dispatcher, not the auth layer.
+func impersonationWires(randID string) []impersonationWire {
+	return []impersonationWire{
+		{
+			name:    "v1.0 SendMessage",
+			headers: map[string]string{"A2A-Version": "1.0"},
+			body: jsonRPCCall("SendMessage", map[string]interface{}{
+				"message": map[string]interface{}{
+					"messageId": "batesian-pi-" + randID,
+					"role":      "ROLE_USER",
+					"parts":     []interface{}{map[string]interface{}{"text": "ping"}},
+				},
+			}),
+		},
+		{
+			// v0.3: slash method, lowercase role, and parts carry a kind. messageId
+			// is required by the Message schema, which the previous body omitted.
+			name: "v0.3 message/send",
+			body: jsonRPCCall("message/send", map[string]interface{}{
+				"message": map[string]interface{}{
+					"messageId": "batesian-pi-" + randID,
+					"role":      "user",
+					"parts":     []interface{}{map[string]interface{}{"kind": "text", "text": "ping"}},
+				},
+			}),
+		},
+	}
+}
+
+// probeWires sends the forged and baseline probes on each revision and returns the
+// first pair where the method exists. A revision answering -32601 to both is not
+// implemented here and says nothing about credential handling.
+func (e *PeerImpersonationExecutor) probeWires(ctx context.Context, client, unauthClient *attack.HTTPClient,
+	endpoint, forgedToken, randID string) (forged, baseline *attack.Response, wire string, ok bool) {
+	for _, w := range impersonationWires(randID) {
+		forgedHeaders := map[string]string{"Authorization": "Bearer " + forgedToken}
+		for k, v := range w.headers {
+			forgedHeaders[k] = v
+		}
+		fResp, err := client.POST(ctx, endpoint, forgedHeaders, w.body)
+		if err != nil {
+			continue
+		}
+		bResp, err := unauthClient.POST(ctx, endpoint, w.headers, w.body)
+		if err != nil {
+			continue
+		}
+		if methodAbsent(fResp) && methodAbsent(bResp) {
+			continue
+		}
+		return fResp, bResp, w.name, true
+	}
+	return nil, nil, "", false
+}
+
+// methodAbsent reports whether a response is a -32601, which real SDKs return at
+// HTTP 200 for a method name the revision does not define.
+func methodAbsent(resp *attack.Response) bool {
+	code, ok := jsonRPCErrorCode(resp.Body)
+	return ok && code == methodNotFound
 }
 
 // fallbackForgedIssuer is used only when the target publishes no issuer anywhere.
@@ -260,8 +319,21 @@ func deriveForgedClaims(ctx context.Context, client *attack.HTTPClient, baseURL,
 	if card == nil {
 		return out
 	}
-	for name, scheme := range card.SecuritySchemes {
-		if iss := issuerFromScheme(scheme); iss != "" {
+	// Sorted, not map order. Go randomizes map iteration, and both the forged
+	// token's iss and this evidence string come from whichever scheme is seen
+	// first, so a card declaring two issuer-bearing schemes (an openIdConnect and
+	// an oauth2 at different IdPs, normal during a migration) produced a different
+	// issuer per run. Measured on such a card: two distinct issuers across 30 runs,
+	// 25 to 5. Against an issuer-filtering server that decides whether the rule
+	// fires at all. oauthFlowEndpoints below was already sorted for this reason;
+	// the walk enclosing it was not.
+	names := make([]string, 0, len(card.SecuritySchemes))
+	for name := range card.SecuritySchemes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if iss := issuerFromScheme(card.SecuritySchemes[name]); iss != "" {
 			out.iss = iss
 			out.source = fmt.Sprintf("agent card securityScheme %q", name)
 			return out

--- a/internal/attack/a2a/peer_impersonation_test.go
+++ b/internal/attack/a2a/peer_impersonation_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -345,5 +346,155 @@ func TestPeerImpersonation_NotA2AServer(t *testing.T) {
 	}
 	if len(findings) != 0 {
 		t.Errorf("expected zero findings on non-A2A server, got %d", len(findings))
+	}
+}
+
+// v03IssuerAllowlistServer is issuerAllowlistServer speaking v0.3 only: it answers
+// the v1.0 method name with -32601 at HTTP 200, the way a real SDK does.
+//
+// The rule sent only v1.0 SendMessage, so both probes were refused by the
+// DISPATCHER, neither was accepted, no switch case matched, and a server that
+// trusts a published issuer and never verifies a signature was reported clean.
+func v03IssuerAllowlistServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "agent-card.json") {
+			writeJSON(w, cardWithIssuer("v03-agent"))
+			return
+		}
+		var req struct {
+			Method string `json:"method"`
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &req)
+		if req.Method != "message/send" {
+			// This revision does not define that name.
+			writeJSON(w, map[string]interface{}{"jsonrpc": "2.0", "id": 1,
+				"error": map[string]interface{}{"code": -32601, "message": "Method not found"}})
+			return
+		}
+		auth := r.Header.Get("Authorization")
+		if !strings.HasPrefix(auth, "Bearer ") {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		parts := strings.Split(strings.TrimPrefix(auth, "Bearer "), ".")
+		if len(parts) != 3 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+		if err != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		var claims struct {
+			Iss string `json:"iss"`
+		}
+		if json.Unmarshal(raw, &claims) != nil || claims.Iss != testIssuer {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		writeJSON(w, map[string]interface{}{"jsonrpc": "2.0", "id": 1,
+			"result": map[string]interface{}{"id": "task-v03", "status": map[string]interface{}{"state": "completed"}}})
+	}))
+}
+
+func TestPeerImpersonation_V03AgentIsStillTested(t *testing.T) {
+	ts := v03IssuerAllowlistServer(t)
+	defer ts.Close()
+
+	exec := a2aattack.NewPeerImpersonationExecutor(peerImpersonationRC())
+	findings, err := exec.Execute(context.Background(), ts.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) == 0 {
+		t.Fatal("expected a finding: the v0.3 agent accepts a randomly signed token bearing its published issuer")
+	}
+	if !strings.Contains(findings[0].Evidence, "v0.3 message/send") {
+		t.Errorf("evidence should name the revision that answered, got: %s", findings[0].Evidence)
+	}
+}
+
+// An agent implementing neither send method tells us nothing about credential
+// handling, so it must be not-tested rather than clean.
+func TestPeerImpersonation_NoSendMethodIsInconclusive(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "agent-card.json") {
+			writeJSON(w, cardWithIssuer("no-send"))
+			return
+		}
+		writeJSON(w, map[string]interface{}{"jsonrpc": "2.0", "id": 1,
+			"error": map[string]interface{}{"code": -32601, "message": "Method not found"}})
+	}))
+	defer ts.Close()
+
+	exec := a2aattack.NewPeerImpersonationExecutor(peerImpersonationRC())
+	findings, err := exec.Execute(context.Background(), ts.URL, testOpts())
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive when no send method exists, got err=%v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected no findings, got %d", len(findings))
+	}
+}
+
+// Both the forged token's issuer and the finding's evidence come from a walk over
+// the card's securitySchemes map, and Go randomizes map order. A card declaring two
+// issuer-bearing schemes is normal during an IdP migration. Measured before the
+// fix: two distinct issuers across 30 runs.
+func TestPeerImpersonation_IssuerIsDeterministic(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "agent-card.json") {
+			writeJSON(w, map[string]interface{}{
+				"name": "two-idp", "version": "1.0",
+				"securitySchemes": map[string]interface{}{
+					"legacy-sso": map[string]interface{}{
+						"type":             "openIdConnect",
+						"openIdConnectUrl": "https://old-idp.example.test/.well-known/openid-configuration",
+					},
+					"new-sso": map[string]interface{}{
+						"type": "oauth2",
+						"flows": map[string]interface{}{
+							"clientCredentials": map[string]interface{}{
+								"tokenUrl": "https://new-idp.example.test/oauth/token",
+								"scopes":   map[string]interface{}{},
+							},
+						},
+					},
+				},
+			})
+			return
+		}
+		if r.Header.Get("Authorization") == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		writeJSON(w, map[string]interface{}{"jsonrpc": "2.0", "id": 1,
+			"result": map[string]interface{}{"id": "t", "status": map[string]interface{}{"state": "completed"}}})
+	}))
+	defer srv.Close()
+
+	first := ""
+	for i := 0; i < 30; i++ {
+		exec := a2aattack.NewPeerImpersonationExecutor(peerImpersonationRC())
+		f, err := exec.Execute(context.Background(), srv.URL, testOpts())
+		if err != nil || len(f) == 0 {
+			t.Fatalf("run %d: expected a finding, got %d findings err=%v", i, len(f), err)
+		}
+		var iss string
+		for _, line := range strings.Split(f[0].Evidence, "\n") {
+			if strings.HasPrefix(line, "iss: ") {
+				iss = line
+			}
+		}
+		if i == 0 {
+			first = iss
+			continue
+		}
+		if iss != first {
+			t.Fatalf("run %d derived %q but run 0 derived %q; the issuer must not depend on map order", i, iss, first)
+		}
 	}
 }

--- a/internal/attack/a2a/taskref.go
+++ b/internal/attack/a2a/taskref.go
@@ -1,0 +1,48 @@
+package a2a
+
+import "encoding/json"
+
+// resultReferencesTask reports whether a JSON-RPC result really is the task
+// identified by taskID/contextID, by comparing the identifiers rather than
+// searching the body for text.
+//
+// Two rules used to decide this with
+// resp.ContainsAny(`"history"`, `"contextId"`, taskID, contextID). ContainsAny is
+// OR, and the first two needles are KEY NAMES present in virtually every A2A Task
+// envelope, so the check reduced to "the caller got some accepted result".
+//
+// That is a live false positive in a2a-delegation-integrity-001, which asks
+// whether principal B's continuation landed on principal A's task. A server with
+// tenant-scoped task stores does not error on an unknown taskId: it treats the
+// message as a new conversation and answers with a NEW task, whose envelope
+// contains "contextId" and therefore matched. The rule then emitted
+// high/ConfirmedExploit "A2A delegated task continued by the wrong principal",
+// with a chain step asserting the wrong principal advanced the delegated step,
+// about a server that had correctly refused to expose A's task.
+//
+// a2a-multitenant-isolation-001 carried the same needles. There the secure answer
+// to a get-by-id is a JSON-RPC error, which IsAccepted already filters, so it was
+// latent rather than live; it is corrected here because the flaw is identical.
+//
+// A Task carries id and contextId in both revisions. A result that is a Message
+// rather than a Task has neither, and returns false: whether it touched A's task
+// cannot be established from it.
+func resultReferencesTask(body []byte, taskID, contextID string) bool {
+	var envelope struct {
+		Result *struct {
+			ID        string `json:"id"`
+			TaskID    string `json:"taskId"`
+			ContextID string `json:"contextId"`
+		} `json:"result"`
+	}
+	if json.Unmarshal(body, &envelope) != nil || envelope.Result == nil {
+		return false
+	}
+	r := envelope.Result
+	if taskID != "" && (r.ID == taskID || r.TaskID == taskID) {
+		return true
+	}
+	// contextId alone is enough: a continuation accepted into A's context is the
+	// boundary crossing, whatever task id the server chose to report.
+	return contextID != "" && r.ContextID == contextID
+}

--- a/internal/attack/a2a/taskref_test.go
+++ b/internal/attack/a2a/taskref_test.go
@@ -1,0 +1,70 @@
+package a2a
+
+import "testing"
+
+// The oracle these replaced was ContainsAny(`"history"`, `"contextId"`, taskID,
+// contextID) — OR semantics over two KEY NAMES, so any accepted Task envelope
+// matched and the check meant "the caller got a result".
+func TestResultReferencesTask(t *testing.T) {
+	const taskID, ctxID = "task-A", "ctx-A"
+
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			// The live false positive: a tenant-scoped server does not error on an
+			// unknown taskId, it starts a new conversation and answers with a NEW
+			// task. The old needle `"contextId"` matched this.
+			name: "a different task is not A's task",
+			body: `{"jsonrpc":"2.0","id":1,"result":{"id":"task-B-7","contextId":"ctx-B","status":{"state":"working"}}}`,
+			want: false,
+		},
+		{
+			name: "the same task id references it",
+			body: `{"jsonrpc":"2.0","id":1,"result":{"id":"task-A","contextId":"ctx-A","status":{"state":"completed"}}}`,
+			want: true,
+		},
+		{
+			name: "A's context is enough even under another task id",
+			body: `{"jsonrpc":"2.0","id":1,"result":{"id":"task-A-2","contextId":"ctx-A"}}`,
+			want: true,
+		},
+		{
+			name: "taskId spelling is accepted too",
+			body: `{"jsonrpc":"2.0","id":1,"result":{"taskId":"task-A","contextId":"ctx-Z"}}`,
+			want: true,
+		},
+		{
+			// A Message result has no identifiers, so nothing can be established.
+			name: "a message result establishes nothing",
+			body: `{"jsonrpc":"2.0","id":1,"result":{"messageId":"m1","role":"agent","parts":[{"text":"hi"}]}}`,
+			want: false,
+		},
+		{
+			// Previously matched on the bare key name.
+			name: "an envelope carrying only the key names does not match",
+			body: `{"jsonrpc":"2.0","id":1,"result":{"contextId":"","history":[]}}`,
+			want: false,
+		},
+		{
+			name: "an error envelope does not match",
+			body: `{"jsonrpc":"2.0","id":1,"error":{"code":-32001,"message":"Task not found"}}`,
+			want: false,
+		},
+		{
+			name: "unparseable body does not match",
+			body: `not json`,
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resultReferencesTask([]byte(tc.body), taskID, ctxID); got != tc.want {
+				t.Errorf("resultReferencesTask(%s) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Three defects across two rules, all found by the project review.

## 1. `a2a-peer-impersonation-001` could not test a v0.3 agent

It sent only the v1.0 `SendMessage` and had no v0.3 fallback — alone among the A2A rules. A v0.3 agent answers that name with `-32601` at HTTP 200 for *both* the forged probe and the baseline, so neither was accepted, no switch case matched, and the rule returned clean. A server that trusts a published issuer and never verifies a signature was reported secure because the scanner spoke the wrong revision at it: the rejection it saw came from the dispatcher, not the auth layer.

Both revisions are now tried, newest first; a revision answering `-32601` to both probes is skipped as unimplemented. The probe also gained the `messageId` its schema requires and each revision's role spelling. When no send method exists anywhere, the rule reports not-tested, and findings now record which wire answered.

## 2. The same rule's forged issuer was nondeterministic — my regression from #156

The issuer came from a walk over the card's `securitySchemes` **map**. Go randomizes map order, so a card declaring two issuer-bearing schemes (ordinary during an IdP migration) produced a different issuer per run:

```
distinct issuers derived across 30 runs: 2
   iss: https://old-idp.example.test    25/30
   iss: https://new-idp.example.test     5/30
```

Against an issuer-filtering server that decides whether the rule fires at all. `oauthFlowEndpoints` one level down was already sorted for exactly this reason; the walk enclosing it was not. The 25/5 skew is why a small sample would have looked stable.

## 3. `a2a-delegation-integrity-001` reported a false positive at confirmed tier

It decided B's continuation had landed on A's task with ``ContainsAny(taskID, contextID, `"contextId"`)`` — OR over a **key name** present in virtually every Task envelope, so the check meant "B got some accepted result".

Verified by hand against `testdata/a2a_task_cancel_server.py`:

```
A creates:              task-1 / ctx-task-1
B continues "task-1" -> task-2 / ctx-task-2     (a new task in B's own namespace)
```

The server correctly refused to expose A's task, and the rule emitted **high/ConfirmedExploit** "A2A delegated task continued by the wrong principal" with a chain step asserting the wrong principal advanced the delegated step.

Identifiers are now compared rather than searched for, via a shared `resultReferencesTask`. `a2a-multitenant-isolation-001` carried the same needles plus a bare `"history"`; there the secure answer is a JSON-RPC error that `IsAccepted` already filters, so it was latent — corrected because the flaw is identical.

## Verification

Sweep against the previous build: the rule **still fires on its own fixture** (1 finding before and after), and the only findings lost are three `a2a-delegation-integrity-001` reports against fixtures built for other rules — each confirmed false by hand, as above.

Non-vacuity checked on all three changes separately: reverting the v0.3 wire fails the v0.3 test, reverting the sort fails the 30-run determinism test, reverting the oracle fails the new-task test. Ten unit tests added or extended. Full suite green, `golangci-lint` clean.
