### PR TITLE
fix(a2a): read the v1.0 nested task envelope, and stop clearing a broken delegation chain

### DIFF
--- a/docs/validation-results.md
+++ b/docs/validation-results.md
@@ -32,6 +32,18 @@ against a server that genuinely exhibited the condition. A false negative in a
 security scanner is worse than a noisy one, and none of them were reachable from
 a self-authored fixture.
 
+A **negative control** is what the exercise was missing for a long time, and adding
+one found a third false negative. Running against an agent built to be vulnerable in
+one specific way, rather than against an open agent, showed
+`a2a-delegation-integrity-001` reporting that a delegated task's chain of custody
+held while the wrong principal was demonstrably continuing it. Its oracle compared
+identifiers in the reply, and read only the flat envelope: in A2A v1.0 a send-style
+reply is a `SendMessageResponse`, a protobuf oneof, so the Task arrives nested under
+`result.task`, while `GetTask` returns it flat. The read checks were therefore fine
+and the continuation check silently never matched. An open agent could not have
+surfaced it, because the rule's own discriminator suppresses on a server with no
+authorization at all.
+
 The same exercise has also caught a false positive before it shipped.
 `mcp-session-as-credential-001` passed every posture in its own harness, then
 reported the official MCP C# SDK's stateful sample as vulnerable. That sample

--- a/internal/attack/a2a/taskref.go
+++ b/internal/attack/a2a/taskref.go
@@ -27,22 +27,47 @@ import "encoding/json"
 // A Task carries id and contextId in both revisions. A result that is a Message
 // rather than a Task has neither, and returns false: whether it touched A's task
 // cannot be established from it.
+//
+// Both envelope shapes are read, and the first version of this helper knew only the
+// flat one, which cost a2a-delegation-integrity-001 its whole oracle on the v1.0
+// wire. In v1.0 a send-style reply is a SendMessageResponse, a protobuf oneof of
+// task or message, so protobuf JSON mapping renders the Task NESTED under
+// result.task. GetTask returns a bare Task, so it arrives flat. Reading only the
+// flat shape therefore worked for the read checks and silently failed for the
+// continuation check: measured against an a2a-sdk agent with no ownership check,
+// principal B's continuation landed on A's task, the agent confirmed it by
+// returning A's task under result.task, and the rule reported that the delegation
+// binding held.
 func resultReferencesTask(body []byte, taskID, contextID string) bool {
+	// task carries the identifiers wherever it appears in the envelope.
+	type task struct {
+		ID        string `json:"id"`
+		TaskID    string `json:"taskId"`
+		ContextID string `json:"contextId"`
+	}
 	var envelope struct {
 		Result *struct {
-			ID        string `json:"id"`
-			TaskID    string `json:"taskId"`
-			ContextID string `json:"contextId"`
+			task
+			// v1.0 send-style responses: the oneof member's field name.
+			Task *task `json:"task"`
 		} `json:"result"`
 	}
 	if json.Unmarshal(body, &envelope) != nil || envelope.Result == nil {
 		return false
 	}
-	r := envelope.Result
-	if taskID != "" && (r.ID == taskID || r.TaskID == taskID) {
-		return true
+	candidates := []task{envelope.Result.task}
+	if envelope.Result.Task != nil {
+		candidates = append(candidates, *envelope.Result.Task)
 	}
-	// contextId alone is enough: a continuation accepted into A's context is the
-	// boundary crossing, whatever task id the server chose to report.
-	return contextID != "" && r.ContextID == contextID
+	for _, c := range candidates {
+		if taskID != "" && (c.ID == taskID || c.TaskID == taskID) {
+			return true
+		}
+		// contextId alone is enough: a continuation accepted into A's context is the
+		// boundary crossing, whatever task id the server chose to report.
+		if contextID != "" && c.ContextID == contextID {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/attack/a2a/taskref_test.go
+++ b/internal/attack/a2a/taskref_test.go
@@ -49,6 +49,38 @@ func TestResultReferencesTask(t *testing.T) {
 			want: false,
 		},
 		{
+			// The false NEGATIVE this helper shipped with, and the one that cost
+			// a2a-delegation-integrity-001 its whole oracle on the v1.0 wire. A v1.0
+			// send-style reply is a SendMessageResponse, a protobuf oneof, so the Task
+			// arrives NESTED under result.task. Measured against an a2a-sdk agent with
+			// no ownership check: B's continuation landed on A's task, the agent
+			// returned A's task in this shape, and the rule reported the binding held.
+			name: "v1.0 nested task envelope references it",
+			body: `{"jsonrpc":"2.0","id":1,"result":{"task":{"id":"task-A","contextId":"ctx-A",` +
+				`"status":{"state":"TASK_STATE_SUBMITTED"}}}}`,
+			want: true,
+		},
+		{
+			// The nested shape must discriminate as sharply as the flat one, or fixing
+			// the false negative would buy a false positive: a tenant-scoped server
+			// answering with a NEW task nests it exactly the same way.
+			name: "a different task nested is still not A's task",
+			body: `{"jsonrpc":"2.0","id":1,"result":{"task":{"id":"task-B-7","contextId":"ctx-B"}}}`,
+			want: false,
+		},
+		{
+			name: "A's context nested is enough",
+			body: `{"jsonrpc":"2.0","id":1,"result":{"task":{"id":"task-A-2","contextId":"ctx-A"}}}`,
+			want: true,
+		},
+		{
+			// The other oneof member. A Message carries no task identifiers, so nothing
+			// can be established from it either way.
+			name: "v1.0 nested message result establishes nothing",
+			body: `{"jsonrpc":"2.0","id":1,"result":{"message":{"messageId":"m1","role":"ROLE_AGENT"}}}`,
+			want: false,
+		},
+		{
 			name: "an error envelope does not match",
 			body: `{"jsonrpc":"2.0","id":1,"error":{"code":-32001,"message":"Task not found"}}`,
 			want: false,


### PR DESCRIPTION
`a2a-delegation-integrity-001` reported that a delegated task's chain of custody held
while the wrong principal was demonstrably continuing it. Against an a2a-sdk agent
with no ownership check: A creates a task, an unauthenticated continuation is refused
`401`, and B's continuation is accepted and answered with **A's own task**. The rule
read that as "delegation binding holds".

`resultReferencesTask` compares identifiers in the reply, which is right, and knew
only the flat envelope. In A2A v1.0 a send-style reply is a `SendMessageResponse`, a
protobuf oneof of `task` or `message`, so the Task arrives nested under
`result.task`; `GetTask` returns a bare Task, so it arrives flat:

```
SendMessage  ->  {"result":{"task":{"id":"…","contextId":"…"}}}   nested
GetTask      ->  {"result":{"id":"…","contextId":"…"}}            flat
```

**The shape depends on the method, not the revision.** That is why the read checks in
`a2a-multitenant-isolation-001` were unaffected and only the continuation check
silently never matched.

The nested shape has to discriminate as sharply as the flat one, or fixing a false
negative buys a false positive: a tenant-scoped server that refuses to expose A's
task answers with a *new* task nested exactly the same way, which is the live false
positive #163 removed from this same helper. Both cases are pinned.

An open agent could not have surfaced this — the rule's own discriminator suppresses
against a server with no authorization at all, so it needs an agent that enforces
authorization *and* has the specific bug. That is what a negative-control fixture is
for, and it is the third false negative this exercise has found.

Audited the rest of the class: every other result-envelope parse in the package
either already handles the nesting (`artifact_tamper`'s `extractTaskID`,
`session_smuggle`'s `extractTaskContext`) or reads a `GetTask` reply, which is flat
(`session_smuggle`'s history check). This was the only one.

Verification:

- 4 new cases over the nested envelope, including a non-matching task and the
  `message` member of the oneof; ignoring the nested shape again fails exactly the two
  that should
- live: the rule now fires on the vulnerable posture with evidence matching what curl
  shows by hand, and the **secured** and **open** postures are unchanged, so no false
  positive
- 43-case fixture sweep: nothing changed, because the fixtures answer on the flat wire