### PR TITLE
fix(mcp): name the real reason a rule could not run, instead of blaming the network

### DIFF
--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -57,6 +57,15 @@ against a server this rule set cannot handshake with they report **inconclusive
 or skip**, never a clean pass. A target that could not be exercised is reported
 as not tested rather than as secure.
 
+A skip names the reason where the handshake explained itself, because the actions
+they call for differ. The common one is a server that requires a credential
+scanned without one: it answers every request and refuses the handshake, so the
+skip says so and points at `--token`, rather than reporting a target that is
+plainly reachable as unreachable. An endpoint that answers but does not implement
+`initialize` is reported as not speaking MCP. `could not reach a testable
+endpoint` is now reserved for what it says: nothing answered, or no candidate path
+is served.
+
 ## OAuth-gated rules
 
 `mcp-oauth-dcr-001`, `mcp-oauth-audience-002`, `mcp-token-replay-001`,

--- a/internal/attack/mcp/era.go
+++ b/internal/attack/mcp/era.go
@@ -19,16 +19,118 @@ var errModernEra = errors.New("server implements a protocol era these rules do n
 // server rather than an unreachable one.
 func IsModernEraErr(err error) bool { return errors.Is(err, errModernEra) }
 
+// handshakeRefusal carries why an initialize handshake did not complete, in terms
+// an operator can act on.
+//
+// It is a distinct type so inconclusive can tell a diagnosis apart from an
+// internal error: only a refusal the walk actually classified reaches a scan
+// report, and anything else collapses to the generic reachability message rather
+// than leaking implementation detail as if it were a finding about the target.
+type handshakeRefusal struct{ reason string }
+
+func (h handshakeRefusal) Error() string { return h.reason }
+
 // inconclusive converts an initializeMCP failure into the error a rule should
 // return. Either way the rule was not exercised and the engine records it as
-// skipped rather than clean, but a modern-era target carries its reason forward
-// so the operator learns the protocol version is unsupported instead of being
-// told only that nothing was reachable.
+// skipped rather than clean, but a classified failure carries its reason forward
+// so the operator learns what actually happened.
+//
+// The default message, "could not reach a testable endpoint", sends an operator to
+// look at their network. That is right when nothing answered and wrong the rest of
+// the time, and the most common wrong case is the ordinary one: scanning a server
+// that requires a credential without passing one. The server answers every
+// request, refuses the handshake, and twelve rules used to report it as
+// unreachable.
 func inconclusive(err error) error {
 	if IsModernEraErr(err) {
 		return fmt.Errorf("%w: %s", attack.ErrInconclusive, err)
 	}
+	var refusal handshakeRefusal
+	if errors.As(err, &refusal) {
+		return fmt.Errorf("%w: %s", attack.ErrInconclusive, refusal.reason)
+	}
 	return attack.ErrInconclusive
+}
+
+// How much a failed candidate tells us. The candidate list is walked in a fixed
+// order (/mcp, /, /api, /rpc), so a 404 from a path the server does not serve can
+// be seen before the auth refusal from the path it does. The reason therefore has
+// to be ranked rather than last-one-wins, or the message depends on path order.
+const (
+	rankNothing = iota
+	rankStatusOnly
+	rankNotMCP
+	rankRefused
+	rankUnauthorized
+)
+
+// initObservation is the best explanation seen while walking the candidates.
+type initObservation struct {
+	rank   int
+	reason string
+}
+
+// observe keeps o when it explains more than what is already held.
+func (i *initObservation) observe(o initObservation) {
+	if o.rank > i.rank {
+		*i = o
+	}
+}
+
+// classifyInitFailure explains why one candidate did not complete a handshake.
+//
+// The ranking is about what an operator can do next. An unauthorized refusal is
+// the top rank because it names the fix; "answered but does not implement
+// initialize" is above a bare status because it says the target is not MCP at all
+// rather than unreachable.
+func classifyInitFailure(endpoint string, resp *attack.Response) initObservation {
+	// A path the server does not serve explains nothing: the candidate walk exists
+	// precisely because the endpoint is unknown, so most of these 404s are the cost
+	// of looking rather than a fact about the target. Reporting one as the reason
+	// would name an arbitrary candidate and frame a routing miss as a refused
+	// handshake. When every candidate is absent, the generic reachability message is
+	// the honest answer.
+	if endpointAbsent(resp) {
+		return initObservation{}
+	}
+
+	code, hasErr := jsonRPCErrorCode(resp.Body)
+	msg := jsonRPCErrorMessage(resp.Body)
+
+	// An auth refusal can arrive either as an HTTP status or as a JSON-RPC error at
+	// HTTP 200, which is what the real SDKs do, so both shapes are checked.
+	if resp.StatusCode == 401 || resp.StatusCode == 403 {
+		return initObservation{rankUnauthorized, fmt.Sprintf(
+			"the MCP handshake at %s was refused with HTTP %d, so this server requires a "+
+				"credential and the scan carried none; pass --token or a --principal",
+			endpoint, resp.StatusCode)}
+	}
+	if hasErr && authFlavoredError(code, msg) {
+		return initObservation{rankUnauthorized, fmt.Sprintf(
+			"the MCP handshake at %s was refused as unauthorized (JSON-RPC %d: %q), so this "+
+				"server requires a credential and the scan carried none; pass --token or a --principal",
+			endpoint, code, msg)}
+	}
+	if hasErr && code == mcpMethodNotFound {
+		return initObservation{rankNotMCP, fmt.Sprintf(
+			"%s answered but does not implement the MCP initialize method (JSON-RPC %d), so "+
+				"nothing at this target speaks MCP", endpoint, code)}
+	}
+	if hasErr {
+		return initObservation{rankRefused, fmt.Sprintf(
+			"the MCP handshake at %s was refused (JSON-RPC %d: %q)", endpoint, code, msg)}
+	}
+	if !resp.IsSuccess() {
+		return initObservation{rankStatusOnly, fmt.Sprintf(
+			"the MCP handshake at %s was answered with HTTP %d and no JSON-RPC error",
+			endpoint, resp.StatusCode)}
+	}
+	// HTTP 2xx, no JSON-RPC error, and yet not a handshake: something is there and
+	// it is not answering as an MCP server.
+	return initObservation{rankNotMCP, fmt.Sprintf(
+		"%s answered the handshake with HTTP %d but the reply carried no protocolVersion, "+
+			"serverInfo or capabilities, so it did not complete an MCP handshake",
+		endpoint, resp.StatusCode)}
 }
 
 // MCP split into two incompatible eras. Revisions up to 2025-11-25 ("legacy")

--- a/internal/attack/mcp/handshake_reason_test.go
+++ b/internal/attack/mcp/handshake_reason_test.go
@@ -1,0 +1,148 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+// "Could not reach a testable endpoint" sends an operator to look at their
+// network. That is right when nothing answered, and wrong the rest of the time.
+// The most common wrong case is the ordinary one: scanning a server that requires
+// a credential without passing one. It answers every request, refuses the
+// handshake, and the rule reported it as unreachable.
+//
+// These tests drive mcp-tools-unauth-001, which reaches the shared handshake
+// through runOnEachWire -> openSessions -> inconclusive, the funnel every rule in
+// this increment uses.
+
+// toolsUnauthErr returns the error mcp-tools-unauth-001 reports against target.
+func toolsUnauthErr(t *testing.T, target string) error {
+	t.Helper()
+	exec := mcpattack.NewToolsUnauthExecutor(attack.RuleContext{ID: "mcp-tools-unauth-001"})
+	_, err := exec.Execute(context.Background(), target, testOpts())
+	return err
+}
+
+// assertReason fails unless err is ErrInconclusive carrying every want substring.
+func assertReason(t *testing.T, err error, want ...string) {
+	t.Helper()
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive, got %v", err)
+	}
+	for _, w := range want {
+		if !strings.Contains(err.Error(), w) {
+			t.Errorf("reason should contain %q; got: %v", w, err)
+		}
+	}
+}
+
+// jsonRPCError writes a JSON-RPC error envelope at the given HTTP status.
+func jsonRPCError(w http.ResponseWriter, status, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"jsonrpc": "2.0", "id": 1,
+		"error": map[string]interface{}{"code": code, "message": msg},
+	})
+}
+
+// A credential-gated server answering with an HTTP status. The reason has to name
+// the credential, because that is the operator's next action.
+func TestHandshakeReason_UnauthorizedByStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	assertReason(t, toolsUnauthErr(t, srv.URL), "HTTP 401", "requires a credential", "--token")
+}
+
+// The same refusal as the real SDKs deliver it: a JSON-RPC error at HTTP 200.
+// Gating on the status alone would miss every one of them.
+func TestHandshakeReason_UnauthorizedByJSONRPCErrorAt200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		jsonRPCError(w, http.StatusOK, -32000, "authentication required")
+	}))
+	defer srv.Close()
+
+	assertReason(t, toolsUnauthErr(t, srv.URL),
+		"refused as unauthorized", "authentication required", "--token")
+}
+
+// Something is listening and it is not MCP. That is a different fact from
+// unreachable, and the operator should not go looking at their network for it.
+func TestHandshakeReason_AnsweredButNotMCP(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		jsonRPCError(w, http.StatusOK, -32601, "Method not found")
+	}))
+	defer srv.Close()
+
+	assertReason(t, toolsUnauthErr(t, srv.URL), "does not implement the MCP initialize method")
+}
+
+// The candidate walk is the reason a path can 404: the endpoint is unknown, so
+// most of those 404s are the cost of looking rather than a fact about the target.
+// When every candidate is absent, the generic message is the honest one, and
+// naming an arbitrary candidate's 404 would be worse than saying nothing.
+func TestHandshakeReason_AllCandidatesAbsentStaysGeneric(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	err := toolsUnauthErr(t, srv.URL)
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive, got %v", err)
+	}
+	if err.Error() != attack.ErrInconclusive.Error() {
+		t.Errorf("expected the bare generic reason, got a detail: %v", err)
+	}
+}
+
+// Nothing answered at all, which is what the generic message was written for.
+func TestHandshakeReason_NothingListeningStaysGeneric(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close() // now nothing is listening on that port
+
+	err := toolsUnauthErr(t, url)
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive, got %v", err)
+	}
+	if err.Error() != attack.ErrInconclusive.Error() {
+		t.Errorf("expected the bare generic reason, got a detail: %v", err)
+	}
+}
+
+// Candidates are walked in a fixed order (/mcp, /, /api, /rpc), so a less
+// informative answer from a path the server barely serves can be seen before the
+// refusal from the path it does. The reason must be ranked rather than first- or
+// last-one-wins, or which message an operator gets depends on where the server
+// happens to be mounted.
+//
+// The earlier candidates answer HTTP 500 with no JSON-RPC error, which is a real
+// observation and the lowest rank. A first-one-wins implementation reports that
+// and buries the refusal.
+func TestHandshakeReason_RefusalOutranksALesserAnswer(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api", func(w http.ResponseWriter, r *http.Request) {
+		jsonRPCError(w, http.StatusOK, -32000, "authentication required")
+	})
+	// ServeMux treats "/" as a catch-all, so /mcp lands here too, which is what
+	// gives both earlier candidates the lesser answer.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	assertReason(t, toolsUnauthErr(t, srv.URL), "/api", "requires a credential")
+}

--- a/internal/attack/mcp/resources_unauth.go
+++ b/internal/attack/mcp/resources_unauth.go
@@ -253,6 +253,10 @@ func (e *ResourcesUnauthExecutor) readResource(ctx context.Context, client *atta
 // requests; omitting it causes 4xx errors that silently suppress findings.
 func initializeMCP(ctx context.Context, client *attack.HTTPClient, baseURL string) (mcpSession, error) {
 	endpoints := endpointCandidates(baseURL)
+	// Why the walk failed, so a rule that could not run can say what happened
+	// instead of sending the operator to check their network. Classified from the
+	// responses this loop already has, so it costs no extra requests.
+	var observed initObservation
 	for _, ep := range endpoints {
 		initResp, err := client.POST(ctx, ep, nil, map[string]interface{}{
 			"jsonrpc": "2.0",
@@ -264,10 +268,11 @@ func initializeMCP(ctx context.Context, client *attack.HTTPClient, baseURL strin
 				"clientInfo":      map[string]interface{}{"name": "batesian", "version": "1.0"},
 			},
 		})
-		if err != nil || !initResp.IsSuccess() {
-			continue
+		if err != nil {
+			continue // transport failure: nothing answered, so nothing to explain
 		}
-		if !initResp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
+		if !initResp.IsSuccess() || !initResp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
+			observed.observe(classifyInitFailure(ep, initResp))
 			continue
 		}
 
@@ -292,6 +297,13 @@ func initializeMCP(ctx context.Context, client *attack.HTTPClient, baseURL strin
 	// which has no initialize method at all.
 	if err := modernEraReason(ctx, client, endpoints); err != nil {
 		return mcpSession{}, err
+	}
+
+	// Something answered and explained itself. Era detection still gets first say,
+	// because "your server speaks a revision we do not" is a better answer than the
+	// refusal that revision produced.
+	if observed.rank > rankNothing {
+		return mcpSession{}, handshakeRefusal{observed.reason}
 	}
 
 	return mcpSession{}, fmt.Errorf("no MCP server found at %s", baseURL)


### PR DESCRIPTION
Every `ErrInconclusive` with no reason rendered as "could not reach a testable
endpoint". That is right when nothing answered and wrong the rest of the time, and
the most common wrong case is the ordinary one:

```bash
batesian scan --target https://mcp.example.com   # server requires a credential
```

Twelve MCP rules reported that server as unreachable, so the operator goes to check
their network when the fix is `--token`. The server answered every request and
refused only the handshake.

`initializeMCP` already holds the failing response inside its candidate loop, and
`inconclusive()` was the single place the reason got discarded, so the walk now
classifies what it saw and carries it forward at no extra cost: **315 requests
before and after** on a full scan of a gated server.

Eight rules gain an accurate reason through paths they already share (`tools`,
`resources`, `prompt`, `completion` via `runOnEachWire`, plus `logging`,
`session-fixation`, `era-downgrade`, `header-body-split`). The other four bail
through their own probe loops and are a separate increment.

Before and after, same gated server:

```
mcp-tools-unauth-001   could not reach a testable endpoint
mcp-tools-unauth-001   not tested: the MCP handshake at http://…/mcp was refused as
                       unauthorized (JSON-RPC -32000: "authentication required"), so
                       this server requires a credential and the scan carried none;
                       pass --token or a --principal
```

Three details worth keeping:

- **Refusals are ranked**, not first- or last-one-wins. Candidates are walked in a
  fixed order, so without ranking the message depends on where the server happens
  to be mounted.
- **A 404 or 405 is deliberately not reported.** The walk exists because the
  endpoint is unknown, so most of those are the cost of looking, not a fact about
  the target. When every candidate is absent, the generic message is honest.
- **Only a classified refusal reaches a report.** `handshakeRefusal` is its own type
  so an unclassified internal error collapses to the generic message instead of
  leaking implementation detail as if it were a diagnosis.

Verification:

- 6 tests over the message classes, each control checked by breaking it: first-one-wins
  fails the ranking test, dropping the 404 guard fails the absent-path test, dropping
  the reason branch fails the three naming tests
- live matrix over four target classes: nothing listening and a server that serves no
  MCP path both keep the generic message; a gated server names the credential; an open
  server still runs
- 43-case fixture sweep against the previous binary: no finding or skip changed