### PR TITLE
fix(mcp): scope task-IDOR to the core tasks wire, and record why it must not be ported

### DIFF
--- a/internal/attack/mcp/task_idor.go
+++ b/internal/attack/mcp/task_idor.go
@@ -29,6 +29,35 @@ import (
 // skips entirely when no such tool exists.
 //
 // Tasks are marked experimental in 2025-11-25, so this rule is version-scoped.
+//
+// DO NOT PORT THIS CLAIM TO THE 2026-07-28 TASKS EXTENSION. In 2026-07-28 tasks
+// left the core spec for extension io.modelcontextprotocol/tasks, whose normative
+// text lives in the separate modelcontextprotocol/ext-tasks repository and releases
+// independently. That extension deliberately DROPPED the requirement this rule
+// tests. Its Security Considerations read, in full on this point:
+//
+//	"Task ID unguessability. A server MAY use task IDs as bearer tokens for a
+//	server's stored state. Servers MUST generate them with sufficient entropy that
+//	a third party cannot enumerate or guess them."
+//
+// So on the extension wire a server is EXPLICITLY PERMITTED to treat a
+// high-entropy task ID as a capability, and answering tasks/get for anyone holding
+// one is conformant. Reporting that as an IDOR would accuse a compliant server.
+// The extension also removes tasks/result and tasks/list outright, so the two
+// stronger findings here have no wire to sit on, and its own text notes that
+// without tasks/list "a server cannot inadvertently leak the existence of one
+// caller's tasks to another".
+//
+// What IS testable on the extension wire is the entropy MUST above, which is a
+// different rule with a different oracle: predict the next task ID, committed
+// before observation, and compare byte-for-byte.
+//
+// The 2025-11-25 requirement this rule does test is also conditional, which is why
+// the anonymous-access discriminator below is not optional: "If context-binding is
+// available, receivers MUST reject tasks/get, tasks/result, and tasks/cancel
+// requests for tasks that do not belong to the same authorization context as the
+// requestor." A server with no authorization context is held to the entropy
+// requirement instead, not to this one.
 type TaskIDORExecutor struct {
 	rule attack.RuleContext
 }
@@ -87,6 +116,16 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 
 	// Gate on the tasks capability and on task-augmented tools/call specifically.
 	if !sessA.ServerSupports("tasks") || !tasksSupportsToolCall(sessA.RawInit) {
+		// A server carrying tasks under the 2026-07-28 extension advertises them
+		// somewhere this rule does not look and speaks a wire it does not drive, so
+		// the surface is present and untested rather than absent. Reporting clean
+		// would assert that task scoping is sound on a server whose task surface was
+		// never touched.
+		if tasksExtensionAdvertised(sessA.RawInit) || sessA.ProtocolVersion >= modernEraVersion {
+			return nil, fmt.Errorf("%w: %s carries tasks under the %s extension rather than the "+
+				"2025-11-25 core capability, and this rule drives the core wire only",
+				attack.ErrInconclusive, sessA.Endpoint, tasksExtensionName)
+		}
 		return nil, nil
 	}
 
@@ -574,4 +613,30 @@ func (e *TaskIDORExecutor) resultFinding(endpoint, taskID, toolName, content str
 		Remediation: e.rule.Remediation,
 		TargetURL:   endpoint,
 	}
+}
+
+// tasksExtensionName is the identifier the 2026-07-28 tasks extension is
+// advertised under.
+const tasksExtensionName = "io.modelcontextprotocol/tasks"
+
+// tasksExtensionAdvertised reports whether the handshake declared the 2026-07-28
+// tasks extension, at capabilities.extensions["io.modelcontextprotocol/tasks"].
+//
+// A server advertising this is not one this rule can assess: the extension removed
+// tasks/result and tasks/list and dropped the context-binding requirement, so the
+// rule's oracle does not apply to it. Distinguishing it from a server with no tasks
+// at all is what keeps the report honest.
+func tasksExtensionAdvertised(rawInit []byte) bool {
+	var body struct {
+		Result struct {
+			Capabilities struct {
+				Extensions map[string]json.RawMessage `json:"extensions"`
+			} `json:"capabilities"`
+		} `json:"result"`
+	}
+	if json.Unmarshal(rawInit, &body) != nil {
+		return false
+	}
+	_, ok := body.Result.Capabilities.Extensions[tasksExtensionName]
+	return ok
 }

--- a/internal/attack/mcp/task_idor_test.go
+++ b/internal/attack/mcp/task_idor_test.go
@@ -3,6 +3,7 @@ package mcp_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -399,4 +400,72 @@ func TestTaskIDOR_NotMCP(t *testing.T) {
 	defer srv.Close()
 
 	assertInconclusive(t, mcpattack.NewTaskIDORExecutor(attack.RuleContext{ID: "mcp-task-idor-001"}), srv.URL, testOpts())
+}
+
+// A server carrying tasks under the 2026-07-28 io.modelcontextprotocol/tasks
+// extension has a task surface this rule cannot assess: the extension removed
+// tasks/result and tasks/list and dropped the context-binding requirement the rule
+// tests, so its oracle does not apply. That is different from a server with no
+// tasks at all, and reporting it clean would assert task scoping is sound on a
+// surface never touched.
+func TestTaskIDOR_TasksExtensionIsNotTested(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		method, _ := req["method"].(string)
+		id := req["id"]
+		w.Header().Set("Content-Type", "application/json")
+		if method == "initialize" {
+			w.Header().Set("Mcp-Session-Id", "ext-1")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{
+					"protocolVersion": "2025-06-18",
+					"serverInfo":      map[string]interface{}{"name": "ext", "version": "1"},
+					// The extension shape: no core "tasks" capability at all.
+					"capabilities": map[string]interface{}{
+						"tools": map[string]interface{}{},
+						"extensions": map[string]interface{}{
+							"io.modelcontextprotocol/tasks": map[string]interface{}{},
+						},
+					},
+				}})
+			return
+		}
+		if method == "notifications/initialized" {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id,
+			"error": map[string]interface{}{"code": -32601, "message": "Method not found"}})
+	}))
+	defer srv.Close()
+
+	exec := mcpattack.NewTaskIDORExecutor(attack.RuleContext{ID: "mcp-task-idor-001"})
+	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("the extension wire is untested, not clean; got err=%v", err)
+	}
+	if !strings.Contains(err.Error(), "io.modelcontextprotocol/tasks") {
+		t.Errorf("the reason should name the extension, got: %v", err)
+	}
+}
+
+// A server with no tasks anywhere is genuinely not applicable, and must stay
+// clean. This is the control that keeps the check above from becoming a blanket
+// "any server without core tasks is untested".
+func TestTaskIDOR_NoTasksAnywhereStaysClean(t *testing.T) {
+	srv := taskIDORServer("no-tasks-cap")
+	defer srv.Close()
+
+	exec := mcpattack.NewTaskIDORExecutor(attack.RuleContext{ID: "mcp-task-idor-001"})
+	findings, err := exec.Execute(context.Background(), srv.URL, testOpts())
+	if err != nil {
+		t.Fatalf("a server with no tasks capability is not applicable, which is clean: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected no findings, got %d", len(findings))
+	}
 }


### PR DESCRIPTION
The queued work was to port `mcp-task-idor-001` to the 2026-07-28 tasks extension, since `tasks/list` and `tasks/result` no longer exist there. **Reading both specifications first, that port would have accused conformant servers.** It is deliberately not done, and the reasoning now lives in the rule so nobody does it later.

## Why the port is wrong

**2025-11-25**, which this rule tests:

> "If context-binding is available, receivers **MUST** reject `tasks/get`, `tasks/result`, and `tasks/cancel` requests for tasks that do not belong to the same authorization context as the requestor."

Note the condition — which is precisely what the rule's anonymous-access discriminator stands in for. A server with no authorization context is held to an entropy requirement instead. That retroactively justifies the #155 discriminator design.

**ext-tasks**, the current wire, dropped it and says instead:

> "A server **MAY** use task IDs as bearer tokens for a server's stored state. Servers **MUST** generate them with sufficient entropy that a third party cannot enumerate or guess them."

So answering `tasks/get` for anyone holding a high-entropy task ID is **conformant** there. Reporting it as an IDOR would be a false positive by construction. The extension also removes `tasks/result` and `tasks/list` outright, so two of the three findings have no wire to sit on, and its own text notes that without `tasks/list` one caller's tasks cannot leak to another.

What the extension *does* make testable is the entropy MUST, which needs a different oracle — predict the next task ID, committed before observation, compared byte-for-byte. That is a separate rule.

## The behaviour change

The capability gate already failed closed on an extension server, because the extension MUST NOT advertise the core `tasks` capability — but it returned `nil, nil`, which claims the feature is **absent**. It is not absent; it is on a wire this rule does not drive.

A server advertising `capabilities.extensions["io.modelcontextprotocol/tasks"]`, or negotiating 2026-07-28, is now reported as not tested and names the extension. A server with no tasks anywhere stays clean, with a test so the new check cannot widen into a blanket skip.

## Verification

Thirteen task-IDOR tests pass, including the two new ones and the clean control. Non-vacuity: removing the extension check fails the new test and only that test. Sweep against the previous build: nothing changed. `golangci-lint` clean.
