### PR TITLE
fix(mcp): offer the current handshake revision, not one two revisions old

### DIFF
--- a/internal/attack/a2a/endpoint.go
+++ b/internal/attack/a2a/endpoint.go
@@ -161,7 +161,7 @@ func servesMCPResourceMetadata(ctx context.Context, client *attack.HTTPClient, b
 	// The challenge itself carries the pointer, which is how the C# sample answers.
 	resp, err := client.POST(ctx, endpoint, nil, map[string]interface{}{
 		"jsonrpc": "2.0", "id": "batesian-a2a-mcp-check", "method": "initialize",
-		"params": map[string]interface{}{"protocolVersion": "2025-06-18",
+		"params": map[string]interface{}{"protocolVersion": mcpProbeVersion,
 			"capabilities": map[string]interface{}{},
 			"clientInfo":   map[string]interface{}{"name": "batesian", "version": attack.Version}},
 	})
@@ -355,7 +355,7 @@ func answersMCPInitialize(ctx context.Context, client *attack.HTTPClient, endpoi
 		"id":      "batesian-a2a-discovery-mcp",
 		"method":  "initialize",
 		"params": map[string]interface{}{
-			"protocolVersion": "2025-06-18",
+			"protocolVersion": mcpProbeVersion,
 			"capabilities":    map[string]interface{}{},
 			"clientInfo":      map[string]interface{}{"name": "batesian", "version": attack.Version},
 		},
@@ -365,6 +365,15 @@ func answersMCPInitialize(ctx context.Context, client *attack.HTTPClient, endpoi
 	}
 	return resp.ContainsAny(`"protocolVersion"`)
 }
+
+// mcpProbeVersion is the MCP revision these probes offer when asking whether a
+// candidate is an MCP server rather than an A2A agent. It mirrors the mcp package's
+// latestStable, duplicated because that constant is unexported and this is a
+// different package. A stale value is less harmful here than there, since
+// answersMCPInitialize counts a version rejection as proof the endpoint speaks MCP,
+// but offering the current handshake revision keeps the two probes saying the same
+// thing about the same server.
+const mcpProbeVersion = "2025-11-25"
 
 // jsonRPCErrorMessage extracts the message from a JSON-RPC error envelope, or ""
 // when there is none. A2A defines no numeric auth code, so the message is what

--- a/internal/attack/mcp/handshake_reason_test.go
+++ b/internal/attack/mcp/handshake_reason_test.go
@@ -168,3 +168,59 @@ func TestHandshakeReason_RejectedCredentialSaysSo(t *testing.T) {
 		t.Errorf("a scan that carried a credential must not be told it carried none: %v", err)
 	}
 }
+
+// latestStable sat at 2025-06-18 for two revisions while its own comment said it
+// stays current. Offering a stale version costs coverage twice over: a strict server
+// rejects the handshake outright, which reads as unreachable, and a lenient one
+// negotiates down and never advertises the capabilities a later revision introduced.
+//
+// This server accepts only the newest handshake revision. If the offered version
+// drifts behind again, the handshake fails and the rule reports not tested, which is
+// exactly the silent false negative the constant exists to avoid.
+func TestOffersCurrentHandshakeRevision(t *testing.T) {
+	const current = "2025-11-25"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		params, _ := req["params"].(map[string]interface{})
+		offered, _ := params["protocolVersion"].(string)
+		method, _ := req["method"].(string)
+
+		if method == "initialize" && offered != current {
+			jsonRPCError(w, -32600, "Unsupported protocol version: "+offered)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch method {
+		case "initialize":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req["id"],
+				"result": map[string]interface{}{
+					"protocolVersion": current,
+					"serverInfo":      map[string]interface{}{"name": "strict", "version": "1"},
+					"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+				},
+			})
+		case "tools/list":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req["id"],
+				"result": map[string]interface{}{
+					"tools": []interface{}{map[string]interface{}{"name": "echo"}},
+				},
+			})
+		default:
+			w.WriteHeader(http.StatusAccepted)
+		}
+	}))
+	defer srv.Close()
+
+	exec := mcpattack.NewToolsUnauthExecutor(attack.RuleContext{ID: "mcp-tools-unauth-001"})
+	findings, err := exec.Execute(context.Background(), srv.URL, testOpts())
+	if err != nil {
+		t.Fatalf("a server accepting only %s refused the handshake, so the offered version "+
+			"is behind: %v", current, err)
+	}
+	if len(findings) == 0 {
+		t.Errorf("expected the open tool listing to be reported once the handshake succeeded")
+	}
+}

--- a/internal/attack/mcp/init_downgrade.go
+++ b/internal/attack/mcp/init_downgrade.go
@@ -41,8 +41,14 @@ func NewInitDowngradeExecutor(r attack.RuleContext) *InitDowngradeExecutor {
 }
 
 // legacyVersion is the pre-OAuth MCP spec version published before authorization
-// was mandated. modernVersion is the version that introduced the authorization
-// spec, used as the auth-enforcing baseline.
+// was mandated. modernVersion is the auth-enforcing baseline it is compared
+// against: the current handshake revision, which specifies authorization.
+//
+// It tracks latestStable rather than naming a revision, because what the oracle
+// needs is a version that mandates authorization AND that a current server will
+// accept, and those are the same thing. The comment here used to call it "the
+// version that introduced the authorization spec", which it was not: authorization
+// arrived before the revision this then pointed at.
 const (
 	legacyVersion = "2024-11-05"
 	modernVersion = latestStable

--- a/internal/attack/mcp/init_downgrade_test.go
+++ b/internal/attack/mcp/init_downgrade_test.go
@@ -15,13 +15,16 @@ import (
 
 const (
 	legacyVer = "2024-11-05"
-	modernVer = "2025-06-18"
 )
 
 // versionAwareServer models a server that tracks each session's negotiated
 // protocol version and enforces authorization on resources/list per version.
 // legacyAllows/modernAllows control whether resources/list is granted for a
 // session that initialized with the legacy/modern version respectively.
+// versionAwareServer gates resources/list on the protocol version the session
+// negotiated. Any version other than the pre-auth revision counts as modern, rather
+// than one hardcoded string: pinning the version the rule offers made a fully-open
+// server look like a critical downgrade bypass the moment that version was updated.
 func versionAwareServer(t *testing.T, legacyAllows, modernAllows bool) *httptest.Server {
 	t.Helper()
 	var mu sync.Mutex
@@ -59,7 +62,7 @@ func versionAwareServer(t *testing.T, legacyAllows, modernAllows bool) *httptest
 			mu.Lock()
 			version := sessions[r.Header.Get("Mcp-Session-Id")]
 			mu.Unlock()
-			allow := (version == legacyVer && legacyAllows) || (version == modernVer && modernAllows)
+			allow := (version == legacyVer && legacyAllows) || (version != legacyVer && modernAllows)
 			if !allow {
 				json.NewEncoder(w).Encode(map[string]interface{}{
 					"jsonrpc": "2.0", "id": id,
@@ -145,7 +148,7 @@ func tokenGatedDowngradeServer(t *testing.T, validToken string) *httptest.Server
 			mu.Unlock()
 			hasValidToken := r.Header.Get("Authorization") == "Bearer "+validToken
 			// Legacy path skips auth (the bug); modern path requires the token.
-			allow := version == legacyVer || (version == modernVer && hasValidToken)
+			allow := version == legacyVer || hasValidToken
 			if !allow {
 				json.NewEncoder(w).Encode(map[string]interface{}{
 					"jsonrpc": "2.0", "id": id,
@@ -252,4 +255,63 @@ func TestInitDowngrade_NotMCPServer(t *testing.T) {
 
 	exec := mcpattack.NewInitDowngradeExecutor(attack.RuleContext{ID: "mcp-init-downgrade-001"})
 	assertInconclusive(t, exec, srv.URL, attack.Options{TimeoutSeconds: 5})
+}
+
+// An OLD server: it supports the pre-auth revision and nothing newer, and it enforces
+// no authorization at all. Offering a current revision means the modern probe is
+// refused at initialize while the legacy one succeeds, which is the exact shape of a
+// downgrade bypass without being one.
+//
+// This matters more the further the offered version moves ahead: every server that
+// predates it answers this way. The rule is safe because it requires the modern
+// handshake to SUCCEED before comparing the two paths, and this pins that.
+func TestInitDowngrade_OldServerRejectingModernIsNotABypass(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		method, _ := req["method"].(string)
+		params, _ := req["params"].(map[string]interface{})
+		version, _ := params["protocolVersion"].(string)
+		w.Header().Set("Content-Type", "application/json")
+		switch method {
+		case "initialize":
+			if version != legacyVer {
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"jsonrpc": "2.0", "id": req["id"],
+					"error": map[string]interface{}{"code": -32602, "message": "Unsupported protocol version"},
+				})
+				return
+			}
+			w.Header().Set("Mcp-Session-Id", "s1")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req["id"],
+				"result": map[string]interface{}{
+					"protocolVersion": legacyVer,
+					"serverInfo":      map[string]interface{}{"name": "old", "version": "1"},
+					"capabilities":    map[string]interface{}{"resources": map[string]interface{}{}},
+				},
+			})
+		case "resources/list":
+			// Wide open, which is what makes this a false-positive risk rather than a
+			// missed finding: the legacy path returns data.
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req["id"],
+				"result": map[string]interface{}{"resources": []interface{}{
+					map[string]interface{}{"uri": "file:///x", "name": "x"}}},
+			})
+		default:
+			w.WriteHeader(http.StatusAccepted)
+		}
+	}))
+	defer srv.Close()
+
+	exec := mcpattack.NewInitDowngradeExecutor(attack.RuleContext{ID: "mcp-init-downgrade-001"})
+	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("a server that simply does not support the offered revision is not a "+
+			"downgrade bypass; got %d finding(s): %v", len(findings), findings)
+	}
 }

--- a/internal/attack/mcp/session.go
+++ b/internal/attack/mcp/session.go
@@ -134,12 +134,20 @@ func (s mcpSession) header() map[string]string {
 	return h
 }
 
-// latestStable is the MCP protocol version offered in initialize requests. The
-// spec says clients should offer the latest version they support; the server
-// negotiates by responding with its own version. Offering a stale version risks
-// an "Unsupported protocol version" rejection on current servers (a silent
-// false negative), so this stays current.
-const latestStable = "2025-06-18"
+// latestStable is the MCP protocol version offered in initialize requests.
+//
+// It is the newest HANDSHAKE-BASED revision, which the specification's own
+// versioning page describes as "2025-11-25 and earlier". The current revision is
+// 2026-07-28, and it is deliberately not offered here: that era removes initialize
+// entirely, so these rules target the handshake wire and era detection reports a
+// modern-only server as speaking an unsupported version rather than as unreachable.
+//
+// Offering a stale version risks an "Unsupported protocol version" rejection on a
+// current server, which is a silent false negative, and it negotiates away
+// capabilities a later revision introduced. This sat at 2025-06-18, two revisions
+// behind, while its own comment said it stays current: hence
+// TestOffersCurrentHandshakeRevision, which fails if it drifts again.
+const latestStable = "2025-11-25"
 
 // negotiatedVersion reads the protocolVersion the server chose from its
 // initialize result body, falling back to latestStable if the server did not


### PR DESCRIPTION
`latestStable` is the version every legacy `initialize` offers, and it sat at
`2025-06-18` while its own comment said it stays current. The specification's
versioning page describes the handshake-based revisions as "**2025-11-25** and
earlier", so the value was two behind.

It costs coverage twice over: a strict server answers an unsupported offer with
`Unsupported protocol version`, which these rules read as a target that could not be
reached, and a lenient one negotiates down and never advertises capabilities a later
revision introduced. Both are silent false negatives — which is why the constant
carries that warning in the first place.

`2026-07-28` is deliberately **not** offered: it removes `initialize` entirely, these
rules target the handshake wire, and era detection already reports a modern-only
server as speaking an unsupported version rather than as unreachable.

`TestOffersCurrentHandshakeRevision` is the guard — a server accepting only the newest
handshake revision must still be scanned. Reverting the constant fails it with the
server's own rejection quoted back.

**Two things the bump exposed, both worth keeping.**

`init_downgrade`'s `modernVersion` comment called it *"the version that introduced the
authorization spec"*, which it was not: authorization arrived before the revision it
then pointed at. What the oracle needs is a version that mandates authorization *and*
that a current server accepts, and tracking `latestStable` gives both.

Its test fixtures allow-listed two exact version strings, one of them a copy of the
offered version — so the modern session matched neither, fell through to deny, and a
**fully-open server was reported as a critical downgrade bypass**. A fixture that pins
the value under test breaks the moment that value is corrected. They now treat any
non-legacy version as modern.

That failure raised a real-world question worth answering rather than assuming: an old
server supporting only the pre-auth revision refuses the modern probe while the legacy
one succeeds, which is the shape of a downgrade bypass without being one — and the
further ahead the offered version moves, the more servers answer that way. Measured: no
finding, because the rule requires the modern handshake to succeed before comparing.
Now pinned by `TestInitDowngrade_OldServerRejectingModernIsNotABypass`.

The A2A package's MCP-detection probes carried the same stale literal and are bumped
alongside, as a named constant rather than two copies.

Verification:

- full suite; the currency guard confirmed to fail when the constant is reverted
- the old-server shape measured, not assumed
- 45-case fixture sweep against the previous binary: no finding or skip changed