### PR TITLE
fix(a2a): stop reporting cross-principal rules clean when no second identity exists

### DIFF
--- a/internal/attack/a2a/context_fixation.go
+++ b/internal/attack/a2a/context_fixation.go
@@ -49,12 +49,13 @@ func (e *ContextFixationExecutor) Execute(ctx context.Context, target string, op
 
 // ExecuteChained runs the context-fixation check.
 func (e *ContextFixationExecutor) ExecuteChained(ctx context.Context, target string, opts attack.Options, bb *attack.Blackboard) ([]attack.Finding, error) {
-	if len(opts.Principals) < 2 {
-		return nil, nil
-	}
-	a, b := opts.Principals[0], opts.Principals[1]
-	if a.Token == b.Token {
-		return nil, nil
+	// Two distinct identities are this rule's premise; without them it cannot run.
+	// See twoPrincipals: all five cross-principal rules used to report clean here,
+	// so a scan with no --principal flags called 29 percent of the A2A set secure
+	// without sending a packet.
+	a, b, err := twoPrincipals(opts)
+	if err != nil {
+		return nil, err
 	}
 
 	vars := attack.NewVars(target, opts.OOBListenerURL)

--- a/internal/attack/a2a/context_fixation_test.go
+++ b/internal/attack/a2a/context_fixation_test.go
@@ -2,6 +2,7 @@ package a2a_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -203,10 +204,13 @@ func TestContextFixation_RequiresTwoPrincipals(t *testing.T) {
 
 	findings, err := a2a.NewContextFixationExecutor(testRuleCtx()).
 		Execute(context.Background(), ts.URL, mtOpts(tenantPrincipals()[:1]...))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	// A rule that sends no packets has not tested anything. This used to assert
+	// err == nil, which under the project's convention means "tested, and the target
+	// is secure" - about a deliberately vulnerable fixture, with zero requests sent.
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("one principal cannot exercise a cross-principal rule; want ErrInconclusive, got %v", err)
 	}
 	if len(findings) != 0 {
-		t.Errorf("expected clean skip with one principal, got %d findings", len(findings))
+		t.Errorf("expected zero findings, got %d", len(findings))
 	}
 }

--- a/internal/attack/a2a/delegation_integrity.go
+++ b/internal/attack/a2a/delegation_integrity.go
@@ -48,12 +48,13 @@ func (e *DelegationIntegrityExecutor) Execute(ctx context.Context, target string
 
 // ExecuteChained runs the delegation chain-of-custody check.
 func (e *DelegationIntegrityExecutor) ExecuteChained(ctx context.Context, target string, opts attack.Options, bb *attack.Blackboard) ([]attack.Finding, error) {
-	if len(opts.Principals) < 2 {
-		return nil, nil
-	}
-	a, b := opts.Principals[0], opts.Principals[1]
-	if a.Token == b.Token {
-		return nil, nil // same identity cannot demonstrate a wrong-principal continuation
+	// Two distinct identities are this rule's premise; without them it cannot run.
+	// See twoPrincipals: all five cross-principal rules used to report clean here,
+	// so a scan with no --principal flags called 29 percent of the A2A set secure
+	// without sending a packet.
+	a, b, err := twoPrincipals(opts)
+	if err != nil {
+		return nil, err
 	}
 
 	vars := attack.NewVars(target, opts.OOBListenerURL)

--- a/internal/attack/a2a/delegation_integrity_test.go
+++ b/internal/attack/a2a/delegation_integrity_test.go
@@ -3,6 +3,7 @@ package a2a_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -157,11 +158,14 @@ func TestDelegation_RequiresTwoPrincipals(t *testing.T) {
 
 	findings, err := a2a.NewDelegationIntegrityExecutor(testRuleCtx()).
 		Execute(context.Background(), ts.URL, mtOpts(tenantPrincipals()[:1]...))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	// A rule that sends no packets has not tested anything. This used to assert
+	// err == nil, which under the project's convention means "tested, and the target
+	// is secure" - about a deliberately vulnerable fixture, with zero requests sent.
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("one principal cannot exercise a cross-principal rule; want ErrInconclusive, got %v", err)
 	}
 	if len(findings) != 0 {
-		t.Errorf("expected clean skip with one principal, got %d findings", len(findings))
+		t.Errorf("expected zero findings, got %d", len(findings))
 	}
 }
 

--- a/internal/attack/a2a/multitenant_isolation.go
+++ b/internal/attack/a2a/multitenant_isolation.go
@@ -46,14 +46,13 @@ func (e *MultiTenantIsolationExecutor) Execute(ctx context.Context, target strin
 // ExecuteChained runs the multi-tenant isolation check.
 func (e *MultiTenantIsolationExecutor) ExecuteChained(ctx context.Context, target string, opts attack.Options, bb *attack.Blackboard) ([]attack.Finding, error) {
 	// Precondition: need two valid, distinguishable principals.
-	if len(opts.Principals) < 2 {
-		return nil, nil
-	}
-	a, b := opts.Principals[0], opts.Principals[1]
-	if a.Token == b.Token {
-		// Same (or both-empty) credentials cannot demonstrate isolation between
-		// two distinct tenants.
-		return nil, nil
+	// Two distinct identities are this rule's premise; without them it cannot run.
+	// See twoPrincipals: all five cross-principal rules used to report clean here,
+	// so a scan with no --principal flags called 29 percent of the A2A set secure
+	// without sending a packet.
+	a, b, err := twoPrincipals(opts)
+	if err != nil {
+		return nil, err
 	}
 
 	vars := attack.NewVars(target, opts.OOBListenerURL)

--- a/internal/attack/a2a/multitenant_isolation_test.go
+++ b/internal/attack/a2a/multitenant_isolation_test.go
@@ -2,6 +2,7 @@ package a2a_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -169,11 +170,14 @@ func TestMultiTenant_RequiresTwoPrincipals(t *testing.T) {
 
 	findings, err := a2a.NewMultiTenantIsolationExecutor(testRuleCtx()).
 		Execute(context.Background(), ts.URL, mtOpts(tenantPrincipals()[:1]...))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	// A rule that sends no packets has not tested anything. This used to assert
+	// err == nil, which under the project's convention means "tested, and the target
+	// is secure" - about a deliberately vulnerable fixture, with zero requests sent.
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("one principal cannot exercise a cross-principal rule; want ErrInconclusive, got %v", err)
 	}
 	if len(findings) != 0 {
-		t.Errorf("expected clean skip with one principal, got %d findings", len(findings))
+		t.Errorf("expected zero findings, got %d", len(findings))
 	}
 }
 
@@ -189,10 +193,11 @@ func TestMultiTenant_SameTokenSkips(t *testing.T) {
 	}
 	findings, err := a2a.NewMultiTenantIsolationExecutor(testRuleCtx()).
 		Execute(context.Background(), ts.URL, mtOpts(same...))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("two principals sharing a token are one identity, so there is no boundary to "+
+			"cross; want ErrInconclusive, got %v", err)
 	}
 	if len(findings) != 0 {
-		t.Errorf("expected clean skip when principals share a token, got %d findings", len(findings))
+		t.Errorf("expected zero findings, got %d", len(findings))
 	}
 }

--- a/internal/attack/a2a/principals.go
+++ b/internal/attack/a2a/principals.go
@@ -1,0 +1,39 @@
+package a2a
+
+import (
+	"fmt"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// twoPrincipals returns the two identities a cross-principal rule needs, or an
+// error saying why the rule cannot run.
+//
+// Five rules carried this precondition and all five answered it with nil,nil,
+// which under this project's convention means "tested, and the target is secure".
+// They send no packets in that state. So a default invocation, with no --principal
+// flags, reported a2a-multitenant-isolation-001,
+// a2a-delegation-integrity-001, a2a-context-fixation-001, a2a-push-binding-001 and
+// a2a-task-cancel-idor-001 as clean: 5 of 17 A2A rules, 29 percent of the set,
+// silently self-disabling while the operator was told the target appeared clean for
+// the tested rules. Measured against testdata/a2a_multitenant_server.py, which is
+// deliberately vulnerable: 5 rules run, zero requests, "No findings. Target appears
+// clean for the tested rules."
+//
+// Two distinct credentials are the whole premise of these rules. Without them there
+// is no second authorization context to cross, which is a reason the rule could not
+// run and not a property of the target.
+func twoPrincipals(opts attack.Options) (a, b attack.Principal, err error) {
+	if len(opts.Principals) < 2 {
+		return a, b, fmt.Errorf("%w: this rule compares two authenticated identities and %d "+
+			"were configured; pass two --principal flags (or a config with two principals) to run it",
+			attack.ErrInconclusive, len(opts.Principals))
+	}
+	a, b = opts.Principals[0], opts.Principals[1]
+	if a.Token == b.Token {
+		return a, b, fmt.Errorf("%w: principals %q and %q carry the same token, so there is no "+
+			"second authorization context for this rule to cross",
+			attack.ErrInconclusive, a.Name, b.Name)
+	}
+	return a, b, nil
+}

--- a/internal/attack/a2a/principals_test.go
+++ b/internal/attack/a2a/principals_test.go
@@ -1,0 +1,66 @@
+package a2a
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// All five cross-principal rules answered this precondition with nil,nil, which
+// means "tested, and the target is secure". They send no packets in that state, so
+// a default scan with no --principal flags reported 5 of 17 A2A rules clean without
+// touching the target.
+func TestTwoPrincipals(t *testing.T) {
+	t.Run("none configured", func(t *testing.T) {
+		_, _, err := twoPrincipals(attack.Options{})
+		if !errors.Is(err, attack.ErrInconclusive) {
+			t.Fatalf("want ErrInconclusive, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "--principal") {
+			t.Errorf("the reason should tell the operator how to make the rule run, got: %v", err)
+		}
+	})
+
+	t.Run("only one configured", func(t *testing.T) {
+		_, _, err := twoPrincipals(attack.Options{Principals: []attack.Principal{{Name: "a", Token: "t"}}})
+		if !errors.Is(err, attack.ErrInconclusive) {
+			t.Fatalf("want ErrInconclusive, got %v", err)
+		}
+	})
+
+	t.Run("two sharing a token is one identity", func(t *testing.T) {
+		_, _, err := twoPrincipals(attack.Options{Principals: []attack.Principal{
+			{Name: "a", Token: "same"}, {Name: "b", Token: "same"},
+		}})
+		if !errors.Is(err, attack.ErrInconclusive) {
+			t.Fatalf("want ErrInconclusive, got %v", err)
+		}
+		// The reason has to name them, or an operator cannot tell which two.
+		if !strings.Contains(err.Error(), `"a"`) || !strings.Contains(err.Error(), `"b"`) {
+			t.Errorf("the reason should name both principals, got: %v", err)
+		}
+	})
+
+	t.Run("two distinct identities run", func(t *testing.T) {
+		a, b, err := twoPrincipals(attack.Options{Principals: []attack.Principal{
+			{Name: "a", Token: "tok-a"}, {Name: "b", Token: "tok-b"},
+		}})
+		if err != nil {
+			t.Fatalf("two distinct principals must be accepted: %v", err)
+		}
+		if a.Name != "a" || b.Name != "b" {
+			t.Errorf("returned the wrong pair: %q and %q", a.Name, b.Name)
+		}
+	})
+
+	t.Run("a third principal is ignored, not an error", func(t *testing.T) {
+		_, _, err := twoPrincipals(attack.Options{Principals: []attack.Principal{
+			{Name: "a", Token: "1"}, {Name: "b", Token: "2"}, {Name: "c", Token: "3"},
+		}})
+		if err != nil {
+			t.Errorf("extra principals are ignored by these rules, not rejected: %v", err)
+		}
+	})
+}

--- a/internal/attack/a2a/push_binding.go
+++ b/internal/attack/a2a/push_binding.go
@@ -42,12 +42,13 @@ func (e *PushBindingExecutor) Execute(ctx context.Context, target string, opts a
 }
 
 func (e *PushBindingExecutor) ExecuteChained(ctx context.Context, target string, opts attack.Options, bb *attack.Blackboard) ([]attack.Finding, error) {
-	if len(opts.Principals) < 2 {
-		return nil, nil
-	}
-	a, b := opts.Principals[0], opts.Principals[1]
-	if a.Token == b.Token {
-		return nil, nil
+	// Two distinct identities are this rule's premise; without them it cannot run.
+	// See twoPrincipals: all five cross-principal rules used to report clean here,
+	// so a scan with no --principal flags called 29 percent of the A2A set secure
+	// without sending a packet.
+	a, b, err := twoPrincipals(opts)
+	if err != nil {
+		return nil, err
 	}
 
 	vars := attack.NewVars(target, opts.OOBListenerURL)

--- a/internal/attack/a2a/push_binding_test.go
+++ b/internal/attack/a2a/push_binding_test.go
@@ -3,6 +3,7 @@ package a2a_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -212,7 +213,14 @@ func TestPushBinding_InsufficientPrincipals(t *testing.T) {
 	ts := pushServer("unbound")
 	defer ts.Close()
 
-	if findings := runPushBinding(t, ts, pushPrincipals()[:1]); len(findings) != 0 {
-		t.Errorf("expected zero findings with <2 principals, got %d", len(findings))
+	// Not via runPushBinding: that helper fatals on any error, and the point here is
+	// which error comes back.
+	findings, err := a2a.NewPushBindingExecutor(testRuleCtx()).Execute(context.Background(), ts.URL,
+		attack.Options{TimeoutSeconds: 5, Principals: pushPrincipals()[:1]})
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("one principal cannot exercise a cross-principal rule; want ErrInconclusive, got %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings, got %d", len(findings))
 	}
 }

--- a/internal/attack/a2a/task_cancel_idor.go
+++ b/internal/attack/a2a/task_cancel_idor.go
@@ -54,12 +54,13 @@ const (
 )
 
 func (e *TaskCancelIDORExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
-	if len(opts.Principals) < 2 {
-		return nil, nil
-	}
-	a, b := opts.Principals[0], opts.Principals[1]
-	if a.Token == b.Token {
-		return nil, nil // same identity cannot demonstrate a cross-principal cancel
+	// Two distinct identities are this rule's premise; without them it cannot run.
+	// See twoPrincipals: all five cross-principal rules used to report clean here,
+	// so a scan with no --principal flags called 29 percent of the A2A set secure
+	// without sending a packet.
+	a, b, err := twoPrincipals(opts)
+	if err != nil {
+		return nil, err
 	}
 
 	vars := attack.NewVars(target, opts.OOBListenerURL)


### PR DESCRIPTION
Five rules compare two authenticated identities, and all five answered a missing second identity with `nil, nil` — which under this project's convention means "tested, and the target is secure". In that state they send **no packets at all**.

So a default invocation with no `--principal` flags reported `a2a-multitenant-isolation-001`, `a2a-delegation-integrity-001`, `a2a-context-fixation-001`, `a2a-push-binding-001` and `a2a-task-cancel-idor-001` as clean: **5 of 17 A2A rules, 29% of the set, silently self-disabling.**

Measured against `testdata/a2a_multitenant_server.py`, which is deliberately vulnerable:

```
before: No findings. Target appears clean for the tested rules.
after:  No findings, but 5 of 5 rule(s) were not exercised, so the target was
        not fully tested. Run with -v to see why each was skipped.
```

Two distinct credentials are the premise of these rules; without them there is no second authorization context to cross. That is a reason the rule could not run, not a property of the target, so both preconditions now return `ErrInconclusive` with a reason — how many principals were configured, or which two share a token.

## One helper, not five copies

The precondition lived in five places. That is exactly how the severity ranking (#160), the auth-refusal keywords (#164) and the SSE response predicate (#165) each drifted apart earlier in this pass, so it is now a single `twoPrincipals`.

## The tests were pinning the wrong side

**Five** tests asserted the old behaviour — one more than the review found, including the same-token case. Each is flipped to require `ErrInconclusive`. `push_binding`'s went through a helper that fatals on any error, so it now calls the executor directly. `a2a-task-cancel-idor-001` had no test for this path at all and is covered by the helper's.

## Verification

Both directions checked. With two principals every fixture produces exactly the findings it did before:

| fixture | baseline | fixed |
|---|---|---|
| multitenant | 2 | 2 |
| delegation | 1 | 1 |
| context-fixation | 4 | 4 |
| push-binding | 2 | 2 |
| task-cancel | 2 | 2 |

No finding changed anywhere in the fixture sweep; the only differences are these five rules correctly reporting not-tested on the fixtures scanned without principals. Non-vacuity: reverting the count gate alone fails seven tests. `golangci-lint` clean.
