### PR TITLE
fix(mcp): delete the OAuth clients a scan registers, and report the ones it cannot

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ CLI for adversarial testing of [A2A](https://a2a-protocol.org) and [MCP](https:/
 >
 > **Secrets and TLS.** Prefer `BATESIAN_TOKEN` or your secret manager over embedding long-lived bearer material in shared terminals, config repos, or CI logs. Use `--skip-tls` only when you must hit a host with intentionally broken TLS, such as a local lab on self-signed certificates.
 >
+> **State on the target.** Three OAuth rules register a client on the authorization server, because that is the only way to test what dynamic client registration will accept. Each one deletes its client afterwards via RFC 7592 client management. A server that does not implement that protocol keeps the registration: the scan says so in the finding's evidence and names the client, which is always prefixed `batesian-`, so leftovers can be found and removed. Nothing else a scan does persists.
+>
 > **Artifacts.** JSON and SARIF can contain URLs, snippets, and evidence. Treat exports the same way you treat other sensitive scanner output in shared pipelines.
 >
 > **Custom rules.** `--rules-dir` loads YAML from disk. Treat rule packs as untrusted input: they define what gets sent to the target.

--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -83,6 +83,25 @@ settled with a single `initialize` per candidate, on the bail path only, and a
 2026-07-28 server is reported as speaking an unsupported protocol version rather
 than as unreachable.
 
+### Client registrations are cleaned up
+
+Three of them register an OAuth client, because what DCR accepts cannot be tested
+without asking it to accept something: `mcp-confused-deputy-001` registers one whose
+`redirect_uri` points off-origin, `mcp-oauth-dcr-001` one requesting privileged
+scopes, and `mcp-oauth-metadata-ssrf-001` one whose metadata URLs point at the scan's
+OOB listener. All three delete the client afterwards via RFC 7592 client management,
+authenticated with the `registration_access_token` the server itself issued.
+
+Cleanup is best effort and never changes a verdict. A server that returns no
+`registration_client_uri`, no `registration_access_token`, or refuses the delete keeps
+the client, and the finding's evidence says so and names it: every client is prefixed
+`batesian-`, so leftovers are findable. A `registration_client_uri` on a different
+host is reported rather than followed, for the same reason the operator's token is
+never sent off-host.
+
+The SSRF rule deletes only after its OOB wait, because there the registration *is* the
+payload and removing the client first could cancel the fetch being listened for.
+
 ## Both protocol wires
 
 A server built on the current SDKs answers **both** the handshake-based revisions

--- a/internal/attack/http.go
+++ b/internal/attack/http.go
@@ -263,6 +263,14 @@ func (c *HTTPClient) OPTIONS(ctx context.Context, urlTpl string, headers map[str
 	return c.do(ctx, http.MethodOptions, c.vars.Expand(urlTpl), nil, c.vars.ExpandMap(headers))
 }
 
+// DELETE sends a DELETE request. The OAuth rules use it to remove the client
+// registrations they create (RFC 7592), so a scan does not leave them on the target.
+// It runs through the same transport as every other verb, so a dry run records it and
+// sends nothing.
+func (c *HTTPClient) DELETE(ctx context.Context, urlTpl string, headers map[string]string) (*Response, error) {
+	return c.do(ctx, http.MethodDelete, c.vars.Expand(urlTpl), nil, c.vars.ExpandMap(headers))
+}
+
 // POST sends a POST request with a JSON body. body may be a map or struct.
 func (c *HTTPClient) POST(ctx context.Context, urlTpl string, headers map[string]string, body interface{}) (*Response, error) {
 	jsonBytes, err := marshalBody(body, c.vars)

--- a/internal/attack/mcp/confused_deputy.go
+++ b/internal/attack/mcp/confused_deputy.go
@@ -66,7 +66,23 @@ func (e *ConfusedDeputyExecutor) Execute(ctx context.Context, target string, opt
 	// Register a client with an off-origin redirect. We use a domain unrelated to
 	// the target's own origin so a server with a redirect allowlist rejects it.
 	registeredRedirect := fmt.Sprintf("https://batesian-%s-registered.invalid/cb", vars.RandID)
-	clientID, dcrEchoedRedirect, dcrResult := registerDCRClient(ctx, unauthClient, regEP, registeredRedirect, vars.RandID)
+	clientName := "batesian-cd-" + vars.RandID
+	clientID, dcrEchoedRedirect, dcrResult, regResp := registerDCRClient(ctx, unauthClient, regEP, registeredRedirect, vars.RandID)
+
+	// Remove the client this probe created, whatever the outcome below. The deferred
+	// call is the guarantee; cleanup runs before the findings are built so its result
+	// can be reported in their evidence, and the flag keeps the two from duplicating.
+	var cleanup dcrCleanup
+	cleanedUp := false
+	removeClient := func() {
+		if cleanedUp || clientID == "" {
+			return
+		}
+		cleanup = deregisterDCRClient(ctx, unauthClient, regEP, clientName, regResp)
+		cleanedUp = true
+	}
+	defer removeClient()
+
 	if clientID == "" {
 		if dcrResult.redirectRefused {
 			// The allowlist refused our off-origin redirect. That is the mitigation
@@ -85,6 +101,10 @@ func (e *ConfusedDeputyExecutor) Execute(ctx context.Context, target string, opt
 	attackerRedirect := "https://" + attackerHost + "/cb"
 	loc, status := authorizeRedirectProbe(ctx, opts, authEP, clientID, attackerRedirect, vars.RandID)
 
+	// The client_id has served its purpose, so remove the registration before
+	// reporting, which is what lets the report say whether anything was left behind.
+	removeClient()
+
 	if redirectsToHost(status, loc, attackerHost) {
 		return []attack.Finding{{
 			RuleID:     e.rule.ID,
@@ -101,8 +121,8 @@ func (e *ConfusedDeputyExecutor) Execute(ctx context.Context, target string, opt
 				"takeover primitive.",
 			Evidence: fmt.Sprintf(
 				"authorization_endpoint: %s\nregistered redirect_uri: %s\nunregistered redirect_uri sent: %s\n"+
-					"server response: HTTP %d, Location: %s",
-				authEP, registeredRedirect, attackerRedirect, status, loc),
+					"server response: HTTP %d, Location: %s\n%s",
+				authEP, registeredRedirect, attackerRedirect, status, loc, cleanup.evidenceLine()),
 			Remediation: e.rule.Remediation,
 			TargetURL:   authEP,
 		}}, nil
@@ -122,8 +142,9 @@ func (e *ConfusedDeputyExecutor) Execute(ctx context.Context, target string, opt
 				"disproven. Manually verify that the proxy stores per-client consent and does not skip the " +
 				"upstream consent screen for the static client_id.",
 			Evidence: fmt.Sprintf(
-				"registration_endpoint: %s\naccepted off-origin redirect_uri: %s\nauthorize probe: HTTP %d, Location: %s",
-				regEP, registeredRedirect, status, loc),
+				"registration_endpoint: %s\naccepted off-origin redirect_uri: %s\nauthorize probe: HTTP %d, "+
+					"Location: %s\n%s",
+				regEP, registeredRedirect, status, loc, cleanup.evidenceLine()),
 			Remediation: e.rule.Remediation,
 			TargetURL:   regEP,
 		}}, nil
@@ -163,7 +184,13 @@ func discoverOAuthEndpoints(ctx context.Context, client *attack.HTTPClient, base
 // token (RFC 7591 section 3) and answers 401, or which fails for any unrelated
 // reason, has told us nothing about redirect validation, and reporting that clean
 // grades an endpoint the rule never reached.
-func registerDCRClient(ctx context.Context, client *attack.HTTPClient, registrationEndpoint, redirectURI, randID string) (clientID string, echoedRedirect bool, outcome dcrOutcome) {
+//
+// The registration response is returned as well, so the caller can deregister the
+// client it just created once the client_id has served its purpose. See
+// deregisterDCRClient: a scan that registers a client with an attacker-shaped
+// redirect_uri and leaves it there has changed the target and not changed it back.
+func registerDCRClient(ctx context.Context, client *attack.HTTPClient, registrationEndpoint, redirectURI,
+	randID string) (clientID string, echoedRedirect bool, outcome dcrOutcome, reg *attack.Response) {
 	resp, err := client.POST(ctx, registrationEndpoint, nil, map[string]interface{}{
 		"client_name":    "batesian-cd-" + randID,
 		"redirect_uris":  []string{redirectURI},
@@ -171,28 +198,28 @@ func registerDCRClient(ctx context.Context, client *attack.HTTPClient, registrat
 		"response_types": []string{"code"},
 	})
 	if err != nil {
-		return "", false, dcrOutcome{unavailable: true, detail: "the registration request failed: " + err.Error()}
+		return "", false, dcrOutcome{unavailable: true, detail: "the registration request failed: " + err.Error()}, nil
 	}
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusCreated:
 		clientID = resp.JSONField("client_id")
 		if clientID == "" {
 			return "", false, dcrOutcome{unavailable: true,
-				detail: fmt.Sprintf("registration returned HTTP %d with no client_id", resp.StatusCode)}
+				detail: fmt.Sprintf("registration returned HTTP %d with no client_id", resp.StatusCode)}, resp
 		}
 		echoedRedirect = strings.Contains(resp.BodyString(), redirectURI)
-		return clientID, echoedRedirect, dcrOutcome{}
+		return clientID, echoedRedirect, dcrOutcome{}, resp
 	case http.StatusUnauthorized, http.StatusForbidden:
 		// DCR itself is credential-gated. Nothing about redirect policy follows.
 		return "", false, dcrOutcome{unavailable: true,
-			detail: fmt.Sprintf("registration requires credentials (HTTP %d)", resp.StatusCode)}
+			detail: fmt.Sprintf("registration requires credentials (HTTP %d)", resp.StatusCode)}, resp
 	case http.StatusBadRequest, http.StatusUnprocessableEntity:
 		// A client-error rejection of the registration we sent. This is the
 		// allowlist doing its job, which is the mitigation, not an untested surface.
-		return "", false, dcrOutcome{redirectRefused: true}
+		return "", false, dcrOutcome{redirectRefused: true}, resp
 	default:
 		return "", false, dcrOutcome{unavailable: true,
-			detail: fmt.Sprintf("registration answered HTTP %d", resp.StatusCode)}
+			detail: fmt.Sprintf("registration answered HTTP %d", resp.StatusCode)}, resp
 	}
 }
 

--- a/internal/attack/mcp/dcr.go
+++ b/internal/attack/mcp/dcr.go
@@ -1,0 +1,134 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// Three rules register an OAuth client on the target, and none of them removed it.
+// A scan against an authorization server with open dynamic client registration
+// therefore left three clients behind, permanently:
+//
+//	mcp-confused-deputy-001     a client whose redirect_uri points off-origin, which
+//	                            is the attacker-shaped value the rule exists to see
+//	                            accepted
+//	mcp-oauth-dcr-001           a client holding whatever privileged scopes the
+//	                            server was willing to grant an anonymous registrant
+//	mcp-oauth-metadata-ssrf-001 a client whose metadata URL fields point at the
+//	                            scan's OOB listener, a host that stops existing when
+//	                            the scan ends
+//
+// That is a scanner changing the state of the system it was pointed at and not
+// changing it back. RFC 7592 is the way back: a registration response MAY carry a
+// registration_client_uri and a registration_access_token, and a DELETE to that URI
+// with that token deregisters the client.
+
+// dcrCleanup is what happened to a client this scan registered. It is reported in
+// the finding's evidence, because an operator who authorized a scan needs to know
+// whether it left anything behind, and if so what to look for.
+type dcrCleanup struct {
+	clientName string
+	deleted    bool
+	// reason is why the client could not be removed, empty when it was.
+	reason string
+}
+
+// evidenceLine renders the outcome for a finding's evidence. It names the client
+// either way: on success so the record is complete, and on failure so the operator
+// has the string to search their authorization server for.
+func (c dcrCleanup) evidenceLine() string {
+	if c.clientName == "" {
+		return ""
+	}
+	if c.deleted {
+		return fmt.Sprintf("client registered by this probe (%s): deleted afterwards via RFC 7592\n", c.clientName)
+	}
+	return fmt.Sprintf("client registered by this probe (%s): LEFT REGISTERED on the target, %s; "+
+		"remove it by hand\n", c.clientName, c.reason)
+}
+
+// deregisterDCRClient removes a client this scan registered, following RFC 7592.
+//
+// Best effort by design: a server that does not implement the management protocol
+// cannot be cleaned up, and that is a fact to report rather than an error to fail
+// on. The rule's own verdict never depends on this.
+//
+// The URI is the SERVER'S to choose, so it is only followed when it stays on the
+// registration endpoint's host. Following a target-chosen absolute URL to another
+// host would make the scanner issue requests wherever the target pointed it, which
+// is the same class of mistake as sending the operator's token off-host (see
+// tokenAllowedFor). The token sent here is the registration_access_token the target
+// itself just issued, not the operator's credential.
+func deregisterDCRClient(ctx context.Context, client *attack.HTTPClient,
+	registrationEndpoint, clientName string, reg *attack.Response) dcrCleanup {
+	out := dcrCleanup{clientName: clientName}
+	if reg == nil {
+		out.reason = "the registration produced no response to read a management URI from"
+		return out
+	}
+
+	clientURI := reg.JSONField("registration_client_uri")
+	accessToken := reg.JSONField("registration_access_token")
+	switch {
+	case clientURI == "" && accessToken == "":
+		out.reason = "the server returned neither registration_client_uri nor " +
+			"registration_access_token, so it does not implement RFC 7592 client management"
+		return out
+	case clientURI == "":
+		out.reason = "the server returned no registration_client_uri, so there is no " +
+			"documented address to delete the client at"
+		return out
+	case accessToken == "":
+		out.reason = "the server returned no registration_access_token, so a delete would " +
+			"be unauthenticated"
+		return out
+	}
+
+	if !sameHost(clientURI, registrationEndpoint) {
+		out.reason = fmt.Sprintf("its registration_client_uri points at %s while registration "+
+			"happened at %s, and a target-chosen URI on another host is not followed",
+			hostOrRaw(clientURI), hostOrRaw(registrationEndpoint))
+		return out
+	}
+
+	resp, err := client.DELETE(ctx, clientURI, map[string]string{
+		"Authorization": "Bearer " + accessToken,
+	})
+	if err != nil {
+		out.reason = "the delete request failed: " + err.Error()
+		return out
+	}
+	// RFC 7592 section 2.3 specifies 204 on success. Accept any 2xx: implementations
+	// answer 200 with a body, and 202 when deletion is queued.
+	if resp.IsSuccess() || resp.StatusCode == http.StatusNoContent {
+		out.deleted = true
+		return out
+	}
+	out.reason = fmt.Sprintf("the delete was refused with HTTP %d", resp.StatusCode)
+	return out
+}
+
+// sameHost reports whether two URLs share a host, case-insensitively.
+func sameHost(a, b string) bool {
+	ua, erra := url.Parse(a)
+	ub, errb := url.Parse(b)
+	if erra != nil || errb != nil || ua.Host == "" || ub.Host == "" {
+		return false
+	}
+	return strings.EqualFold(ua.Host, ub.Host)
+}
+
+// hostOrRaw returns a URL's host for use in a message, falling back to the raw
+// string so an unparseable value is still shown rather than dropped.
+func hostOrRaw(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return raw
+	}
+	return u.Host
+}

--- a/internal/attack/mcp/dcr_test.go
+++ b/internal/attack/mcp/dcr_test.go
@@ -1,0 +1,310 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+// Three rules register an OAuth client on the target and none of them removed it, so
+// a scan against a server with open dynamic client registration left three behind
+// permanently: one with an off-origin redirect_uri, one holding whatever privileged
+// scopes the server would grant an anonymous registrant, and one whose metadata URLs
+// point at an OOB listener that stops existing when the scan ends.
+//
+// RFC 7592 is the way back: a registration response may carry a
+// registration_client_uri and a registration_access_token, and a DELETE to that URI
+// with that token deregisters the client. These tests drive a server that implements
+// it, and the ways a server can fail to.
+
+// dcrServer is an authorization server with open registration. It records which
+// clients exist so a test can assert the scan removed what it created.
+type dcrServer struct {
+	*httptest.Server
+	mu sync.Mutex
+	// live maps client_id to client_name for every registration not yet deleted.
+	live map[string]string
+	// deleteAuth records the Authorization header seen on each DELETE.
+	deleteAuth []string
+	// support toggles what the registration response advertises.
+	support dcrSupport
+	// grantedScope is echoed back so mcp-oauth-dcr-001 has something to report.
+	grantedScope string
+}
+
+// dcrSupport describes how much of RFC 7592 the server implements.
+type dcrSupport int
+
+const (
+	dcrFull       dcrSupport = iota // registration_client_uri + registration_access_token
+	dcrNoneAtAll                    // neither: the client cannot be removed
+	dcrNoToken                      // a URI but no token, so a delete would be unauthenticated
+	dcrOffHostURI                   // a URI on another host, which must not be followed
+	dcrRefuseDel                    // full advertisement, but DELETE is refused
+)
+
+func newDCRServer(t *testing.T, support dcrSupport, grantedScope string) *dcrServer {
+	t.Helper()
+	d := &dcrServer{live: map[string]string{}, support: support, grantedScope: grantedScope}
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		base := "http://" + r.Host
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"issuer":                 base,
+			"registration_endpoint":  base + "/register",
+			"authorization_endpoint": base + "/authorize",
+			"token_endpoint":         base + "/token",
+		})
+	})
+
+	mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		name, _ := body["client_name"].(string)
+		redirects, _ := body["redirect_uris"].([]interface{})
+
+		d.mu.Lock()
+		id := fmt.Sprintf("client-%d", len(d.live)+len(d.deleteAuth)+1)
+		d.live[id] = name
+		d.mu.Unlock()
+
+		out := map[string]interface{}{"client_id": id, "client_name": name, "redirect_uris": redirects}
+		if d.grantedScope != "" {
+			out["scope"] = d.grantedScope
+		}
+		base := "http://" + r.Host
+		switch d.support {
+		case dcrFull, dcrRefuseDel:
+			out["registration_client_uri"] = base + "/register/" + id
+			out["registration_access_token"] = "rat-" + id
+		case dcrNoToken:
+			out["registration_client_uri"] = base + "/register/" + id
+		case dcrOffHostURI:
+			out["registration_client_uri"] = "http://elsewhere.invalid/register/" + id
+			out["registration_access_token"] = "rat-" + id
+		case dcrNoneAtAll:
+			// Advertise nothing: an RFC 7591 server without the management protocol.
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(out)
+	})
+
+	mux.HandleFunc("/register/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		id := strings.TrimPrefix(r.URL.Path, "/register/")
+		d.mu.Lock()
+		d.deleteAuth = append(d.deleteAuth, r.Header.Get("Authorization"))
+		if d.support == dcrRefuseDel {
+			d.mu.Unlock()
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		delete(d.live, id)
+		d.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	// Enough of an MCP surface for the OAuth-gated rules to consider the target live.
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": 1,
+			"error": map[string]interface{}{"code": -32000, "message": "authentication required"},
+		})
+	})
+
+	d.Server = httptest.NewServer(mux)
+	return d
+}
+
+// liveNames returns the client_names still registered.
+func (d *dcrServer) liveNames() []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	out := make([]string, 0, len(d.live))
+	for _, n := range d.live {
+		out = append(out, n)
+	}
+	return out
+}
+
+func (d *dcrServer) deletes() []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]string(nil), d.deleteAuth...)
+}
+
+// The scope-escalation rule reads everything it needs out of the registration
+// response, so the client it created must be gone by the time the rule returns.
+func TestDCRCleanup_ScopeEscalationRemovesItsClient(t *testing.T) {
+	srv := newDCRServer(t, dcrFull, "tools:write admin")
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthDCRExecutor(attack.RuleContext{ID: "mcp-oauth-dcr-001", Severity: "high"})
+	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected the escalated-scope finding, got %d", len(findings))
+	}
+	if left := srv.liveNames(); len(left) != 0 {
+		t.Errorf("the scan left %d client(s) registered: %v", len(left), left)
+	}
+	// RFC 7592 authenticates the delete with the registration access token, not with
+	// the operator's credential.
+	for _, auth := range srv.deletes() {
+		if !strings.HasPrefix(auth, "Bearer rat-") {
+			t.Errorf("delete should present the registration_access_token, got %q", auth)
+		}
+	}
+	if !strings.Contains(findings[0].Evidence, "deleted afterwards via RFC 7592") {
+		t.Errorf("the finding should record that the client was removed; got:\n%s", findings[0].Evidence)
+	}
+}
+
+// A server without the management protocol keeps the client. That is not an error,
+// but the operator has to be told, and told what to search for.
+func TestDCRCleanup_NoManagementProtocolIsReported(t *testing.T) {
+	srv := newDCRServer(t, dcrNoneAtAll, "tools:write admin")
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthDCRExecutor(attack.RuleContext{ID: "mcp-oauth-dcr-001", Severity: "high"})
+	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected the escalated-scope finding, got %d", len(findings))
+	}
+	ev := findings[0].Evidence
+	if !strings.Contains(ev, "LEFT REGISTERED") {
+		t.Errorf("a client that could not be removed must be reported as left behind; got:\n%s", ev)
+	}
+	if !strings.Contains(ev, "batesian-probe-") {
+		t.Errorf("the report must name the client so it can be found by hand; got:\n%s", ev)
+	}
+	if !strings.Contains(ev, "RFC 7592") {
+		t.Errorf("the reason should say what the server does not implement; got:\n%s", ev)
+	}
+}
+
+// registration_client_uri is chosen by the TARGET. Following it to another host would
+// let the target direct the scanner's requests, which is the same mistake as sending
+// the operator's token off-host. It must be reported rather than followed.
+func TestDCRCleanup_OffHostManagementURIIsNotFollowed(t *testing.T) {
+	srv := newDCRServer(t, dcrOffHostURI, "tools:write admin")
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthDCRExecutor(attack.RuleContext{ID: "mcp-oauth-dcr-001", Severity: "high"})
+	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected the escalated-scope finding, got %d", len(findings))
+	}
+	ev := findings[0].Evidence
+	if !strings.Contains(ev, "another host is not followed") {
+		t.Errorf("an off-host management URI must be reported, not followed; got:\n%s", ev)
+	}
+	if !strings.Contains(ev, "elsewhere.invalid") {
+		t.Errorf("the reason should name the host it declined to contact; got:\n%s", ev)
+	}
+}
+
+// A server that advertises management and then refuses the delete has kept the
+// client. The rule's verdict must not depend on cleanup either way.
+func TestDCRCleanup_RefusedDeleteIsReportedNotFatal(t *testing.T) {
+	srv := newDCRServer(t, dcrRefuseDel, "tools:write admin")
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthDCRExecutor(attack.RuleContext{ID: "mcp-oauth-dcr-001", Severity: "high"})
+	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+	if err != nil {
+		t.Fatalf("cleanup failure must not fail the rule: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected the escalated-scope finding, got %d", len(findings))
+	}
+	if !strings.Contains(findings[0].Evidence, "refused with HTTP 403") {
+		t.Errorf("the refusal should be reported with its status; got:\n%s", findings[0].Evidence)
+	}
+	if len(srv.deletes()) == 0 {
+		t.Error("expected a delete to have been attempted")
+	}
+}
+
+// A server with no token to authenticate the delete with cannot be cleaned up, and
+// an unauthenticated delete must not be attempted.
+func TestDCRCleanup_MissingAccessTokenIsNotDeletedBlind(t *testing.T) {
+	srv := newDCRServer(t, dcrNoToken, "tools:write admin")
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthDCRExecutor(attack.RuleContext{ID: "mcp-oauth-dcr-001", Severity: "high"})
+	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected the escalated-scope finding, got %d", len(findings))
+	}
+	if len(srv.deletes()) != 0 {
+		t.Errorf("no delete should be sent without a registration_access_token, saw %d", len(srv.deletes()))
+	}
+	if !strings.Contains(findings[0].Evidence, "no registration_access_token") {
+		t.Errorf("the reason should name the missing token; got:\n%s", findings[0].Evidence)
+	}
+}
+
+// The confused-deputy rule uses its client_id for an authorize probe, so cleanup has
+// to happen after that and still happen when the rule returns early.
+func TestDCRCleanup_ConfusedDeputyRemovesItsClient(t *testing.T) {
+	srv := newDCRServer(t, dcrFull, "")
+	defer srv.Close()
+
+	exec := mcpattack.NewConfusedDeputyExecutor(attack.RuleContext{
+		ID: "mcp-confused-deputy-001", Severity: "high",
+	})
+	_, _ = exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+
+	if left := srv.liveNames(); len(left) != 0 {
+		t.Errorf("the confused-deputy probe left %d client(s) registered: %v", len(left), left)
+	}
+}
+
+// A dry run must not register anything, so there is nothing to clean up and no
+// cleanup request either.
+func TestDCRCleanup_DryRunRegistersNothing(t *testing.T) {
+	srv := newDCRServer(t, dcrFull, "tools:write admin")
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthDCRExecutor(attack.RuleContext{ID: "mcp-oauth-dcr-001", Severity: "high"})
+	_, _ = exec.Execute(context.Background(), srv.URL, attack.Options{
+		TimeoutSeconds: 5,
+		DryRun:         true,
+		Recorder:       &attack.Recorder{},
+	})
+
+	if left := srv.liveNames(); len(left) != 0 {
+		t.Errorf("a dry run must send nothing, but %d client(s) were registered: %v", len(left), left)
+	}
+	if len(srv.deletes()) != 0 {
+		t.Errorf("a dry run must send no delete either, saw %d", len(srv.deletes()))
+	}
+}

--- a/internal/attack/mcp/oauth_dcr.go
+++ b/internal/attack/mcp/oauth_dcr.go
@@ -69,8 +69,9 @@ func (e *OAuthDCRExecutor) Execute(ctx context.Context, target string, opts atta
 
 	// Step 2: Unauthenticated registration requesting admin/write scopes.
 	escalatedScope := "tools:read tools:write resources:write prompts:write admin superuser"
+	clientName := "batesian-probe-" + vars.RandID + "-esc"
 	escalatedResp, err := unauthClient.POST(ctx, registrationEndpoint, nil, map[string]interface{}{
-		"client_name":    "batesian-probe-" + vars.RandID + "-esc",
+		"client_name":    clientName,
 		"redirect_uris":  []string{"https://batesian.invalid/callback"},
 		"grant_types":    []string{"authorization_code"},
 		"response_types": []string{"code"},
@@ -79,6 +80,12 @@ func (e *OAuthDCRExecutor) Execute(ctx context.Context, target string, opts atta
 	if err != nil {
 		return nil, fmt.Errorf("DCR registration request failed: %w", err)
 	}
+
+	// This rule reads everything it needs out of the registration response, so the
+	// client it just created can go straight away. Leaving it there would leave an
+	// anonymously registered client holding whatever privileged scopes the server was
+	// willing to grant, which is the very thing being reported.
+	cleanup := deregisterDCRClient(ctx, unauthClient, registrationEndpoint, clientName, escalatedResp)
 
 	// Step 3: Fire only when registration succeeded AND the server registered a
 	// privileged scope. A rejected registration (auth required / scope policy)
@@ -105,7 +112,9 @@ func (e *OAuthDCRExecutor) Execute(ctx context.Context, target string, opts atta
 			"actually issued depends on the grant/consent step, so manually verify whether the authorization "+
 			"server issues a token with these scopes to the anonymous client.",
 			registrationEndpoint, granted),
-		Evidence:    fmt.Sprintf("Requested: %q\nGranted: %q\nPrivileged tokens granted: %v\nHTTP %d from %s\n%s", escalatedScope, grantedScope, granted, escalatedResp.StatusCode, registrationEndpoint, snippetMCP(escalatedResp.Body)),
+		Evidence: fmt.Sprintf("Requested: %q\nGranted: %q\nPrivileged tokens granted: %v\nHTTP %d from %s\n%s\n%s",
+			escalatedScope, grantedScope, granted, escalatedResp.StatusCode, registrationEndpoint,
+			snippetMCP(escalatedResp.Body), cleanup.evidenceLine()),
 		Remediation: e.rule.Remediation,
 		TargetURL:   registrationEndpoint,
 	}}, nil

--- a/internal/attack/mcp/oauth_metadata_ssrf.go
+++ b/internal/attack/mcp/oauth_metadata_ssrf.go
@@ -71,8 +71,9 @@ func (e *OAuthMetadataSSRFExecutor) Execute(ctx context.Context, target string, 
 
 	// Build a registration whose URL metadata fields all target the OOB listener,
 	// each with a field-specific marker path.
+	clientName := "batesian-ssrf-" + vars.RandID
 	body := map[string]interface{}{
-		"client_name":    "batesian-ssrf-" + vars.RandID,
+		"client_name":    clientName,
 		"redirect_uris":  []string{"https://batesian.invalid/callback"},
 		"grant_types":    []string{"authorization_code"},
 		"response_types": []string{"code"},
@@ -121,7 +122,12 @@ func (e *OAuthMetadataSSRFExecutor) Execute(ctx context.Context, target string, 
 	}
 
 	// Local OOB: wait for the server to fetch one of the seeded URLs.
+	//
+	// The registration IS the payload here, so the client cannot be removed until the
+	// wait is over: deleting it first could cancel the very fetch this rule is
+	// listening for, trading a real finding for a tidier target.
 	cb, received := listener.WaitForMarker(ctx, 10*time.Second, "batesian-"+vars.RandID)
+	cleanup := deregisterDCRClient(ctx, unauthClient, registrationEndpoint, clientName, resp)
 	if !received {
 		return nil, nil
 	}
@@ -136,8 +142,8 @@ func (e *OAuthMetadataSSRFExecutor) Execute(ctx context.Context, target string, 
 			"URL (field %q) during dynamic client registration. A registrant can point this field at internal "+
 			"services, cloud metadata endpoints, or other private resources, so the OAuth discovery chain is an SSRF "+
 			"vector.", registrationEndpoint, field),
-		Evidence: fmt.Sprintf("Registration endpoint: %s\nOOB callback: %s %s\nFetched field: %s",
-			registrationEndpoint, cb.Method, cb.URL, field),
+		Evidence: fmt.Sprintf("Registration endpoint: %s\nOOB callback: %s %s\nFetched field: %s\n%s",
+			registrationEndpoint, cb.Method, cb.URL, field, cleanup.evidenceLine()),
 		Remediation: e.rule.Remediation,
 		TargetURL:   registrationEndpoint,
 	}}, nil

--- a/internal/attack/mcp/oauth_metadata_ssrf_test.go
+++ b/internal/attack/mcp/oauth_metadata_ssrf_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -23,9 +24,24 @@ func omRuleCtx() attack.RuleContext {
 //   - "fetch":   fetches the registrant-supplied jwks_uri (vulnerable SSRF)
 //   - "nofetch": stores metadata without fetching (safe)
 //   - "no-oauth": serves no authorization-server metadata
-func metadataSSRFServer(mode string) *httptest.Server {
+//   - "fetch-managed": as "fetch", and implements RFC 7592 client management
+//
+// deleted, when non-nil, receives each client_id the server deregisters.
+func metadataSSRFServerManaged(mode string, deleted *[]string) *httptest.Server {
 	mux := http.NewServeMux()
 	ts := httptest.NewServer(mux)
+	if mode == "fetch-managed" {
+		mux.HandleFunc("/register/", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodDelete {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			if deleted != nil {
+				*deleted = append(*deleted, r.URL.Path)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+	}
 
 	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
 		if mode == "no-oauth" {
@@ -44,7 +60,7 @@ func metadataSSRFServer(mode string) *httptest.Server {
 		raw, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(raw, &body)
 
-		if mode == "fetch" {
+		if mode == "fetch" || mode == "fetch-managed" {
 			if u, _ := body["jwks_uri"].(string); u != "" {
 				// VULNERABLE: fetch the registrant-supplied URL server-side.
 				c := &http.Client{Timeout: 3 * time.Second}
@@ -55,12 +71,23 @@ func metadataSSRFServer(mode string) *httptest.Server {
 				}
 			}
 		}
+		out := map[string]interface{}{"client_id": "c-123", "client_name": body["client_name"]}
+		if mode == "fetch-managed" {
+			out["registration_client_uri"] = ts.URL + "/register/c-123"
+			out["registration_access_token"] = "rat-c-123"
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{"client_id": "c-123", "client_name": body["client_name"]})
+		_ = json.NewEncoder(w).Encode(out)
 	})
 
 	return ts
+}
+
+// metadataSSRFServer keeps the original signature for the tests that do not care
+// about client management.
+func metadataSSRFServer(mode string) *httptest.Server {
+	return metadataSSRFServerManaged(mode, nil)
 }
 
 func runMetadataSSRF(t *testing.T, ts *httptest.Server) []attack.Finding {
@@ -116,5 +143,26 @@ func TestMetadataSSRF_NothingReachableIsNotTested(t *testing.T) {
 		Execute(context.Background(), ts.URL, testOpts())
 	if !errors.Is(err, attack.ErrInconclusive) {
 		t.Fatalf("expected ErrInconclusive when nothing answered, got err=%v", err)
+	}
+}
+
+// This rule's payload IS the registration, so the client cannot be removed until the
+// OOB wait is over: deleting it first risks cancelling the very fetch being listened
+// for. Both halves are asserted here, because getting the order wrong would trade a
+// real finding for a tidier target and the finding is the point.
+func TestMetadataSSRF_ClientRemovedWithoutLosingTheFinding(t *testing.T) {
+	var deleted []string
+	ts := metadataSSRFServerManaged("fetch-managed", &deleted)
+	defer ts.Close()
+
+	findings := runMetadataSSRF(t, ts)
+	if len(findings) != 1 {
+		t.Fatalf("cleanup must not cost the finding, got %d: %+v", len(findings), findings)
+	}
+	if len(deleted) != 1 {
+		t.Fatalf("expected the registered client to be deleted once, saw %d: %v", len(deleted), deleted)
+	}
+	if !strings.Contains(findings[0].Evidence, "deleted afterwards via RFC 7592") {
+		t.Errorf("the finding should record the cleanup; got:\n%s", findings[0].Evidence)
 	}
 }

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -52,7 +52,7 @@ fixtures for live-validation / manual smoke testing.
 | `a2a_card_security_unenforced_server.py` | 3110 | `a2a-card-security-unenforced-001` |
 | `a2a_secured_agent.py` | 3111 | negative control, two postures: NO rule may fire on `secured`; `a2a-multitenant-isolation-001`, `a2a-delegation-integrity-001`, `a2a-task-cancel-idor-001` and `a2a-push-binding-001` must all fire on `idor` (needs `--token tok-a` and two principals, see below) |
 | `mcp_unauth_resources_server.py` | 7787 | `mcp-resources-unauth-001` |
-| `mcp_oauth_dcr_server.py` | 7788 | `mcp-oauth-dcr-001` |
+| `mcp_oauth_dcr_server.py` | 7788 | `mcp-oauth-dcr-001` (two postures, see below; tracks registrations at `/__clients`) |
 | `mcp_oauth_audience_server.py` | 7785 | `mcp-oauth-audience-002` (four sub-paths, one per bug class; target each, not the root) |
 | `mcp_new_rules_server.py` | 3100 | `mcp-prompt-unauth-001`, `mcp-tools-unauth-001`; `mcp-init-downgrade-001` needs the `downgrade` posture, see below |
 | `mcp_session_fixation_server.py` | 7786 | `mcp-session-fixation-001` |
@@ -206,6 +206,21 @@ as "the modern wire is served", which turned that server's `400 Bad Request:
 protocol version "2026-07-28" is only supported on stateless HTTP servers` into
 the refused half of an authorization asymmetry and produced a critical
 `mcp-era-downgrade-001` finding against a target with no authorization at all.
+
+**`mcp_oauth_dcr_server.py` takes a posture argument**, defaulting to `managed`, and
+the two differ only in whether the server implements RFC 7592 client management:
+
+```sh
+python testdata/mcp_oauth_dcr_server.py managed    # the scan must leave 0 clients behind
+python testdata/mcp_oauth_dcr_server.py unmanaged  # the scan cannot clean up, and must say so
+```
+
+Testing what dynamic client registration accepts means asking it to accept something,
+so three rules necessarily create a client here: `mcp-oauth-dcr-001`,
+`mcp-confused-deputy-001` and `mcp-oauth-metadata-ssrf-001`. `GET /__clients` reports
+what is still registered, which is a validation helper and no part of any OAuth spec.
+Measured across the two postures: `managed` ends with `{"count":0}`, `unmanaged` ends
+with three `batesian-*` clients and three findings that say so in their evidence.
 
 **`a2a_secured_agent.py` is the only fixture here that ENFORCES AUTHORIZATION**, and
 it is a negative control rather than a target. Every other A2A fixture enforces

--- a/testdata/mcp_oauth_dcr_server.py
+++ b/testdata/mcp_oauth_dcr_server.py
@@ -7,20 +7,45 @@ Registration endpoint (RFC 7591) that:
   - Echoes back whatever scopes were requested without validation
   - Accepts any redirect URI including localhost and open-redirect targets
 
+Two postures, selected by the first argument, differing only in whether the server
+implements RFC 7592 client management:
+
+    managed     (default) returns registration_client_uri and
+                registration_access_token, so a scan can delete the client it
+                registered. After a scan, GET /__clients must report 0.
+    unmanaged   returns neither, so the client cannot be removed. The scan must
+                report that it left one behind rather than staying silent.
+
+Testing what DCR accepts means asking it to accept something, so a scan
+necessarily creates clients here. Registrations are tracked (and exposed at
+/__clients, which is a validation helper and no part of any OAuth spec) so the
+cleanup can be observed rather than assumed.
+
 Run:
-    python testdata/mcp_oauth_dcr_server.py
+    python testdata/mcp_oauth_dcr_server.py managed
+    python testdata/mcp_oauth_dcr_server.py unmanaged
 
 Endpoints:
-    GET  http://localhost:7788/.well-known/oauth-authorization-server
-    POST http://localhost:7788/register
+    GET    http://localhost:7788/.well-known/oauth-authorization-server
+    POST   http://localhost:7788/register
+    DELETE http://localhost:7788/register/{client_id}   (managed posture only)
+    GET    http://localhost:7788/__clients              (validation helper)
 """
 import json
 import secrets
+import sys
 import uvicorn
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import JSONResponse
+from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
+
+
+POSTURES = ("managed", "unmanaged")
+POSTURE = sys.argv[1] if len(sys.argv) > 1 else "managed"
+
+# client_id -> {client_name, scope, token}. Registrations this server currently holds.
+CLIENTS: dict = {}
 
 
 async def oauth_metadata(request: Request) -> JSONResponse:
@@ -44,7 +69,17 @@ async def register_client(request: Request) -> JSONResponse:
 
     requested_scope = body.get("scope", "tools:read")
 
-    return JSONResponse({
+    # Registrations are tracked so a validator can see whether the scan cleaned up
+    # after itself. Testing what DCR accepts means asking it to accept something, so
+    # a scan necessarily creates clients here; leaving them would be a scanner
+    # changing the state of the system it was pointed at and not changing it back.
+    CLIENTS[client_id] = {
+        "client_name": body.get("client_name", "unnamed"),
+        "scope": requested_scope,
+        "token": secrets.token_hex(8),
+    }
+
+    result = {
         "client_id": client_id,
         "client_secret": client_secret,
         "client_name": body.get("client_name", "unnamed"),
@@ -53,18 +88,59 @@ async def register_client(request: Request) -> JSONResponse:
         "response_types": body.get("response_types", ["code"]),
         "scope": requested_scope,
         "token_endpoint_auth_method": "client_secret_basic",
-    }, status_code=201)
+    }
+    if POSTURE == "managed":
+        # RFC 7592 client management, which is what lets a client be deleted again.
+        base = str(request.base_url).rstrip("/")
+        result["registration_client_uri"] = f"{base}/register/{client_id}"
+        result["registration_access_token"] = CLIENTS[client_id]["token"]
+    return JSONResponse(result, status_code=201)
+
+
+async def manage_client(request: Request) -> Response:
+    """RFC 7592 DELETE. Present only under the `managed` posture."""
+    client_id = request.path_params["client_id"]
+    record = CLIENTS.get(client_id)
+    if record is None:
+        return Response(status_code=404)
+    if request.headers.get("authorization", "") != f"Bearer {record['token']}":
+        # A delete must be authenticated with the registration access token.
+        return Response(status_code=401)
+    del CLIENTS[client_id]
+    return Response(status_code=204)
+
+
+async def list_clients(request: Request) -> JSONResponse:
+    """Validation helper: what is still registered. Not part of any OAuth spec.
+
+    Count this after a scan. Under `managed` it must be empty; under `unmanaged` the
+    clients remain, which is the case the scan reports as left behind.
+    """
+    return JSONResponse({
+        "count": len(CLIENTS),
+        "clients": [c["client_name"] for c in CLIENTS.values()],
+    })
 
 
 routes = [
     Route("/.well-known/oauth-authorization-server", oauth_metadata, methods=["GET"]),
     Route("/register", register_client, methods=["POST"]),
+    Route("/register/{client_id}", manage_client, methods=["DELETE"]),
+    Route("/__clients", list_clients, methods=["GET"]),
 ]
 
 app = Starlette(routes=routes)
 
 if __name__ == "__main__":
-    print("Starting vulnerable OAuth DCR server on http://localhost:7788")
+    if POSTURE not in POSTURES:
+        sys.exit(f"unknown posture {POSTURE!r}; expected one of {', '.join(POSTURES)}")
+    print(f"Starting vulnerable OAuth DCR server ({POSTURE}) on http://localhost:7788")
     print("  GET  /.well-known/oauth-authorization-server")
     print("  POST /register  (no auth, accepts any scopes and redirect URIs)")
+    if POSTURE == "managed":
+        print("  DELETE /register/{client_id}  (RFC 7592, needs the registration access token)")
+        print("  -> a scan must leave 0 clients behind; check GET /__clients")
+    else:
+        print("  no RFC 7592 management: a scan CANNOT clean up, and must report that")
+    print("  GET  /__clients  (validation helper: what is still registered)")
     uvicorn.run(app, host="127.0.0.1", port=7788)


### PR DESCRIPTION
Three rules register a client on the target's authorization server, because what
dynamic client registration accepts cannot be tested without asking it to accept
something. **None of them removed it.** A scan against a server with open DCR left
three clients behind, permanently:

| rule | what it left | 
|---|---|
| `mcp-confused-deputy-001` | a client whose `redirect_uri` points off-origin — the attacker-shaped value the rule exists to see accepted |
| `mcp-oauth-dcr-001` | a client holding whatever privileged scopes the server would grant an anonymous registrant |
| `mcp-oauth-metadata-ssrf-001` | a client whose metadata URLs point at the scan's OOB listener, a host that stops existing when the scan ends |

That is a scanner changing the state of the system it was pointed at and not changing
it back — a different and worse class than mis-reporting, because the operator
authorized traffic, not a permanent client.

RFC 7592 is the way back: a registration response may carry a
`registration_client_uri` and a `registration_access_token`, and a DELETE to that URI
with that token deregisters the client. All three rules now do it, through one shared
helper. **Measured live** against the fixture, which now tracks registrations:

```
unmanaged server: {"count":3,"clients":["batesian-cd-…","batesian-probe-…-esc","batesian-ssrf-…"]}
managed server:   {"count":0,"clients":[]}
```

Cleanup is best effort and never changes a verdict. Where it cannot happen the finding
says so and names the client — always prefixed `batesian-` — so leftovers can be found
and removed. The reasons are distinguished because they call for different things: no
management protocol, a URI without a token, a refused delete.

**Three details that are the whole difficulty:**

`registration_client_uri` is chosen by the **target**, so it is only followed while it
stays on the registration endpoint's host. Following a target-chosen absolute URL
elsewhere would let the target direct the scanner's requests — the same mistake as
sending the operator's token off-host. The token presented is the
`registration_access_token` the target itself just issued, never the operator's.

`confused-deputy` needs its `client_id` for the authorize probe, so cleanup runs after
that and before the findings are built, with a deferred call as the guarantee for
early-return paths.

`metadata-ssrf` deletes only **after** its OOB wait: there the registration *is* the
payload, and removing the client first risks cancelling the fetch being listened for,
trading a real finding for a tidier target. That ordering is a precaution rather than
an observed server behaviour, and the test asserts the finding survives cleanup.

Verification:

- 7 tests over the management variants: full support, none at all, URI without token
  (no blind delete), off-host URI (not followed), refused delete (not fatal), and a dry
  run that must register nothing
- the SSRF ordering pinned by a test requiring both the deletion and the finding
- live before-and-after on the fixture: 3 clients → 0
- 46-case fixture sweep against the previous binary: no finding or skip changed