### PR TITLE
fix(a2a): stop accusing a secured agent of a JSON-RPC batch auth bypass

### DIFF
--- a/internal/attack/a2a/jsonrpc_batch_bypass.go
+++ b/internal/attack/a2a/jsonrpc_batch_bypass.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/calbebop/batesian/internal/attack"
 )
@@ -163,10 +162,6 @@ func a2aBatchDispatched(body []byte) bool {
 	return false
 }
 
-// authKeywords are substrings that mark a JSON-RPC error message as an auth
-// failure. A2A has no numeric auth error code, so classification is message-based.
-var authKeywords = []string{"unauth", "authentic", "forbidden", "credential", "permission"}
-
 func errMessageIsAuth(body []byte) bool {
 	var obj struct {
 		Error json.RawMessage `json:"error"`
@@ -184,11 +179,9 @@ func errMessageIsAuthRaw(rawErr json.RawMessage) bool {
 	if err := json.Unmarshal(rawErr, &e); err != nil {
 		return false
 	}
-	msg := strings.ToLower(e.Message)
-	for _, kw := range authKeywords {
-		if strings.Contains(msg, kw) {
-			return true
-		}
-	}
-	return false
+	// A2A defines no numeric auth error code, so this is message-based. The list
+	// lives in internal/attack: the copy that used to be here omitted "authoriz",
+	// "access denied" and "login", so a batch refused with "Not authorized" was read
+	// as dispatched and the rule accused a correctly secured agent of a bypass.
+	return attack.AuthFlavoredMessage(e.Message)
 }

--- a/internal/attack/a2a/jsonrpc_batch_bypass_test.go
+++ b/internal/attack/a2a/jsonrpc_batch_bypass_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/calbebop/batesian/internal/attack"
@@ -139,5 +140,44 @@ func TestBatchBypass_NotA2A(t *testing.T) {
 	}
 	if len(findings) != 0 {
 		t.Errorf("expected 0 findings, got %d", len(findings))
+	}
+}
+
+// A correctly secured agent: the single request is refused at the HTTP layer, and
+// every element of a batch is refused with a JSON-RPC error reading "Not
+// authorized". Nothing is bypassed.
+//
+// The A2A copy of the auth-keyword list omitted "authoriz", so that message was
+// not recognized as a refusal. a2aBatchDispatched's predicate is inverted, so an
+// unrecognized element error counted as proof the dispatcher had run, and the rule
+// emitted high/confirmed "A2A authentication bypassed by JSON-RPC batch wrapping"
+// with evidence reading "batch [request]: HTTP 200 (processed)".
+func TestBatchBypass_AuthRefusalWordingIsRecognized(t *testing.T) {
+	for _, msg := range []string{"Not authorized", "Access denied", "Login required", "Invalid token"} {
+		t.Run(msg, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.Contains(r.URL.Path, ".well-known") {
+					writeJSON(w, map[string]interface{}{"name": "secure", "version": "1.0"})
+					return
+				}
+				body, _ := io.ReadAll(r.Body)
+				w.Header().Set("Content-Type", "application/json")
+				if strings.HasPrefix(strings.TrimSpace(string(body)), "[") {
+					// Batch: every element refused for auth.
+					_, _ = w.Write([]byte(`[{"jsonrpc":"2.0","id":"1","error":{"code":-32600,"message":"` + msg + `"}}]`))
+					return
+				}
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"` + msg + `"}}`))
+			}))
+			defer srv.Close()
+
+			exec := a2aattack.NewBatchBypassExecutor(attack.RuleContext{ID: "a2a-jsonrpc-batch-bypass-001"})
+			findings, _ := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+			if len(findings) != 0 {
+				t.Errorf("FALSE POSITIVE for %q: the batch was refused for auth, got %q",
+					msg, findings[0].Title)
+			}
+		})
 	}
 }

--- a/internal/attack/authsignal.go
+++ b/internal/attack/authsignal.go
@@ -1,0 +1,47 @@
+package attack
+
+import "strings"
+
+// authErrorKeywords are substrings that mark a JSON-RPC error message as an
+// authentication or authorization refusal rather than a request-processing or
+// validation error.
+//
+// Bare "token" is deliberately absent. A validation message such as "unexpected
+// token" would otherwise read as an auth refusal, which in the rules that gate on
+// this either hides a real finding or invents one.
+var authErrorKeywords = []string{
+	"unauth",
+	"authentic",
+	"authoriz",
+	"forbidden",
+	"credential",
+	"permission",
+	"access denied",
+	"not allowed",
+	"invalid token",
+	"missing token",
+	"log in",
+	"login",
+}
+
+// AuthFlavoredMessage reports whether a JSON-RPC error message reads as an auth
+// refusal. It is the one place that judgement lives.
+//
+// Three copies of this list existed and had drifted, which is how a scanner came
+// to accuse a correctly secured agent. The A2A copy omitted "authoriz", "access
+// denied" and "login", so a batch refused with "Not authorized" was not recognized
+// as gated; because that rule's predicate is inverted, the unrecognized refusal
+// counted as proof the dispatcher had run, and a2a-jsonrpc-batch-bypass-001
+// emitted a high/confirmed "authentication bypassed by JSON-RPC batch wrapping"
+// whose evidence read "batch [request]: HTTP 200 (processed)" about a request the
+// server had refused. The MCP batch copy diverged the other way, including bare
+// "token" that the canonical list excludes on purpose.
+func AuthFlavoredMessage(msg string) bool {
+	m := strings.ToLower(msg)
+	for _, kw := range authErrorKeywords {
+		if strings.Contains(m, kw) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/attack/authsignal_test.go
+++ b/internal/attack/authsignal_test.go
@@ -1,0 +1,33 @@
+package attack
+
+import "testing"
+
+// Three copies of this judgement existed and drifted. The A2A copy omitted
+// "authoriz", "access denied" and "login", which is how a correctly secured agent
+// was accused of a JSON-RPC batch auth bypass.
+func TestAuthFlavoredMessage(t *testing.T) {
+	refusals := []string{
+		"Not authorized", "Unauthorized", "Access denied", "Forbidden",
+		"Login required", "Please log in", "Invalid token", "Missing token",
+		"Authentication failed", "insufficient permission", "missing credential",
+		"NOT ALLOWED",
+	}
+	for _, msg := range refusals {
+		if !AuthFlavoredMessage(msg) {
+			t.Errorf("AuthFlavoredMessage(%q) = false; a refusal in this wording was read as a "+
+				"processed request, which is what accused a secured agent", msg)
+		}
+	}
+
+	// Bare "token" is excluded on purpose: a validation message must not pass as an
+	// auth refusal, or the batch rules attempt a bypass against an ungated method.
+	notRefusals := []string{
+		"unexpected token in JSON at position 4", "Invalid params", "Method not found",
+		"Task not found", "Internal error", "",
+	}
+	for _, msg := range notRefusals {
+		if AuthFlavoredMessage(msg) {
+			t.Errorf("AuthFlavoredMessage(%q) = true; this is not an auth refusal", msg)
+		}
+	}
+}

--- a/internal/attack/mcp/dispatch.go
+++ b/internal/attack/mcp/dispatch.go
@@ -3,7 +3,6 @@ package mcp
 import (
 	"encoding/json"
 	"net/http"
-	"strings"
 
 	"github.com/calbebop/batesian/internal/attack"
 )
@@ -93,30 +92,9 @@ func authFlavoredError(code int, msg string) bool {
 	case -32001, -32002: // unauthenticated / forbidden (project convention)
 		return true
 	}
-	m := strings.ToLower(msg)
-	for _, kw := range authErrorKeywords {
-		if strings.Contains(m, kw) {
-			return true
-		}
-	}
-	return false
-}
-
-// authErrorKeywords are message substrings that unambiguously indicate an auth
-// rejection. Kept specific to avoid suppressing real findings.
-var authErrorKeywords = []string{
-	"unauth",
-	"authentic",
-	"authoriz",
-	"forbidden",
-	"credential",
-	"permission",
-	"access denied",
-	"not allowed",
-	"invalid token",
-	"missing token",
-	"log in",
-	"login",
+	// The keyword list lives in internal/attack so the A2A rules share it; three
+	// divergent copies is how a secured agent came to be accused of a bypass.
+	return attack.AuthFlavoredMessage(msg)
 }
 
 // dispatchSignal classifies how an unauthenticated probe response proves the

--- a/internal/attack/mcp/jsonrpc_batch_bypass.go
+++ b/internal/attack/mcp/jsonrpc_batch_bypass.go
@@ -187,17 +187,11 @@ func isAuthRejection(resp *attack.Response) bool {
 	if err := json.Unmarshal(resp.Body, &obj); err != nil || obj.Error == nil {
 		return false
 	}
-	// -32001/-32002 are the codes this project uses for unauthenticated/forbidden.
-	if obj.Error.Code == -32001 || obj.Error.Code == -32002 {
-		return true
-	}
-	msg := strings.ToLower(obj.Error.Message)
-	for _, kw := range []string{"unauth", "authentic", "authoriz", "forbidden", "token", "credential", "permission"} {
-		if strings.Contains(msg, kw) {
-			return true
-		}
-	}
-	return false
+	// authFlavoredError is this package's shared predicate. The inline list here
+	// diverged from it, notably by including bare "token", which the canonical list
+	// excludes so a validation message like "unexpected token" cannot pass as an
+	// auth refusal and trigger a bypass attempt against an ungated method.
+	return authFlavoredError(obj.Error.Code, obj.Error.Message)
 }
 
 // isMCPInitialize reports whether a response is a successful MCP initialize result.


### PR DESCRIPTION
Three copies of "does this error message mean the request was refused for auth" existed and had drifted apart.

## The false positive

The A2A copy omitted `authoriz`, `access denied` and `login`. `a2aBatchDispatched` **inverts** the predicate, so an element error it does not recognize counts as proof the dispatcher ran.

Against an agent that refuses the single request with 401 and refuses every batch element with `"Not authorized"`:

```
findings=1
  high / A2A authentication bypassed by JSON-RPC batch wrapping
    evidence: batch [request]: HTTP 200 (processed)
```

The batch was refused. `"Access denied"`, `"Login required"` and `"Invalid token"` all did the same — every one a common way to word a refusal.

## The other direction

The MCP batch copy diverged the opposite way, including bare `"token"` that the canonical list excludes on purpose. A validation message such as `"unexpected token in JSON at position 4"` read as an auth refusal, and since that predicate decides whether a bypass is even *attempted*, it invited a bypass test against an ungated method.

## The fix

The judgement now lives once, in `internal/attack.AuthFlavoredMessage`, and all three sites call it. Numeric codes stay in the MCP package, since A2A defines no auth error code.

## Verification

Four refusal phrasings driven end-to-end through the rule against a secured agent, all now silent. A table test pins both directions of the list, including that bare `"token"` is *not* a refusal.

Non-vacuity checked at both levels: shortening the list back to the old A2A set fails the unit test **and** the end-to-end rule test — the second is the one that matters, since a unit test on the predicate alone would not have caught the wiring.

Fixture sweep against the previous build: no finding and no skip changed anywhere.
