### PR TITLE
fix(mcp): stop reporting audience validation clean when the probes could not test it

### DIFF
--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -155,6 +155,16 @@ or RFC 9728 auto-discovery). Without one, the outcome depends on whether anythin
 answered: an MCP server that advertises no metadata has no audience to check
 against, so that is a **clean** result, while a target where nothing answered the
 handshake is reported as **not tested**.
+
+Every probe is derived from that expected value, and RFC 7519 section 4.1.3
+compares the `aud` claim exactly, so a `--audience-claim` that does not byte-match
+what the server uses makes all four probes plain mismatches: the server refuses
+them whether or not its matching logic is sound. Before reporting clean on an
+operator-supplied value, the rule therefore checks it against the audience the
+server advertises and reports **not tested** when the two disagree, naming both.
+A finding is never withheld for a disagreement. Hostname case is the likeliest way
+to hit this, since DNS is case-insensitive and audience comparison is not.
+
 It submits a **negative control** plus three trap probes as forged HS256 JWTs:
 
 - `aud-control-unrelated` - isolates the audience logic from blanket signature

--- a/internal/attack/mcp/oauth_audience.go
+++ b/internal/attack/mcp/oauth_audience.go
@@ -19,6 +19,16 @@ import (
 // audience value is known. The expected value is taken from
 // opts.AudienceClaim or, when unset, RFC 9728 protected-resource-metadata.
 //
+// Every probe is derived from that value, so it decides whether the rule tests
+// anything at all: the server compares the forged `aud` against its OWN
+// configured audience, and RFC 7519 section 4.1.3 makes that comparison exact.
+// A value that does not byte-match is a plain mismatch the server refuses
+// whether or not its matching logic is sound, which reads as a clean result. So
+// before reporting clean on an operator-supplied value, the rule checks it
+// against what the server advertises and reports not tested when they disagree.
+// Hostname case is the likeliest way for that to happen, since DNS is
+// case-insensitive and audience comparison is not.
+//
 // Because probes are forged HS256 self-signed tokens, acceptance indicates a
 // compound failure: signature validation AND audience matching both inadequate.
 // The "validly signed cross-resource token" class (Parse CVE-2026-30863) is
@@ -80,7 +90,8 @@ func (e *OAuthAudienceExecutor) Execute(ctx context.Context, target string, opts
 	client := attack.NewHTTPClient(opts, vars)
 
 	expected := strings.TrimSpace(opts.AudienceClaim)
-	if expected == "" {
+	operatorSupplied := expected != ""
+	if !operatorSupplied {
 		discovered, mcpReached := discoverExpectedAudience(ctx, client, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
 		if discovered == "" {
 			// Precondition not met: no operator input and no discoverable
@@ -112,10 +123,27 @@ func (e *OAuthAudienceExecutor) Execute(ctx context.Context, target string, opts
 	}
 
 	finding := coalesceOutcomes(e.rule, endpoint, expected, outcomes)
-	if finding == nil {
-		return nil, nil
+	if finding != nil {
+		return []attack.Finding{*finding}, nil
 	}
-	return []attack.Finding{*finding}, nil
+
+	// Nothing was accepted. That is only a clean result if the probes were built
+	// from the audience this server actually uses, so verify the premise before
+	// reporting one. The check runs here rather than up front for two reasons: a
+	// scan that found something needs no premise check, and a disagreement is not
+	// a reason to withhold a finding the server demonstrated.
+	if operatorSupplied {
+		if advertised, _ := discoverExpectedAudience(ctx, client,
+			attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL); advertised != "" && advertised != expected {
+			return nil, fmt.Errorf("%w: the probes were built from the --audience-claim value %q, "+
+				"but %s advertises %q as its resource audience; RFC 7519 section 4.1.3 compares the "+
+				"aud claim exactly, so every probe was a plain mismatch this server refuses whether "+
+				"or not its audience matching is sound; rerun with the advertised value, or with no "+
+				"--audience-claim to use it automatically",
+				attack.ErrInconclusive, expected, endpoint, advertised)
+		}
+	}
+	return nil, nil
 }
 
 // buildProbes constructs the v1 probe set from the operator's expected audience.

--- a/internal/attack/mcp/oauth_audience_test.go
+++ b/internal/attack/mcp/oauth_audience_test.go
@@ -482,3 +482,99 @@ func TestOAuthAudience_MethodNotAllowedIsNotARejection(t *testing.T) {
 		t.Errorf("want ErrInconclusive for a target answering 405 everywhere, got %v", err)
 	}
 }
+
+// audienceServerAdvertising is an audienceServer that also serves RFC 9728
+// resource metadata naming `advertised`, so a test can put the operator's
+// --audience-claim and the server's own audience in disagreement.
+func audienceServerAdvertising(t *testing.T, advertised string, acceptFn func(aud interface{}) bool) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-protected-resource", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"resource":              advertised,
+			"authorization_servers": []string{"https://issuer.acme.com"},
+		})
+	})
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		aud := decodeJWTAud(t, r.Header.Get("Authorization"))
+		if acceptFn(aud) {
+			initializeOK(w)
+			return
+		}
+		challenge401(w)
+	})
+	return httptest.NewServer(mux)
+}
+
+// Every probe is derived from the expected audience, and RFC 7519 compares the
+// claim exactly, so a --audience-claim that does not byte-match what the server
+// uses turns all four probes into plain mismatches. The server refuses them
+// whether or not its matching logic is sound, and reporting that as clean claims
+// coverage the scan does not have.
+//
+// This server has the substring bug and would be caught with the right value.
+// Hostname case is the whole difference, which is the realistic mistake: DNS is
+// case-insensitive, audience comparison is not.
+func TestOAuthAudience_ClaimDisagreesWithAdvertisedIsNotTested(t *testing.T) {
+	const advertised = "https://API.acme.com/mcp"
+	srv := audienceServerAdvertising(t, advertised, func(aud interface{}) bool {
+		s, ok := aud.(string)
+		return ok && strings.Contains(s, advertised)
+	})
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC())
+	findings, err := exec.Execute(context.Background(), srv.URL, optsWithAudience("https://api.acme.com/mcp"))
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings from probes built on the wrong audience, got %d", len(findings))
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive, got %v", err)
+	}
+	// The operator cannot act on this without both values.
+	for _, want := range []string{"https://api.acme.com/mcp", advertised} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("reason should name %q; got: %v", want, err)
+		}
+	}
+}
+
+// A disagreement is not a reason to withhold a finding the server demonstrated.
+// This one accepts any forged token, which the control probe catches regardless
+// of which audience the traps were built from.
+func TestOAuthAudience_ClaimDisagreesButFindingStillReported(t *testing.T) {
+	srv := audienceServerAdvertising(t, "https://API.acme.com/mcp", func(aud interface{}) bool {
+		return true // accepts every forged token, audience irrelevant
+	})
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC())
+	findings, err := exec.Execute(context.Background(), srv.URL, optsWithAudience("https://api.acme.com/mcp"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected the finding to survive the disagreement, got %d", len(findings))
+	}
+}
+
+// The premise check must not turn a genuine clean result into not tested. Same
+// server, same advertised audience, and the operator passed exactly that value.
+func TestOAuthAudience_ClaimMatchesAdvertisedStaysClean(t *testing.T) {
+	const advertised = "https://API.acme.com/mcp"
+	srv := audienceServerAdvertising(t, advertised, func(aud interface{}) bool {
+		s, ok := aud.(string)
+		return ok && s == advertised // strict, exact, case-sensitive
+	})
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC())
+	findings, err := exec.Execute(context.Background(), srv.URL, optsWithAudience(advertised))
+	if err != nil {
+		t.Fatalf("expected a clean result, got %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings on a strict server, got %d", len(findings))
+	}
+}

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -87,8 +87,15 @@ when it is not, so check them before concluding a rule has regressed:
   `mcp_oauth_metadata_ssrf_server.py`, `mcp_confused_deputy_server.py`) are
   scanned at the root, not at `/mcp`. `mcp_oauth_audience_server.py` is the
   opposite: each bug class lives at its own sub-path, so the target must name the
-  endpoint (`http://127.0.0.1:7785/vulnerable-substring/mcp` and so on), and it
-  takes `--audience-claim`. Scanning its root correctly reports "not tested".
+  endpoint (`http://127.0.0.1:7785/vulnerable-substring/mcp` and so on). Scanning
+  its root correctly reports "not tested".
+- **Audience case.** `mcp_oauth_audience_server.py` advertises
+  `https://API.example.com/mcp`, mixed case on purpose so the case-fold endpoint
+  has something to vary. Either omit `--audience-claim` and let RFC 9728 discovery
+  supply it, or pass that exact value. Passing an all-lowercase spelling used to
+  silently disable the substring and case-fold probes, because every probe is built
+  from the value given and RFC 7519 compares the claim exactly; the rule now
+  reports "not tested" and names both values instead.
 - **Postures.** Several fixtures need a non-default argument, listed above.
 
 **`mcp_modern_era_server.py` is the one server here that is not deliberately

--- a/testdata/mcp_oauth_audience_server.py
+++ b/testdata/mcp_oauth_audience_server.py
@@ -19,18 +19,19 @@ Endpoint matrix:
                                   per RFC 7519 section 4.1.3.
 
 The expected audience advertised by every endpoint is
-`https://api.example.com/mcp` (also exposed at
-`/.well-known/oauth-protected-resource`) so a Batesian scan run with
-`--audience-claim https://api.example.com/mcp` (or no claim, relying on RFC
-9728 auto-discovery) exercises every probe.
+`https://API.example.com/mcp` (also exposed at
+`/.well-known/oauth-protected-resource`). THE CASE MATTERS: every probe is built
+from the expected value the scan is given, and RFC 7519 section 4.1.3 compares the
+aud claim exactly, so an all-lowercase spelling makes the substring and case-fold
+probes plain mismatches this server refuses. Either omit `--audience-claim` and let
+RFC 9728 discovery supply the advertised value, or pass it verbatim.
 
 Run:
     python testdata/mcp_oauth_audience_server.py
 
-Then scan with the rule:
-    batesian scan --target http://127.0.0.1:7785 \
-                  --rule-ids mcp-oauth-audience-002 \
-                  --audience-claim https://api.example.com/mcp -v
+Then scan one bug class at a time (the root correctly reports "not tested"):
+    batesian scan --target http://127.0.0.1:7785/vulnerable-substring/mcp \
+                  --rule-ids mcp-oauth-audience-002 -v
 
 This server is intentionally misconfigured. Do not run on a public network.
 """


### PR DESCRIPTION
Every `mcp-oauth-audience-002` probe is derived from the expected audience, and RFC
7519 section 4.1.3 compares the `aud` claim exactly. So an `--audience-claim` that
does not byte-match what the server uses makes all four probes plain mismatches:
the server refuses them whether or not its matching logic is sound, and the rule
reported the target clean. Hostname case is the likeliest way to hit it, since DNS
is case-insensitive and audience comparison is not. The rule already knew how to
read the advertised audience from RFC 9728 but only did so when no claim was given.

Before reporting clean on an operator-supplied claim, it now resolves the
advertised audience and reports not tested when the two differ, naming both values.
A finding is never withheld for a disagreement, and because the check runs only on
the path that was about to report clean, it costs nothing when a scan found
something: 4 requests before and after on the finding path, 4 to 6 on the clean one.

The project's own fixture was hiding this. It advertises
`https://API.example.com/mcp`, mixed case on purpose so the case-fold endpoint has
something to vary, while `testdata/README.md` documented scanning it with an
all-lowercase claim, which silently disabled the substring and case-fold probes.
Two of three vulnerable sub-paths reported clean and the registry row claimed
coverage the fixture was not providing. The documented invocation now uses RFC 9728
discovery.

Live matrix over the four sub-paths, before and after:

| sub-path | lowercase claim (was) | lowercase claim (now) | advertised value | no claim |
|---|---|---|---|---|
| `vulnerable-substring` | clean | not tested | 1 finding | 1 finding |
| `vulnerable-casefold` | clean | not tested | 1 finding | 1 finding |
| `vulnerable-array-skip` | 1 finding | 1 finding | 1 finding | 1 finding |
| `secure` (control) | clean | not tested | clean | clean |

Verification:

- 3 tests: disagreement with a clean result, a finding surviving a disagreement,
  and a matching claim not turning clean into not tested. The first fails with the
  check removed; the other two pass either way, which is the point of them
- request cost measured through a counting proxy, both paths
- 43-case sweep of every testdata fixture against the previous binary: no finding
  or skip changed. The sweep does not exercise the new gate (no fixture is scanned
  with a mismatched claim), so it is evidence of no regression, not of the fix