### PR TITLE
fix(mcp): finish naming the reason, and stop telling operators to pass a flag they already passed

### DIFF
--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -58,13 +58,15 @@ or skip**, never a clean pass. A target that could not be exercised is reported
 as not tested rather than as secure.
 
 A skip names the reason where the handshake explained itself, because the actions
-they call for differ. The common one is a server that requires a credential
-scanned without one: it answers every request and refuses the handshake, so the
-skip says so and points at `--token`, rather than reporting a target that is
-plainly reachable as unreachable. An endpoint that answers but does not implement
-`initialize` is reported as not speaking MCP. `could not reach a testable
-endpoint` is now reserved for what it says: nothing answered, or no candidate path
-is served.
+they call for differ. The common one is a server that requires a credential: it
+answers every request and refuses the handshake, so the skip says so rather than
+reporting a plainly reachable target as unreachable. It also distinguishes a
+refused **anonymous** handshake from a **rejected credential**, since telling an
+operator to pass `--token` when they already did is worse than saying nothing, and
+several of these rules send no credential by design so that `--token` would change
+nothing. An endpoint that answers but does not implement `initialize` is reported
+as not speaking MCP. `could not reach a testable endpoint` means what it says:
+nothing answered, or no candidate path is served.
 
 ## OAuth-gated rules
 

--- a/internal/attack/http.go
+++ b/internal/attack/http.go
@@ -76,6 +76,21 @@ func (c *HTTPClient) tokenAllowedFor(rawURL string) bool {
 	return strings.EqualFold(u.Host, c.targetHost)
 }
 
+// PresentsCredential reports whether a request this client sends to rawURL will
+// carry the operator's bearer token.
+//
+// It exists so a rule that could not run can say which of two things happened: a
+// server refused an anonymous handshake, or it refused the credential the scan was
+// given. Those call for opposite actions, and telling an operator to pass --token
+// when they already did is worse than saying nothing. It answers the same question
+// the injection site asks, including the off-host guard, so the two cannot drift.
+//
+// An explicit per-request Authorization header still overrides this, so a caller
+// that sets its own header knows more than this reports.
+func (c *HTTPClient) PresentsCredential(rawURL string) bool {
+	return c.token != "" && c.tokenAllowedFor(rawURL)
+}
+
 // hostOf returns the host:port of a URL, or "" when it cannot be determined.
 func hostOf(rawURL string) string {
 	u, err := url.Parse(rawURL)

--- a/internal/attack/mcp/dns_rebind_origin.go
+++ b/internal/attack/mcp/dns_rebind_origin.go
@@ -40,17 +40,25 @@ func (e *DNSRebindOriginExecutor) Execute(ctx context.Context, target string, op
 	vars := attack.NewVars(target, opts.OOBListenerURL)
 	client := attack.NewHTTPClient(opts, vars)
 
+	// Why the baseline never succeeded, classified from the responses this loop
+	// already has. Without it a server that answers and refuses the handshake reads
+	// the same as a host that is not there.
+	var observed initObservation
 	for _, ep := range endpointCandidates(vars.BaseURL) {
 		// Baseline: a normal initialize with no Origin must be accepted, so we know
 		// this endpoint is a responsive MCP server and the probe is meaningful.
-		if !e.initAccepted(ctx, client, ep, "") {
+		accepted, baseline := e.initAccepted(ctx, client, ep, "")
+		if !accepted {
+			if baseline != nil {
+				observed.observe(classifyInitFailure(ep, client.PresentsCredential(ep), baseline))
+			}
 			continue
 		}
 		// Probe: the same initialize with a foreign Origin. A compliant server
 		// rejects it with HTTP 403; a server that still processes it does not
 		// validate Origin. The only difference from the baseline is the Origin
 		// header, so acceptance isolates Origin handling.
-		if e.initAccepted(ctx, client, ep, foreignOrigin) {
+		if forged, _ := e.initAccepted(ctx, client, ep, foreignOrigin); forged {
 			return []attack.Finding{{
 				RuleID:     e.rule.ID,
 				RuleName:   e.rule.Name,
@@ -77,21 +85,28 @@ func (e *DNSRebindOriginExecutor) Execute(ctx context.Context, target string, op
 		// validated. No finding, and no need to try other endpoints.
 		return nil, nil
 	}
-	// No candidate accepted a baseline initialize: not a testable MCP endpoint.
+	// No candidate accepted a baseline initialize: not a testable MCP endpoint. Say
+	// which of those it was where the target explained itself.
+	if observed.rank > rankNothing {
+		return nil, inconclusive(handshakeRefusal{observed.reason})
+	}
 	return nil, attack.ErrInconclusive
 }
 
 // initAccepted sends an MCP initialize to ep (optionally with an Origin header)
 // and reports whether the server accepted it (HTTP 200 with a JSON-RPC result
 // rather than an error envelope or a 403).
-func (e *DNSRebindOriginExecutor) initAccepted(ctx context.Context, client *attack.HTTPClient, ep, origin string) bool {
+// The response is returned alongside the verdict so a failed baseline can be
+// explained rather than only counted. It is nil when the request never got an
+// answer, which is the one case there is nothing to explain.
+func (e *DNSRebindOriginExecutor) initAccepted(ctx context.Context, client *attack.HTTPClient, ep, origin string) (bool, *attack.Response) {
 	headers := map[string]string{"Content-Type": "application/json"}
 	if origin != "" {
 		headers["Origin"] = origin
 	}
 	resp, err := client.POST(ctx, ep, headers, json.RawMessage(mcpInitBody))
-	if err != nil || !resp.IsAccepted() {
-		return false
+	if err != nil {
+		return false, nil
 	}
-	return true
+	return resp.IsAccepted(), resp
 }

--- a/internal/attack/mcp/era.go
+++ b/internal/attack/mcp/era.go
@@ -70,6 +70,16 @@ type initObservation struct {
 	reason string
 }
 
+// credentialNote completes an unauthorized-refusal message with what the request
+// actually presented, which is the part an operator acts on.
+func credentialNote(credentialed bool) string {
+	if credentialed {
+		return "even though the request presented the credential this scan was given, " +
+			"so that credential is not accepted here"
+	}
+	return "and the request presented no credential, so this server does not serve MCP anonymously"
+}
+
 // observe keeps o when it explains more than what is already held.
 func (i *initObservation) observe(o initObservation) {
 	if o.rank > i.rank {
@@ -80,10 +90,16 @@ func (i *initObservation) observe(o initObservation) {
 // classifyInitFailure explains why one candidate did not complete a handshake.
 //
 // The ranking is about what an operator can do next. An unauthorized refusal is
-// the top rank because it names the fix; "answered but does not implement
+// the top rank because it points at the fix; "answered but does not implement
 // initialize" is above a bare status because it says the target is not MCP at all
 // rather than unreachable.
-func classifyInitFailure(endpoint string, resp *attack.Response) initObservation {
+//
+// credentialed says whether the refused request carried the operator's token,
+// because a server refusing an anonymous handshake and a server rejecting the
+// credential it was given call for opposite actions. The message states which
+// happened and does not prescribe a flag: whether --token would change anything
+// depends on the rule, and several of these rules send no credential by design.
+func classifyInitFailure(endpoint string, credentialed bool, resp *attack.Response) initObservation {
 	// A path the server does not serve explains nothing: the candidate walk exists
 	// precisely because the endpoint is unknown, so most of these 404s are the cost
 	// of looking rather than a fact about the target. Reporting one as the reason
@@ -101,15 +117,13 @@ func classifyInitFailure(endpoint string, resp *attack.Response) initObservation
 	// HTTP 200, which is what the real SDKs do, so both shapes are checked.
 	if resp.StatusCode == 401 || resp.StatusCode == 403 {
 		return initObservation{rankUnauthorized, fmt.Sprintf(
-			"the MCP handshake at %s was refused with HTTP %d, so this server requires a "+
-				"credential and the scan carried none; pass --token or a --principal",
-			endpoint, resp.StatusCode)}
+			"the MCP handshake at %s was refused with HTTP %d %s",
+			endpoint, resp.StatusCode, credentialNote(credentialed))}
 	}
 	if hasErr && authFlavoredError(code, msg) {
 		return initObservation{rankUnauthorized, fmt.Sprintf(
-			"the MCP handshake at %s was refused as unauthorized (JSON-RPC %d: %q), so this "+
-				"server requires a credential and the scan carried none; pass --token or a --principal",
-			endpoint, code, msg)}
+			"the MCP handshake at %s was refused as unauthorized (JSON-RPC %d: %q) %s",
+			endpoint, code, msg, credentialNote(credentialed))}
 	}
 	if hasErr && code == mcpMethodNotFound {
 		return initObservation{rankNotMCP, fmt.Sprintf(

--- a/internal/attack/mcp/handshake_reason_test.go
+++ b/internal/attack/mcp/handshake_reason_test.go
@@ -44,44 +44,46 @@ func assertReason(t *testing.T, err error, want ...string) {
 	}
 }
 
-// jsonRPCError writes a JSON-RPC error envelope at the given HTTP status.
-func jsonRPCError(w http.ResponseWriter, status, code int, msg string) {
+// jsonRPCError writes a JSON-RPC error envelope at HTTP 200, which is how the real
+// SDKs deliver one and the shape a status-only classifier would miss.
+func jsonRPCError(w http.ResponseWriter, code int, msg string) {
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
+	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
 		"jsonrpc": "2.0", "id": 1,
 		"error": map[string]interface{}{"code": code, "message": msg},
 	})
 }
 
-// A credential-gated server answering with an HTTP status. The reason has to name
-// the credential, because that is the operator's next action.
+// A credential-gated server answering with an HTTP status. The reason has to say
+// the request carried no credential, because that is what the operator acts on.
 func TestHandshakeReason_UnauthorizedByStatus(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
 	defer srv.Close()
 
-	assertReason(t, toolsUnauthErr(t, srv.URL), "HTTP 401", "requires a credential", "--token")
+	assertReason(t, toolsUnauthErr(t, srv.URL),
+		"HTTP 401", "presented no credential", "does not serve MCP anonymously")
 }
 
 // The same refusal as the real SDKs deliver it: a JSON-RPC error at HTTP 200.
 // Gating on the status alone would miss every one of them.
 func TestHandshakeReason_UnauthorizedByJSONRPCErrorAt200(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		jsonRPCError(w, http.StatusOK, -32000, "authentication required")
+		jsonRPCError(w, -32000, "authentication required")
 	}))
 	defer srv.Close()
 
 	assertReason(t, toolsUnauthErr(t, srv.URL),
-		"refused as unauthorized", "authentication required", "--token")
+		"refused as unauthorized", "authentication required", "presented no credential")
 }
 
 // Something is listening and it is not MCP. That is a different fact from
 // unreachable, and the operator should not go looking at their network for it.
 func TestHandshakeReason_AnsweredButNotMCP(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		jsonRPCError(w, http.StatusOK, -32601, "Method not found")
+		jsonRPCError(w, -32601, "Method not found")
 	}))
 	defer srv.Close()
 
@@ -134,7 +136,7 @@ func TestHandshakeReason_NothingListeningStaysGeneric(t *testing.T) {
 func TestHandshakeReason_RefusalOutranksALesserAnswer(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api", func(w http.ResponseWriter, r *http.Request) {
-		jsonRPCError(w, http.StatusOK, -32000, "authentication required")
+		jsonRPCError(w, -32000, "authentication required")
 	})
 	// ServeMux treats "/" as a catch-all, so /mcp lands here too, which is what
 	// gives both earlier candidates the lesser answer.
@@ -144,5 +146,25 @@ func TestHandshakeReason_RefusalOutranksALesserAnswer(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	assertReason(t, toolsUnauthErr(t, srv.URL), "/api", "requires a credential")
+	assertReason(t, toolsUnauthErr(t, srv.URL), "/api", "refused as unauthorized")
+}
+
+// The distinction that matters once a token IS configured: this server refuses it.
+// Reporting "the request presented no credential", or advising --token, would send
+// the operator to add a flag they already passed. mcp-session-fixation-001 uses the
+// authenticated client, so it is the rule that exposes this.
+func TestHandshakeReason_RejectedCredentialSaysSo(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		jsonRPCError(w, -32000, "authentication required")
+	}))
+	defer srv.Close()
+
+	exec := mcpattack.NewSessionFixationExecutor(attack.RuleContext{ID: "mcp-session-fixation-001"})
+	_, err := exec.Execute(context.Background(), srv.URL,
+		attack.Options{TimeoutSeconds: 5, Token: "a-token-this-server-rejects"})
+
+	assertReason(t, err, "presented the credential this scan was given", "not accepted here")
+	if strings.Contains(err.Error(), "presented no credential") {
+		t.Errorf("a scan that carried a credential must not be told it carried none: %v", err)
+	}
 }

--- a/internal/attack/mcp/oauth_audience.go
+++ b/internal/attack/mcp/oauth_audience.go
@@ -92,7 +92,8 @@ func (e *OAuthAudienceExecutor) Execute(ctx context.Context, target string, opts
 	expected := strings.TrimSpace(opts.AudienceClaim)
 	operatorSupplied := expected != ""
 	if !operatorSupplied {
-		discovered, mcpReached := discoverExpectedAudience(ctx, client, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
+		discovered, mcpReached, observed := discoverExpectedAudience(ctx, client,
+			attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
 		if discovered == "" {
 			// Precondition not met: no operator input and no discoverable
 			// resource metadata. Operators who want this rule to run should pass
@@ -104,6 +105,9 @@ func (e *OAuthAudienceExecutor) Execute(ctx context.Context, target string, opts
 			// was never exercised, and clean there would claim coverage the scan
 			// does not have.
 			if !mcpReached {
+				if observed.rank > rankNothing {
+					return nil, inconclusive(handshakeRefusal{observed.reason})
+				}
 				return nil, attack.ErrInconclusive
 			}
 			return nil, nil
@@ -133,7 +137,7 @@ func (e *OAuthAudienceExecutor) Execute(ctx context.Context, target string, opts
 	// scan that found something needs no premise check, and a disagreement is not
 	// a reason to withhold a finding the server demonstrated.
 	if operatorSupplied {
-		if advertised, _ := discoverExpectedAudience(ctx, client,
+		if advertised, _, _ := discoverExpectedAudience(ctx, client,
 			attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL); advertised != "" && advertised != expected {
 			return nil, fmt.Errorf("%w: the probes were built from the --audience-claim value %q, "+
 				"but %s advertises %q as its resource audience; RFC 7519 section 4.1.3 compares the "+
@@ -264,15 +268,16 @@ func hasUpper(s string) bool {
 // Returns the resource URI on success, or an empty string if nothing
 // usable was found (caller treats that as "skip").
 // metaClient is unauthenticated because step 2 follows a URL the target chose.
-func discoverExpectedAudience(ctx context.Context, client, metaClient *attack.HTTPClient, baseURL string) (audience string, mcpReached bool) {
-	metaURL, mcpReached := probeWWWAuthenticateResourceMetadata(ctx, client, baseURL)
+func discoverExpectedAudience(ctx context.Context, client, metaClient *attack.HTTPClient,
+	baseURL string) (audience string, mcpReached bool, observed initObservation) {
+	metaURL, mcpReached, observed := probeWWWAuthenticateResourceMetadata(ctx, client, baseURL)
 	if metaURL != "" {
 		if resource := fetchResourceFromMetadata(ctx, metaClient, metaURL); resource != "" {
-			return resource, mcpReached
+			return resource, mcpReached, observed
 		}
 	}
 	wellKnown := baseURL + "/.well-known/oauth-protected-resource"
-	return fetchResourceFromMetadata(ctx, metaClient, wellKnown), mcpReached
+	return fetchResourceFromMetadata(ctx, metaClient, wellKnown), mcpReached, observed
 }
 
 // probeWWWAuthenticateResourceMetadata sends an unauth initialize request to
@@ -282,7 +287,8 @@ func discoverExpectedAudience(ctx context.Context, client, metaClient *attack.HT
 // separates "this MCP server exposes no OAuth" from "nothing here answered at
 // all". The first is a clean result for an OAuth-gated rule; the second is a
 // target that was never tested.
-func probeWWWAuthenticateResourceMetadata(ctx context.Context, client *attack.HTTPClient, baseURL string) (metadataURL string, mcpReached bool) {
+func probeWWWAuthenticateResourceMetadata(ctx context.Context, client *attack.HTTPClient,
+	baseURL string) (metadataURL string, mcpReached bool, observed initObservation) {
 	body := json.RawMessage(mcpInitBody)
 	for _, ep := range endpointCandidates(baseURL) {
 		// Use no Authorization header (override any opts.Token) so the server
@@ -298,16 +304,21 @@ func probeWWWAuthenticateResourceMetadata(ctx context.Context, client *attack.HT
 		// header on 403. We accept any response that carries the header.
 		if u := parseResourceMetadataURL(resp.Headers.Get("WWW-Authenticate")); u != "" {
 			// A challenge is itself proof the endpoint is live and gated.
-			return u, true
+			return u, true, observed
 		}
 		// An endpoint that answered the handshake is the server, and it issued no
 		// challenge. The remaining candidates are the same server at paths it does
 		// not serve, so walking them only adds 404s.
 		if isMCPInitialize(resp) {
-			return "", true
+			return "", true, observed
 		}
+		// It answered and it was neither a challenge nor a handshake. Record why, so
+		// a rule that ends up reporting nothing can say what it met. This probe is
+		// deliberately unauthenticated, so a refusal here is about the anonymous
+		// request rather than about any credential the operator supplied.
+		observed.observe(classifyInitFailure(ep, false, resp))
 	}
-	return "", false
+	return "", false, observed
 }
 
 // resourceMetadataRE extracts the resource_metadata="..." parameter from a

--- a/internal/attack/mcp/resources_unauth.go
+++ b/internal/attack/mcp/resources_unauth.go
@@ -272,7 +272,7 @@ func initializeMCP(ctx context.Context, client *attack.HTTPClient, baseURL strin
 			continue // transport failure: nothing answered, so nothing to explain
 		}
 		if !initResp.IsSuccess() || !initResp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
-			observed.observe(classifyInitFailure(ep, initResp))
+			observed.observe(classifyInitFailure(ep, client.PresentsCredential(ep), initResp))
 			continue
 		}
 

--- a/internal/attack/mcp/session_as_credential.go
+++ b/internal/attack/mcp/session_as_credential.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/calbebop/batesian/internal/attack"
@@ -59,10 +60,18 @@ func (e *SessionAsCredentialExecutor) Execute(ctx context.Context, target string
 
 	authed := map[string]string{"Authorization": "Bearer " + token}
 
-	return probeCandidates(vars.BaseURL, func(ep string) ([]attack.Finding, bool) {
+	// Why no candidate could be exercised. The credential is this rule's premise, so
+	// the most likely failure is that the one it was given is not accepted, and
+	// saying "could not reach a testable endpoint" about a server that answered and
+	// refused it sends the operator to the wrong place.
+	var observed initObservation
+	findings, err := probeCandidates(vars.BaseURL, func(ep string) ([]attack.Finding, bool) {
 		// Step 1: handshake with the credential and capture the session id.
-		session, ok := e.initialize(ctx, client, ep, authed)
+		session, ok, resp := e.initialize(ctx, client, ep, authed)
 		if !ok {
+			if resp != nil {
+				observed.observe(classifyInitFailure(ep, true, resp))
+			}
 			return nil, false // not a reachable MCP endpoint
 		}
 		if session == "" {
@@ -95,7 +104,7 @@ func (e *SessionAsCredentialExecutor) Execute(ctx context.Context, target string
 		// servers this rule exists to find. What answers the question is whether the
 		// session the anonymous caller was given can then call tools/list.
 		var anonSession string
-		if s, anonOK := e.initialize(ctx, client, ep, nil); anonOK {
+		if s, anonOK, _ := e.initialize(ctx, client, ep, nil); anonOK {
 			anonSession = s
 			if anonSession == "" {
 				// It handshakes anonymously but issues this caller no session, so there
@@ -140,6 +149,10 @@ func (e *SessionAsCredentialExecutor) Execute(ctx context.Context, target string
 
 		return []attack.Finding{e.finding(ep, session, bogus, anonSession)}, true
 	})
+	if errors.Is(err, attack.ErrInconclusive) && observed.rank > rankNothing {
+		return nil, inconclusive(handshakeRefusal{observed.reason})
+	}
+	return findings, err
 }
 
 // credentialFor returns the credential to establish the session with, preferring
@@ -155,8 +168,10 @@ func credentialFor(opts attack.Options) string {
 
 // initialize performs the handshake and returns the session id the server minted,
 // which is empty when the server assigns none.
+// The response is returned alongside the verdict so a walk that established no
+// session can say why. It is nil when nothing answered.
 func (e *SessionAsCredentialExecutor) initialize(ctx context.Context, client *attack.HTTPClient,
-	endpoint string, headers map[string]string) (session string, ok bool) {
+	endpoint string, headers map[string]string) (session string, ok bool, resp *attack.Response) {
 	resp, err := client.POST(ctx, endpoint, headers, map[string]interface{}{
 		"jsonrpc": "2.0",
 		"id":      1,
@@ -167,10 +182,13 @@ func (e *SessionAsCredentialExecutor) initialize(ctx context.Context, client *at
 			"clientInfo":      map[string]interface{}{"name": "batesian", "version": attack.Version},
 		},
 	})
-	if err != nil || !resp.IsAccepted() {
-		return "", false
+	if err != nil {
+		return "", false, nil
 	}
-	return resp.Headers.Get("Mcp-Session-Id"), true
+	if !resp.IsAccepted() {
+		return "", false, resp
+	}
+	return resp.Headers.Get("Mcp-Session-Id"), true, resp
 }
 
 // toolsList reports whether tools/list was answered with a result under the given

--- a/internal/attack/mcp/sse_resume_replay.go
+++ b/internal/attack/mcp/sse_resume_replay.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -44,14 +45,27 @@ func (e *SSEResumeReplayExecutor) Execute(ctx context.Context, target string, op
 		tokenA, tokenB = opts.Principals[0].Token, opts.Principals[1].Token
 	}
 
-	return probeCandidates(vars.BaseURL, func(ep string) ([]attack.Finding, bool) {
-		return e.probe(ctx, client, raw, ep, tokenA, tokenB)
+	// Why no candidate could be exercised, classified from the handshake responses
+	// the probe already has, so this reports what happened rather than blaming the
+	// network. The closure captures it, which keeps probeCandidates unchanged for
+	// the five other rules that share it.
+	var observed initObservation
+	findings, err := probeCandidates(vars.BaseURL, func(ep string) ([]attack.Finding, bool) {
+		return e.probe(ctx, client, raw, ep, tokenA, tokenB, &observed)
 	})
+	if errors.Is(err, attack.ErrInconclusive) && observed.rank > rankNothing {
+		return nil, inconclusive(handshakeRefusal{observed.reason})
+	}
+	return findings, err
 }
 
-func (e *SSEResumeReplayExecutor) probe(ctx context.Context, client *attack.HTTPClient, raw *http.Client, ep, tokenA, tokenB string) ([]attack.Finding, bool) {
-	sessionA, ok := e.initialize(ctx, client, ep, tokenA)
+func (e *SSEResumeReplayExecutor) probe(ctx context.Context, client *attack.HTTPClient, raw *http.Client, ep, tokenA, tokenB string,
+	observed *initObservation) ([]attack.Finding, bool) {
+	sessionA, ok, resp := e.initialize(ctx, client, ep, tokenA)
 	if !ok {
+		if resp != nil {
+			observed.observe(classifyInitFailure(ep, tokenA != "" || client.PresentsCredential(ep), resp))
+		}
 		return nil, false // not a responsive MCP endpoint
 	}
 	if sessionA == "" {
@@ -69,7 +83,7 @@ func (e *SSEResumeReplayExecutor) probe(ctx context.Context, client *attack.HTTP
 		return nil, true // no resumable event surface to test
 	}
 
-	sessionB, ok := e.initialize(ctx, client, ep, tokenB)
+	sessionB, ok, _ := e.initialize(ctx, client, ep, tokenB)
 	if !ok || sessionB == "" || sessionB == sessionA {
 		return nil, true // need a second, distinct server-minted session
 	}
@@ -108,7 +122,10 @@ func (e *SSEResumeReplayExecutor) probe(ctx context.Context, client *attack.HTTP
 
 // initialize performs an MCP initialize as the given token and returns the
 // server-minted session id.
-func (e *SSEResumeReplayExecutor) initialize(ctx context.Context, client *attack.HTTPClient, ep, token string) (string, bool) {
+// The failing response is returned alongside the verdict so a walk that never
+// established a session can say why. It is nil when nothing answered, which is the
+// one case there is nothing to explain.
+func (e *SSEResumeReplayExecutor) initialize(ctx context.Context, client *attack.HTTPClient, ep, token string) (string, bool, *attack.Response) {
 	headers := map[string]string{}
 	if token != "" {
 		headers["Authorization"] = "Bearer " + token
@@ -123,11 +140,11 @@ func (e *SSEResumeReplayExecutor) initialize(ctx context.Context, client *attack
 			"clientInfo":      map[string]interface{}{"name": "batesian", "version": "1.0"},
 		},
 	})
-	if err != nil || !resp.IsSuccess() {
-		return "", false
+	if err != nil {
+		return "", false, nil
 	}
-	if !resp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
-		return "", false
+	if !resp.IsSuccess() || !resp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
+		return "", false, resp
 	}
 	sid := resp.Headers.Get("Mcp-Session-Id")
 	inited := map[string]string{"Mcp-Protocol-Version": latestStable}
@@ -138,7 +155,7 @@ func (e *SSEResumeReplayExecutor) initialize(ctx context.Context, client *attack
 		inited["Mcp-Session-Id"] = sid
 	}
 	_, _ = client.POST(ctx, ep, inited, map[string]interface{}{"jsonrpc": "2.0", "method": "notifications/initialized"})
-	return sid, true
+	return sid, true, resp
 }
 
 // sseCollect issues a GET for an SSE stream and returns the events read within

--- a/internal/attack/mcp/task_idor.go
+++ b/internal/attack/mcp/task_idor.go
@@ -109,9 +109,9 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 	}
 
 	// Session A, which also discovers the endpoint.
-	sessA, ok := e.initSession(ctx, client, vars.BaseURL, tokenA)
-	if !ok {
-		return nil, attack.ErrInconclusive // not an MCP server
+	sessA, initErr := e.initSession(ctx, client, vars.BaseURL, tokenA)
+	if initErr != nil {
+		return nil, inconclusive(initErr) // not an MCP server, and why
 	}
 
 	// Gate on the tasks capability and on task-augmented tools/call specifically.
@@ -159,7 +159,7 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 		enforcedOn: "the MCP endpoint",
 		anonProbe:  "anonymous initialize: refused",
 	}
-	if anonSess, anonOK := e.initSession(ctx, client, vars.BaseURL, ""); anonOK {
+	if anonSess, anonErr := e.initSession(ctx, client, vars.BaseURL, ""); anonErr == nil {
 		auth = authEvidence{
 			enforcedOn: "task creation and reads",
 			anonProbe:  "anonymous task creation: refused",
@@ -176,8 +176,8 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 	}
 
 	// Step 3: a second session, as principal B, tries to read A's task.
-	sessB, ok := e.initSession(ctx, client, vars.BaseURL, tokenB)
-	if !ok || sessB.SessionID == sessA.SessionID {
+	sessB, errB := e.initSession(ctx, client, vars.BaseURL, tokenB)
+	if errB != nil || sessB.SessionID == sessA.SessionID {
 		return nil, nil // need a distinct session to demonstrate the boundary
 	}
 
@@ -212,7 +212,10 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 
 // initSession performs an initialize handshake as the given token, discovering
 // the endpoint across the candidate paths, and returns the resulting session.
-func (e *TaskIDORExecutor) initSession(ctx context.Context, client *attack.HTTPClient, baseURL, token string) (mcpSession, bool) {
+func (e *TaskIDORExecutor) initSession(ctx context.Context, client *attack.HTTPClient, baseURL, token string) (mcpSession, error) {
+	// Why the walk failed, classified from the responses this loop already has, so a
+	// rule that could not run says what happened instead of blaming the network.
+	var observed initObservation
 	for _, ep := range endpointCandidates(baseURL) {
 		headers := map[string]string{}
 		if token != "" {
@@ -232,10 +235,13 @@ func (e *TaskIDORExecutor) initSession(ctx context.Context, client *attack.HTTPC
 				"clientInfo": map[string]interface{}{"name": "batesian", "version": "1.0"},
 			},
 		})
-		if err != nil || !resp.IsSuccess() {
-			continue
+		if err != nil {
+			continue // transport failure: nothing answered, so nothing to explain
 		}
-		if !resp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
+		if !resp.IsSuccess() || !resp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
+			// This rule presents a token explicitly, so the client's ambient
+			// credential is not what decides whether the request carried one.
+			observed.observe(classifyInitFailure(ep, token != "", resp))
 			continue
 		}
 		session := mcpSession{
@@ -248,9 +254,12 @@ func (e *TaskIDORExecutor) initSession(ctx context.Context, client *attack.HTTPC
 			"jsonrpc": "2.0",
 			"method":  "notifications/initialized",
 		})
-		return session, true
+		return session, nil
 	}
-	return mcpSession{}, false
+	if observed.rank > rankNothing {
+		return mcpSession{}, handshakeRefusal{observed.reason}
+	}
+	return mcpSession{}, fmt.Errorf("no MCP server found at %s", baseURL)
 }
 
 // headers builds the per-request headers for a session and principal.


### PR DESCRIPTION
Two things, both about the same message.

**The advice shipped in #173 was wrong for two callers.** It ended "so this server
requires a credential and the scan carried none; pass `--token` or a `--principal`",
but `mcp-session-fixation-001` and `mcp-header-body-split-001` use the authenticated
client, so a scan that *did* pass a token and had it rejected was told to pass one.
The four unauthenticated-surface rules send no credential by design, so `--token`
would not change what they do either. Reproduced against the gated fixture with a
deliberately invalid token: all three shapes claimed the scan carried none.

The message now states which happened and prescribes no flag, because whether
`--token` helps is a per-rule question and a shared classifier is the wrong place to
answer it:

```
… refused as unauthorized (JSON-RPC -32000: "authentication required") and the
  request presented no credential, so this server does not serve MCP anonymously

… refused as unauthorized (JSON-RPC -32000: "authentication required") even though
  the request presented the credential this scan was given, so that credential is
  not accepted here
```

`attack.HTTPClient.PresentsCredential` reuses the injection site's own logic,
including the off-host guard from #158, so the two cannot drift.

**The remaining five rules now carry a reason**, each classified from responses its
own probe loop already had: `task-idor`, `dns-rebind-origin`, `sse-resume-replay`,
`session-as-credential`, and `oauth-audience`. That last one's probes carry forged
tokens, so its refusals are reported as anonymous ones: a server rejecting a forged
token is behaving correctly, and the operator's own credential is not what was
refused.

`session-as-credential` is on that list because #173 pushed it into the same
failure: with a token supplied it clears its own credential gate and then bails
through `probeCandidates`, so it became the one rule left blaming the network.
`sse-resume-replay` and `session-as-credential` thread the observation out through a
closure rather than changing `probeCandidates`, leaving the four other rules that
share it untouched.

Verification:

- full scan of a gated server with a rejected token: **320 requests before and
  after**, and no rule reports the generic message (6 say the credential was
  rejected, 7 say none was presented)
- a host with nothing listening, and a server that serves no MCP path, both still
  report `could not reach a testable endpoint`
- 7 tests over the message classes, including a rejected credential that must not be
  told it carried none
- 43-case fixture sweep against the previous binary: no finding or skip changed