### PR TITLE
fix(mcp): stop inferring a refusal from a probe that did not answer

### DIFF
--- a/internal/attack/mcp/dispatch.go
+++ b/internal/attack/mcp/dispatch.go
@@ -136,3 +136,50 @@ func classifyDispatch(body map[string]interface{}) (dispatchSignal, int) {
 	}
 	return dispatchNone, 0
 }
+
+// accessVerdict is what an unauthenticated probe established about a surface.
+type accessVerdict int
+
+const (
+	// accessUndetermined: the server did not say. A transport failure, a bare 202,
+	// a 429, a 502, an unparseable body. Nothing about authorization follows.
+	accessUndetermined accessVerdict = iota
+	// accessGranted: answered with a JSON-RPC result, so no gate stopped the call.
+	accessGranted
+	// accessRefused: an auth status, or a JSON-RPC error envelope. The server said no.
+	accessRefused
+)
+
+// classifyAccess grades an unauthenticated probe as granted, refused, or neither.
+//
+// The rules that compare two probes to each other need this three-way split, and
+// deriving "refused" from the absence of acceptance is what made them fabricate
+// findings. era_downgrade set granted = resp.IsAccepted() and treated everything
+// else as a refusal, so a dual-era server that delivers POST responses over the GET
+// stream and answers with a bare 202 Accepted on the legacy wire, which the
+// transport permits, looked like a wire that refused an unauthenticated call while
+// the stateless wire answered inline. That is a critical/ConfirmedExploit
+// "authorization enforced on the legacy wire but not the modern wire" against a
+// server enforcing nothing, and a 429 from a rate limiter or a one-off 502
+// produced the same report.
+//
+// A comparison rule must treat accessUndetermined as "no comparison available"
+// rather than folding it into either side.
+func classifyAccess(resp *attack.Response, err error) accessVerdict {
+	if err != nil || resp == nil {
+		return accessUndetermined
+	}
+	if resp.IsAccepted() {
+		return accessGranted
+	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return accessRefused
+	}
+	var body map[string]interface{}
+	if json.Unmarshal(resp.Body, &body) == nil && body != nil {
+		if _, hasErr := body["error"]; hasErr {
+			return accessRefused
+		}
+	}
+	return accessUndetermined
+}

--- a/internal/attack/mcp/era_downgrade.go
+++ b/internal/attack/mcp/era_downgrade.go
@@ -62,21 +62,31 @@ func (e *EraDowngradeExecutor) Execute(ctx context.Context, target string, opts 
 	legacyOutcome := e.probeList(ctx, client, *legacy)
 	modernOutcome := e.probeList(ctx, client, *modern)
 	if legacyOutcome.method == "" || modernOutcome.method == "" {
-		// Neither wire advertised a listable capability, so there is nothing whose
-		// gating could be compared.
+		// A wire advertising nothing listable leaves nothing whose gating could be
+		// compared, and that is a genuine not-applicable.
 		return nil, nil
+	}
+	if !legacyOutcome.comparable() || !modernOutcome.comparable() {
+		// One wire did not answer: a transport failure, a bare 202, a 429, a 502.
+		// The comparison is unavailable, and calling the silent wire "refused" is
+		// how this rule fabricated a critical against a server gating nothing.
+		return nil, fmt.Errorf("%w: the %s wire answered %s with HTTP %d, which is "+
+			"neither a result nor a refusal, so the two wires' gating could not be compared",
+			attack.ErrInconclusive, undeterminedEra(legacyOutcome, modernOutcome),
+			undeterminedMethod(legacyOutcome, modernOutcome),
+			undeterminedStatus(legacyOutcome, modernOutcome))
 	}
 
 	// Both granted means the server gates nothing, which is
 	// mcp-resources-unauth-001 and mcp-tools-unauth-001 territory rather than a
 	// difference between wires. Both refused is the secure outcome. Either way
 	// there is no asymmetry to report.
-	if legacyOutcome.granted == modernOutcome.granted {
+	if legacyOutcome.granted() == modernOutcome.granted() {
 		return nil, nil
 	}
 
 	open, closed := legacyOutcome, modernOutcome
-	if modernOutcome.granted {
+	if modernOutcome.granted() {
 		open, closed = modernOutcome, legacyOutcome
 	}
 	return []attack.Finding{e.finding(*legacy, open, closed)}, nil
@@ -88,9 +98,18 @@ type listOutcome struct {
 	method string // "" when the wire advertised nothing listable
 	status int
 	body   string
-	// granted is true when the call was answered with a JSON-RPC result rather
-	// than refused, which for an unauthenticated probe means no gate stopped it.
-	granted bool
+	// verdict is what the probe established: granted, refused, or neither. It used
+	// to be a bool derived from IsAccepted, which made every non-answer a refusal.
+	verdict accessVerdict
+}
+
+// granted reports whether the wire answered the unauthenticated call.
+func (o listOutcome) granted() bool { return o.verdict == accessGranted }
+
+// comparable reports whether this outcome can take part in a wire comparison. An
+// undetermined probe cannot: it says nothing about authorization.
+func (o listOutcome) comparable() bool {
+	return o.method != "" && o.verdict != accessUndetermined
 }
 
 // probeList asks one wire for a listing, choosing a method that wire advertises.
@@ -119,16 +138,17 @@ func (e *EraDowngradeExecutor) probeList(ctx context.Context, client *attack.HTT
 	}
 
 	resp, err := session.post(ctx, client, 2, out.method, nil)
+	out.verdict = classifyAccess(resp, err)
 	if err != nil {
-		// A transport failure is not a refusal, and treating it as one would invent
-		// an asymmetry out of a dropped connection. Leaving method set with granted
-		// false would do exactly that, so the outcome is blanked.
-		out.method = ""
+		// A transport failure is not a refusal. The method stays set so the caller
+		// can distinguish "this wire did not answer" from "this wire advertised
+		// nothing listable"; comparable() excludes it from the comparison either way.
+		// Blanking the method conflated the two, and Execute then reported clean
+		// under a comment claiming neither wire advertised a listable capability.
 		return out
 	}
 	out.status = resp.StatusCode
 	out.body = resp.BodyString()
-	out.granted = resp.IsAccepted()
 	return out
 }
 
@@ -154,4 +174,26 @@ func (e *EraDowngradeExecutor) finding(session mcpSession, open, closed listOutc
 		Remediation: e.rule.Remediation,
 		TargetURL:   session.Endpoint,
 	}
+}
+
+// undeterminedEra names the wire that did not answer, for the inconclusive reason.
+func undeterminedEra(legacy, modern listOutcome) Era {
+	if !legacy.comparable() {
+		return legacy.era
+	}
+	return modern.era
+}
+
+func undeterminedMethod(legacy, modern listOutcome) string {
+	if !legacy.comparable() {
+		return legacy.method
+	}
+	return modern.method
+}
+
+func undeterminedStatus(legacy, modern listOutcome) int {
+	if !legacy.comparable() {
+		return legacy.status
+	}
+	return modern.status
 }

--- a/internal/attack/mcp/fabrication_test.go
+++ b/internal/attack/mcp/fabrication_test.go
@@ -1,0 +1,171 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+// dualEraServer serves both wires. legacyList controls how the LEGACY wire answers
+// tools/list; the modern wire always answers with a result. Nothing is ever
+// authorization-checked, so no wire-gating asymmetry exists to report.
+func dualEraServer(t *testing.T, legacyList func(w http.ResponseWriter)) *httptest.Server {
+	t.Helper()
+	caps := map[string]interface{}{"tools": map[string]interface{}{}}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		method, _ := req["method"].(string)
+		id := req["id"]
+		modern := r.Header.Get("Mcp-Protocol-Version") == "2026-07-28" ||
+			strings.Contains(r.Header.Get("Mcp-Method"), "server/discover") ||
+			method == "server/discover"
+		w.Header().Set("Content-Type", "application/json")
+		result := func(v interface{}) {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id, "result": v})
+		}
+
+		switch method {
+		case "server/discover":
+			result(map[string]interface{}{
+				"supportedVersions": []string{"2025-06-18", "2026-07-28"},
+				"capabilities":      caps,
+				"serverInfo":        map[string]interface{}{"name": "dual", "version": "1"},
+			})
+		case "initialize":
+			w.Header().Set("Mcp-Session-Id", "dual-session")
+			result(map[string]interface{}{
+				"protocolVersion": "2025-06-18",
+				"serverInfo":      map[string]interface{}{"name": "dual", "version": "1"},
+				"capabilities":    caps,
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			if modern {
+				result(map[string]interface{}{"tools": []interface{}{map[string]interface{}{"name": "echo"}}})
+				return
+			}
+			legacyList(w)
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": -32601, "message": "Method not found"}})
+		}
+	}))
+}
+
+// A bare 202 is permitted on the legacy wire: the transport lets a server deliver
+// the POST response over the GET stream instead. It is not a refusal.
+//
+// granted was derived from IsAccepted and everything else counted as refused, so
+// this looked like a wire that gated an unauthenticated call while the stateless
+// wire answered it, and the rule emitted critical/ConfirmedExploit "authorization
+// enforced on the legacy wire but not the modern wire" against a server that
+// enforces nothing at all.
+func TestEraDowngrade_UndeterminedWireIsNotARefusal(t *testing.T) {
+	cases := map[string]func(w http.ResponseWriter){
+		"bare 202 accepted":  func(w http.ResponseWriter) { w.WriteHeader(http.StatusAccepted) },
+		"429 from a limiter": func(w http.ResponseWriter) { w.WriteHeader(http.StatusTooManyRequests) },
+		"502 from a gateway": func(w http.ResponseWriter) { w.WriteHeader(http.StatusBadGateway) },
+	}
+	for name, legacyList := range cases {
+		t.Run(name, func(t *testing.T) {
+			srv := dualEraServer(t, legacyList)
+			defer srv.Close()
+
+			exec := mcpattack.NewEraDowngradeExecutor(attack.RuleContext{ID: "mcp-era-downgrade-001"})
+			findings, err := exec.Execute(context.Background(), srv.URL, testOpts())
+			if len(findings) > 0 {
+				t.Errorf("FABRICATED: %s is not a refusal, got %q", name, findings[0].Title)
+			}
+			if !errors.Is(err, attack.ErrInconclusive) {
+				t.Errorf("a wire that did not answer must be inconclusive, got err=%v", err)
+			}
+		})
+	}
+}
+
+// hbsServer serves one legacy wire whose tools/list answers per the shape function,
+// so the header-presence probe can be driven independently of the others.
+func hbsServer(t *testing.T, list func(w http.ResponseWriter, hasMethodHeader bool)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		method, _ := req["method"].(string)
+		id := req["id"]
+		w.Header().Set("Content-Type", "application/json")
+		switch method {
+		case "initialize":
+			w.Header().Set("Mcp-Session-Id", "hbs")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{
+					"protocolVersion": "2025-06-18",
+					"serverInfo":      map[string]interface{}{"name": "hbs", "version": "1"},
+					"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+				}})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			list(w, r.Header.Get("Mcp-Method") != "")
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": -32601, "message": "Method not found"}})
+		}
+	}))
+}
+
+// A legacy server has no Mcp-Method requirement, so probes 2 and 3 succeed by
+// construction. One transient failure of probe 1 was read as "presence enforced"
+// and carried the rule all the way to a high/ConfirmedExploit finding asserting a
+// requirement the server does not have.
+func TestHeaderBodySplit_TransientProbeIsNotEnforcement(t *testing.T) {
+	first := true
+	srv := hbsServer(t, func(w http.ResponseWriter, hasMethodHeader bool) {
+		if first {
+			first = false
+			w.WriteHeader(http.StatusBadGateway) // probe 1 fails transiently
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": 2,
+			"result": map[string]interface{}{"tools": []interface{}{}}})
+	})
+	defer srv.Close()
+
+	exec := mcpattack.NewHeaderBodySplitExecutor(attack.RuleContext{ID: "mcp-header-body-split-001"})
+	findings, err := exec.Execute(context.Background(), srv.URL, testOpts())
+	if len(findings) > 0 {
+		t.Errorf("FABRICATED: a 502 on probe 1 is not proof of header-presence enforcement, got %q",
+			findings[0].Title)
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Errorf("expected inconclusive after an undetermined presence probe, got err=%v", err)
+	}
+}
+
+// tools/list gated behind credentials means the mismatch can never be sent, so the
+// SEP-2243 surface was never examined. This used to report clean.
+func TestHeaderBodySplit_GatedToolsListIsNotClean(t *testing.T) {
+	srv := hbsServer(t, func(w http.ResponseWriter, hasMethodHeader bool) {
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, `{"jsonrpc":"2.0","id":2,"error":{"code":-32001,"message":"Unauthorized"}}`)
+	})
+	defer srv.Close()
+
+	exec := mcpattack.NewHeaderBodySplitExecutor(attack.RuleContext{ID: "mcp-header-body-split-001"})
+	findings, err := exec.Execute(context.Background(), srv.URL, testOpts())
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Errorf("a mismatch that was never sent is not a clean result, got err=%v", err)
+	}
+}

--- a/internal/attack/mcp/header_body_split.go
+++ b/internal/attack/mcp/header_body_split.go
@@ -39,16 +39,20 @@ func (e *HeaderBodySplitExecutor) Execute(ctx context.Context, target string, op
 	// version that wire speaks. A wire that does enforce presence is tested on its
 	// merits and never sets this.
 	unawareAt := ""
+	blockedReason := ""
 	anyTested := false
 	var findings []attack.Finding
 	for _, session := range sessions {
-		f, unaware, tested := e.probe(ctx, client, session)
+		f, unaware, tested, blocked := e.probe(ctx, client, session)
 		findings = append(findings, labelEra(session, f)...)
 		if unaware != "" {
 			unawareAt = unaware
 		}
 		if tested {
 			anyTested = true
+		}
+		if blocked != "" && blockedReason == "" {
+			blockedReason = blocked
 		}
 	}
 	if len(findings) > 0 {
@@ -78,6 +82,14 @@ func (e *HeaderBodySplitExecutor) Execute(ctx context.Context, target string, op
 		return nil, fmt.Errorf("%w: no SEP-2243 surface at MCP %s; Mcp-Method validation was introduced in %s",
 			attack.ErrInconclusive, unawareAt, headerValidationVersion)
 	}
+	// A run that could not reach the mismatch probe has not shown the header/body
+	// surface to be sound. This used to fall through to clean, so any server whose
+	// tools/list is credential-gated, or which answers -32601 because it exposes no
+	// tools, had its SEP-2243 handling reported as fine without a single mismatch
+	// being sent.
+	if blockedReason != "" {
+		return nil, fmt.Errorf("%w: %s", attack.ErrInconclusive, blockedReason)
+	}
 	return nil, nil
 }
 
@@ -91,26 +103,35 @@ const headerValidationVersion = modernEraVersion
 // carries the version that wire speaks. tested says whether the mismatch was
 // actually driven, which is what separates a clean result from one where the rule
 // never got far enough to judge.
-func (e *HeaderBodySplitExecutor) probe(ctx context.Context, client *attack.HTTPClient, session mcpSession) (findings []attack.Finding, unawareAt string, tested bool) {
+func (e *HeaderBodySplitExecutor) probe(ctx context.Context, client *attack.HTTPClient, session mcpSession) (findings []attack.Finding, unawareAt string, tested bool, blocked string) {
 	wireVersion := session.ProtocolVersion
 
-	// Probe 1: omit Mcp-Method. If the server still executes tools/list, it does
-	// not enforce header presence (not SEP-2243-aware) - nothing to confirm.
-	if e.toolsList(ctx, client, session, omitMethodHeader) {
-		return nil, wireVersion, false
+	// Probe 1: omit Mcp-Method. Executing tools/list anyway means the server does
+	// not enforce header presence (not SEP-2243-aware) and there is nothing to
+	// confirm. Only an explicit REFUSAL establishes that presence is enforced; a
+	// probe that merely failed to answer establishes nothing, so the rule stops
+	// rather than treating it as enforcement.
+	switch e.toolsList(ctx, client, session, omitMethodHeader) {
+	case accessGranted:
+		return nil, wireVersion, false, ""
+	case accessUndetermined:
+		return nil, "", false, "the tools/list probe with no Mcp-Method header " +
+			"returned neither a result nor a refusal, so whether the server enforces " +
+			"header presence could not be established"
 	}
 
 	// Probe 2: matching Mcp-Method. Must be accepted, otherwise we cannot drive
 	// the mismatch test (the endpoint may require headers we are not sending).
 	// Presence is enforced by this point, so the rule is testing a server that
 	// implements SEP-2243 whatever version it advertises.
-	if !e.toolsList(ctx, client, session, matchMethodHeader) {
-		return nil, "", false
+	if e.toolsList(ctx, client, session, matchMethodHeader) != accessGranted {
+		return nil, "", false, "tools/list was refused even with a matching Mcp-Method " +
+			"header, so the header/body mismatch could never be sent"
 	}
 
 	// Probe 3: mismatched Mcp-Method. A compliant server MUST reject; if it
 	// executes the body's tools/list, header value is not validated.
-	if e.toolsList(ctx, client, session, mismatchMethodHeader) {
+	if e.toolsList(ctx, client, session, mismatchMethodHeader) == accessGranted {
 		return []attack.Finding{{
 			RuleID:     e.rule.ID,
 			RuleName:   e.rule.Name,
@@ -132,9 +153,9 @@ func (e *HeaderBodySplitExecutor) probe(ctx context.Context, client *attack.HTTP
 				session.Endpoint),
 			Remediation: e.rule.Remediation,
 			TargetURL:   session.Endpoint,
-		}}, "", true
+		}}, "", true, ""
 	}
-	return nil, "", true
+	return nil, "", true, ""
 }
 
 // The two deliberate malformations. Omitting the header tests whether presence is
@@ -151,22 +172,33 @@ func mismatchMethodHeader(h map[string]string) { h["Mcp-Method"] = "tools/call" 
 // toolsList sends a tools/list body. methodHeader controls the Mcp-Method header:
 // nil omits it; otherwise it is set to the given (possibly mismatched) value. It
 // reports whether the server EXECUTED tools/list (returned a result.tools array).
-func (e *HeaderBodySplitExecutor) toolsList(ctx context.Context, client *attack.HTTPClient, session mcpSession, shape func(map[string]string)) bool {
+// toolsList grades one shaped tools/list call.
+//
+// This returned a bool, so a transport failure, a 502, a 429 and an unparseable
+// body were all indistinguishable from the server REFUSING the call. Probe 1's
+// failure is read as "the server enforces Mcp-Method presence", so one transient
+// failure on a legacy server carried the rule into probes 2 and 3, which succeed by
+// construction there because the header means nothing, and it emitted a
+// high/ConfirmedExploit finding asserting presence was enforced on a server with no
+// such requirement.
+func (e *HeaderBodySplitExecutor) toolsList(ctx context.Context, client *attack.HTTPClient, session mcpSession, shape func(map[string]string)) accessVerdict {
 	resp, err := session.postShaping(ctx, client, 2, "tools/list", nil, shape)
-	if err != nil || !resp.IsSuccess() {
-		return false
+	v := classifyAccess(resp, err)
+	if v != accessGranted {
+		return v
 	}
+	// A result envelope that is not a tools listing is not an execution of
+	// tools/list, and nothing follows from it either way.
 	var b map[string]interface{}
 	if json.Unmarshal(resp.Body, &b) != nil {
-		return false
-	}
-	if _, hasErr := b["error"]; hasErr {
-		return false
+		return accessUndetermined
 	}
 	result, ok := b["result"].(map[string]interface{})
 	if !ok {
-		return false
+		return accessUndetermined
 	}
-	_, hasTools := result["tools"]
-	return hasTools
+	if _, hasTools := result["tools"]; !hasTools {
+		return accessUndetermined
+	}
+	return accessGranted
 }


### PR DESCRIPTION
Two rules derived "the server refused" from the absence of acceptance, so a non-answer became evidence of authorization and each fabricated a finding against a server that enforces nothing.

## `era_downgrade`

`granted = resp.IsAccepted()`, everything else treated as a refusal. A dual-era server that delivers POST responses over the GET stream answers the legacy wire with a bare **202 Accepted** — which the transport permits — while the stateless wire must answer inline with a result. That looks like one wire gating an unauthenticated call and the other not:

```
critical / ConfirmedExploit
  "authorization enforced on the legacy wire but not the modern wire"
  evidence: legacy wire: tools/list -> HTTP 202, refused
```

A 429 from a rate limiter or a one-off 502 produced the same report. Its transport-error path also returned clean under a comment stating "neither wire advertised a listable capability" — false whenever the blanking came from a dropped connection.

## `header_body_split`

Probe 1's failure was read as proof the server enforces `Mcp-Method` presence. `toolsList` returned a bool, so a transport error, a 502, a 429 and an unparseable body were indistinguishable from a refusal. On a legacy wire the header means nothing, so probes 2 and 3 then succeed **by construction**, and one transient failure produced high/ConfirmedExploit "enforces Mcp-Method presence but not header/body consistency" about a server with no such requirement.

## The fix

`classifyAccess` grades a probe as granted, refused, or neither — sitting next to `classifyProbe`, which already drew this distinction for the unauth family. A comparison rule now treats an undetermined probe as *no comparison available* rather than folding it into either side.

Also fixed, same rule and same class: `header_body_split` reported **clean** whenever `tools/list` was credential-gated or absent, so any server with gated tools had its SEP-2243 handling called sound without one mismatch being sent. It now reports what blocked it:

```
not tested: tools/list was refused even with a matching Mcp-Method header,
            so the header/body mismatch could never be sent
```

## Verification

Six regression cases: 202, 429 and 502 on one wire for era-downgrade, plus a transient probe-1 failure and a gated `tools/list` for header-body-split. Non-vacuity checked per rule — each fails on its own revert.

Sweep against the previous build: **no finding changed anywhere**, and header-body-split still fires on its own fixture (1 finding before and after). Five fixtures move that rule from clean to not-tested, each because their `tools/list` is absent, gated or failing — precisely the case it could never examine.
