### PR TITLE
feat(mcp): detect servers that accept their session id as a credential

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -147,7 +147,7 @@ release:
     ## Batesian {{.Version}}
 
     Adversarial red-team CLI for AI agent protocols (A2A and MCP).
-    36 bundled attack rules (17 A2A + 19 MCP). Single binary. No runtime dependencies.
+    37 bundled attack rules (17 A2A + 20 MCP). Single binary. No runtime dependencies.
 
     Every release is published with a cosign signature over `checksums.txt`, a
     CycloneDX SBOM per archive, and SLSA build provenance.

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ CLI for adversarial testing of [A2A](https://a2a-protocol.org) and [MCP](https:/
 
 ## What ships
 
-Bundled rules: **17 A2A, 19 MCP (36 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
+Bundled rules: **17 A2A, 20 MCP (37 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
 
 - [A2A rules](docs/rules-a2a.md) (17)
-- [MCP rules](docs/rules-mcp.md) (18)
+- [MCP rules](docs/rules-mcp.md) (20)
 
 Rules are validated against third-party reference implementations, not only against the bundled fixtures. [Validation results](docs/validation-results.md) records what fires, what correctly stays silent on a server with no authentication at all, and the scanner defects that exercise has found.
 
@@ -31,7 +31,7 @@ Coverage spans:
 - **OAuth & token validation** - OAuth 2.1 / DCR scope escalation, audience binding, token replay, version-downgrade bypass, forged-token acceptance, redirect_uri confused deputy
 - **Agent-card trust (A2A)** - JWS signatures, canonicalization, cache/freshness, required-extension downgrade, host-header injection, unauthenticated extended card, declared-but-unenforced auth
 - **Request & task integrity** - task IDOR, agent-role injection, artifact tampering, SEP-2243 header/body routing, SSE resumption replay
-- **Multi-party isolation** - cross-tenant isolation, session/context fixation, delegation chain-of-custody, cross-principal task cancellation, cross-context MCP task and result access
+- **Multi-party isolation** - cross-tenant isolation, session/context fixation, session id accepted as a credential, delegation chain-of-custody, cross-principal task cancellation, cross-context MCP task and result access
 - **SSRF & secret leakage** - push-notification SSRF, push control-plane binding, OAuth discovery/metadata SSRF, credential leakage into responses
 - **Unauthenticated & cross-origin access** - exposed MCP tools, resources, prompt templates, completion suggestions, and log-level control, Streamable HTTP Origin validation (DNS rebinding)
 

--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -1,6 +1,6 @@
 # MCP Attack Rules
 
-Batesian ships **19 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
+Batesian ships **20 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
 Every rule is an active probe: it sends crafted protocol traffic and judges the
 server's actual response. Rules are deliberately scoped to MCP-specific semantics
 (OAuth 2.1 authorization, DCR, audience binding, discovery-chain metadata-fetch
@@ -122,6 +122,7 @@ candidate answers does a rule report that it could not test.
 | `mcp-confused-deputy-001` | [OAuth Confused Deputy via redirect_uri](#mcp-confused-deputy-001) | High / Medium | confirmed / indicator | CWE-441 |
 | `mcp-dns-rebind-origin-001` | [Origin Validation / DNS Rebinding](#mcp-dns-rebind-origin-001) | High | confirmed | CWE-350 |
 | `mcp-jsonrpc-batch-bypass-001` | [JSON-RPC Batch Authentication Bypass](#mcp-jsonrpc-batch-bypass-001) | High | confirmed | CWE-288 |
+| `mcp-session-as-credential-001` | [Session ID Accepted as a Credential](#mcp-session-as-credential-001) | High | confirmed | CWE-287 / CWE-565 |
 
 ---
 
@@ -599,3 +600,58 @@ Currency: JSON-RPC batching is normative in revisions 2024-11-05 and 2025-03-26
 and was removed in 2025-06-18, so a compliant current server rejects batches. The
 rule targets servers on the earlier revisions and any later server that still
 processes batches (non-compliant), where the bypass is exploitable.
+
+---
+
+### mcp-session-as-credential-001
+
+**MCP Session ID Accepted as a Credential** | Severity: High | CWE-287 / CWE-565
+
+Tests whether a server treats its own `Mcp-Session-Id` as proof of identity. The
+Security Best Practices are explicit: "MCP servers that implement authorization
+MUST verify all inbound requests. MCP Servers MUST NOT use sessions for
+authentication." A server that authenticates by session has turned a header into
+a bearer token, and one that is not scoped, rotated or revocable the way a token
+is, travels in plaintext on every request, and is logged by every proxy in the
+path. Anyone who reads one out of a log replays the authenticated session, which
+is the specification's own Session Hijack Impersonation flow.
+
+The rule needs one working credential (`--token` or a principal), because it asks
+whether a session id can stand in for one, which cannot be asked without a
+credential to compare against. Without one it reports **inconclusive**, not clean.
+
+1. Handshake **with** the credential and capture the server-minted session id. No
+   session id means the server is stateless and the rule does not apply.
+2. `tools/list` with the session id **and** the credential must succeed, or the
+   session is not usable and there is nothing to strip.
+3. Control: attempt an **anonymous** handshake, and if it yields a session, call
+   `tools/list` with that session and no credential. A server that answers it has
+   served a caller who never presented a credential, so it implements no
+   authorization, the requirement above does not bind on it, and the surface
+   belongs to `mcp-tools-unauth-001`. An open handshake alone proves nothing: many
+   servers leave `initialize` ungated and authorize what follows. If the anonymous
+   handshake is accepted but issues no session, the rule stops, since a refusal
+   below could then be about the missing session rather than the missing credential.
+4. Control: `tools/list` with **no session and no credential**. A server that
+   answers it is open on this surface, so a later success cannot be attributed to
+   the session id.
+5. Control: `tools/list` presenting a **random, never-issued** session id and no
+   credential. A server that accepts this treats the presence of the header as
+   authorization, so the issued id is not what decided it.
+6. `tools/list` presenting the **real** session id and no credential.
+
+A **confirmed** finding is raised only when step 6 is answered. Steps 5 and 6 are
+the same request differing in one detail, so the session id is provably the
+deciding factor rather than an inference. When step 3 produced an anonymous
+session, steps 3 and 6 form a second and stronger such pair: both ids were minted
+by this server, and the only difference is whether a credential was presented when
+they were opened. Step 3 is what separates a server that
+authenticates by session from one that merely requires a session and authenticates
+nothing: both refuse steps 4 and 5, for different reasons. The official C# SDK's
+stateful sample is the second kind, and was reported as vulnerable until that
+control was added.
+
+Currency: `Mcp-Session-Id` is normative in revisions 2025-03-26 through
+2025-11-25. The 2026-07-28 revision removes protocol-level sessions, so a server
+on that revision returns no session id and the rule reports itself not applicable
+at step 1.

--- a/docs/validation-results.md
+++ b/docs/validation-results.md
@@ -32,6 +32,17 @@ against a server that genuinely exhibited the condition. A false negative in a
 security scanner is worse than a noisy one, and none of them were reachable from
 a self-authored fixture.
 
+The same exercise has also caught a false positive before it shipped.
+`mcp-session-as-credential-001` passed every posture in its own harness, then
+reported the official MCP C# SDK's stateful sample as vulnerable. That sample
+implements no authorization at all, but requires an `Mcp-Session-Id` on every
+non-initialize request, so it refused each of the rule's unauthenticated controls
+for session reasons rather than credential ones and the controls read those
+refusals as an enforced authorization boundary. The rule now settles the question
+with an anonymous handshake before drawing any conclusion, and
+`testdata/mcp_session_as_credential_server.py session-presence-auth` reproduces
+that server's shape so the regression stays covered.
+
 ---
 
 ## MCP: `@modelcontextprotocol/server-everything`

--- a/internal/attack/mcp/session_as_credential.go
+++ b/internal/attack/mcp/session_as_credential.go
@@ -1,0 +1,238 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// SessionAsCredentialExecutor tests whether an MCP server accepts its own
+// Mcp-Session-Id as proof of identity (rule mcp-session-as-credential-001).
+//
+// The Security Best Practices are explicit, and the second sentence is what this
+// rule tests: "MCP servers that implement authorization MUST verify all inbound
+// requests. MCP Servers MUST NOT use sessions for authentication."
+//
+// Note the condition on the first sentence. The requirement binds on servers that
+// implement authorization, so the rule has to establish that the server enforces
+// authorization at all before it can accuse it of authenticating by session. That
+// is what the unauthenticated control does; without it, a server with no
+// authorization anywhere would be reported here instead of by
+// mcp-tools-unauth-001, which owns that failure.
+//
+// The oracle is a pair of requests that differ in one detail. Both carry no
+// credential. One presents a session id the server issued, the other a random id
+// it never issued. If the first is answered and the second refused, the session id
+// alone authorized the call. That is the exploit performed rather than inferred,
+// and it is the spec's own Session Hijack Impersonation flow: anyone who reads a
+// session id out of a proxy log replays the authenticated session.
+type SessionAsCredentialExecutor struct {
+	rule attack.RuleContext
+}
+
+func init() {
+	attack.Register("mcp-session-as-credential", func(rc attack.RuleContext) attack.Executor {
+		return NewSessionAsCredentialExecutor(rc)
+	})
+}
+
+func NewSessionAsCredentialExecutor(r attack.RuleContext) *SessionAsCredentialExecutor {
+	return &SessionAsCredentialExecutor{rule: r}
+}
+
+func (e *SessionAsCredentialExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
+	// A credential is the premise: the rule asks whether a session id can stand in
+	// for one, which cannot be asked without a working credential to compare
+	// against. Reporting clean without one would claim the server was tested.
+	token := credentialFor(opts)
+	if token == "" {
+		return nil, fmt.Errorf("%w: this rule needs one working credential, to establish a session "+
+			"that a later request can then present without it; pass --token or a principal",
+			attack.ErrInconclusive)
+	}
+
+	vars := attack.NewVars(target, opts.OOBListenerURL)
+	// No ambient token: every request here states its own credentials, because the
+	// whole measurement is which requests carry one.
+	client := attack.NewUnauthHTTPClient(opts, vars)
+
+	authed := map[string]string{"Authorization": "Bearer " + token}
+
+	return probeCandidates(vars.BaseURL, func(ep string) ([]attack.Finding, bool) {
+		// Step 1: handshake with the credential and capture the session id.
+		session, ok := e.initialize(ctx, client, ep, authed)
+		if !ok {
+			return nil, false // not a reachable MCP endpoint
+		}
+		if session == "" {
+			// Stateless, or a 2026-07-28 server, which removed protocol-level
+			// sessions. There is no session id to misuse.
+			return nil, true
+		}
+
+		// Step 2: the session must actually work when presented with the credential,
+		// or there is nothing to strip.
+		if !e.toolsList(ctx, client, ep, session, authed) {
+			return nil, true
+		}
+
+		// Step 3: control. Does this server implement authorization at all? The
+		// requirement is conditional on that, so it has to be established rather than
+		// assumed.
+		//
+		// Measured against the official MCP C# SDK's stateful sample, which has no
+		// authorization: it demands a session id for every non-initialize request and
+		// answers one without it with -32000 "A new session can only be created by an
+		// initialize request". So a request lacking a session is refused for SESSION
+		// reasons, and the later controls cannot tell that apart from a refusal for
+		// missing credentials. Every one of them passed and the rule reported a
+		// false positive on a server that authenticates nothing.
+		//
+		// An anonymous handshake settles it, but the handshake alone does not: plenty
+		// of servers leave initialize ungated and authorize the calls that follow, and
+		// reading an open handshake as "no authorization" would suppress exactly the
+		// servers this rule exists to find. What answers the question is whether the
+		// session the anonymous caller was given can then call tools/list.
+		var anonSession string
+		if s, anonOK := e.initialize(ctx, client, ep, nil); anonOK {
+			anonSession = s
+			if anonSession == "" {
+				// It handshakes anonymously but issues this caller no session, so there
+				// is no anonymous session to compare against, and a refusal below cannot
+				// be attributed to the missing credential rather than the missing
+				// session. Report nothing rather than guess.
+				return nil, true
+			}
+			if e.toolsList(ctx, client, ep, anonSession, nil) {
+				// A caller who presented no credential at any point reads the tool list.
+				// The server implements no authorization, the MUST NOT above does not
+				// bind on it, and mcp-tools-unauth-001 owns that surface.
+				return nil, true
+			}
+			// The anonymous session was refused while the credentialed one was
+			// accepted, on the same call with the same headers. That is the asymmetry
+			// this rule reports, and it is stronger evidence than the never-issued-id
+			// control below: both ids were minted by this server, and the only
+			// difference between them is the credential presented when they were
+			// opened.
+		}
+
+		// Step 4: control. No session, no credential. A server that answers this is
+		// open on the surface under test, so a later success cannot be attributed to
+		// the session id.
+		if e.toolsList(ctx, client, ep, "", nil) {
+			return nil, true
+		}
+
+		// Step 5: control. A random never-issued session id, no credential. A server
+		// that accepts this treats the presence of the header as authorization, so the
+		// issued id was not what decided it.
+		bogus := "batesian-never-issued-" + vars.RandID
+		if e.toolsList(ctx, client, ep, bogus, nil) {
+			return nil, true
+		}
+
+		// Step 6: the real session id, no credential.
+		if !e.toolsList(ctx, client, ep, session, nil) {
+			return nil, true // the session carries no authority: secure
+		}
+
+		return []attack.Finding{e.finding(ep, session, bogus, anonSession)}, true
+	})
+}
+
+// credentialFor returns the credential to establish the session with, preferring
+// an explicit principal so a multi-principal scan behaves predictably.
+func credentialFor(opts attack.Options) string {
+	for _, p := range opts.Principals {
+		if p.Token != "" {
+			return p.Token
+		}
+	}
+	return opts.Token
+}
+
+// initialize performs the handshake and returns the session id the server minted,
+// which is empty when the server assigns none.
+func (e *SessionAsCredentialExecutor) initialize(ctx context.Context, client *attack.HTTPClient,
+	endpoint string, headers map[string]string) (session string, ok bool) {
+	resp, err := client.POST(ctx, endpoint, headers, map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]interface{}{
+			"protocolVersion": latestStable,
+			"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+			"clientInfo":      map[string]interface{}{"name": "batesian", "version": attack.Version},
+		},
+	})
+	if err != nil || !resp.IsAccepted() {
+		return "", false
+	}
+	return resp.Headers.Get("Mcp-Session-Id"), true
+}
+
+// toolsList reports whether tools/list was answered with a result under the given
+// session id and headers. An empty session omits the header entirely.
+//
+// It requires a result envelope, not merely a 2xx: a server refusing the call with
+// a JSON-RPC error at HTTP 200 has refused it, and reading that as success is the
+// mistake that produced fabricated findings elsewhere in this package.
+func (e *SessionAsCredentialExecutor) toolsList(ctx context.Context, client *attack.HTTPClient,
+	endpoint, session string, headers map[string]string) bool {
+	h := map[string]string{"Mcp-Protocol-Version": latestStable}
+	for k, v := range headers {
+		h[k] = v
+	}
+	if session != "" {
+		h["Mcp-Session-Id"] = session
+	}
+	resp, err := client.POST(ctx, endpoint, h, map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/list",
+		"params":  map[string]interface{}{},
+	})
+	if err != nil {
+		return false
+	}
+	return resp.IsAccepted()
+}
+
+func (e *SessionAsCredentialExecutor) finding(endpoint, session, bogus, anonSession string) attack.Finding {
+	// The anonymous-handshake control reads differently depending on how the server
+	// answered it, and both readings are evidence, so state which one happened
+	// rather than asserting a refusal that may not have been the one observed.
+	anonLine := "initialize with no credential: refused, so the handshake is gated\n"
+	if anonSession != "" {
+		anonLine = fmt.Sprintf("tools/list with a session issued to an ANONYMOUS handshake (%s) "+
+			"and no credential: refused\n", anonSession)
+	}
+	return attack.Finding{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "high",
+		Confidence: attack.ConfirmedExploit,
+		Title:      "MCP server accepts its session ID as a credential (session used for authentication)",
+		Description: fmt.Sprintf(
+			"tools/list at %s was answered for a request carrying no credential, on the strength of "+
+				"the Mcp-Session-Id the server itself issued. The same request presenting a session id "+
+				"the server never issued was refused, and an unauthenticated request with no session at "+
+				"all was refused, so authorization is enforced and the session id is what satisfied it. "+
+				"The Security Best Practices require that servers implementing authorization verify all "+
+				"inbound requests and state that servers MUST NOT use sessions for authentication. A "+
+				"session id is a plaintext header logged by every proxy in the path, so anyone who reads "+
+				"one replays the authenticated session.", endpoint),
+		Evidence: fmt.Sprintf(
+			"endpoint: %s\nsession id issued to the credentialed handshake: %s\n"+
+				"tools/list with session + credential: answered\n"+
+				"%s"+
+				"tools/list with no session and no credential: refused\n"+
+				"tools/list with a never-issued session id (%s) and no credential: refused\n"+
+				"tools/list with the issued session id and NO credential: answered",
+			endpoint, session, anonLine, bogus),
+		Remediation: e.rule.Remediation,
+		TargetURL:   endpoint,
+	}
+}

--- a/internal/attack/mcp/session_as_credential_test.go
+++ b/internal/attack/mcp/session_as_credential_test.go
@@ -1,0 +1,336 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+// sessionCredServer models how a server decides whether a tools/list call is
+// authorized. mode picks the posture:
+//
+//	"session-authenticates": only an ISSUED session id is accepted   => the finding
+//	"token-required":        every call needs the credential         => secure
+//	"no-auth":               nothing is ever checked                 => suppressed
+//	"session-presence-auth": ANY session id works without a token    => suppressed by
+//	                         the never-issued control, because the issued id was not
+//	                         what mattered
+//	"sessionless-open":      no session at all works, unknown ids are refused =>
+//	                         suppressed by the no-session control, because the call
+//	                         did not need a session either
+//	"no-auth-session-required": no authorization, but a session id is mandatory =>
+//	                         suppressed by the anonymous-handshake control. This is
+//	                         the official C# SDK's stateful sample.
+//	"open-init-session-auth": initialize is UNGATED, and a session opened by a
+//	                         credentialed caller then authorizes calls  => the
+//	                         finding. An open handshake is not the same thing as no
+//	                         authorization, and treating it as such suppressed this.
+//	"open-init-no-anon-session": initialize is ungated but only a credentialed caller
+//	                         is issued a session => suppressed, because with no
+//	                         anonymous session to compare against a refusal cannot be
+//	                         attributed to the missing credential.
+//	"stateless":             no session id is ever issued            => not applicable
+func sessionCredServer(t *testing.T, mode string) *httptest.Server {
+	t.Helper()
+	const validToken = "operator-token"
+	issued := map[string]bool{}
+	// Which sessions were opened by a credentialed caller. Distinct from issued:
+	// the postures where the handshake is ungated mint sessions for both callers,
+	// and the whole question is whether the two are then treated alike.
+	bornAuthed := map[string]bool{}
+	minted := 0
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		method, _ := req["method"].(string)
+		id := req["id"]
+		sid := r.Header.Get("Mcp-Session-Id")
+		authed := r.Header.Get("Authorization") == "Bearer "+validToken
+		w.Header().Set("Content-Type", "application/json")
+
+		result := func(v interface{}) {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id, "result": v})
+		}
+		refuse := func() {
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": -32001, "message": "Unauthorized"}})
+		}
+
+		switch method {
+		case "initialize":
+			switch mode {
+			case "no-auth", "no-auth-session-required", "open-init-session-auth",
+				"open-init-no-anon-session":
+				// Handshake is ungated in these postures.
+			default:
+				if !authed {
+					refuse()
+					return
+				}
+			}
+			issueSession := mode != "stateless" &&
+				(mode != "open-init-no-anon-session" || authed)
+			if issueSession {
+				minted++
+				s := fmt.Sprintf("sess-%s-%d", mode, minted)
+				issued[s] = true
+				bornAuthed[s] = authed
+				w.Header().Set("Mcp-Session-Id", s)
+			}
+			result(map[string]interface{}{
+				"protocolVersion": "2025-06-18",
+				"serverInfo":      map[string]interface{}{"name": "sc", "version": "1"},
+				"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			ok := false
+			switch mode {
+			case "no-auth":
+				ok = true
+			case "no-auth-session-required":
+				// The official C# SDK's stateful sample. No authorization anywhere, but
+				// every non-initialize request must carry a session id the server issued.
+				ok = issued[sid]
+			case "session-presence-auth":
+				// Presence of any session id is treated as authorization, so the
+				// issued id is not what decided it. Isolates the never-issued control.
+				ok = authed || sid != ""
+			case "sessionless-open":
+				// A call with no session is allowed; an unknown session id is refused
+				// per the transport spec. Isolates the no-session control, and without
+				// it step 5 would report a finding the session id did not cause.
+				ok = authed || sid == "" || issued[sid]
+			case "session-authenticates":
+				ok = authed || issued[sid]
+			case "open-init-session-auth", "open-init-no-anon-session":
+				// The handshake is open, but the session remembers who opened it and
+				// that memory is what authorizes the call.
+				ok = authed || bornAuthed[sid]
+			default: // token-required, stateless
+				ok = authed
+			}
+			if !ok {
+				refuse()
+				return
+			}
+			result(map[string]interface{}{"tools": []interface{}{map[string]interface{}{"name": "echo"}}})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": -32601, "message": "Method not found"}})
+		}
+	}))
+}
+
+func runSessionCred(t *testing.T, srv *httptest.Server) ([]attack.Finding, error) {
+	t.Helper()
+	exec := mcpattack.NewSessionAsCredentialExecutor(attack.RuleContext{ID: "mcp-session-as-credential-001"})
+	return exec.Execute(context.Background(), srv.URL, attack.Options{
+		TimeoutSeconds: 5, Token: "operator-token",
+	})
+}
+
+// The finding: a request carrying no credential is answered because it presents a
+// session id the server issued, while the same request with a never-issued id is
+// refused. The session id alone authorized the call.
+func TestSessionAsCredential_Vulnerable(t *testing.T) {
+	srv := sessionCredServer(t, "session-authenticates")
+	defer srv.Close()
+
+	findings, err := runSessionCred(t, srv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 finding, got %d", len(findings))
+	}
+	f := findings[0]
+	if f.Severity != "high" || f.Confidence != attack.ConfirmedExploit {
+		t.Errorf("want high/ConfirmedExploit, got %s/%s", f.Severity, f.Confidence)
+	}
+	// The evidence has to show both controls, or the claim is not supported.
+	for _, want := range []string{
+		"with no session and no credential: refused",
+		"never-issued session id",
+		"NO credential: answered",
+	} {
+		if !strings.Contains(f.Evidence, want) {
+			t.Errorf("evidence missing %q; got:\n%s", want, f.Evidence)
+		}
+	}
+}
+
+// Every call needs the credential. The session id carries no authority.
+func TestSessionAsCredential_TokenRequiredIsSecure(t *testing.T) {
+	srv := sessionCredServer(t, "token-required")
+	defer srv.Close()
+
+	findings, err := runSessionCred(t, srv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("a server that checks the credential on every call is secure, got %d findings", len(findings))
+	}
+}
+
+// A server with no authorization anywhere is mcp-tools-unauth-001's finding. The
+// MUST NOT binds only on servers that implement authorization, so this rule must
+// not claim it.
+func TestSessionAsCredential_NoAuthIsSuppressed(t *testing.T) {
+	srv := sessionCredServer(t, "no-auth")
+	defer srv.Close()
+
+	findings, err := runSessionCred(t, srv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("no authorization anywhere is a different rule's finding, got %d", len(findings))
+	}
+}
+
+// A server that accepts ANY session id is not authenticating by the identity of the
+// session, it is treating presence of the header as authorization. Step 5 would
+// succeed there too, so without the never-issued control the rule would claim the
+// issued session id was what authorized the call when any string would have done.
+func TestSessionAsCredential_AnySessionIDIsSuppressed(t *testing.T) {
+	srv := sessionCredServer(t, "session-presence-auth")
+	defer srv.Close()
+
+	findings, err := runSessionCred(t, srv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("a server that ignores session ids must not be reported, got %d", len(findings))
+	}
+}
+
+// No session id means nothing to misuse. 2026-07-28 removed protocol-level
+// sessions, so this is also how the rule behaves on that revision.
+func TestSessionAsCredential_StatelessIsNotApplicable(t *testing.T) {
+	srv := sessionCredServer(t, "stateless")
+	defer srv.Close()
+
+	findings, err := runSessionCred(t, srv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("a stateless server has no session id to misuse, got %d", len(findings))
+	}
+}
+
+// Without a credential the rule cannot establish a session to strip one from, so
+// it has nothing to compare and must say so rather than report clean.
+func TestSessionAsCredential_NoCredentialIsInconclusive(t *testing.T) {
+	srv := sessionCredServer(t, "session-authenticates")
+	defer srv.Close()
+
+	exec := mcpattack.NewSessionAsCredentialExecutor(attack.RuleContext{ID: "mcp-session-as-credential-001"})
+	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("want ErrInconclusive without a credential, got %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected no findings, got %d", len(findings))
+	}
+}
+
+// A server that allows a call with no session at all, while refusing session ids it
+// never issued, is simply open on that surface. Without the no-session control the
+// never-issued probe would be refused, step 5 would be answered, and the rule would
+// report a finding the session id did not cause.
+func TestSessionAsCredential_SessionlessOpenIsSuppressed(t *testing.T) {
+	srv := sessionCredServer(t, "sessionless-open")
+	defer srv.Close()
+
+	findings, err := runSessionCred(t, srv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("the call did not need a session, so the session id authorized nothing; got %d findings",
+			len(findings))
+	}
+}
+
+// The false positive this rule shipped with in development, caught against the
+// official MCP C# SDK's stateful sample rather than in a unit test.
+//
+// That server has no authorization at all, and requires a session id on every
+// non-initialize request. So a call with no session is refused, and a call with a
+// never-issued session is refused, both for SESSION reasons rather than credential
+// reasons. Those controls cannot tell the two apart, every one of them passed, and
+// the final probe succeeded because nothing is ever authenticated. Establishing
+// that the server implements authorization at all, by attempting an ANONYMOUS
+// handshake, is what separates the two.
+func TestSessionAsCredential_NoAuthButSessionRequiredIsSuppressed(t *testing.T) {
+	srv := sessionCredServer(t, "no-auth-session-required")
+	defer srv.Close()
+
+	findings, err := runSessionCred(t, srv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("this server authenticates nothing, so the session id authorized nothing; "+
+			"got %d finding(s)", len(findings))
+	}
+}
+
+// An ungated handshake is not the same thing as no authorization. This server
+// lets anyone call initialize, but a session opened by a credentialed caller is
+// what authorizes the calls that follow, which is precisely the failure the rule
+// tests for. Reading "initialize answered anonymously" as "implements no
+// authorization" suppressed it.
+//
+// The oracle here is stronger than the never-issued-id control: both session ids
+// were minted by this server, and the only difference between them is whether a
+// credential was presented when they were opened.
+func TestSessionAsCredential_OpenHandshakeStillFires(t *testing.T) {
+	srv := sessionCredServer(t, "open-init-session-auth")
+	defer srv.Close()
+
+	findings, err := runSessionCred(t, srv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 finding, got %d", len(findings))
+	}
+	if !strings.Contains(findings[0].Evidence, "ANONYMOUS handshake") {
+		t.Errorf("evidence should name the anonymous session it was compared against; got:\n%s",
+			findings[0].Evidence)
+	}
+}
+
+// The handshake is open but only a credentialed caller is issued a session, so
+// there is no anonymous session to compare against. The refusals below could be
+// about the missing session rather than the missing credential, and that is the
+// ambiguity that produced the C# SDK false positive. Report nothing.
+func TestSessionAsCredential_NoAnonymousSessionIsSuppressed(t *testing.T) {
+	srv := sessionCredServer(t, "open-init-no-anon-session")
+	defer srv.Close()
+
+	findings, err := runSessionCred(t, srv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("no anonymous session was available to attribute the refusals to the "+
+			"missing credential; got %d finding(s)", len(findings))
+	}
+}

--- a/rules/mcp/session-as-credential-001.yaml
+++ b/rules/mcp/session-as-credential-001.yaml
@@ -1,0 +1,94 @@
+id: mcp-session-as-credential-001
+info:
+  name: MCP Session ID Accepted as a Credential (Session Used for Authentication)
+  author: batesian
+  severity: high
+  description: |
+    Tests whether an MCP server treats its own Mcp-Session-Id as proof of
+    identity. The Security Best Practices are explicit: "MCP servers that
+    implement authorization MUST verify all inbound requests. MCP Servers MUST NOT
+    use sessions for authentication."
+
+    A server that authenticates by session turns a header into a bearer token. The
+    session id travels in plaintext on every request, is logged by proxies and
+    gateways, and is not scoped, rotated or revocable the way a token is. Anyone
+    who reads one from a log replays the authenticated session, which is the
+    spec's own Session Hijack Impersonation flow.
+
+    The rule needs one working credential, and confirms the failure with three
+    controls so it cannot fire on a server that has no authorization at all, one
+    that merely requires a session and authenticates nothing, one that needs no
+    session for the call, or one that accepts any session id at all:
+
+      1. Handshake WITH the credential and capture the server-minted session id.
+         No session id means the server is stateless and the rule does not apply.
+      2. Call tools/list with the session id AND the credential. It must succeed,
+         or the session is not usable and there is nothing to test.
+      3. Control: attempt an ANONYMOUS handshake, and if it yields a session, call
+         tools/list with that session and no credential. If that succeeds, a caller
+         who never presented a credential read the tool list: the server implements
+         no authorization, the requirement above does not bind on it, and the
+         surface belongs to mcp-tools-unauth-001. An open handshake on its own
+         proves nothing, since plenty of servers leave initialize ungated and
+         authorize what follows. If the anonymous handshake is accepted but issues
+         no session, the rule stops: with no anonymous session to compare against,
+         a refusal below cannot be attributed to the missing credential rather than
+         to the missing session.
+      4. Control: call tools/list with NO session and NO credential. A server
+         that answers it is open on this surface, so a later success cannot be
+         attributed to the session id.
+      5. Control: call tools/list presenting a RANDOM never-issued session id and
+         no credential. A server that accepts this treats the presence of the
+         header as authorization, so the issued id was not what decided it.
+      6. Call tools/list presenting the REAL session id and no credential. A
+         result here is the finding: the request carried no credential, an
+         identical request with a never-issued session id was refused, and the
+         only difference between them is whether the session id was one the
+         server issued. The session id alone authorized the call.
+
+    Steps 5 and 6 are the same request differing in one detail, which is what
+    makes the session id provably the deciding factor rather than an inference.
+    When step 3 produced an anonymous session, steps 3 and 6 are a second such
+    pair, and a stronger one: both session ids were minted by this server, and the
+    only difference between them is whether a credential was presented when they
+    were opened.
+
+    Step 3 exists because the official MCP C# SDK's stateful sample, which has no
+    authorization and requires a session id on every non-initialize request,
+    passed steps 4 through 6 and was reported as vulnerable without it.
+
+    Currency: Mcp-Session-Id is normative in revisions 2025-03-26 through
+    2025-11-25. The 2026-07-28 revision removes protocol-level sessions, so a
+    server on that revision returns no session id and the rule reports itself not
+    applicable at step 1.
+
+  references:
+    - https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices
+    - https://modelcontextprotocol.io/specification/2025-11-25/basic/transports
+    - https://cwe.mitre.org/data/definitions/287.html
+    - https://cwe.mitre.org/data/definitions/565.html
+
+  tags:
+    - mcp
+    - session
+    - authentication
+    - authorization
+    - cwe-287
+    - cwe-565
+
+attack:
+  protocol: mcp
+  type: mcp-session-as-credential
+
+remediation: |
+  1. Authenticate every inbound request on its own credential. Resolve the
+     principal from the Authorization header (or mTLS identity) on each call, and
+     never from the session id alone.
+  2. Treat Mcp-Session-Id purely as transport state: it selects which conversation
+     a request belongs to, and carries no authority.
+  3. Bind each session to the principal established at initialize, and reject a
+     request whose credential resolves to a different principal than the session
+     was opened by. The spec suggests keying stored session state as
+     <user_id>:<session_id> for exactly this reason.
+  4. Reject requests that present a session id but no credential, rather than
+     falling back to the session's stored identity.

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -31,7 +31,7 @@ a run that treats it as a clean result is reporting coverage it does not have.
 
 ## Server Registry
 
-The bundled rule set is **17 A2A + 19 MCP = 36 rules**. Every rule's primary
+The bundled rule set is **17 A2A + 20 MCP = 37 rules**. Every rule's primary
 validation is an in-process `net/http/httptest` harness in its Go
 `*_test.go` (multiple server postures: vulnerable must fire / patched / open /
 benign must stay silent). The Python servers below are optional standalone
@@ -69,8 +69,9 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_era_downgrade_server.py` | 7800 | `mcp-era-downgrade-001` (two postures, see below) |
 | `mcp_large_body_server.py` | 7801 | the unauth family at responses past the body read limit, see below |
 | `mcp_transient_failure_server.py` | 7802 | the unauth family when a probe fails without refusing, see below |
+| `mcp_session_as_credential_server.py` | 7803 | `mcp-session-as-credential-001` (needs `--token tok-a`; four postures, see below) |
 
-**Coverage.** 35 of the 36 rules have a standalone Python fixture above, and each
+**Coverage.** 36 of the 37 rules have a standalone Python fixture above, and each
 of those was checked by actually running it rather than by reading this table. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
 (`internal/attack/mcp/token_replay_test.go`); the same is true of the per-rule
@@ -197,6 +198,31 @@ as "the modern wire is served", which turned that server's `400 Bad Request:
 protocol version "2026-07-28" is only supported on stateless HTTP servers` into
 the refused half of an authorization asymmetry and produced a critical
 `mcp-era-downgrade-001` finding against a target with no authorization at all.
+
+**`mcp_session_as_credential_server.py` takes a posture argument**, defaulting to
+`vulnerable`, and needs `--token tok-a`:
+
+```sh
+python testdata/mcp_session_as_credential_server.py vulnerable             # rule must fire
+python testdata/mcp_session_as_credential_server.py open-handshake         # rule must fire
+python testdata/mcp_session_as_credential_server.py patched                # rule must stay silent
+python testdata/mcp_session_as_credential_server.py session-presence-auth  # rule must stay silent
+```
+
+All four are stateful and reject a session id they never issued, which is what
+lets the rule attribute a success to the issued id. `open-handshake` is the same
+bug as `vulnerable` on a server that gates nothing at `initialize`: the session
+remembers who opened it, and that memory authorizes later calls that carry no
+credential. It exists because an open handshake is not the same thing as no
+authorization, and a rule that treats it as such reports nothing here.
+`patched` authenticates every request on its own credential.
+`session-presence-auth` authenticates nothing but
+demands a session id on every non-initialize request, so a stripped request is
+refused for session reasons rather than credential ones; it is the shape of the
+official MCP C# SDK's stateful sample, which this rule reported as vulnerable
+until the anonymous-handshake control was added. Without `--token` the rule
+reports inconclusive against all three, since it cannot ask whether a session id
+substitutes for a credential it was never given.
 
 The multi-tenant and delegation fixtures exercise the chained rules: they require
 two principals supplied with `--principal name=...,token=...,tenant=...` (or a

--- a/testdata/mcp_session_as_credential_server.py
+++ b/testdata/mcp_session_as_credential_server.py
@@ -1,0 +1,147 @@
+"""
+MCP server for validating:
+  - mcp-session-as-credential-001: the server accepts its own Mcp-Session-Id as
+    proof of identity (CWE-287 / CWE-565).
+
+The Security Best Practices are explicit: "MCP servers that implement
+authorization MUST verify all inbound requests. MCP Servers MUST NOT use sessions
+for authentication."
+
+Four postures, selected by the first argument.
+
+`vulnerable` requires a bearer token at initialize, mints a session id, and then
+accepts that session id alone on every later request. Stripping the Authorization
+header changes nothing as long as the session id is one it issued. That is a
+bearer token in a plaintext header that no proxy log redacts.
+
+`open-handshake` is the same failure on a server that leaves initialize ungated:
+anyone may handshake, but the session remembers who opened it and that memory is
+what authorizes later calls. It must fire. An open handshake is not the same thing
+as no authorization, and reading it that way suppressed this case.
+
+`patched` is the same server with the fix: every request is authenticated on its
+own credential, and the session id only selects which conversation the request
+belongs to. It must produce no finding.
+
+`session-presence-auth` is the false-positive posture, and it is the reason step 3
+of the rule exists. It has no authorization at all, but it demands a session id on
+every non-initialize request, so a stripped request is refused for SESSION reasons
+rather than credential ones. This is the shape of the official MCP C# SDK's
+stateful sample, which the rule reported as vulnerable before the anonymous
+handshake control was added. It must produce no finding.
+
+Validate against it:
+  python testdata/mcp_session_as_credential_server.py vulnerable
+  batesian scan --target http://127.0.0.1:7803 --token tok-a \\
+      --rule-ids mcp-session-as-credential-001 -v
+
+The token matters: the rule asks whether a session id can stand in for a
+credential, which it cannot ask without a credential to compare against. With no
+--token it reports inconclusive rather than clean.
+
+Endpoint: http://127.0.0.1:7803/mcp
+"""
+import sys
+import uuid
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route
+import uvicorn
+
+PORT = 7803
+TOKEN = "tok-a"
+
+POSTURES = ("vulnerable", "open-handshake", "patched", "session-presence-auth")
+POSTURE = sys.argv[1] if len(sys.argv) > 1 else "vulnerable"
+
+# Postures that let anyone handshake. session-presence-auth authenticates nothing
+# at all; open-handshake authorizes later calls from the session's own memory of
+# who opened it, which is the failure under test.
+OPEN_HANDSHAKE = ("open-handshake", "session-presence-auth")
+
+# session id -> the principal the session was opened by
+SESSIONS: dict = {}
+
+
+def _result(req_id, result, session_id=None):
+    headers = {"Mcp-Session-Id": session_id} if session_id else None
+    return JSONResponse({"jsonrpc": "2.0", "id": req_id, "result": result}, headers=headers)
+
+
+def _error(req_id, code, message):
+    return JSONResponse({"jsonrpc": "2.0", "id": req_id,
+                         "error": {"code": code, "message": message}})
+
+
+def _credentialed(request: Request) -> bool:
+    return request.headers.get("authorization", "") == f"Bearer {TOKEN}"
+
+
+async def mcp_endpoint(request: Request) -> Response:
+    body = await request.json()
+    method = body.get("method", "")
+    req_id = body.get("id")
+    supplied = request.headers.get("mcp-session-id", "")
+    authed = _credentialed(request)
+
+    if method == "initialize":
+        if POSTURE not in OPEN_HANDSHAKE and not authed:
+            return _error(req_id, -32000, "authentication required")
+        session_id = uuid.uuid4().hex
+        # The session remembers the principal that opened it. In the vulnerable
+        # postures that memory is what later authorizes calls made without a
+        # credential, which is the bug.
+        SESSIONS[session_id] = "tenant-a" if authed else "anonymous"
+        return _result(req_id, {
+            "protocolVersion": "2025-11-25",
+            "serverInfo": {"name": "session-as-credential-target", "version": "1.0"},
+            "capabilities": {"tools": {}},
+        }, session_id=session_id)
+
+    if method == "notifications/initialized":
+        return Response(status_code=202)
+
+    # Every posture is stateful: an id the server never issued is rejected, per the
+    # Streamable HTTP transport. Without this the rule cannot attribute a success to
+    # the issued session id, and its never-issued-id control suppresses the finding.
+    if supplied not in SESSIONS:
+        return _error(req_id, -32000, "no valid session id provided")
+
+    if POSTURE == "vulnerable":
+        # VULNERABLE: the session id resolved a principal, so the request is
+        # authorized. The Authorization header is never looked at again.
+        pass
+    elif POSTURE == "open-handshake":
+        # VULNERABLE the same way, on a server that gates nothing at initialize.
+        # A session opened anonymously carries no authority; one opened with the
+        # credential authorizes calls that present no credential at all.
+        if not authed and SESSIONS[supplied] == "anonymous":
+            return _error(req_id, -32000, "authentication required")
+    elif POSTURE == "patched":
+        # FIXED: authenticate this request on its own credential.
+        if not authed:
+            return _error(req_id, -32000, "authentication required")
+    # session-presence-auth: the session id was enough because nothing is
+    # authenticated here at all. The refusal above was about session state.
+
+    if method == "tools/list":
+        return _result(req_id, {"tools": [{"name": "echo", "description": "Echo input"}]})
+
+    return _error(req_id, -32601, "Method not found")
+
+
+app = Starlette(routes=[Route("/mcp", mcp_endpoint, methods=["POST"])])
+
+if __name__ == "__main__":
+    if POSTURE not in POSTURES:
+        sys.exit(f"unknown posture {POSTURE!r}; expected one of {', '.join(POSTURES)}")
+    print(f"[*] MCP session-as-credential target ({POSTURE}) on "
+          f"http://127.0.0.1:{PORT}/mcp", flush=True)
+    if POSTURE == "vulnerable":
+        print("[*] Vulnerability: the issued Mcp-Session-Id authorizes requests "
+              "on its own (CWE-287/CWE-565)", flush=True)
+    else:
+        print("[*] Expected: no finding", flush=True)
+    print(f"[*] Credential: --token {TOKEN}", flush=True)
+    uvicorn.run(app, host="127.0.0.1", port=PORT)


### PR DESCRIPTION
The Security Best Practices require that servers implementing authorization verify
all inbound requests, and state that servers MUST NOT use sessions for
authentication. Nothing in the rule set tested the second sentence: a server that
authenticates by `Mcp-Session-Id` scanned clean.

`mcp-session-as-credential-001` opens a session with a working credential, then
calls `tools/list` with that session and no credential. A result is the finding.
Three controls keep it off servers where the session id was not what decided the
call: an anonymous handshake whose session is then used (an open handshake alone
proves nothing), a call with no session and no credential, and a call presenting a
never-issued session id. With no credential the rule reports inconclusive, not
clean.

Verification:

- 10 posture tests; each control removed in turn to confirm its suppression test then fails
- live against `testdata/mcp_session_as_credential_server.py`, four postures: two fire, two silent
- live against the official MCP C# SDK stateful sample, which stays silent. It has no
  authorization and requires a session id on every request, and was reported as
  vulnerable before the anonymous-handshake control
- 43-case sweep of every testdata fixture against the previous binary: the only
  findings deltas are the two intended ones, and the rule reports inconclusive
  wherever it has no credential