### PR TITLE
fix(mcp): stop reporting OAuth surfaces clean when the probe never happened

### DIFF
--- a/internal/attack/mcp/confused_deputy.go
+++ b/internal/attack/mcp/confused_deputy.go
@@ -66,11 +66,18 @@ func (e *ConfusedDeputyExecutor) Execute(ctx context.Context, target string, opt
 	// Register a client with an off-origin redirect. We use a domain unrelated to
 	// the target's own origin so a server with a redirect allowlist rejects it.
 	registeredRedirect := fmt.Sprintf("https://batesian-%s-registered.invalid/cb", vars.RandID)
-	clientID, dcrEchoedRedirect := registerDCRClient(ctx, unauthClient, regEP, registeredRedirect, vars.RandID)
+	clientID, dcrEchoedRedirect, dcrResult := registerDCRClient(ctx, unauthClient, regEP, registeredRedirect, vars.RandID)
 	if clientID == "" {
-		// Registration was rejected or required auth: cannot drive the authorize
-		// probe, and an enforced-DCR server is correct behaviour. No finding.
-		return nil, nil
+		if dcrResult.redirectRefused {
+			// The allowlist refused our off-origin redirect. That is the mitigation
+			// this rule exists to look for, so a clean result is honest.
+			return nil, nil
+		}
+		// Registration could not be completed for an unrelated reason, so
+		// /authorize was never probed and its redirect validation is unknown.
+		return nil, fmt.Errorf("%w: dynamic client registration at %s issued no client_id (%s), "+
+			"so the authorize endpoint's redirect_uri validation was never probed",
+			attack.ErrInconclusive, regEP, dcrResult.detail)
 	}
 
 	// Authorize with a DIFFERENT, unregistered off-origin redirect.
@@ -144,21 +151,60 @@ func discoverOAuthEndpoints(ctx context.Context, client *attack.HTTPClient, base
 }
 
 // registerDCRClient registers a client via DCR with the given redirect_uri and
-// returns the issued client_id plus whether the response echoed the off-origin
-// redirect back (i.e. DCR accepted an arbitrary external redirect target).
-func registerDCRClient(ctx context.Context, client *attack.HTTPClient, registrationEndpoint, redirectURI, randID string) (clientID string, echoedRedirect bool) {
+// returns the issued client_id, whether the response echoed the off-origin
+// redirect back (i.e. DCR accepted an arbitrary external redirect target), and
+// how the registration itself went.
+//
+// The outcome matters because a refused registration has two very different
+// meanings. A server that refuses to register an off-origin redirect_uri has
+// applied the very mitigation this rule is about: the confused-deputy chain needs
+// an attacker-controlled redirect registered, and the allowlist stopped it at step
+// one, so a clean result is honest. A server whose DCR requires an initial access
+// token (RFC 7591 section 3) and answers 401, or which fails for any unrelated
+// reason, has told us nothing about redirect validation, and reporting that clean
+// grades an endpoint the rule never reached.
+func registerDCRClient(ctx context.Context, client *attack.HTTPClient, registrationEndpoint, redirectURI, randID string) (clientID string, echoedRedirect bool, outcome dcrOutcome) {
 	resp, err := client.POST(ctx, registrationEndpoint, nil, map[string]interface{}{
 		"client_name":    "batesian-cd-" + randID,
 		"redirect_uris":  []string{redirectURI},
 		"grant_types":    []string{"authorization_code"},
 		"response_types": []string{"code"},
 	})
-	if err != nil || (resp.StatusCode != 200 && resp.StatusCode != 201) {
-		return "", false
+	if err != nil {
+		return "", false, dcrOutcome{unavailable: true, detail: "the registration request failed: " + err.Error()}
 	}
-	clientID = resp.JSONField("client_id")
-	echoedRedirect = strings.Contains(resp.BodyString(), redirectURI)
-	return clientID, echoedRedirect
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusCreated:
+		clientID = resp.JSONField("client_id")
+		if clientID == "" {
+			return "", false, dcrOutcome{unavailable: true,
+				detail: fmt.Sprintf("registration returned HTTP %d with no client_id", resp.StatusCode)}
+		}
+		echoedRedirect = strings.Contains(resp.BodyString(), redirectURI)
+		return clientID, echoedRedirect, dcrOutcome{}
+	case http.StatusUnauthorized, http.StatusForbidden:
+		// DCR itself is credential-gated. Nothing about redirect policy follows.
+		return "", false, dcrOutcome{unavailable: true,
+			detail: fmt.Sprintf("registration requires credentials (HTTP %d)", resp.StatusCode)}
+	case http.StatusBadRequest, http.StatusUnprocessableEntity:
+		// A client-error rejection of the registration we sent. This is the
+		// allowlist doing its job, which is the mitigation, not an untested surface.
+		return "", false, dcrOutcome{redirectRefused: true}
+	default:
+		return "", false, dcrOutcome{unavailable: true,
+			detail: fmt.Sprintf("registration answered HTTP %d", resp.StatusCode)}
+	}
+}
+
+// dcrOutcome records why a registration produced no client_id.
+type dcrOutcome struct {
+	// redirectRefused: the server rejected the registration we sent, which for an
+	// off-origin redirect_uri is the mitigation this rule looks for.
+	redirectRefused bool
+	// unavailable: registration could not be completed for reasons unrelated to
+	// redirect policy, so the authorize endpoint was never probed.
+	unavailable bool
+	detail      string
 }
 
 // authorizeRedirectProbe issues a single authorization request with the given

--- a/internal/attack/mcp/oauth_metadata_ssrf.go
+++ b/internal/attack/mcp/oauth_metadata_ssrf.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -107,6 +108,16 @@ func (e *OAuthMetadataSSRFExecutor) Execute(ctx context.Context, target string, 
 			}}, nil
 		}
 		return nil, nil
+	}
+
+	// A registration the server refused means the metadata URLs were never stored,
+	// so no fetch could follow and there is nothing to conclude. The external-OOB
+	// branch above already gates on 200/201; this one did not, so a DCR endpoint
+	// answering 401 or 400 produced a clean "no metadata-fetch SSRF" verdict.
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("%w: the registration at %s was refused with HTTP %d, so the "+
+			"registrant-supplied metadata URLs were never stored and no fetch could occur",
+			attack.ErrInconclusive, registrationEndpoint, resp.StatusCode)
 	}
 
 	// Local OOB: wait for the server to fetch one of the seeded URLs.

--- a/internal/attack/mcp/oauth_untested_test.go
+++ b/internal/attack/mcp/oauth_untested_test.go
@@ -1,0 +1,123 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+// oauthOnlyServer publishes OAuth metadata but mounts its MCP handler nowhere the
+// candidate walk looks. The pre-2025-03-26 HTTP+SSE transport (/sse + /messages) is
+// still widely deployed, and /v1/mcp is a common choice too.
+func oauthOnlyServer(t *testing.T, dcrStatus int) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-protected-resource", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"resource":"http://%s/v1/mcp","authorization_servers":["http://%s"]}`, r.Host, r.Host)
+	})
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"issuer":"http://%s","authorization_endpoint":"http://%s/authorize",`+
+			`"token_endpoint":"http://%s/token","registration_endpoint":"http://%s/register"}`,
+			r.Host, r.Host, r.Host, r.Host)
+	})
+	mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(dcrStatus)
+		if dcrStatus == http.StatusUnauthorized {
+			fmt.Fprint(w, `{"error":"invalid_token","error_description":"initial access token required"}`)
+			return
+		}
+		fmt.Fprint(w, `{"client_id":"c1"}`)
+	})
+	// The MCP handler lives here, which the candidate walk never tries.
+	mux.HandleFunc("/v1/mcp", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": 1,
+			"result": map[string]interface{}{"protocolVersion": "2025-06-18",
+				"serverInfo": map[string]interface{}{"name": "s", "version": "1"}, "capabilities": map[string]interface{}{}}})
+	})
+	return httptest.NewServer(mux)
+}
+
+// token_replay had no endpoint gate at all: it POSTed forged tokens to the
+// candidate paths, treated every 404 as a rejection, and returned clean. So a
+// server whose MCP handler is mounted elsewhere was reported as rejecting alg:none
+// and forged-signature JWTs without one having been examined.
+func TestTokenReplay_NoMCPEndpointIsNotClean(t *testing.T) {
+	srv := oauthOnlyServer(t, http.StatusCreated)
+	defer srv.Close()
+
+	exec := mcpattack.NewTokenReplayExecutor(attack.RuleContext{ID: "mcp-token-replay-001"})
+	findings, err := exec.Execute(context.Background(), srv.URL, testOpts())
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Errorf("no MCP endpoint answered, so no token was examined; want inconclusive, got err=%v", err)
+	}
+}
+
+// A DCR that requires an initial access token says nothing about whether
+// /authorize validates redirect_uri, which is this rule's subject.
+func TestConfusedDeputy_CredentialGatedDCRIsNotClean(t *testing.T) {
+	srv := oauthOnlyServer(t, http.StatusUnauthorized)
+	defer srv.Close()
+
+	exec := mcpattack.NewConfusedDeputyExecutor(attack.RuleContext{ID: "mcp-confused-deputy-001"})
+	findings, err := exec.Execute(context.Background(), srv.URL, testOpts())
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("a credential-gated DCR leaves /authorize unprobed; want inconclusive, got err=%v", err)
+	}
+	if !strings.Contains(err.Error(), "credentials") {
+		t.Errorf("the reason should name the credential requirement, got: %v", err)
+	}
+}
+
+// The mirror case, which must stay clean: refusing to REGISTER an off-origin
+// redirect_uri is the mitigation this rule looks for, since the confused-deputy
+// chain needs that redirect registered. Distinguishing this from the case above is
+// the whole point; an earlier version of this fix reported both as inconclusive and
+// broke the existing dcr-restricted test.
+func TestConfusedDeputy_RedirectRefusedAtRegistrationStaysClean(t *testing.T) {
+	srv := oauthOnlyServer(t, http.StatusBadRequest)
+	defer srv.Close()
+
+	exec := mcpattack.NewConfusedDeputyExecutor(attack.RuleContext{ID: "mcp-confused-deputy-001"})
+	findings, err := exec.Execute(context.Background(), srv.URL, testOpts())
+	if err != nil {
+		t.Fatalf("an allowlist refusing our redirect is a tested, clean result: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected no findings, got %d", len(findings))
+	}
+}
+
+// oauth_metadata_ssrf waited for an OOB callback without checking that the
+// registration carrying the seeded URLs had been accepted, so a DCR answering 401
+// produced a clean "no metadata-fetch SSRF" verdict.
+func TestOAuthMetadataSSRF_RefusedRegistrationIsNotClean(t *testing.T) {
+	srv := oauthOnlyServer(t, http.StatusUnauthorized)
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthMetadataSSRFExecutor(attack.RuleContext{ID: "mcp-oauth-metadata-ssrf-001"})
+	findings, err := exec.Execute(context.Background(), srv.URL, testOpts())
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Errorf("a refused registration stored no URLs, so no fetch could occur; want inconclusive, got err=%v", err)
+	}
+}

--- a/internal/attack/mcp/token_replay.go
+++ b/internal/attack/mcp/token_replay.go
@@ -148,6 +148,14 @@ func (e *TokenReplayExecutor) Execute(ctx context.Context, target string, opts a
 	// Since the OAuth metadata confirmed this is an OAuth-protected MCP server,
 	// we try all standard candidate paths rather than doing an unauthenticated
 	// discover probe (which would fail because the endpoint requires a token).
+	// anyEndpoint records that at least one candidate answered as something other
+	// than an unrouted path. Without it the rule reported clean when every candidate
+	// 404'd: the MCP handler may be mounted at /sse + /messages, or at /v1/mcp,
+	// while the OAuth metadata sits at the root, and then no forged token was ever
+	// examined yet the server was reported as rejecting alg:none and forged
+	// signatures. oauth_audience took this fix in #148 against the same candidate
+	// list and the same init body; this rule did not.
+	anyEndpoint := false
 	var findings []attack.Finding
 	for _, p := range probes {
 		headers := map[string]string{
@@ -158,6 +166,9 @@ func (e *TokenReplayExecutor) Execute(ctx context.Context, target string, opts a
 			resp, err := client.POST(ctx, ep, headers, json.RawMessage(mcpInitBody))
 			if err != nil {
 				continue // Network error is not a finding.
+			}
+			if !endpointAbsent(resp) {
+				anyEndpoint = true
 			}
 			// Acceptance = HTTP 200 with a JSON-RPC result envelope. A 200 that
 			// carries a JSON-RPC error is a protocol-layer rejection of the
@@ -182,6 +193,11 @@ func (e *TokenReplayExecutor) Execute(ctx context.Context, target string, opts a
 		}
 	}
 
+	if len(findings) == 0 && !anyEndpoint {
+		return nil, fmt.Errorf("%w: %s publishes OAuth metadata but no MCP endpoint answered at "+
+			"any candidate path, so no forged token was ever examined",
+			attack.ErrInconclusive, vars.BaseURL)
+	}
 	return findings, nil
 }
 


### PR DESCRIPTION
Three rules in the OAuth family returned a clean result on paths where nothing was examined.

## `token_replay` had no endpoint gate at all

It POSTed forged tokens to the candidate paths, treated every reply that was not an accepted result as a rejection, and returned no error. A server publishing OAuth metadata at the root while mounting its MCP handler somewhere the walk does not look — `/sse` + `/messages` on the pre-2025-03-26 transport, or `/v1/mcp` — had every candidate 404 and was reported as rejecting `alg:none` and forged-signature JWTs without one being examined.

Verified against `testdata/mcp_oauth_dcr_server.py`, where all four candidates 404:

```
/mcp -> 404   / -> 404   /api -> 404   /rpc -> 404

after: not tested: publishes OAuth metadata but no MCP endpoint answered at
       any candidate path, so no forged token was ever examined
```

`oauth_audience` took this fix in #148 against the same candidate list and the same init body; this rule did not.

## `oauth_metadata_ssrf` never checked the registration was accepted

It waited for an OOB callback without confirming that the registration carrying the seeded URLs succeeded, so a DCR answering 401 stored no URLs, produced no fetch, and yielded a clean "no metadata-fetch SSRF" verdict. The external-OOB branch immediately beside it already gated on 200/201.

## `confused_deputy` conflated two different refusals

It returned clean whenever registration issued no `client_id`. Only one of those cases is a clean result:

- **Registration refuses the off-origin `redirect_uri`** → the allowlist is the mitigation this rule looks for, since the confused-deputy chain needs that redirect registered. Clean is honest.
- **DCR requires an initial access token** (RFC 7591 §3) and answers 401 → nothing is known about redirect validation, and `/authorize` was never probed.

That distinction is load-bearing: my first attempt reported both as inconclusive and broke `TestConfusedDeputy_DCRRestricted`, whose premise is correct. Both cases now have their own test so the difference cannot be collapsed again.

## Verification

Four tests, including the mitigation case that must stay clean. Non-vacuity checked per rule — each fails on its own revert. (All three reverts first failed to compile on unused symbols, so I silenced those and re-ran; a revert that does not build proves nothing.)

Sweep against the previous build: **no finding changed anywhere.** Three fixtures move `token_replay` from clean to not-tested, each an OAuth-only fixture with no MCP handler at any candidate path.
