### PR TITLE
fix(a2a): stop reporting a secured agent clean when no task could be created

### DIFF
--- a/docs/rules-a2a.md
+++ b/docs/rules-a2a.md
@@ -75,6 +75,30 @@ The three card-analysis rules (`a2a-card-trust-001`, `a2a-jws-algconf-001`,
 no card is served, even against a target that is plainly an agent by other
 evidence. A card rule with no card has nothing to say either way.
 
+### Rules that need a task first
+
+Eight rules cannot say anything until they have created a task: `a2a-task-idor-001`,
+`a2a-push-ssrf-001`, `a2a-session-smuggle-001`, `a2a-context-fixation-001`,
+`a2a-delegation-integrity-001`, `a2a-multitenant-isolation-001`,
+`a2a-push-binding-001` and `a2a-task-cancel-idor-001`. Against an agent that
+enforces authorization, whether they can depends on the credential the scan was
+given, so a failure to create one is reported as **not tested**, naming the refusal
+and whether the request carried a credential at all. A clean result there would
+claim the agent does not leak tasks across principals when no task ever existed.
+
+Two things stay clean, deliberately. An agent that does not implement the surface
+(`-32601`, or A2A's own `-32003` push-not-supported and `-32004`
+unsupported-operation) is not applicable rather than untested, the same call the
+OAuth-gated MCP rules make for a server exposing no OAuth. And where the request is
+one the agent is *supposed* to refuse, that refusal is the pass being looked for:
+`a2a-session-smuggle-001` sends a message claiming the agent role, and
+`a2a-context-fixation-001` sends a client-chosen `contextId`. For those two, only an
+authorization refusal counts as untested.
+
+Note that `a2a-task-idor-001`, `a2a-push-ssrf-001` and `a2a-session-smuggle-001` use
+`--token` rather than `--principal`, so a scan that passes only principals will
+report them not tested against a secured agent, and say so.
+
 | Rule ID | Attack | Severity | Confidence | CWE |
 |---|---|:---:|:---:|---|
 | `a2a-extcard-unauth-001` | [Extended Agent Card Unauthenticated Disclosure](#a2a-extcard-unauth-001) | High | confirmed | CWE-862 |

--- a/internal/attack/a2a/context_fixation.go
+++ b/internal/attack/a2a/context_fixation.go
@@ -72,10 +72,17 @@ func (e *ContextFixationExecutor) ExecuteChained(ctx context.Context, target str
 	marker := "batesian-secret-" + vars.RandID
 
 	// Step 1: as A, send under a client-chosen contextId.
-	taskA, returnedCtx := e.sendUnderContext(ctx, clientA, endpoint, a.Headers, fixedCtx, "batesian ctx-fix probe "+vars.RandID, vars.RandID)
-	if taskA == "" || returnedCtx != fixedCtx {
-		// Either not a responsive A2A server, or the server minted its own
-		// contextId (did not honor the client-supplied one) - secure.
+	taskA, returnedCtx, obsA := e.sendUnderContext(ctx, clientA, endpoint, a.Headers, fixedCtx,
+		"batesian ctx-fix probe "+vars.RandID, vars.RandID, "sending a message as principal "+a.Name)
+	if taskA == "" {
+		// No task at all. A server that refuses a client-chosen contextId outright is
+		// behaving correctly, so only an authorization refusal means this rule did not
+		// get to test anything; see errIfAuthRefused.
+		return nil, obsA.errIfAuthRefused()
+	}
+	if returnedCtx != fixedCtx {
+		// The server minted its own contextId rather than honouring the client's, which
+		// is the secure behaviour and a real tested result.
 		return nil, nil
 	}
 	bb.Publish(attack.Artifact{Kind: attack.ArtifactContextID, Value: fixedCtx, Principal: a.Name, Producer: e.rule.ID})
@@ -83,14 +90,18 @@ func (e *ContextFixationExecutor) ExecuteChained(ctx context.Context, target str
 	// Step 2: open-server discriminator. An unauthenticated message under the
 	// fixed context must be rejected; if it is accepted, the server enforces no
 	// auth at all (not fixation).
-	if anonTask, _ := e.sendUnderContext(ctx, unauthClient, endpoint, nil, fixedCtx, "batesian anon "+vars.RandID, vars.RandID); anonTask != "" {
+	if anonTask, _, _ := e.sendUnderContext(ctx, unauthClient, endpoint, nil, fixedCtx,
+		"batesian anon "+vars.RandID, vars.RandID, "sending an unauthenticated message"); anonTask != "" {
 		return nil, nil
 	}
 
 	// Step 3: as victim B, send a secret marker under the SAME fixed context.
-	taskB, _ := e.sendUnderContext(ctx, clientB, endpoint, b.Headers, fixedCtx, marker, vars.RandID)
+	taskB, _, obsB := e.sendUnderContext(ctx, clientB, endpoint, b.Headers, fixedCtx, marker, vars.RandID,
+		"sending the victim's message as principal "+b.Name)
 	if taskB == "" {
-		return nil, nil // B could not post (invalid creds) - cannot confirm a merge
+		// B could not post, so no merge could be confirmed either way. This returned a
+		// clean result while its own comment said the credentials might be invalid.
+		return nil, obsB.err()
 	}
 
 	// Step 4: as A, read the context back. Confirmed only if A can see B's marker.
@@ -104,7 +115,12 @@ func (e *ContextFixationExecutor) ExecuteChained(ctx context.Context, target str
 // sendUnderContext sends a SendMessage carrying a client-supplied contextId,
 // trying the A2A v1.0 shape first then the v0.3 slash-method shape. It returns
 // the created task id and the contextId the server associated with it.
-func (e *ContextFixationExecutor) sendUnderContext(ctx context.Context, c *attack.HTTPClient, endpoint string, extraHeaders map[string]string, contextID, text, randID string) (taskID, returnedCtx string) {
+// what names the attempt for the reason a caller may have to report. The
+// observation covers both wires: losing the first would let a v1.0-only agent that
+// refuses for auth reasons look like one with no task surface, since the v0.3
+// fallback answers -32601 and that maps to a clean result.
+func (e *ContextFixationExecutor) sendUnderContext(ctx context.Context, c *attack.HTTPClient, endpoint string,
+	extraHeaders map[string]string, contextID, text, randID, what string) (taskID, returnedCtx string, obs setupObservation) {
 	v1Headers := map[string]string{"A2A-Version": "1.0"}
 	for k, v := range extraHeaders {
 		v1Headers[k] = v
@@ -123,6 +139,7 @@ func (e *ContextFixationExecutor) sendUnderContext(ctx context.Context, c *attac
 		},
 	})
 	if err != nil || !resp.IsAccepted() {
+		obs.observe(classifyTaskSetup(what, endpoint, c.PresentsCredential(endpoint), resp))
 		resp, err = c.POST(ctx, endpoint, extraHeaders, map[string]interface{}{
 			"jsonrpc": "2.0",
 			"id":      "batesian-ctxfix-send-" + randID,
@@ -138,10 +155,14 @@ func (e *ContextFixationExecutor) sendUnderContext(ctx context.Context, c *attac
 		})
 	}
 	if err != nil || !resp.IsAccepted() {
-		return "", ""
+		obs.observe(classifyTaskSetup(what, endpoint, c.PresentsCredential(endpoint), resp))
+		return "", "", obs
 	}
 	taskID, returnedCtx = extractTaskContext(resp.Body)
-	return taskID, returnedCtx
+	if taskID == "" {
+		obs.observe(classifyTaskSetup(what, endpoint, c.PresentsCredential(endpoint), resp))
+	}
+	return taskID, returnedCtx, obs
 }
 
 // taskHistoryContains reads a task via GetTask (v1.0) / tasks/get (v0.3) and

--- a/internal/attack/a2a/delegation_integrity.go
+++ b/internal/attack/a2a/delegation_integrity.go
@@ -70,11 +70,14 @@ func (e *DelegationIntegrityExecutor) ExecuteChained(ctx context.Context, target
 	// Step 1: obtain a task owned by delegator A. Prefer an upstream artifact
 	// (true cross-rule chaining); otherwise create one as A.
 	taskID, contextID, consumed := e.consumeOwnedTask(bb, a)
+	var obs setupObservation
 	if taskID == "" {
-		taskID, contextID, _ = e.createTask(ctx, clientA, endpoint, a, vars.RandID)
+		taskID, contextID, _, obs = e.createTask(ctx, clientA, endpoint, a, vars.RandID)
 	}
 	if taskID == "" {
-		return nil, nil // could not establish a delegator-owned task
+		// No delegator-owned task, so the chain-of-custody boundary this rule reports
+		// on was never exercised. Clean only when the agent implements no task surface.
+		return nil, obs.err()
 	}
 
 	// Step 2: discriminator. An unauthenticated continuation of A's task must be
@@ -108,7 +111,12 @@ func (e *DelegationIntegrityExecutor) consumeOwnedTask(bb *attack.Blackboard, a 
 // createTask creates a task as the given principal, trying the A2A v1.0 shape
 // first and falling back to the v0.3 slash-method shape. Returns the created
 // task/context IDs and whether creation was accepted.
-func (e *DelegationIntegrityExecutor) createTask(ctx context.Context, c *attack.HTTPClient, endpoint string, p attack.Principal, randID string) (taskID, contextID string, accepted bool) {
+// The observation is returned so a caller that got no task can say why. Both wires
+// are classified, because losing the first would let a v1.0-only agent that refuses
+// for auth reasons look like an agent with no task surface: the v0.3 fallback
+// answers -32601, and that maps to a clean result.
+func (e *DelegationIntegrityExecutor) createTask(ctx context.Context, c *attack.HTTPClient, endpoint string,
+	p attack.Principal, randID string) (taskID, contextID string, accepted bool, obs setupObservation) {
 	v1Headers := map[string]string{"A2A-Version": "1.0"}
 	for k, v := range p.Headers {
 		v1Headers[k] = v
@@ -126,6 +134,8 @@ func (e *DelegationIntegrityExecutor) createTask(ctx context.Context, c *attack.
 		},
 	})
 	if err != nil || !resp.IsAccepted() {
+		obs.observe(classifyTaskSetup("creating a probe task as principal "+p.Name, endpoint,
+			c.PresentsCredential(endpoint), resp))
 		resp, err = c.POST(ctx, endpoint, p.Headers, map[string]interface{}{
 			"jsonrpc": "2.0",
 			"id":      "batesian-deleg-create-" + p.Name + "-" + randID,
@@ -140,10 +150,16 @@ func (e *DelegationIntegrityExecutor) createTask(ctx context.Context, c *attack.
 		})
 	}
 	if err != nil || !resp.IsAccepted() {
-		return "", "", false
+		obs.observe(classifyTaskSetup("creating a probe task as principal "+p.Name, endpoint,
+			c.PresentsCredential(endpoint), resp))
+		return "", "", false, obs
 	}
 	taskID, contextID = extractTaskContext(resp.Body)
-	return taskID, contextID, taskID != ""
+	if taskID == "" {
+		obs.observe(classifyTaskSetup("creating a probe task as principal "+p.Name, endpoint,
+			c.PresentsCredential(endpoint), resp))
+	}
+	return taskID, contextID, taskID != "", obs
 }
 
 // continueTask sends a follow-up message that references an existing task/context

--- a/internal/attack/a2a/endpoint.go
+++ b/internal/attack/a2a/endpoint.go
@@ -366,6 +366,21 @@ func answersMCPInitialize(ctx context.Context, client *attack.HTTPClient, endpoi
 	return resp.ContainsAny(`"protocolVersion"`)
 }
 
+// jsonRPCErrorMessage extracts the message from a JSON-RPC error envelope, or ""
+// when there is none. A2A defines no numeric auth code, so the message is what
+// decides whether a refusal was about authorization.
+func jsonRPCErrorMessage(body []byte) string {
+	var envelope struct {
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil || envelope.Error == nil {
+		return ""
+	}
+	return envelope.Error.Message
+}
+
 // jsonRPCErrorCode extracts the numeric code from a JSON-RPC error envelope. ok
 // is false when the body is not JSON, carries no error object, or the error has
 // no numeric code.

--- a/internal/attack/a2a/multitenant_isolation.go
+++ b/internal/attack/a2a/multitenant_isolation.go
@@ -67,10 +67,15 @@ func (e *MultiTenantIsolationExecutor) ExecuteChained(ctx context.Context, targe
 
 	// Step 1: each principal creates its own task. Both must succeed to prove two
 	// valid, distinct identities.
-	taskA, ctxA, okA := e.createTask(ctx, clientA, endpoint, a, vars.RandID)
-	taskB, ctxB, okB := e.createTask(ctx, clientB, endpoint, b, vars.RandID)
+	taskA, ctxA, okA, obsA := e.createTask(ctx, clientA, endpoint, a, vars.RandID)
+	taskB, ctxB, okB, obsB := e.createTask(ctx, clientB, endpoint, b, vars.RandID)
 	if !okA || !okB {
-		return nil, nil
+		// Neither identity's task can be skipped: this rule compares one principal's
+		// task against the other's. Report the failure that explains most, and only
+		// call it clean when the agent implements no task surface at all.
+		obs := obsA
+		obs.observe(obsB)
+		return nil, obs.err()
 	}
 	bb.Publish(attack.Artifact{Kind: attack.ArtifactToken, Value: a.Token, Principal: a.Name, Producer: e.rule.ID})
 	bb.Publish(attack.Artifact{Kind: attack.ArtifactToken, Value: b.Token, Principal: b.Name, Producer: e.rule.ID})
@@ -98,7 +103,10 @@ func (e *MultiTenantIsolationExecutor) ExecuteChained(ctx context.Context, targe
 // createTask issues a SendMessage create as the given principal, trying the A2A
 // v1.0 PascalCase shape first and falling back to the v0.3 slash-method shape.
 // It returns the created task/context IDs and whether the creation was accepted.
-func (e *MultiTenantIsolationExecutor) createTask(ctx context.Context, c *attack.HTTPClient, endpoint string, p attack.Principal, randID string) (taskID, contextID string, accepted bool) {
+// The observation is returned so a caller that got no task can say why. Both wires
+// are classified, and the one that explains most wins.
+func (e *MultiTenantIsolationExecutor) createTask(ctx context.Context, c *attack.HTTPClient, endpoint string,
+	p attack.Principal, randID string) (taskID, contextID string, accepted bool, obs setupObservation) {
 	v1Headers := map[string]string{"A2A-Version": "1.0"}
 	for k, v := range p.Headers {
 		v1Headers[k] = v
@@ -116,6 +124,8 @@ func (e *MultiTenantIsolationExecutor) createTask(ctx context.Context, c *attack
 		},
 	})
 	if err != nil || !resp.IsAccepted() {
+		obs.observe(classifyTaskSetup("creating a probe task as principal "+p.Name, endpoint,
+			c.PresentsCredential(endpoint), resp))
 		slashHeaders := map[string]string{}
 		for k, v := range p.Headers {
 			slashHeaders[k] = v
@@ -134,10 +144,16 @@ func (e *MultiTenantIsolationExecutor) createTask(ctx context.Context, c *attack
 		})
 	}
 	if err != nil || !resp.IsAccepted() {
-		return "", "", false
+		obs.observe(classifyTaskSetup("creating a probe task as principal "+p.Name, endpoint,
+			c.PresentsCredential(endpoint), resp))
+		return "", "", false, obs
 	}
 	taskID, contextID = extractTaskContext(resp.Body)
-	return taskID, contextID, taskID != ""
+	if taskID == "" {
+		obs.observe(classifyTaskSetup("creating a probe task as principal "+p.Name, endpoint,
+			c.PresentsCredential(endpoint), resp))
+	}
+	return taskID, contextID, taskID != "", obs
 }
 
 // readTask attempts a GetTask for taskID over the given client (carrying its own

--- a/internal/attack/a2a/push_binding.go
+++ b/internal/attack/a2a/push_binding.go
@@ -62,11 +62,13 @@ func (e *PushBindingExecutor) ExecuteChained(ctx context.Context, target string,
 
 	// Step 1: establish a task owned by A.
 	taskID, consumed := e.ownedTask(bb, a)
+	var obs setupObservation
 	if taskID == "" {
-		taskID = e.createTask(ctx, clientA, endpoint, a, vars.RandID)
+		taskID, obs = e.createTask(ctx, clientA, endpoint, a, vars.RandID)
 	}
 	if taskID == "" {
-		return nil, nil
+		// No task owned by A, so the push-config binding was never tested.
+		return nil, obs.err()
 	}
 
 	// Step 1b: control - A configures a webhook with a unique marker URL. If even
@@ -104,7 +106,13 @@ func (e *PushBindingExecutor) ownedTask(bb *attack.Blackboard, a attack.Principa
 	return "", false
 }
 
-func (e *PushBindingExecutor) createTask(ctx context.Context, c *attack.HTTPClient, endpoint string, p attack.Principal, randID string) string {
+// The observation is returned so a caller that got no task can say why. Both wires
+// are classified, because losing the first would let a v1.0-only agent that refuses
+// for auth reasons look like an agent with no task surface: the v0.3 fallback
+// answers -32601, and that maps to a clean result.
+func (e *PushBindingExecutor) createTask(ctx context.Context, c *attack.HTTPClient, endpoint string,
+	p attack.Principal, randID string) (string, setupObservation) {
+	var obs setupObservation
 	headers := map[string]string{"A2A-Version": "1.0"}
 	for k, v := range p.Headers {
 		headers[k] = v
@@ -122,6 +130,8 @@ func (e *PushBindingExecutor) createTask(ctx context.Context, c *attack.HTTPClie
 		},
 	})
 	if err != nil || !resp.IsAccepted() {
+		obs.observe(classifyTaskSetup("creating a probe task as principal "+p.Name, endpoint,
+			c.PresentsCredential(endpoint), resp))
 		resp, err = c.POST(ctx, endpoint, p.Headers, map[string]interface{}{
 			"jsonrpc": "2.0",
 			"id":      "batesian-pb-create-" + p.Name + "-" + randID,
@@ -136,10 +146,16 @@ func (e *PushBindingExecutor) createTask(ctx context.Context, c *attack.HTTPClie
 		})
 	}
 	if err != nil || !resp.IsAccepted() {
-		return ""
+		obs.observe(classifyTaskSetup("creating a probe task as principal "+p.Name, endpoint,
+			c.PresentsCredential(endpoint), resp))
+		return "", obs
 	}
 	taskID, _ := extractTaskContext(resp.Body)
-	return taskID
+	if taskID == "" {
+		obs.observe(classifyTaskSetup("creating a probe task as principal "+p.Name, endpoint,
+			c.PresentsCredential(endpoint), resp))
+	}
+	return taskID, obs
 }
 
 // setPush attempts to register a push-notification config for taskID, trying the

--- a/internal/attack/a2a/push_ssrf.go
+++ b/internal/attack/a2a/push_ssrf.go
@@ -92,6 +92,14 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 	if err == nil && sendResp.StatusCode != 404 {
 		reached = true
 	}
+	// Why no binding accepted a push registration. Classified from the responses the
+	// attempts below already have, so a refused credential is not reported as "this
+	// agent does not fetch attacker-controlled callbacks".
+	var obs setupObservation
+	credentialed := client.PresentsCredential(endpoint)
+	if err != nil || !sendResp.IsAccepted() {
+		obs.observe(classifyTaskSetup("creating a task to attach a push config to", endpoint, credentialed, sendResp))
+	}
 	if err == nil && sendResp.IsAccepted() {
 		// Got a task - try to register push notification config for it
 		taskID, _ := extractTaskContext(sendResp.Body)
@@ -130,6 +138,9 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 		sendResp2, err2 := client.POST(ctx, endpoint, map[string]string{}, buildV03SendRequest(callbackURL, token, vars.RandID))
 		if err2 == nil && sendResp2.StatusCode != 404 {
 			reached = true
+		}
+		if err2 != nil || !sendResp2.IsAccepted() {
+			obs.observe(classifyTaskSetup("creating a task on the v0.3 wire", endpoint, credentialed, sendResp2))
 		}
 		if err2 == nil && sendResp2.IsAccepted() {
 			// A task id is what makes this a registration rather than a plain
@@ -203,7 +214,15 @@ func (e *PushSSRFExecutor) Execute(ctx context.Context, target string, opts atta
 		// reached only records a response that was not a 404, which any JSON-RPC
 		// service satisfies. Confirm the target is an A2A agent before calling
 		// this not applicable.
-		return nil, notTestableGiven(ctx, client, vars.BaseURL, endpointOK)
+		if err := notTestableGiven(ctx, client, vars.BaseURL, endpointOK); err != nil {
+			return nil, err
+		}
+		// It is an A2A agent that accepted no push registration. "Push is not
+		// supported here" is a genuine not-applicable and stays clean; a refused
+		// credential is not, because this rule's clean result claims the agent does
+		// not fetch attacker-controlled callback URLs and nothing was ever registered
+		// to find out.
+		return nil, obs.err()
 	}
 
 	// Wait for OOB callback.

--- a/internal/attack/a2a/session_smuggle.go
+++ b/internal/attack/a2a/session_smuggle.go
@@ -62,6 +62,9 @@ func (e *SessionSmuggleExecutor) Execute(ctx context.Context, target string, opt
 	marker := "batesian-roleinj-" + vars.RandID
 
 	reached := false
+	// Why no endpoint could be exercised, when the answer was an authorization
+	// refusal rather than the spec-required rejection of the forged role.
+	var obs setupObservation
 	for _, ep := range endpoints {
 		// Try both the v1.0 PascalCase method (SDK >=1.0.0) and the legacy slash
 		// method (SDK v0.3 compat), each carrying the marker as the message text.
@@ -98,8 +101,15 @@ func (e *SessionSmuggleExecutor) Execute(ctx context.Context, target string, opt
 			reached = true
 		}
 
-		// Server rejected the agent-role message (per spec). Not vulnerable here.
+		// Server rejected the agent-role message (per spec). Not vulnerable here, which
+		// is a real pass: refusing a client-claimed agent role is what the
+		// specification requires. An AUTHORIZATION refusal is not that, though. It
+		// means the message never reached the role handling, so a clean result would
+		// claim this agent does not preserve a forged role without ever having offered
+		// it one.
 		if !resp.IsAccepted() || !looksLikeTask(resp.Body) {
+			obs.observe(classifyTaskSetup("sending a message claiming the agent role", ep,
+				client.PresentsCredential(ep), resp))
 			continue
 		}
 
@@ -117,7 +127,10 @@ func (e *SessionSmuggleExecutor) Execute(ctx context.Context, target string, opt
 	// reached only records that something answered without a 404, which any
 	// JSON-RPC service satisfies. Confirm the target is an A2A agent before
 	// reporting this as a clean result.
-	return nil, notTestableGiven(ctx, client, vars.BaseURL, endpointOK)
+	if err := notTestableGiven(ctx, client, vars.BaseURL, endpointOK); err != nil {
+		return nil, err
+	}
+	return nil, obs.errIfAuthRefused()
 }
 
 // evaluateAcceptance reads the created task's history and classifies the result.

--- a/internal/attack/a2a/setup.go
+++ b/internal/attack/a2a/setup.go
@@ -1,0 +1,155 @@
+package a2a
+
+import (
+	"fmt"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// Eight A2A rules need a task before they can test anything: task IDOR, push SSRF,
+// session smuggling, context fixation, delegation integrity, multi-tenant
+// isolation, push binding, cross-principal cancel. Each of them used to return a
+// clean result when no task could be created, and "this agent does not leak tasks
+// across principals" and "the scan never got a task" are different claims.
+//
+// It went unnoticed because it needs an agent that is reachable AND enforces
+// authorization, and no fixture in testdata/ is one. Measured against an a2a-sdk
+// agent that requires a bearer token: with no credential three rules reported
+// clean, and with two configured principals whose tokens the agent rejected, eight
+// did. That is the shape of every correctly secured production deployment scanned
+// with the wrong credential, which is the worst place to be silently wrong.
+//
+// a2a-artifact-tamper-001 already reported this honestly, because PR #150 fixed it
+// there. This is the same fix for the rest, with one shared judgement rather than
+// eight copies.
+
+// Ranked because a task-creating attempt is made on more than one wire, and the
+// wires can fail differently: v1.0 SendMessage may be absent while v0.3
+// message/send is refused as unauthorized. The most explanatory observation wins,
+// so the answer does not depend on which wire happened to be tried first.
+const (
+	// setupNothing is the zero value: no answer was obtained at all.
+	setupNothing = iota
+	// setupFeatureAbsent means the agent does not implement this surface. It is the
+	// one outcome that is genuinely not applicable rather than untested, and the
+	// only one that still yields a clean result.
+	setupFeatureAbsent
+	// setupOtherRefusal is any other refusal, or an answer carrying no task.
+	setupOtherRefusal
+	// setupAuthRefused is an authorization refusal, which is the case that used to
+	// be read as clean.
+	setupAuthRefused
+)
+
+// setupObservation is the best explanation seen while attempting to establish the
+// precondition a rule needs.
+type setupObservation struct {
+	rank   int
+	reason string
+}
+
+// observe keeps o when it explains more than what is already held.
+func (s *setupObservation) observe(o setupObservation) {
+	if o.rank > s.rank {
+		*s = o
+	}
+}
+
+// err returns what the rule should report: nil when the absence of a task is a
+// genuine not-applicable, and ErrInconclusive carrying the reason otherwise.
+//
+// Only "the agent does not implement this surface" maps to nil. That follows the
+// convention the OAuth-gated rules already use, where a server exposing no OAuth is
+// not applicable rather than insecure. Everything else means the rule did not get
+// to run, and saying so is the whole point.
+func (s setupObservation) err() error {
+	switch s.rank {
+	case setupFeatureAbsent:
+		return nil
+	case setupNothing:
+		return fmt.Errorf("%w: nothing answered a task-creating request, so there was no task "+
+			"to test with", attack.ErrInconclusive)
+	default:
+		return fmt.Errorf("%w: %s", attack.ErrInconclusive, s.reason)
+	}
+}
+
+// errIfAuthRefused is err() narrowed to authorization refusals.
+//
+// Two rules send a request the agent is SUPPOSED to reject, so for them a non-auth
+// rejection is the secure behaviour they test for rather than a failure to test:
+// a2a-session-smuggle-001 sends a message claiming the agent role, which the
+// specification requires the server to refuse, and a2a-context-fixation-001 sends a
+// client-chosen contextId, which a server is right to refuse outright. Mapping
+// those refusals to "not tested" would take a genuine pass away from every
+// well-behaved agent. An authorization refusal is different in kind: it says nothing
+// about the behaviour under test, because the request never reached it.
+func (s setupObservation) errIfAuthRefused() error {
+	if s.rank != setupAuthRefused {
+		return nil
+	}
+	return s.err()
+}
+
+// A2A's own error codes for a surface the agent does not offer. A rule cannot test
+// what is not implemented, and reporting that as clean is the same call the OAuth
+// rules make for a server with no OAuth.
+//
+//	-32003 PushNotificationNotSupportedError
+//	-32004 UnsupportedOperationError
+const (
+	a2aPushNotSupported     = -32003
+	a2aUnsupportedOperation = -32004
+)
+
+// jsonRPCMethodNotFound is what a JSON-RPC service returns for a method it does
+// not implement, which is how a v0.3-only agent answers the v1.0 method name and
+// vice versa.
+const jsonRPCMethodNotFound = -32601
+
+// classifyTaskSetup explains why one attempt to establish a task did not produce
+// one. what names the attempt, so a rule's reason reads as its own.
+//
+// resp is nil when the request got no answer at all.
+func classifyTaskSetup(what, endpoint string, credentialed bool, resp *attack.Response) setupObservation {
+	if resp == nil {
+		return setupObservation{}
+	}
+
+	// An auth refusal can arrive as an HTTP status or as a JSON-RPC error at HTTP
+	// 200. A2A defines no numeric auth code, so the JSON-RPC form is judged on the
+	// message, using the one keyword list in internal/attack.
+	if resp.StatusCode == 401 || resp.StatusCode == 403 {
+		return setupObservation{setupAuthRefused, fmt.Sprintf(
+			"%s at %s was refused with HTTP %d %s, so no task existed to test with",
+			what, endpoint, resp.StatusCode, attack.CredentialNote(credentialed))}
+	}
+
+	code, hasErr := jsonRPCErrorCode(resp.Body)
+	msg := jsonRPCErrorMessage(resp.Body)
+	if hasErr && attack.AuthFlavoredMessage(msg) {
+		return setupObservation{setupAuthRefused, fmt.Sprintf(
+			"%s at %s was refused as unauthorized (JSON-RPC %d: %q) %s, so no task existed "+
+				"to test with", what, endpoint, code, msg, attack.CredentialNote(credentialed))}
+	}
+	if hasErr {
+		switch code {
+		case jsonRPCMethodNotFound, a2aPushNotSupported, a2aUnsupportedOperation:
+			// The agent does not offer this surface. Nothing to test, and nothing wrong.
+			return setupObservation{setupFeatureAbsent, ""}
+		}
+		return setupObservation{setupOtherRefusal, fmt.Sprintf(
+			"%s at %s was refused (JSON-RPC %d: %q), so no task existed to test with",
+			what, endpoint, code, msg)}
+	}
+	if !resp.IsSuccess() {
+		return setupObservation{setupOtherRefusal, fmt.Sprintf(
+			"%s at %s was answered with HTTP %d and no JSON-RPC error, so no task existed "+
+				"to test with", what, endpoint, resp.StatusCode)}
+	}
+	// Answered, and carried no task. A2A lets an agent reply with a Message instead
+	// of a Task, which is legal and still leaves this rule nothing to work with.
+	return setupObservation{setupOtherRefusal, fmt.Sprintf(
+		"%s at %s was accepted but the reply carried no task id, so no task existed to "+
+			"test with", what, endpoint)}
+}

--- a/internal/attack/a2a/setup_test.go
+++ b/internal/attack/a2a/setup_test.go
@@ -1,0 +1,237 @@
+package a2a_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	a2aattack "github.com/calbebop/batesian/internal/attack/a2a"
+)
+
+// Eight A2A rules need a task before their oracle means anything, and each of them
+// used to report a clean result when no task could be created. On an agent that
+// enforces authorization and is scanned without a usable credential, that is a
+// high- or critical-severity claim with nothing behind it: "this agent does not
+// leak tasks across principals" when no task was ever created.
+//
+// It survived five validation rounds because it needs an agent that is reachable
+// AND enforces authorization, and no fixture in testdata/ is one. This is that
+// fixture, in-process.
+
+// securedAgent serves a valid agent card so endpoint resolution succeeds, then
+// refuses every JSON-RPC call with HTTP 401 unless it carries validToken. That is
+// the shape of the a2a-sdk agent this defect was found against, and of every
+// correctly secured deployment.
+func securedAgent(t *testing.T, validToken string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/.well-known/") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"name":"Secured Agent","description":"d","version":"1.0.0",`+
+				`"protocolVersion":"1.0","capabilities":{},"skills":[],`+
+				`"supportedInterfaces":[{"url":"http://`+r.Host+`/","protocolBinding":"JSONRPC","protocolVersion":"1.0"}]}`)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer "+validToken {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = io.WriteString(w, `{"error":"unauthenticated","message":"a valid bearer token is required"}`)
+			return
+		}
+		// Authorized callers get a task, so the rules have something to work with and
+		// this fixture cannot pass by refusing everything.
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": req["id"],
+			"result": map[string]interface{}{
+				"id": "task-1", "contextId": "ctx-1",
+				"status": map[string]interface{}{"state": "working"},
+			},
+		})
+	}))
+}
+
+// theEightRules are every rule whose oracle needs a task it has to create first.
+func theEightRules() map[string]func(attack.RuleContext) attack.Executor {
+	return map[string]func(attack.RuleContext) attack.Executor{
+		"a2a-task-idor-001": func(rc attack.RuleContext) attack.Executor {
+			return a2aattack.NewTaskIDORExecutor(rc)
+		},
+		"a2a-push-ssrf-001": func(rc attack.RuleContext) attack.Executor {
+			return a2aattack.NewPushSSRFExecutor(rc)
+		},
+		"a2a-session-smuggle-001": func(rc attack.RuleContext) attack.Executor {
+			return a2aattack.NewSessionSmuggleExecutor(rc)
+		},
+		"a2a-context-fixation-001": func(rc attack.RuleContext) attack.Executor {
+			return a2aattack.NewContextFixationExecutor(rc)
+		},
+		"a2a-delegation-integrity-001": func(rc attack.RuleContext) attack.Executor {
+			return a2aattack.NewDelegationIntegrityExecutor(rc)
+		},
+		"a2a-multitenant-isolation-001": func(rc attack.RuleContext) attack.Executor {
+			return a2aattack.NewMultiTenantIsolationExecutor(rc)
+		},
+		"a2a-push-binding-001": func(rc attack.RuleContext) attack.Executor {
+			return a2aattack.NewPushBindingExecutor(rc)
+		},
+		"a2a-task-cancel-idor-001": func(rc attack.RuleContext) attack.Executor {
+			return a2aattack.NewTaskCancelIDORExecutor(rc)
+		},
+	}
+}
+
+// twoRejectedPrincipals is the case that produced eight silent false cleans: the
+// operator configured two identities, so the two-principal gate from #170 passes,
+// and the agent rejects both.
+func twoRejectedPrincipals() attack.Options {
+	return attack.Options{
+		TimeoutSeconds: 5,
+		Token:          "not-the-valid-token",
+		Principals: []attack.Principal{
+			{Name: "a", Token: "rejected-a", Tenant: "A"},
+			{Name: "b", Token: "rejected-b", Tenant: "B"},
+		},
+	}
+}
+
+// No rule may report a clean result when the credential it was given cannot create
+// a task. Every one of these reported clean before.
+func TestTaskSetup_RejectedCredentialIsNotTestedForEveryRule(t *testing.T) {
+	srv := securedAgent(t, "the-valid-token")
+	defer srv.Close()
+
+	for id, build := range theEightRules() {
+		t.Run(id, func(t *testing.T) {
+			exec := build(attack.RuleContext{ID: id, Severity: "high"})
+			findings, err := exec.Execute(context.Background(), srv.URL, twoRejectedPrincipals())
+			if len(findings) != 0 {
+				t.Fatalf("expected no findings against a secured agent, got %d", len(findings))
+			}
+			if !errors.Is(err, attack.ErrInconclusive) {
+				t.Fatalf("a rule that never created a task must report not tested, got err=%v", err)
+			}
+			// The reason has to be usable, or the operator learns nothing from it.
+			if !strings.Contains(err.Error(), srv.URL) {
+				t.Errorf("reason should name the endpoint; got: %v", err)
+			}
+			for _, want := range []string{"401", "credential"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("reason should mention %q; got: %v", want, err)
+				}
+			}
+		})
+	}
+}
+
+// The same agent with the credential it accepts. Every rule must get past setup, so
+// the fixture above cannot be passing merely by being unreachable, and so this
+// change cannot be silencing rules that could in fact run.
+func TestTaskSetup_AcceptedCredentialGetsPastSetup(t *testing.T) {
+	srv := securedAgent(t, "the-valid-token")
+	defer srv.Close()
+
+	opts := attack.Options{
+		TimeoutSeconds: 5,
+		Token:          "the-valid-token",
+		Principals: []attack.Principal{
+			{Name: "a", Token: "the-valid-token", Tenant: "A"},
+			{Name: "b", Token: "the-valid-token", Tenant: "B"},
+		},
+	}
+	for id, build := range theEightRules() {
+		t.Run(id, func(t *testing.T) {
+			exec := build(attack.RuleContext{ID: id, Severity: "high"})
+			_, err := exec.Execute(context.Background(), srv.URL, opts)
+			if errors.Is(err, attack.ErrInconclusive) &&
+				strings.Contains(err.Error(), "no task existed to test with") {
+				t.Errorf("setup should have succeeded with the accepted credential; got: %v", err)
+			}
+		})
+	}
+}
+
+// An agent that implements no task-creation method at all is a different fact: there
+// is nothing to test and nothing wrong, which is the same call the OAuth-gated rules
+// make for a server exposing no OAuth. It must stay a clean result, or every agent
+// without a task surface would be reported as not tested.
+func TestTaskSetup_FeatureAbsentStaysClean(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/.well-known/") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"name":"No Tasks","description":"d","version":"1.0.0",`+
+				`"protocolVersion":"1.0","capabilities":{},"skills":[],`+
+				`"supportedInterfaces":[{"url":"http://`+r.Host+`/","protocolBinding":"JSONRPC","protocolVersion":"1.0"}]}`)
+			return
+		}
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": req["id"],
+			"error": map[string]interface{}{"code": -32601, "message": "method not found"}})
+	}))
+	defer srv.Close()
+
+	for _, id := range []string{
+		"a2a-multitenant-isolation-001", "a2a-delegation-integrity-001",
+		"a2a-push-binding-001", "a2a-task-cancel-idor-001",
+	} {
+		t.Run(id, func(t *testing.T) {
+			exec := theEightRules()[id](attack.RuleContext{ID: id, Severity: "high"})
+			findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{
+				TimeoutSeconds: 5,
+				Principals: []attack.Principal{
+					{Name: "a", Token: "tok-a", Tenant: "A"},
+					{Name: "b", Token: "tok-b", Tenant: "B"},
+				},
+			})
+			if err != nil {
+				t.Fatalf("an agent with no task surface is not applicable, not untested: %v", err)
+			}
+			if len(findings) != 0 {
+				t.Errorf("expected no findings, got %d", len(findings))
+			}
+		})
+	}
+}
+
+// a2a-session-smuggle-001 sends a message claiming the agent role, which the
+// specification requires the server to REFUSE. That refusal is the pass this rule
+// looks for, so it must stay a clean result: only an authorization refusal means the
+// message never reached the role handling. Getting this wrong would take a genuine
+// pass away from every well-behaved agent.
+func TestTaskSetup_SpecRequiredRejectionStaysClean(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/.well-known/") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"name":"Strict Agent","description":"d","version":"1.0.0",`+
+				`"protocolVersion":"1.0","capabilities":{},"skills":[],`+
+				`"supportedInterfaces":[{"url":"http://`+r.Host+`/","protocolBinding":"JSONRPC","protocolVersion":"1.0"}]}`)
+			return
+		}
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+		// Refuses the forged role on its merits, with no authorization involved.
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": req["id"],
+			"error": map[string]interface{}{"code": -32602, "message": "message role must be user"}})
+	}))
+	defer srv.Close()
+
+	exec := a2aattack.NewSessionSmuggleExecutor(attack.RuleContext{ID: "a2a-session-smuggle-001"})
+	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+	if err != nil {
+		t.Fatalf("a spec-required rejection is a pass, not an untested result: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected no findings, got %d", len(findings))
+	}
+}

--- a/internal/attack/a2a/task_cancel_idor.go
+++ b/internal/attack/a2a/task_cancel_idor.go
@@ -74,9 +74,12 @@ func (e *TaskCancelIDORExecutor) Execute(ctx context.Context, target string, opt
 	unauthClient := attack.NewUnauthHTTPClient(opts, attack.NewVars(target, opts.OOBListenerURL))
 
 	// Step 1: create a cancelable task owned by A.
-	taskID := e.createTask(ctx, clientA, endpoint, a, vars.RandID)
+	taskID, obs := e.createTask(ctx, clientA, endpoint, a, vars.RandID)
 	if taskID == "" {
-		return nil, nil // not a responsive A2A server, or no task could be created
+		// No cancelable task, so the ownership boundary on cancel was never tested.
+		// The comment here used to read "or no task could be created" and returned a
+		// clean result for exactly that case.
+		return nil, obs.err()
 	}
 
 	// Step 2: discriminator. Attempt to cancel A's task with no credentials.
@@ -108,7 +111,13 @@ func (e *TaskCancelIDORExecutor) Execute(ctx context.Context, target string, opt
 // createTask creates a task as the given principal, trying the A2A v1.0 shape
 // first and falling back to the v0.3 slash-method shape. Returns the created task
 // id, or empty if creation was not accepted.
-func (e *TaskCancelIDORExecutor) createTask(ctx context.Context, c *attack.HTTPClient, endpoint string, p attack.Principal, randID string) string {
+// The observation is returned so a caller that got no task can say why. Both wires
+// are classified, because losing the first would let a v1.0-only agent that refuses
+// for auth reasons look like an agent with no task surface: the v0.3 fallback
+// answers -32601, and that maps to a clean result.
+func (e *TaskCancelIDORExecutor) createTask(ctx context.Context, c *attack.HTTPClient, endpoint string,
+	p attack.Principal, randID string) (string, setupObservation) {
+	var obs setupObservation
 	v1Headers := map[string]string{"A2A-Version": "1.0"}
 	for k, v := range p.Headers {
 		v1Headers[k] = v
@@ -126,6 +135,8 @@ func (e *TaskCancelIDORExecutor) createTask(ctx context.Context, c *attack.HTTPC
 		},
 	})
 	if err != nil || !resp.IsAccepted() {
+		obs.observe(classifyTaskSetup("creating a probe task as principal "+p.Name, endpoint,
+			c.PresentsCredential(endpoint), resp))
 		resp, err = c.POST(ctx, endpoint, p.Headers, map[string]interface{}{
 			"jsonrpc": "2.0",
 			"id":      "batesian-cancel-create-" + p.Name + "-" + randID,
@@ -140,10 +151,16 @@ func (e *TaskCancelIDORExecutor) createTask(ctx context.Context, c *attack.HTTPC
 		})
 	}
 	if err != nil || !resp.IsAccepted() {
-		return ""
+		obs.observe(classifyTaskSetup("creating a probe task as principal "+p.Name, endpoint,
+			c.PresentsCredential(endpoint), resp))
+		return "", obs
 	}
 	taskID, _ := extractTaskContext(resp.Body)
-	return taskID
+	if taskID == "" {
+		obs.observe(classifyTaskSetup("creating a probe task as principal "+p.Name, endpoint,
+			c.PresentsCredential(endpoint), resp))
+	}
+	return taskID, obs
 }
 
 // cancelTask attempts to cancel taskID over the given client and classifies the

--- a/internal/attack/a2a/task_idor.go
+++ b/internal/attack/a2a/task_idor.go
@@ -102,7 +102,11 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 		if !ok && !restReached {
 			return nil, attack.ErrInconclusive
 		}
-		return nil, nil
+		// It answered, and no task was created. Only an agent that does not implement
+		// task creation is a clean result here; a refused credential means this rule
+		// never got to look at the ownership boundary it reports on.
+		return nil, classifyTaskSetup("creating a probe task as the owner", endpoint,
+			authedClient.PresentsCredential(endpoint), ownerResp).err()
 	}
 	taskID, contextID := extractTaskContext(ownerResp.Body)
 	if taskID == "" {
@@ -115,7 +119,8 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 		if !ok && !restReached {
 			return nil, attack.ErrInconclusive
 		}
-		return nil, nil
+		return nil, classifyTaskSetup("creating a probe task as the owner", endpoint,
+			authedClient.PresentsCredential(endpoint), ownerResp).err()
 	}
 
 	// Step 2: Auth-enforcement discriminator. Attempt the same creation with no

--- a/internal/attack/authsignal.go
+++ b/internal/attack/authsignal.go
@@ -45,3 +45,18 @@ func AuthFlavoredMessage(msg string) bool {
 	}
 	return false
 }
+
+// CredentialNote completes an unauthorized-refusal message with what the refused
+// request actually presented, which is the part an operator acts on.
+//
+// It lives here, beside AuthFlavoredMessage, because both protocol packages report
+// this and a second copy would drift the way the keyword list did. It states the
+// fact and prescribes no flag: whether passing a credential would change anything
+// is a per-rule question, and several rules send none by design.
+func CredentialNote(credentialed bool) string {
+	if credentialed {
+		return "even though the request presented the credential this scan was given, " +
+			"so that credential is not accepted here"
+	}
+	return "and the request presented no credential"
+}

--- a/internal/attack/mcp/era.go
+++ b/internal/attack/mcp/era.go
@@ -64,20 +64,22 @@ const (
 	rankUnauthorized
 )
 
+// mcpCredentialNote is the shared note plus what it means for MCP specifically: a
+// server that refuses an anonymous handshake does not serve the protocol
+// anonymously at all, which is worth saying once rather than leaving the operator
+// to infer it.
+func mcpCredentialNote(credentialed bool) string {
+	note := attack.CredentialNote(credentialed)
+	if !credentialed {
+		note += ", so this server does not serve MCP anonymously"
+	}
+	return note
+}
+
 // initObservation is the best explanation seen while walking the candidates.
 type initObservation struct {
 	rank   int
 	reason string
-}
-
-// credentialNote completes an unauthorized-refusal message with what the request
-// actually presented, which is the part an operator acts on.
-func credentialNote(credentialed bool) string {
-	if credentialed {
-		return "even though the request presented the credential this scan was given, " +
-			"so that credential is not accepted here"
-	}
-	return "and the request presented no credential, so this server does not serve MCP anonymously"
 }
 
 // observe keeps o when it explains more than what is already held.
@@ -118,12 +120,12 @@ func classifyInitFailure(endpoint string, credentialed bool, resp *attack.Respon
 	if resp.StatusCode == 401 || resp.StatusCode == 403 {
 		return initObservation{rankUnauthorized, fmt.Sprintf(
 			"the MCP handshake at %s was refused with HTTP %d %s",
-			endpoint, resp.StatusCode, credentialNote(credentialed))}
+			endpoint, resp.StatusCode, mcpCredentialNote(credentialed))}
 	}
 	if hasErr && authFlavoredError(code, msg) {
 		return initObservation{rankUnauthorized, fmt.Sprintf(
 			"the MCP handshake at %s was refused as unauthorized (JSON-RPC %d: %q) %s",
-			endpoint, code, msg, credentialNote(credentialed))}
+			endpoint, code, msg, mcpCredentialNote(credentialed))}
 	}
 	if hasErr && code == mcpMethodNotFound {
 		return initObservation{rankNotMCP, fmt.Sprintf(


### PR DESCRIPTION
Eight A2A rules need a task before their oracle means anything, and each of them
returned a **clean** result when none could be created. Against an agent that
enforces authorization, scanned without a usable credential, that is a high- or
critical-severity claim with nothing behind it: `a2a-task-idor-001` reported that
tasks are not readable across authorization contexts, having never created one.

Measured against an a2a-sdk agent that requires a bearer token:

| credentials given | rules reporting clean without testing |
|---|---|
| none | 3 |
| an invalid `--token` | 3 |
| two `--principal`s the agent rejects | **8** |
| two valid tokens lacking the scope | **8** |

The eight are `task-idor`, `push-ssrf`, `session-smuggle`, `context-fixation`,
`delegation-integrity`, `multitenant-isolation`, `push-binding`,
`task-cancel-idor`. The five multi-principal ones cleared the two-identity gate from
#170, which checks that two identities are *configured*, not that either *works*.
`a2a/task_idor.go` said so out loud: *"Not a responsive A2A server, or our
credentials were rejected"* — and then returned clean. `a2a-artifact-tamper-001`
already reported this honestly because #150 fixed it there, so the higher-severity
rules were the ones still wrong.

It survived five validation rounds because it needs an agent that is reachable *and*
enforces authorization, and no fixture in `testdata/` is one. The fixture suite was
carrying it all along, though: **the sweep moves 20 of 43 cases**, because six A2A
fixtures answer an anonymous `message/send` with `-32600 "authentication required"`
and the three token-based task rules reported clean against them. Nobody questioned
it, since those rules are not in those fixtures' documented coverage.

One shared judgement rather than eight copies. `classifyTaskSetup` ranks what the
attempt met, across both wires, because losing the first would let a v1.0-only agent
that refuses for auth reasons look like one with no task surface: the v0.3 fallback
answers `-32601`, which is a clean result.

**Two things stay clean, deliberately.** An agent that does not implement the surface
(`-32601`, plus A2A's own `-32003` push-not-supported and `-32004`
unsupported-operation) is not applicable, the same call the OAuth-gated MCP rules
make for a server exposing no OAuth — without it, every agent with push disabled
would be reported untested. And where the request is one the agent is *supposed* to
refuse, the refusal is the pass being looked for: `session-smuggle` sends a message
claiming the agent role, `context-fixation` sends a client-chosen `contextId`. For
those two only an authorization refusal counts as untested, and a test pins it in
both directions.

Verification:

- 21 subtests: the eight rules against a secured agent, the accepted-credential path
  (so the fixture cannot pass by refusing everything), the feature-absent case, and
  the spec-required rejection. Neutering the fix fails all eight; over-reaching fails
  the spec-rejection test
- the live agent in four credential scenarios, plus its `open` and `idor` postures,
  which fire **identically** to the previous binary
- 43-case fixture sweep: **0 findings changed**, and every skip change is one of these
  false cleans disappearing. Adding `--token` to an affected fixture puts the three
  rules back to running and reaching a real verdict