### PR TITLE
test(a2a): give the cross-principal rules a negative control, in CI and on a socket

### DIFF
--- a/internal/attack/a2a/posture_matrix_test.go
+++ b/internal/attack/a2a/posture_matrix_test.go
@@ -1,0 +1,430 @@
+package a2a_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	a2aattack "github.com/calbebop/batesian/internal/attack/a2a"
+)
+
+// A negative control for the cross-principal A2A rules, in process.
+//
+// Three false negatives in this package were found by pointing the scanner at an
+// agent that ENFORCES authorization and has one specific bug, and none of them was
+// reachable from any fixture in testdata/, all of which enforce nothing. The
+// scratchpad agent that found them is not in CI, so the same class could return.
+//
+// This runs both directions on every rule that depends on task ownership:
+//
+//	secured  authorization AND ownership enforced  -> every rule must be silent
+//	idor     authorization enforced, ownership NOT -> the ownership rules must fire
+//
+// The silent half is what catches a false positive; the firing half is what catches
+// a false negative, which is the half no fixture had. Reverting the v1.0 envelope fix
+// in taskref.go fails the delegation case here, so this would have caught PR #176's
+// defect on its own.
+//
+// WIRE SHAPES ARE REPRODUCED FROM CAPTURED a2a-sdk RESPONSES, not written from the
+// specification and not from what these rules happen to send. The distinction
+// matters: a fixture built from the scanner's own assumptions vouches for the
+// scanner instead of testing it, which is how several of these defects survived.
+// Specifically, and this is the shape that mattered, v1.0 SendMessage answers with
+// the Task NESTED under result.task because SendMessageResponse is a protobuf oneof,
+// while v1.0 GetTask answers with a bare Task, flat. The v0.3 slash methods answer
+// flat with lowercase state strings.
+
+type matrixTask struct {
+	id      string
+	ctxID   string
+	owner   string
+	state   string
+	history []map[string]interface{}
+}
+
+// matrixAgent is an in-process A2A agent whose posture decides whether task
+// ownership is enforced. Authorization is enforced in both.
+type matrixAgent struct {
+	posture string // "secured" or "idor"
+
+	mu    sync.Mutex
+	tasks map[string]*matrixTask
+	n     int
+}
+
+const (
+	matrixTokenA = "alice-token"
+	matrixTokenB = "bob-token"
+)
+
+// principalFor returns the principal a bearer token identifies, or "" for none.
+func principalFor(authz string) string {
+	switch strings.TrimPrefix(authz, "Bearer ") {
+	case matrixTokenA:
+		return "alice"
+	case matrixTokenB:
+		return "bob"
+	}
+	return ""
+}
+
+func newMatrixAgent(t *testing.T, posture string) *httptest.Server {
+	t.Helper()
+	ag := &matrixAgent{posture: posture, tasks: map[string]*matrixTask{}}
+	return httptest.NewServer(http.HandlerFunc(ag.serve))
+}
+
+func (a *matrixAgent) serve(w http.ResponseWriter, r *http.Request) {
+	if strings.HasPrefix(r.URL.Path, "/.well-known/") {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"name":"Matrix Agent","description":"d","version":"1.0.0",`+
+			`"protocolVersion":"1.0","capabilities":{"pushNotifications":true},"skills":[],`+
+			`"supportedInterfaces":[{"url":"http://`+r.Host+`/","protocolBinding":"JSONRPC","protocolVersion":"1.0"}]}`)
+		return
+	}
+
+	var req map[string]interface{}
+	_ = json.NewDecoder(r.Body).Decode(&req)
+	method, _ := req["method"].(string)
+	params, _ := req["params"].(map[string]interface{})
+	id := req["id"]
+
+	// Authorization first, in both postures, and exactly as the SDK agent answered
+	// it: HTTP 401 with a JSON body that is not a JSON-RPC envelope.
+	caller := principalFor(r.Header.Get("Authorization"))
+	if caller == "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"error":"unauthenticated","message":"a valid bearer token is required"}`)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	switch method {
+	case "SendMessage", "message/send":
+		a.send(w, id, params, caller, method == "SendMessage")
+	case "GetTask", "tasks/get":
+		a.get(w, id, params, caller, method == "GetTask")
+	case "CancelTask", "tasks/cancel":
+		a.cancel(w, id, params, caller, method == "CancelTask")
+	case "CreateTaskPushNotificationConfig", "tasks/pushNotificationConfig/set":
+		a.setPush(w, id, params, caller)
+	default:
+		rpcError(w, id, -32601, "method not found")
+	}
+}
+
+// mayTouch reports whether caller is allowed to act on t. The postures differ here
+// and nowhere else, which is what makes a diff between them meaningful.
+func (a *matrixAgent) mayTouch(t *matrixTask, caller string) bool {
+	if a.posture == "idor" {
+		return true // any authenticated caller: the bug under test
+	}
+	return t.owner == caller
+}
+
+func (a *matrixAgent) send(w http.ResponseWriter, id, params interface{}, caller string, v1 bool) {
+	p, _ := params.(map[string]interface{})
+	msg, _ := p["message"].(map[string]interface{})
+	taskID, _ := msg["taskId"].(string)
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if taskID != "" {
+		// A continuation. The SDK returns the referenced task rather than appending,
+		// logging "Task already exists. Ignoring task replacement." Reproduced as
+		// observed: what the rules judge is whether the reply references A's task.
+		t, ok := a.tasks[taskID]
+		if !ok {
+			rpcError(w, id, -32001, "Task not found")
+			return
+		}
+		if !a.mayTouch(t, caller) {
+			rpcError(w, id, -32600, "not authorized for this task")
+			return
+		}
+		a.writeTask(w, id, t, v1, true)
+		return
+	}
+
+	a.n++
+	t := &matrixTask{
+		id:    fmt.Sprintf("task-%d", a.n),
+		ctxID: fmt.Sprintf("ctx-%d", a.n),
+		owner: caller,
+		state: "submitted",
+	}
+	if msg != nil {
+		t.history = append(t.history, msg)
+	}
+	a.tasks[t.id] = t
+	a.writeTask(w, id, t, v1, true)
+}
+
+func (a *matrixAgent) get(w http.ResponseWriter, id, params interface{}, caller string, v1 bool) {
+	p, _ := params.(map[string]interface{})
+	taskID, _ := p["id"].(string)
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	t, ok := a.tasks[taskID]
+	if !ok {
+		rpcError(w, id, -32001, "Task not found")
+		return
+	}
+	if !a.mayTouch(t, caller) {
+		rpcError(w, id, -32600, "not authorized for this task")
+		return
+	}
+	// GetTask answers with a bare Task even on v1.0, so never nested.
+	a.writeTask(w, id, t, v1, false)
+}
+
+func (a *matrixAgent) cancel(w http.ResponseWriter, id, params interface{}, caller string, v1 bool) {
+	p, _ := params.(map[string]interface{})
+	taskID, _ := p["id"].(string)
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	t, ok := a.tasks[taskID]
+	if !ok {
+		rpcError(w, id, -32001, "Task not found")
+		return
+	}
+	if !a.mayTouch(t, caller) {
+		rpcError(w, id, -32600, "not authorized for this task")
+		return
+	}
+	t.state = "canceled"
+	a.writeTask(w, id, t, v1, false)
+}
+
+func (a *matrixAgent) setPush(w http.ResponseWriter, id, params interface{}, caller string) {
+	p, _ := params.(map[string]interface{})
+	taskID, _ := p["taskId"].(string)
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	t, ok := a.tasks[taskID]
+	if !ok {
+		rpcError(w, id, -32001, "Task not found")
+		return
+	}
+	if !a.mayTouch(t, caller) {
+		rpcError(w, id, -32600, "not authorized for this task")
+		return
+	}
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"jsonrpc": "2.0", "id": id,
+		"result": map[string]interface{}{"taskId": t.id, "url": "set", "token": "set"},
+	})
+}
+
+// writeTask emits a Task in the envelope the method actually uses. nest is true
+// only for v1.0 send-style replies, where SendMessageResponse is a oneof.
+func (a *matrixAgent) writeTask(w http.ResponseWriter, id interface{}, t *matrixTask, v1, nest bool) {
+	state := t.state
+	if v1 {
+		state = "TASK_STATE_" + strings.ToUpper(t.state)
+	}
+	task := map[string]interface{}{
+		"id":        t.id,
+		"contextId": t.ctxID,
+		"status":    map[string]interface{}{"state": state},
+		"history":   t.history,
+	}
+	if !v1 {
+		task["kind"] = "task"
+	}
+	result := interface{}(task)
+	if v1 && nest {
+		result = map[string]interface{}{"task": task}
+	}
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"jsonrpc": "2.0", "id": id, "result": result,
+	})
+}
+
+func rpcError(w http.ResponseWriter, id interface{}, code int, msg string) {
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"jsonrpc": "2.0", "id": id,
+		"error": map[string]interface{}{"code": code, "message": msg},
+	})
+}
+
+// matrixOpts gives both a --token and two principals, because the rules split on
+// which they use: task-idor reads opts.Token, the cross-principal rules read
+// Principals.
+func matrixOpts() attack.Options {
+	return attack.Options{
+		TimeoutSeconds: 5,
+		Token:          matrixTokenA,
+		Principals: []attack.Principal{
+			{Name: "a", Token: matrixTokenA, Tenant: "A"},
+			{Name: "b", Token: matrixTokenB, Tenant: "B"},
+		},
+	}
+}
+
+// The matrix. wantFires says whether the rule must report a finding against a given
+// posture; anything else is a defect in one direction or the other.
+func TestA2APostureMatrix(t *testing.T) {
+	rules := []struct {
+		id    string
+		build func(attack.RuleContext) attack.Executor
+		// Ownership-sensitive rules must fire on idor and stay silent on secured.
+		ownershipSensitive bool
+	}{
+		{"a2a-multitenant-isolation-001", func(rc attack.RuleContext) attack.Executor {
+			return a2aattack.NewMultiTenantIsolationExecutor(rc)
+		}, true},
+		{"a2a-delegation-integrity-001", func(rc attack.RuleContext) attack.Executor {
+			return a2aattack.NewDelegationIntegrityExecutor(rc)
+		}, true},
+		{"a2a-task-cancel-idor-001", func(rc attack.RuleContext) attack.Executor {
+			return a2aattack.NewTaskCancelIDORExecutor(rc)
+		}, true},
+		{"a2a-push-binding-001", func(rc attack.RuleContext) attack.Executor {
+			return a2aattack.NewPushBindingExecutor(rc)
+		}, true},
+		// Not ownership-sensitive: its oracle is an ANONYMOUS read, which both
+		// postures refuse. It is here as a false-positive control, since it is the
+		// rule most likely to be tripped by a cross-principal fixture.
+		{"a2a-task-idor-001", func(rc attack.RuleContext) attack.Executor {
+			return a2aattack.NewTaskIDORExecutor(rc)
+		}, false},
+	}
+
+	for _, posture := range []string{"secured", "idor"} {
+		for _, r := range rules {
+			t.Run(posture+"/"+r.id, func(t *testing.T) {
+				srv := newMatrixAgent(t, posture)
+				defer srv.Close()
+
+				exec := r.build(attack.RuleContext{ID: r.id, Severity: "high"})
+				findings, err := exec.Execute(context.Background(), srv.URL, matrixOpts())
+
+				wantFires := posture == "idor" && r.ownershipSensitive
+				switch {
+				case wantFires && len(findings) == 0:
+					t.Fatalf("this agent lets any authenticated caller act on another "+
+						"principal's task, so this rule must fire; got 0 findings, err=%v", err)
+				case !wantFires && len(findings) != 0:
+					t.Fatalf("expected no findings against the %s posture, got %d: %+v",
+						posture, len(findings), findings)
+				}
+				if !wantFires && err != nil {
+					// Setup succeeded on both postures, so a rule that reports nothing
+					// here has genuinely tested and found nothing.
+					t.Errorf("expected a clean result, got err=%v", err)
+				}
+			})
+		}
+	}
+}
+
+// The harness has to be able to fail. Ownership enforcement is the only difference
+// between the two postures, so if the secured posture does not actually refuse a
+// cross-principal read the matrix proves nothing about either direction.
+func TestA2APostureMatrix_PosturesDiffer(t *testing.T) {
+	for _, tc := range []struct {
+		posture   string
+		wantAllow bool
+	}{{"secured", false}, {"idor", true}} {
+		t.Run(tc.posture, func(t *testing.T) {
+			srv := newMatrixAgent(t, tc.posture)
+			defer srv.Close()
+
+			// alice creates a task, bob reads it.
+			created := matrixPost(t, srv.URL, matrixTokenA, map[string]interface{}{
+				"jsonrpc": "2.0", "id": 1, "method": "message/send",
+				"params": map[string]interface{}{"message": map[string]interface{}{
+					"role": "user", "messageId": "m1",
+					"parts": []interface{}{map[string]string{"kind": "text", "text": "hi"}},
+				}},
+			})
+			result, _ := created["result"].(map[string]interface{})
+			taskID, _ := result["id"].(string)
+			if taskID == "" {
+				t.Fatalf("no task created: %v", created)
+			}
+
+			read := matrixPost(t, srv.URL, matrixTokenB, map[string]interface{}{
+				"jsonrpc": "2.0", "id": 2, "method": "tasks/get",
+				"params": map[string]interface{}{"id": taskID},
+			})
+			_, allowed := read["result"]
+			if allowed != tc.wantAllow {
+				t.Errorf("posture %s: cross-principal read allowed=%v, want %v (%v)",
+					tc.posture, allowed, tc.wantAllow, read)
+			}
+		})
+	}
+}
+
+// v1.0 send replies must be nested and v1.0 GetTask replies flat, or the matrix is
+// testing a wire no implementation serves. This is the shape that hid a false
+// negative for as long as it did.
+func TestA2APostureMatrix_V1EnvelopeShapes(t *testing.T) {
+	srv := newMatrixAgent(t, "idor")
+	defer srv.Close()
+
+	sent := matrixPost(t, srv.URL, matrixTokenA, map[string]interface{}{
+		"jsonrpc": "2.0", "id": 1, "method": "SendMessage",
+		"params": map[string]interface{}{"message": map[string]interface{}{
+			"role": 1, "messageId": "m1",
+			"parts": []interface{}{map[string]string{"text": "hi"}},
+		}},
+	})
+	result, _ := sent["result"].(map[string]interface{})
+	nested, ok := result["task"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("v1.0 SendMessage must nest the task under result.task, got %v", result)
+	}
+	taskID, _ := nested["id"].(string)
+
+	got := matrixPost(t, srv.URL, matrixTokenA, map[string]interface{}{
+		"jsonrpc": "2.0", "id": 2, "method": "GetTask",
+		"params": map[string]interface{}{"id": taskID},
+	})
+	gotResult, _ := got["result"].(map[string]interface{})
+	if _, nestedGet := gotResult["task"]; nestedGet {
+		t.Errorf("v1.0 GetTask returns a bare Task, so it must not be nested: %v", gotResult)
+	}
+	if gotResult["id"] != taskID {
+		t.Errorf("GetTask should answer flat with the task id, got %v", gotResult)
+	}
+}
+
+// matrixPost sends one JSON-RPC request and returns the decoded reply.
+func matrixPost(t *testing.T, url, token string, body map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url+"/", strings.NewReader(string(raw)))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var out map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return out
+}

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -50,6 +50,7 @@ fixtures for live-validation / manual smoke testing.
 | `a2a_batch_bypass_server.py` | 3108 | `a2a-jsonrpc-batch-bypass-001` |
 | `a2a_task_cancel_server.py` | 3109 | `a2a-task-cancel-idor-001` (two principals; needs two `--principal`s) |
 | `a2a_card_security_unenforced_server.py` | 3110 | `a2a-card-security-unenforced-001` |
+| `a2a_secured_agent.py` | 3111 | negative control, two postures: NO rule may fire on `secured`; `a2a-multitenant-isolation-001`, `a2a-delegation-integrity-001`, `a2a-task-cancel-idor-001` and `a2a-push-binding-001` must all fire on `idor` (needs `--token tok-a` and two principals, see below) |
 | `mcp_unauth_resources_server.py` | 7787 | `mcp-resources-unauth-001` |
 | `mcp_oauth_dcr_server.py` | 7788 | `mcp-oauth-dcr-001` |
 | `mcp_oauth_audience_server.py` | 7785 | `mcp-oauth-audience-002` (four sub-paths, one per bug class; target each, not the root) |
@@ -205,6 +206,33 @@ as "the modern wire is served", which turned that server's `400 Bad Request:
 protocol version "2026-07-28" is only supported on stateless HTTP servers` into
 the refused half of an authorization asymmetry and produced a critical
 `mcp-era-downgrade-001` finding against a target with no authorization at all.
+
+**`a2a_secured_agent.py` is the only fixture here that ENFORCES AUTHORIZATION**, and
+it is a negative control rather than a target. Every other A2A fixture enforces
+nothing, so the cross-principal rules were only ever exercised in the direction where
+they fire; three false negatives were found by pointing the scanner at an agent that
+enforces authorization and has one specific bug, and none of them was reachable from
+this directory.
+
+```sh
+python testdata/a2a_secured_agent.py secured  # NO rule may fire: any finding is a false positive
+python testdata/a2a_secured_agent.py idor     # the four ownership rules must all fire
+```
+
+Ownership enforcement is the only difference between the two postures, which is what
+makes a diff between them mean something. Both require a bearer token, so run it with
+`--token tok-a` and two principals; without them the rules report not tested, and say
+so. `a2a-peer-impersonation-001` reports not tested against both, because the fixture
+publishes no trusted issuer.
+
+Its wire shapes are reproduced from captured `a2a-sdk` responses rather than written
+from the specification, because a fixture built from the scanner's own assumptions
+vouches for the scanner instead of testing it. The shape that matters most is that
+v1.0 `SendMessage` nests the Task under `result.task` while v1.0 `GetTask` returns it
+flat; reading only the flat one is what hid a false negative in
+`a2a-delegation-integrity-001`. The equivalent check runs in CI as the Go posture
+matrix in `internal/attack/a2a/posture_matrix_test.go`, which covers the ownership
+axis in process; this fixture is the all-rules version, on a real socket.
 
 **`mcp_session_as_credential_server.py` takes a posture argument**, defaulting to
 `vulnerable`, and needs `--token tok-a`:

--- a/testdata/a2a_secured_agent.py
+++ b/testdata/a2a_secured_agent.py
@@ -1,0 +1,255 @@
+"""
+A2A agent that ENFORCES AUTHORIZATION. Two postures, one codebase.
+
+Every other A2A fixture here enforces nothing, so for the cross-principal rules
+only the positive direction was ever exercised: they fire when a surface is wide
+open. This is the negative control, and the gap it closes is not hypothetical.
+Three false negatives in the A2A rules were found only by pointing the scanner at
+an agent that enforces authorization and has one specific bug:
+
+  - eight rules reported a secured agent CLEAN when the credential they were given
+    could not create a task, so there was never a task to test with (PR #175)
+  - a2a-delegation-integrity-001 reported that a delegated task's chain of custody
+    held while the wrong principal was demonstrably continuing it, because the
+    v1.0 send envelope nests the task and its oracle read only the flat shape
+    (PR #176)
+  - a2a-session-smuggle-001 reported a high-severity indicator against servers
+    that store no history at all (PR #177)
+
+Postures, selected by the first argument:
+
+  secured   a bearer token is required AND task ownership is enforced on reads,
+            continuations, cancels and push-config writes. Any finding here is a
+            FALSE POSITIVE.
+  idor      a bearer token is required but ownership is NOT enforced: any valid
+            token may act on any task. a2a-multitenant-isolation-001,
+            a2a-delegation-integrity-001, a2a-task-cancel-idor-001 and
+            a2a-push-binding-001 MUST fire. Silence here is a false negative.
+
+Ownership is the only difference between the two, which is what makes a diff
+between them mean something.
+
+WIRE SHAPES ARE REPRODUCED FROM CAPTURED a2a-sdk RESPONSES, not written from the
+specification and not from what the rules happen to send. A fixture built from the
+scanner's own assumptions vouches for the scanner instead of testing it, which is
+how several of these defects survived. The shape that matters most: v1.0
+SendMessage answers with the Task NESTED under result.task, because
+SendMessageResponse is a protobuf oneof, while v1.0 GetTask answers with a bare
+Task, flat. The v0.3 slash methods answer flat with lowercase state strings.
+
+Run:
+    python testdata/a2a_secured_agent.py secured
+    python testdata/a2a_secured_agent.py idor
+
+Scan (two principals are required by the cross-principal rules; --token drives the
+rules that read a single credential):
+    batesian scan --target http://127.0.0.1:3111 --token tok-a \\
+        --principal name=a,token=tok-a,tenant=A \\
+        --principal name=b,token=tok-b,tenant=B -v
+
+Endpoint: http://127.0.0.1:3111/
+"""
+import sys
+import uuid
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route
+import uvicorn
+
+PORT = 3111
+
+POSTURES = ("secured", "idor")
+POSTURE = sys.argv[1] if len(sys.argv) > 1 else "secured"
+
+# The multi-principal fixtures in this directory all expect these two tokens
+# specifically, so a single --principal pair works across the whole set.
+TOKENS = {"tok-a": "tenant-a", "tok-b": "tenant-b"}
+
+# task id -> {"ctx", "owner", "state", "history"}
+TASKS: dict = {}
+
+
+def _principal(request: Request) -> str:
+    """The principal a bearer token identifies, or "" for none."""
+    authz = request.headers.get("authorization", "")
+    if not authz.startswith("Bearer "):
+        return ""
+    return TOKENS.get(authz[len("Bearer "):], "")
+
+
+def _unauthenticated() -> Response:
+    # As the SDK agent answered it: HTTP 401 with a JSON body that is not a
+    # JSON-RPC envelope. Rules must treat this as an auth refusal on the status.
+    return JSONResponse(
+        {"error": "unauthenticated", "message": "a valid bearer token is required"},
+        status_code=401,
+    )
+
+
+def _error(req_id, code, message):
+    return JSONResponse({"jsonrpc": "2.0", "id": req_id,
+                         "error": {"code": code, "message": message}})
+
+
+def _normalized(message: dict) -> dict:
+    """A stored copy of message with the role forced to the client role.
+
+    The specification defines ROLE_AGENT as server-to-client. Storing a
+    client-authored turn under it is what a2a-session-smuggle-001 reports, so a
+    fixture whose findings are meant to be false positives must not do it. Both
+    official SDKs DO store it verbatim, which is why that rule fires against them;
+    normalizing here is the secure behaviour, and it exercises the rule's
+    neutralized branch rather than its confirmed one.
+    """
+    stored = dict(message)
+    role = stored.get("role")
+    stored["role"] = 1 if isinstance(role, int) else "user"
+    return stored
+
+
+def _may_touch(task: dict, caller: str) -> bool:
+    """Whether caller may act on task. The only place the postures differ."""
+    if POSTURE == "idor":
+        return True  # any authenticated caller: the bug under test
+    return task["owner"] == caller
+
+
+def _task_body(task_id: str, v1: bool, nest: bool):
+    """A Task in the envelope the method actually uses."""
+    task = TASKS[task_id]
+    state = task["state"]
+    body = {
+        "id": task_id,
+        "contextId": task["ctx"],
+        "status": {"state": f"TASK_STATE_{state.upper()}" if v1 else state},
+        "history": task["history"],
+    }
+    if not v1:
+        body["kind"] = "task"
+    return {"task": body} if (v1 and nest) else body
+
+
+def _send(req_id, params, caller, v1):
+    message = (params or {}).get("message") or {}
+    task_id = message.get("taskId") or ""
+
+    if task_id:
+        # A continuation. The SDK returns the referenced task rather than appending,
+        # logging "Task already exists. Ignoring task replacement." Reproduced as
+        # observed: what the rules judge is whether the reply references that task.
+        if task_id not in TASKS:
+            return _error(req_id, -32001, "Task not found")
+        if not _may_touch(TASKS[task_id], caller):
+            return _error(req_id, -32600, "not authorized for this task")
+        return JSONResponse({"jsonrpc": "2.0", "id": req_id,
+                             "result": _task_body(task_id, v1, nest=True)})
+
+    task_id = uuid.uuid4().hex
+    TASKS[task_id] = {
+        "ctx": uuid.uuid4().hex,
+        "owner": caller,
+        "state": "submitted",
+        "history": [_normalized(message)] if message else [],
+    }
+    return JSONResponse({"jsonrpc": "2.0", "id": req_id,
+                         "result": _task_body(task_id, v1, nest=True)})
+
+
+def _get(req_id, params, caller, v1):
+    task_id = (params or {}).get("id") or ""
+    if task_id not in TASKS:
+        return _error(req_id, -32001, "Task not found")
+    if not _may_touch(TASKS[task_id], caller):
+        return _error(req_id, -32600, "not authorized for this task")
+    # GetTask answers with a bare Task even on v1.0, so never nested.
+    return JSONResponse({"jsonrpc": "2.0", "id": req_id,
+                         "result": _task_body(task_id, v1, nest=False)})
+
+
+def _cancel(req_id, params, caller, v1):
+    task_id = (params or {}).get("id") or ""
+    if task_id not in TASKS:
+        return _error(req_id, -32001, "Task not found")
+    if not _may_touch(TASKS[task_id], caller):
+        return _error(req_id, -32600, "not authorized for this task")
+    TASKS[task_id]["state"] = "canceled"
+    return JSONResponse({"jsonrpc": "2.0", "id": req_id,
+                         "result": _task_body(task_id, v1, nest=False)})
+
+
+def _set_push(req_id, params, caller):
+    task_id = (params or {}).get("taskId") or ""
+    if task_id not in TASKS:
+        return _error(req_id, -32001, "Task not found")
+    if not _may_touch(TASKS[task_id], caller):
+        return _error(req_id, -32600, "not authorized for this task")
+    return JSONResponse({"jsonrpc": "2.0", "id": req_id,
+                         "result": {"taskId": task_id, "url": "set", "token": "set"}})
+
+
+async def agent_card(request: Request) -> JSONResponse:
+    # The URL is pinned rather than built from request.base_url. Echoing the Host
+    # header into the card is a real weakness (a2a-wellknown-hostinject-001 fires on
+    # it, correctly), and this fixture exists so that a finding against the secured
+    # posture means the scanner is wrong, not the fixture.
+    return JSONResponse(
+        {
+            "name": f"Secured Echo Agent ({POSTURE})",
+            "description": "Authorization-enforcing A2A fixture",
+            "version": "1.0.0",
+            "protocolVersion": "1.0",
+            "capabilities": {"pushNotifications": True},
+            "skills": [],
+            "supportedInterfaces": [
+                {"url": f"http://127.0.0.1:{PORT}/", "protocolBinding": "JSONRPC",
+                 "protocolVersion": "1.0"},
+            ],
+        },
+        # The card is a trust anchor, so it must not be cached without revalidation.
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+async def jsonrpc(request: Request) -> Response:
+    try:
+        body = await request.json()
+    except Exception:
+        return _error(None, -32700, "Parse error")
+    method = body.get("method", "")
+    req_id = body.get("id")
+    params = body.get("params") or {}
+
+    # Authorization first, in both postures.
+    caller = _principal(request)
+    if not caller:
+        return _unauthenticated()
+
+    if method in ("SendMessage", "message/send"):
+        return _send(req_id, params, caller, v1=method == "SendMessage")
+    if method in ("GetTask", "tasks/get"):
+        return _get(req_id, params, caller, v1=method == "GetTask")
+    if method in ("CancelTask", "tasks/cancel"):
+        return _cancel(req_id, params, caller, v1=method == "CancelTask")
+    if method in ("CreateTaskPushNotificationConfig", "tasks/pushNotificationConfig/set"):
+        return _set_push(req_id, params, caller)
+    return _error(req_id, -32601, "Method not found")
+
+
+app = Starlette(routes=[
+    Route("/.well-known/agent-card.json", agent_card, methods=["GET"]),
+    Route("/.well-known/agent.json", agent_card, methods=["GET"]),
+    Route("/", jsonrpc, methods=["POST"]),
+])
+
+if __name__ == "__main__":
+    if POSTURE not in POSTURES:
+        sys.exit(f"unknown posture {POSTURE!r}; expected one of {', '.join(POSTURES)}")
+    print(f"[*] A2A authorization-enforcing agent ({POSTURE}) on http://127.0.0.1:{PORT}/", flush=True)
+    if POSTURE == "secured":
+        print("[*] Expected: no findings. Any finding is a false positive.", flush=True)
+    else:
+        print("[*] Expected: multitenant-isolation, delegation-integrity, "
+              "task-cancel-idor and push-binding all fire.", flush=True)
+    print("[*] Credentials: --token tok-a plus two principals (tok-a, tok-b)", flush=True)
+    uvicorn.run(app, host="127.0.0.1", port=PORT)


### PR DESCRIPTION
Three false negatives in the A2A rules were found by pointing the scanner at an agent
that **enforces authorization and has one specific bug**: eight rules reporting a
secured agent clean when no task could be created (#175), `delegation-integrity`
clearing a chain of custody the wrong principal was demonstrably continuing (#176),
and `session-smuggle` reporting a high-severity indicator against servers that store
nothing (#177). None was reachable from `testdata/`, where every A2A fixture enforces
nothing, so all eleven only ever exercised the direction where a rule fires. The agent
that found them lives in a scratchpad and runs nowhere.

Two additions, because the two mechanisms cover different things.

**`posture_matrix_test.go`** runs the ownership-dependent rules against an in-process
agent in both directions:

| posture | expectation |
|---|---|
| ownership enforced | every rule silent — catches a false positive |
| ownership not enforced | the four ownership rules fire — catches a false negative |

That second row is the half no fixture had, and it gates every PR because CI runs `go
test`. Reverting #176's envelope fix fails the delegation case here; reverting #175's
setup fix fails nine cases across this and its own tests. The harness is checked too:
one test asserts the postures actually differ on a cross-principal read, because if
the secured posture does not refuse, the matrix proves nothing either way.

**`testdata/a2a_secured_agent.py`** is the same control on a real socket, all
seventeen rules, for the sweep and for validating by hand. Port 3111, postures
`secured` and `idor`, **no new prerequisites**: plain Starlette like every other A2A
fixture here rather than the `a2a-sdk`, which nothing in this directory depends on.

Both reproduce **captured** a2a-sdk wire shapes rather than shapes written from the
specification or inferred from what these rules send — a fixture built from the
scanner's own assumptions vouches for the scanner instead of testing it, which is how
several of these defects survived. The shape that matters most is that v1.0
`SendMessage` nests the Task under `result.task` while `GetTask` returns a bare Task.

Making the secured posture genuinely clean took three fixes to the fixture, and each
was a real weakness rather than a scanner error: the card echoed the `Host` header
into `supportedInterfaces[0].url`, carried no `Cache-Control`, and stored a
client-claimed agent role verbatim. A control whose findings are meant to be false
positives cannot have any of those, and normalizing the role also exercises
`session-smuggle`'s neutralized branch rather than its confirmed one.

Verification:

- 12 in-process cases, all passing, both regressions confirmed by reverting the fixes
- the fixture live in both postures: **0** findings on `secured`, exactly the four
  ownership rules on `idor` (5 findings; multitenant emits two)
- 45-case fixture sweep against the previous binary: no finding or skip changed