### PR TITLE
fix(a2a): stop reporting agent-role injection on a server that stored nothing

### DIFF
--- a/docs/rules-a2a.md
+++ b/docs/rules-a2a.md
@@ -104,11 +104,11 @@ report them not tested against a secured agent, and say so.
 | `a2a-extcard-unauth-001` | [Extended Agent Card Unauthenticated Disclosure](#a2a-extcard-unauth-001) | High | confirmed | CWE-862 |
 | `a2a-push-ssrf-001` | [Push Notification SSRF](#a2a-push-ssrf-001) | High | confirmed | CWE-918 |
 | `a2a-task-idor-001` | [Task IDOR via Unauthenticated tasks/get](#a2a-task-idor-001) | High | confirmed | CWE-639 |
-| `a2a-session-smuggle-001` | [Agent Role Injection / Session Smuggling](#a2a-session-smuggle-001) | High | confirmed / indicator | CWE-384 |
+| `a2a-session-smuggle-001` | [Agent Role Injection / Session Smuggling](#a2a-session-smuggle-001) | High | confirmed | CWE-384 |
 | `a2a-wellknown-hostinject-001` | [Agent Card Host Header Injection](#a2a-wellknown-hostinject-001) | High / Medium | indicator | CWE-601 |
 | `a2a-jws-algconf-001` | [AgentCard JWS Algorithm Confusion](#a2a-jws-algconf-001) | Critical | indicator | CWE-327 |
 | `a2a-peer-impersonation-001` | [Peer Agent Impersonation via Forged JWT](#a2a-peer-impersonation-001) | Critical | confirmed | CWE-290 |
-| `a2a-artifact-tamper-001` | [Task Artifact Tampering via Task ID Reuse](#a2a-artifact-tamper-001) | High | confirmed / indicator | CWE-284 |
+| `a2a-artifact-tamper-001` | [Task Artifact Tampering via Task ID Reuse](#a2a-artifact-tamper-001) | High | confirmed | CWE-284 |
 | `a2a-multitenant-isolation-001` | [Multi-Tenant Task Isolation Breach](#a2a-multitenant-isolation-001) | High | confirmed | CWE-639 |
 | `a2a-delegation-integrity-001` | [Delegation Chain-of-Custody Break](#a2a-delegation-integrity-001) | High | confirmed | CWE-863 |
 | `a2a-context-fixation-001` | [Context ID Fixation](#a2a-context-fixation-001) | High | confirmed | CWE-384 |
@@ -197,12 +197,22 @@ task-list probe still runs.
 
 **Agent Role Injection / Session Smuggling** | Severity: High | CWE-384
 
-Sends a `message/send` request with `role: agent` - a role the spec reserves for
-server-originated messages - and then **reads the task history back** to confirm
-whether the injection actually landed. Only when the marker is stored as an
-agent-role turn is a **confirmed** exploit reported. If the server rejects the
-role (`-32602`) or normalizes it to `user`, no finding is raised; if acceptance
-cannot be verified from retrievable history, it is downgraded to an **indicator**.
+Sends a `message/send` request with `role: agent`, then **reads the task history
+back** to confirm whether the injection landed. Only when the marker is stored as an
+agent-role turn is a **confirmed** exploit reported.
+
+What is reported is the stored turn, not the acceptance. The specification defines
+the roles by direction (`ROLE_USER` client-to-server, `ROLE_AGENT` server-to-client)
+and carries no MUST or SHOULD requiring a server to validate or reject a
+client-supplied role; both official SDKs accept one. A client-authored turn
+*persisted* under the agent role is the failure, because anything reading that
+history back cannot tell it from a genuine agent turn.
+
+A server that rejects the role (`-32602`), normalizes it to `user`, or does not
+persist the message is **clean**. When the history cannot be read back, or the reply
+carried no task (A2A permits answering a send with a Message), the rule reports **not
+tested**: its oracle never ran. That case used to be reported as a high-severity
+indicator, which was a finding produced because nothing had been determined.
 
 Demonstrated by Palo Alto Networks Unit 42 (Oct 2025) against a Google ADK sample,
 achieving system-prompt exfiltration and an unauthorized action. Cross-session

--- a/internal/attack/a2a/session_smuggle.go
+++ b/internal/attack/a2a/session_smuggle.go
@@ -22,13 +22,15 @@ import (
 // safe. The executor therefore confirms the injection landed:
 //
 //  1. Send a SendMessage carrying role=agent and a unique marker in the text.
-//  2. If the server rejects it (JSON-RPC error), it is behaving per spec: no
-//     finding.
+//  2. If the server rejects it (JSON-RPC error), no finding. The specification
+//     requires no rejection, so this is simply a server that validates more than
+//     it has to.
 //  3. If accepted, read the resulting task's history back and check whether the
 //     marker is stored as an AGENT-role message. If so the role was honored ->
-//     ConfirmedExploit. If the marker is present but stored as a user message,
-//     the server neutralized it -> no finding. If acceptance cannot be verified
-//     (stateless response / no retrievable history) -> RiskIndicator.
+//     ConfirmedExploit. If the marker is present but stored as a user message, or
+//     absent, the server did not persist a forged agent turn -> no finding. If the
+//     history cannot be read back, or the reply carried no task, nothing was
+//     determined -> ErrInconclusive.
 //
 // Cross-context task-history disclosure is intentionally NOT tested here; that
 // failure is covered rigorously by rule a2a-task-idor-001.
@@ -115,8 +117,12 @@ func (e *SessionSmuggleExecutor) Execute(ctx context.Context, target string, opt
 
 		// Accepted. Confirm whether the agent role was honored by reading the
 		// task history back and checking how the marker message is stored.
-		if f := e.evaluateAcceptance(ctx, client, ep, a2aHeaders, resp.Body, marker, vars); f != nil {
+		f, evalErr := e.evaluateAcceptance(ctx, client, ep, a2aHeaders, resp.Body, marker, vars)
+		if f != nil {
 			return []attack.Finding{*f}, nil
+		}
+		if evalErr != nil {
+			return nil, evalErr
 		}
 		return nil, nil // accepted but neutralized (normalized to user role)
 	}
@@ -135,9 +141,28 @@ func (e *SessionSmuggleExecutor) Execute(ctx context.Context, target string, opt
 
 // evaluateAcceptance reads the created task's history and classifies the result.
 // It returns a confirmed finding when the marker is stored as an agent-role
-// message, a RiskIndicator when acceptance cannot be verified, and nil when the
-// server demonstrably neutralized the role (stored the marker as a user message).
-func (e *SessionSmuggleExecutor) evaluateAcceptance(ctx context.Context, client *attack.HTTPClient, ep string, headers map[string]string, sendBody []byte, marker string, vars attack.Vars) *attack.Finding {
+// message, and nil when the server demonstrably did not persist one.
+// The error is ErrInconclusive when the server accepted the message but the
+// injection could not be read back. That case used to be a high/indicator finding,
+// which is a finding produced BECAUSE nothing was determined: the shape PR #150
+// removed from a2a-artifact-tamper-001.
+//
+// What made it look defensible was a specification requirement that does not exist.
+// The finding read "instead of rejecting it with JSON-RPC -32602. The A2A spec
+// reserves the agent role for server-originated messages", but the specification
+// only defines the roles semantically (ROLE_USER is client-to-server, ROLE_AGENT is
+// server-to-client) and carries no MUST or SHOULD about validating or rejecting a
+// client-supplied role. The nearest normative text is a general "Servers MUST
+// validate all input parameters before processing" under error handling. Accepting
+// the message is therefore not itself a conformance failure, and both official SDKs
+// accept it.
+//
+// The confirmed path is untouched and needs no such mandate: it observes the
+// client-authored turn STORED in task history with the agent role, where anything
+// reading that history back cannot tell it from a genuine agent turn. That is the
+// injection Unit42 demonstrated.
+func (e *SessionSmuggleExecutor) evaluateAcceptance(ctx context.Context, client *attack.HTTPClient, ep string,
+	headers map[string]string, sendBody []byte, marker string, vars attack.Vars) (*attack.Finding, error) {
 	taskID, _ := extractTaskContext(sendBody)
 
 	confirmed := attack.Finding{
@@ -147,11 +172,14 @@ func (e *SessionSmuggleExecutor) evaluateAcceptance(ctx context.Context, client 
 		Confidence: attack.ConfirmedExploit,
 		Title:      "A2A server honored a client-supplied role:\"agent\" message (history injection)",
 		Description: fmt.Sprintf(
-			"POST %s accepted a SendMessage with message.role=\"agent\" and stored it in task "+
-				"history as an agent-role message. The A2A spec reserves the agent role for "+
-				"server-originated messages; honoring it from a client lets an attacker inject "+
-				"fake agent-side turns into a session's LLM context, enabling data exfiltration "+
-				"and unauthorized tool invocation (Unit42, Oct 2025).", ep),
+			"POST %s accepted a SendMessage with message.role=\"agent\" and STORED it in task "+
+				"history as an agent-role message. The specification defines ROLE_AGENT as "+
+				"server-to-client, so a client-authored turn persisted under that role is "+
+				"indistinguishable from a genuine agent turn to anything that reads the history "+
+				"back. That is how an attacker injects fake agent-side turns into a session's LLM "+
+				"context, which Unit42 used for system-prompt exfiltration and an unauthorized "+
+				"stock purchase (Oct 2025). The stored turn is the finding, not the acceptance: "+
+				"the specification requires no rejection of a client-supplied role.", ep),
 		Remediation: e.rule.Remediation,
 		TargetURL:   ep,
 	}
@@ -162,33 +190,34 @@ func (e *SessionSmuggleExecutor) evaluateAcceptance(ctx context.Context, client 
 			switch {
 			case injectedAgentMessagePresent(history, marker):
 				confirmed.Evidence = fmt.Sprintf("taskId: %s\ninjected marker stored as agent role in history\nmarker: %s\n%s", taskID, marker, snippet(history, 400))
-				return &confirmed
+				return &confirmed, nil
 			case containsAnyStr(string(history), marker):
-				// Marker present but not as an agent message: the server
-				// normalized the role. Injection neutralized - no finding.
-				return nil
+				// Marker present but not as an agent message: the server normalized the
+				// role. Injection neutralized, and a real result: the history was read
+				// and the role had been rewritten.
+				return nil, nil
+			default:
+				// History readable and the marker is absent, so the message was not
+				// persisted. Nothing was injected.
+				return nil, nil
 			}
 		}
 	}
 
-	// Accepted without rejection, but we could not retrieve history to confirm
-	// whether the agent role was honored. Report as an indicator, not confirmed.
-	return &attack.Finding{
-		RuleID:     e.rule.ID,
-		RuleName:   e.rule.Name,
-		Severity:   "high",
-		Confidence: attack.RiskIndicator,
-		Title:      "A2A server accepted a client-supplied role:\"agent\" message without rejecting it",
-		Description: fmt.Sprintf(
-			"POST %s returned a task result for a SendMessage carrying message.role=\"agent\" "+
-				"instead of rejecting it with JSON-RPC -32602. The A2A spec reserves the agent "+
-				"role for server-originated messages. The injected message could not be read back "+
-				"to confirm it was stored as an agent turn, so exploitability is unconfirmed; "+
-				"verify manually whether agent-role content reaches the session's LLM context.", ep),
-		Evidence:    fmt.Sprintf("endpoint: %s\nmarker: %s\nsend response:\n%s", ep, marker, snippet(sendBody, 400)),
-		Remediation: e.rule.Remediation,
-		TargetURL:   ep,
+	// Accepted, and the injection could not be read back. The whole oracle of this
+	// rule is whether the client-authored turn is STORED with the agent role, so
+	// without the history nothing was determined and there is nothing to report.
+	// Acceptance on its own is not a finding: the specification requires no rejection.
+	why := "the task history could not be read back"
+	if taskID == "" {
+		// A2A permits answering a send with a Message rather than a Task, and then
+		// there is no history to inspect at all.
+		why = "the reply carried no task id, so there is no history to inspect"
 	}
+	return nil, fmt.Errorf("%w: %s accepted a message carrying the agent role, but %s, so whether "+
+		"the turn is stored as an agent turn could not be established; what this rule reports is the "+
+		"stored turn, not the acceptance",
+		attack.ErrInconclusive, ep, why)
 }
 
 // readTaskHistory fetches a task via GetTask (v1.0) or tasks/get (v0.3) and

--- a/internal/attack/a2a/session_smuggle_test.go
+++ b/internal/attack/a2a/session_smuggle_test.go
@@ -2,8 +2,11 @@ package a2a_test
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/calbebop/batesian/internal/attack"
@@ -201,10 +204,16 @@ func TestSessionSmuggle_AcceptedButNormalized(t *testing.T) {
 	}
 }
 
-// TestSessionSmuggle_AcceptedUnverifiable: the server accepts the agent-role
-// message but exposes no retrievable history (GetTask errors). The rule MUST
-// report a RiskIndicator (accepted without rejection, exploitability unconfirmed).
-func TestSessionSmuggle_AcceptedUnverifiable(t *testing.T) {
+// The server accepts the agent-role message but exposes no retrievable history
+// (GetTask errors). This used to be a high/RiskIndicator finding, and it was a
+// finding produced BECAUSE nothing was determined.
+//
+// Acceptance on its own is not the failure. The specification defines the roles by
+// direction and carries no MUST or SHOULD requiring a server to validate or reject a
+// client-supplied role, and both official SDKs accept one, so the old finding rested
+// on a requirement that does not exist. What this rule reports is the STORED turn,
+// and without the history that cannot be established either way: not tested.
+func TestSessionSmuggle_AcceptedUnverifiableIsNotTested(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" {
 			http.NotFound(w, r)
@@ -223,13 +232,82 @@ func TestSessionSmuggle_AcceptedUnverifiable(t *testing.T) {
 	defer ts.Close()
 
 	findings, err := a2a.NewSessionSmuggleExecutor(testRuleCtx()).Execute(context.Background(), ts.URL, testOpts())
+	if len(findings) != 0 {
+		t.Fatalf("acceptance alone is not a finding, got %d: %+v", len(findings), findings)
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive, got %v", err)
+	}
+	// The reason has to say which half was missing, or an operator cannot act on it.
+	if !strings.Contains(err.Error(), "history could not be read back") {
+		t.Errorf("reason should name the unreadable history; got: %v", err)
+	}
+}
+
+// A2A permits answering a send with a Message rather than a Task. There is then no
+// history at all, so the same not-tested applies, and the reason has to say so
+// rather than blaming an unreadable history that was never involved.
+func TestSessionSmuggle_AcceptedWithNoTaskIsNotTested(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		body := readBody(r)
+		id := body["id"]
+		w.Header().Set("Content-Type", "application/json")
+		// A Message result: legal, and it carries no task identifiers. The state string
+		// keeps looksLikeTask satisfied, so this exercises the no-task path rather than
+		// being filtered out before it.
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": id,
+			"result": map[string]interface{}{
+				"messageId": "srv-1", "role": "ROLE_AGENT",
+				"parts": []interface{}{map[string]string{"text": "TASK_STATE_SUBMITTED"}},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	findings, err := a2a.NewSessionSmuggleExecutor(testRuleCtx()).Execute(context.Background(), ts.URL, testOpts())
+	if len(findings) != 0 {
+		t.Fatalf("no task means no stored turn to report, got %d: %+v", len(findings), findings)
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "no task id") {
+		t.Errorf("reason should name the missing task; got: %v", err)
+	}
+}
+
+// History readable and the marker absent: the server persisted nothing, which is a
+// real result and a clean one. The old switch had no branch for it, so it fell
+// through to the indicator and reported a high-severity finding about a server that
+// stores no history at all. Found by the fixture sweep, on two fixtures written for
+// entirely different rules.
+func TestSessionSmuggle_ReadableHistoryWithoutTheMarkerIsClean(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		body := readBody(r)
+		id := body["id"]
+		w.Header().Set("Content-Type", "application/json")
+		// A minimal task, echoed back by tasks/get, carrying no history whatsoever.
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": id,
+			"result": map[string]interface{}{"id": "task-1", "contextId": "ctx-1", "status": "working"},
+		})
+	}))
+	defer ts.Close()
+
+	findings, err := a2a.NewSessionSmuggleExecutor(testRuleCtx()).Execute(context.Background(), ts.URL, testOpts())
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("the history was readable, so this is a tested result: %v", err)
 	}
-	if len(findings) != 1 {
-		t.Fatalf("expected one indicator finding, got %d: %+v", len(findings), findings)
-	}
-	if findings[0].Confidence != attack.RiskIndicator {
-		t.Errorf("want RiskIndicator, got %q", findings[0].Confidence)
+	if len(findings) != 0 {
+		t.Errorf("nothing was persisted, so there is nothing to report; got %d: %+v", len(findings), findings)
 	}
 }

--- a/rules/a2a/session-smuggle-001.yaml
+++ b/rules/a2a/session-smuggle-001.yaml
@@ -4,18 +4,23 @@ info:
   author: batesian
   severity: high
   description: |
-    Tests whether an A2A server accepts AND honors message/send requests where
-    the client sets role "agent" - a role the spec reserves exclusively for
-    server-originated messages. Honoring it from an arbitrary client injects fake
-    agent-side history into the LLM context of a session.
+    Tests whether an A2A server STORES a message the client sent with role
+    "agent". The specification defines the roles by direction: ROLE_USER is
+    client-to-server and ROLE_AGENT is server-to-client. A client-authored turn
+    persisted under the agent role is therefore indistinguishable from a genuine
+    agent turn to everything that reads the history back, which is how fake
+    agent-side history reaches a session's LLM context.
 
-    To avoid false positives, the rule confirms the injection landed: after the
-    server accepts the agent-role message it reads the task history back and only
-    reports a confirmed exploit when the message is stored as an agent-role turn.
-    If the server rejects the role (JSON-RPC -32602) or normalizes it to "user",
-    no finding is raised; if acceptance cannot be verified (no retrievable
-    history) it is reported as an indicator rather than confirmed. Cross-session
-    task-history disclosure is covered separately by a2a-task-idor-001.
+    What is reported is the STORED turn, not the acceptance. The specification
+    carries no MUST or SHOULD requiring a server to validate or reject a
+    client-supplied role, and both official SDKs accept one, so acceptance on its
+    own is not a finding. After the server accepts the message the rule reads the
+    task history back, and reports a confirmed exploit only when the message is
+    there under the agent role. A server that rejects the role, or normalizes it
+    to "user", or does not persist the message, is clean. When the history cannot
+    be read back at all, or the reply carried no task, the rule reports not tested:
+    its oracle never ran. Cross-session task-history disclosure is covered
+    separately by a2a-task-idor-001.
 
     Demonstrated by Palo Alto Networks Unit42 (Oct 2025) against Google ADK
     financial-assistant sample: achieved system prompt exfiltration and
@@ -25,7 +30,7 @@ info:
 
   references:
     - https://unit42.paloaltonetworks.com/ai-agent-security/
-    - https://a2aprotocol.ai/docs/specification#message-object
+    - https://a2a-protocol.org/latest/specification/
     - https://owasp.org/www-project-top-10-for-large-language-model-applications/
     - https://cwe.mitre.org/data/definitions/384.html
     - https://cwe.mitre.org/data/definitions/20.html


### PR DESCRIPTION
`a2a-session-smuggle-001` emitted a **high-severity indicator** whenever a server
accepted a message carrying the agent role and the injection could not be confirmed.
That is a finding produced because nothing was determined — the shape #150 removed
from `a2a-artifact-tamper-001` — and it rested on a requirement that does not exist.

The finding read *"instead of rejecting it with JSON-RPC -32602. The A2A spec
reserves the agent role for server-originated messages."* The specification defines
the roles by direction (`ROLE_USER` client-to-server, `ROLE_AGENT` server-to-client)
and carries **no MUST or SHOULD** about validating or rejecting a client-supplied
role; the nearest normative text is a general *"Servers MUST validate all input
parameters before processing"* under error handling. Both official SDKs accept the
role. So acceptance is not a conformance failure and cannot carry a finding by
itself.

What this rule reports is the **stored turn**, which needs no mandate: a
client-authored turn persisted under the agent role is indistinguishable from a
genuine one to anything reading the history back, and that is the injection Unit42
demonstrated. The confirmed path is untouched.

Where the old code had one indicator there are now three outcomes:

| observation | result |
|---|---|
| history readable, marker stored as an agent turn | **confirmed** (unchanged) |
| history readable, marker absent or stored as `user` | **clean** |
| history unreadable, or the reply carried no task | **not tested**, with the reason |

The middle row was the worst case, and the sweep found it. The old switch had no
branch for "readable and absent", so it fell through to the indicator: two fixtures
written for entirely different rules (`a2a_extension_downgrade_server.py`,
`a2a_card_security_unenforced_server.py`) answer `tasks/get` with a minimal task
carrying **no history at all**, and the rule read that history, found no marker, and
reported a high-severity finding about a server that stores nothing.

Also corrected the rule's own description, which asserted the same non-existent
requirement, and its reference, which pointed at a third-party specification mirror
rather than `a2a-protocol.org`. The catalog's confidence column drops the indicator
for this rule, and for `a2a-artifact-tamper-001`, which has not emitted one since
#150.

Verification:

- 3 new tests over the split outcomes, each confirmed by restoring the old return
- the live agent in its `open`, `secured` and `idor` postures: the confirmed finding
  is unchanged in all three
- 43-case fixture sweep: the only two deltas are these fabricated indicators
  disappearing