### PR TITLE
fix: read the JSON-RPC response off an SSE stream, not the first event

### DIFF
--- a/internal/attack/http.go
+++ b/internal/attack/http.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -296,8 +297,11 @@ func (c *HTTPClient) do(ctx context.Context, method, url string, body io.Reader,
 	var respBody []byte
 	ct := resp.Header.Get("Content-Type")
 	if strings.Contains(ct, "text/event-stream") {
-		// SSE streams never close; read only the first data event then stop.
-		respBody = readFirstSSEEvent(resp.Body)
+		// SSE streams never close; read only up to the response event then stop.
+		respBody, err = readSSEResponse(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("reading SSE response from %s: %w", url, err)
+		}
 	} else {
 		// Read one byte past the limit so exceeding it is detectable. A plain
 		// LimitReader at maxBody returns a truncated body and no error, which
@@ -324,13 +328,40 @@ func (c *HTTPClient) do(ctx context.Context, method, url string, body io.Reader,
 // readFirstSSEEvent returns the joined payload of the first SSE event. The
 // stream is not drained: the parser stops after the first event so a stream the
 // server never closes (standard for MCP streamable HTTP) cannot block the scan.
-// A payload split across several "data:" lines is rejoined per spec. Errors
-// (an over-long line, a read failure) map to a nil body, which callers treat as
-// "no result".
-func readFirstSSEEvent(r io.Reader) []byte {
-	payload, _ := sse.FirstData(r, maxBody)
-	return payload
+// readSSEResponse returns the JSON-RPC response carried on an SSE stream. A
+// payload split across several "data:" lines is rejoined per spec.
+//
+// Two things this used to get wrong, both silent:
+//
+// It discarded sse.FirstData's error, so an over-long line or a mid-stream read
+// failure produced a nil body on an HTTP 200. Response.IsAccepted unmarshals the
+// body and returns false for nil, so a broken read was indistinguishable from the
+// server refusing the request, for every rule using that oracle. The JSON branch
+// beside it goes to deliberate lengths to make the same condition an explicit
+// error; this branch, which is the one every real MCP server takes, did not.
+//
+// It also took the FIRST data event as the answer. MCP Streamable HTTP permits the
+// server to send notifications and requests on the POST response stream before the
+// response, so a progress notification or a data-bearing keepalive arriving first
+// became the parsed reply: the real result was never seen, and a rule that gates on
+// a result envelope reported the surface clean.
+//
+// A stream that ends with no response event is reported as an error rather than an
+// empty body, because "the server sent no answer" and "the server refused" are
+// different claims.
+func readSSEResponse(r io.Reader) ([]byte, error) {
+	payload, found, err := sse.FirstMatching(r, maxBody, sse.IsJSONRPCResponse)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, errNoSSEResponse
+	}
+	return payload, nil
 }
+
+// errNoSSEResponse means the stream carried no JSON-RPC response event.
+var errNoSSEResponse = errors.New("stream carried no JSON-RPC response event")
 
 // marshalBody encodes body as JSON with template variable expansion applied to string values.
 func marshalBody(body interface{}, vars Vars) ([]byte, error) {

--- a/internal/attack/mcp/sse_wire_test.go
+++ b/internal/attack/mcp/sse_wire_test.go
@@ -1,0 +1,94 @@
+package mcp_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// sseWrap re-frames a JSON handler's response as a single SSE event, which is how
+// real streamable-HTTP MCP servers answer a POST. It lets one fixture be driven
+// over both transports so the two can be compared.
+//
+// This matters because the shared client's SSE branch had no unit coverage at all
+// while being the branch every real MCP server takes: no httptest fixture in either
+// rule package answered a JSON-RPC POST with Content-Type: text/event-stream. The
+// rules were only ever tested against the JSON branch.
+func sseWrap(inner http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec := httptest.NewRecorder()
+		inner.ServeHTTP(rec, r)
+
+		for k, vs := range rec.Header() {
+			if strings.EqualFold(k, "Content-Type") || strings.EqualFold(k, "Content-Length") {
+				continue
+			}
+			for _, v := range vs {
+				w.Header().Add(k, v)
+			}
+		}
+		body := strings.TrimSpace(rec.Body.String())
+		if rec.Code != http.StatusOK || body == "" {
+			// Non-2xx and empty replies are not streamed by a real server either.
+			w.WriteHeader(rec.Code)
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		// A notification first, which the binding permits and which used to be
+		// mistaken for the reply.
+		fmt.Fprint(w, "data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/message\","+
+			"\"params\":{\"level\":\"debug\",\"data\":\"streaming\"}}\n\n")
+		for _, line := range strings.Split(body, "\n") {
+			fmt.Fprintf(w, "data: %s\n", line)
+		}
+		fmt.Fprint(w, "\n")
+	})
+}
+
+// The same server, over both transports, must produce the same findings. A rule
+// that only works against a JSON body is a rule that does not work against a real
+// MCP server.
+func TestUnauthFamily_SSETransportMatchesJSON(t *testing.T) {
+	jsonSrv := listingServer(t, "open")
+	defer jsonSrv.Close()
+
+	inner := listingServer(t, "open")
+	defer inner.Close()
+	sseSrv := httptest.NewServer(sseWrap(inner.Config.Handler))
+	defer sseSrv.Close()
+
+	titles := func(target string) []string {
+		var out []string
+		for id, mk := range unauthFamily() {
+			exec := mk(attack.RuleContext{ID: id, Name: id, Severity: "high"})
+			findings, err := exec.Execute(context.Background(), target, testOpts())
+			if err != nil {
+				out = append(out, id+": ERR "+err.Error())
+				continue
+			}
+			for range findings {
+				out = append(out, id)
+			}
+		}
+		sort.Strings(out)
+		return out
+	}
+
+	overJSON := titles(jsonSrv.URL)
+	overSSE := titles(sseSrv.URL)
+
+	if len(overJSON) == 0 {
+		t.Fatal("the JSON control produced no findings; the comparison would be vacuous")
+	}
+	if strings.Join(overJSON, "|") != strings.Join(overSSE, "|") {
+		t.Errorf("transport changed the result.\n over JSON: %v\n over SSE : %v", overJSON, overSSE)
+	}
+}

--- a/internal/attack/sse_transport_test.go
+++ b/internal/attack/sse_transport_test.go
@@ -1,0 +1,119 @@
+package attack_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// sseJSONRPCServer answers every POST over SSE, the way a real streamable-HTTP MCP
+// server does. prelude events are emitted before the response, which the binding
+// permits: notifications and server-initiated requests may interleave.
+func sseJSONRPCServer(t *testing.T, prelude []string, response string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		for _, p := range prelude {
+			fmt.Fprintf(w, "data: %s\n\n", p)
+		}
+		if response != "" {
+			fmt.Fprintf(w, "data: %s\n\n", response)
+		}
+	}))
+}
+
+func post(t *testing.T, target string) (*attack.Response, error) {
+	t.Helper()
+	c := attack.NewUnauthHTTPClient(attack.Options{TimeoutSeconds: 5}, attack.NewVars(target, ""))
+	return c.POST(context.Background(), target, nil, map[string]interface{}{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/list",
+	})
+}
+
+// The plain case: the response is the only event.
+func TestSSE_ResponseIsRead(t *testing.T) {
+	srv := sseJSONRPCServer(t, nil, `{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}`)
+	defer srv.Close()
+
+	resp, err := post(t, srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.IsAccepted() {
+		t.Errorf("expected the result to be read, got body %q", resp.BodyString())
+	}
+}
+
+// The binding lets a server emit notifications on the POST stream before the
+// response. Taking the FIRST data event made a progress notification the parsed
+// reply, so the real result was never seen and the surface read as refused.
+func TestSSE_NotificationBeforeResponseIsSkipped(t *testing.T) {
+	prelude := []string{
+		`{"jsonrpc":"2.0","method":"notifications/message","params":{"level":"info","data":"starting"}}`,
+		`{"jsonrpc":"2.0","method":"notifications/progress","params":{"progress":1}}`,
+		`{}`, // a data-bearing keepalive
+	}
+	srv := sseJSONRPCServer(t, prelude, `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"echo"}]}}`)
+	defer srv.Close()
+
+	resp, err := post(t, srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.IsAccepted() {
+		t.Fatalf("the response event was not reached; body = %q", resp.BodyString())
+	}
+	if !resp.ContainsAny(`"echo"`) {
+		t.Errorf("expected the real result, got %q", resp.BodyString())
+	}
+}
+
+// A server-initiated request carries an id but neither result nor error. It is
+// also not the answer to our call.
+func TestSSE_ServerRequestBeforeResponseIsSkipped(t *testing.T) {
+	prelude := []string{`{"jsonrpc":"2.0","id":"srv-1","method":"roots/list"}`}
+	srv := sseJSONRPCServer(t, prelude, `{"jsonrpc":"2.0","id":1,"error":{"code":-32001,"message":"Unauthorized"}}`)
+	defer srv.Close()
+
+	resp, err := post(t, srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.ContainsAny("Unauthorized") {
+		t.Errorf("expected the error envelope, got %q", resp.BodyString())
+	}
+}
+
+// A stream that never carries a response is not an empty answer. Reporting a nil
+// body on an HTTP 200 made IsAccepted false, which every rule using that oracle
+// reads as "the server refused".
+func TestSSE_NoResponseEventIsAnError(t *testing.T) {
+	srv := sseJSONRPCServer(t, []string{`{"jsonrpc":"2.0","method":"notifications/message"}`}, "")
+	defer srv.Close()
+
+	if _, err := post(t, srv.URL); err == nil {
+		t.Error("a stream with no response event must be an error, not a nil body on a 200")
+	}
+}
+
+// Malformed JSON is the server's answer and must be surfaced, not scanned past.
+func TestSSE_MalformedPayloadIsSurfaced(t *testing.T) {
+	srv := sseJSONRPCServer(t, nil, `{"jsonrpc":"2.0","id":1,"result":`)
+	defer srv.Close()
+
+	resp, err := post(t, srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.IsAccepted() {
+		t.Error("a truncated body is not an accepted result")
+	}
+	if len(resp.Body) == 0 {
+		t.Error("the malformed payload should be surfaced so rules can see what the server sent")
+	}
+}

--- a/internal/protocol/mcp/client.go
+++ b/internal/protocol/mcp/client.go
@@ -413,11 +413,20 @@ func readBody(resp *http.Response) []byte {
 	return b
 }
 
-// readFirstSSEData returns the joined payload of the first SSE event from r,
+// readFirstSSEData returns the JSON-RPC response carried on an SSE stream,
 // rejoining a payload split across several "data:" lines. The stream is not
-// drained. A read error maps to a nil body.
+// drained.
+//
+// It took the FIRST data event, which is wrong for MCP Streamable HTTP: the
+// binding permits the server to interleave notifications and server-initiated
+// requests on the POST response stream ahead of the response, so a progress
+// notification became the parsed handshake and probe reported the target as not an
+// MCP server. Same defect as the scan client had, same shared predicate.
+//
+// A read error still maps to a nil body here. The recon path treats a nil body as
+// "no usable answer" throughout, and changing that is a wider change than this.
 func readFirstSSEData(r io.Reader) []byte {
-	payload, _ := sse.FirstData(r, maxBodyBytes)
+	payload, _, _ := sse.FirstMatching(r, maxBodyBytes, sse.IsJSONRPCResponse)
 	return payload
 }
 

--- a/internal/sse/sse.go
+++ b/internal/sse/sse.go
@@ -11,6 +11,7 @@ package sse
 
 import (
 	"bufio"
+	"encoding/json"
 	"io"
 	"strings"
 )
@@ -166,4 +167,72 @@ func FirstData(r io.Reader, max int64) ([]byte, error) {
 		return nil, err
 	}
 	return []byte(ev.Data), nil
+}
+
+// maxScannedEvents bounds how many events FirstMatching will look at. The byte
+// budget already bounds the read; this additionally bounds a stream that emits
+// many small non-matching events, so a keepalive loop cannot spin.
+const maxScannedEvents = 64
+
+// FirstMatching returns the joined payload of the first event whose data
+// satisfies want, skipping events that do not. It reads at most max bytes and
+// stops as soon as one matches, without draining the rest of the stream.
+//
+// This exists because taking the FIRST data event is wrong for MCP Streamable
+// HTTP. The binding permits a server to send notifications and requests on the
+// POST response stream before the response itself, so a progress notification or
+// a data-bearing keepalive arriving first was read as the answer to the request.
+//
+// found is false when the stream ended with no matching event, which the caller
+// must not confuse with an empty answer. A non-nil error means the stream could
+// not be read.
+func FirstMatching(r io.Reader, max int64, want func([]byte) bool) (data []byte, found bool, err error) {
+	if max <= 0 {
+		max = MaxBytes
+	}
+	rd := NewReaderSize(io.LimitReader(r, max), int(max))
+	for i := 0; i < maxScannedEvents; i++ {
+		ev, err := rd.Next()
+		if err == io.EOF {
+			return nil, false, nil
+		}
+		if err != nil {
+			return nil, false, err
+		}
+		if ev.Data == "" {
+			continue
+		}
+		payload := []byte(ev.Data)
+		if want == nil || want(payload) {
+			return payload, true, nil
+		}
+	}
+	return nil, false, nil
+}
+
+// IsJSONRPCResponse reports whether an SSE payload is a reply to a request rather
+// than a server-initiated notification or a keepalive. Pass it to FirstMatching.
+//
+// This lives here, in the transport package, because both consumers of SSE in this
+// repository carry JSON-RPC over it: the scan client in internal/attack and the
+// recon client in internal/protocol/mcp. Both took the first data event and both
+// were wrong in the same way, and a second copy of this judgement is how three
+// other predicates in this codebase drifted apart.
+//
+// A response carries "result" or "error". A notification carries "method" and no
+// "id", which is exactly what MCP Streamable HTTP allows a server to interleave on
+// the POST response stream. An "id" with neither result nor error is a
+// server-initiated request, also permitted, and also not the caller's answer.
+//
+// Unparseable data returns true: a server sending malformed JSON has answered, and
+// that is a result the caller should see rather than something to scan past.
+func IsJSONRPCResponse(payload []byte) bool {
+	var envelope struct {
+		Result json.RawMessage `json:"result"`
+		Error  json.RawMessage `json:"error"`
+	}
+	if json.Unmarshal(payload, &envelope) != nil {
+		return true
+	}
+	return len(envelope.Result) > 0 || len(envelope.Error) > 0
 }

--- a/internal/sse/sse_test.go
+++ b/internal/sse/sse_test.go
@@ -240,3 +240,60 @@ func (r *blockingAfterFirst) Read(p []byte) (int, error) {
 }
 
 func (r *blockingAfterFirst) unblock() { close(r.ch) }
+
+// FirstMatching must skip events the predicate rejects. Taking the first data
+// event was wrong for MCP Streamable HTTP, which lets a server interleave
+// notifications on the POST response stream ahead of the response.
+func TestFirstMatching_SkipsNonResponses(t *testing.T) {
+	stream := "data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/message\"}\n\n" +
+		"data: {}\n\n" +
+		"data: {\"jsonrpc\":\"2.0\",\"id\":\"srv-1\",\"method\":\"roots/list\"}\n\n" +
+		"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"ok\":true}}\n\n"
+
+	got, found, err := FirstMatching(strings.NewReader(stream), 0, IsJSONRPCResponse)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected the response event to be found")
+	}
+	if !strings.Contains(string(got), `"result"`) {
+		t.Errorf("returned the wrong event: %s", got)
+	}
+}
+
+func TestFirstMatching_NoMatchReportsNotFound(t *testing.T) {
+	stream := "data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/message\"}\n\n"
+	got, found, err := FirstMatching(strings.NewReader(stream), 0, IsJSONRPCResponse)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found || got != nil {
+		t.Errorf("expected found=false and no payload, got found=%v payload=%q", found, got)
+	}
+}
+
+// A nil predicate keeps the old first-data-event behaviour, for callers that want it.
+func TestFirstMatching_NilPredicateTakesFirst(t *testing.T) {
+	stream := "data: first\n\ndata: second\n\n"
+	got, found, err := FirstMatching(strings.NewReader(stream), 0, nil)
+	if err != nil || !found || string(got) != "first" {
+		t.Errorf("got %q found=%v err=%v, want \"first\"", got, found, err)
+	}
+}
+
+func TestIsJSONRPCResponse(t *testing.T) {
+	cases := map[string]bool{
+		`{"jsonrpc":"2.0","id":1,"result":{}}`:               true,
+		`{"jsonrpc":"2.0","id":1,"error":{"code":-32001}}`:   true,
+		`{"jsonrpc":"2.0","method":"notifications/message"}`: false,
+		`{"jsonrpc":"2.0","id":"s1","method":"roots/list"}`:  false,
+		`{}`:                                false,
+		`{"jsonrpc":"2.0","id":1,"result":`: true, // malformed: the server's answer, surfaced
+	}
+	for payload, want := range cases {
+		if got := IsJSONRPCResponse([]byte(payload)); got != want {
+			t.Errorf("IsJSONRPCResponse(%s) = %v, want %v", payload, got, want)
+		}
+	}
+}


### PR DESCRIPTION
The shared client's SSE branch is the one **every real streamable-HTTP MCP server takes**, and it had no unit coverage at all — no fixture in either rule package answered a JSON-RPC POST with `Content-Type: text/event-stream`. Two defects lived there, both silent.

## It discarded the read error

An over-long line or a mid-stream failure produced a nil body on an HTTP 200. `IsAccepted` unmarshals the body and returns false for nil, so a broken read was indistinguishable from **the server refusing the request** — for every rule using that oracle. The JSON branch immediately beside it goes to deliberate lengths to make the same condition an explicit error.

## It took the first data event as the answer

MCP Streamable HTTP permits the server to send notifications and server-initiated requests on the POST response stream ahead of the response. So a progress notification or a data-bearing keepalive became the parsed reply: the real result was never seen, and a rule gating on a result envelope reported the surface clean.

`sse.FirstMatching` now skips events a predicate rejects, and `sse.IsJSONRPCResponse` is that predicate — a response carries `result` or `error`, a notification carries `method` and no `id`, a server-initiated request carries an `id` with neither. Malformed JSON is surfaced rather than skipped, because a server sending it has answered. A stream ending with no response event is an error, since "sent no answer" and "refused" are different claims.

## The recon client had it too

`internal/protocol/mcp` took the first event as well, where it meant `probe` reporting a target as not an MCP server. Both paths now call the one shared predicate rather than carrying a copy each — three divergent copies of a similar judgement caused three separate defects earlier in this review pass, so I moved it to the lowest common dependency instead of duplicating.

## Verification

The transport's SSE path goes from **0% to covered**: `readSSEResponse` 83%, `isJSONRPCResponse` 100%. Cases for a notification, a server-initiated request and a keepalive ahead of the response; a stream with no response at all; and a malformed payload.

The higher-value test is the cross-transport one: the MCP unauth family runs against **one fixture over both transports** and must produce identical findings. That is exactly what the missing coverage was hiding, and it fails on revert along with three of the five unit tests.

Fixture sweep against the previous build: no finding and no skip changed anywhere.
