### PR TITLE
fix(a2a): stop calling an empty task list a server-wide disclosure

### DIFF
--- a/internal/attack/a2a/task_idor.go
+++ b/internal/attack/a2a/task_idor.go
@@ -191,21 +191,30 @@ func (e *TaskIDORExecutor) probeTaskList(ctx context.Context, unauthClient *atta
 		if err == nil && listResp.StatusCode != 404 {
 			reached = true
 		}
-		if err == nil && listResp.IsSuccess() && listResp.ContainsAny(`"tasks"`, `"contextId"`, `"history"`) {
-			return []attack.Finding{{
-				RuleID:     e.rule.ID,
-				RuleName:   e.rule.Name,
-				Severity:   "critical",
-				Confidence: attack.ConfirmedExploit,
-				Title:      "A2A server exposes tasks/list without authentication - server-wide task disclosure",
-				Description: fmt.Sprintf(
-					"GET %s returned a list of tasks without authentication. This exposes all task "+
-						"IDs, context IDs, and potentially conversation history for every session on "+
-						"the server.", le),
-				Evidence:    fmt.Sprintf("HTTP %d from %s\n%s", listResp.StatusCode, le, snippet(listResp.Body, 400)),
-				Remediation: e.rule.Remediation,
-				TargetURL:   le,
-			}}, reached
+		// Count the tasks actually returned. The check here used to be
+		// ContainsAny(`"tasks"`, `"contextId"`, `"history"`) over the raw body, which
+		// are key names: a server that scopes its list correctly and answers an
+		// anonymous caller with {"tasks":[],"totalSize":0} matched, and this reported
+		// server-wide disclosure at critical/confirmed about a server that disclosed
+		// nothing. An empty list is the secure answer, not the finding.
+		if err == nil && listResp.IsSuccess() {
+			if n := countListedTasks(listResp.Body); n > 0 {
+				return []attack.Finding{{
+					RuleID:     e.rule.ID,
+					RuleName:   e.rule.Name,
+					Severity:   "critical",
+					Confidence: attack.ConfirmedExploit,
+					Title:      "A2A server exposes tasks/list without authentication - server-wide task disclosure",
+					Description: fmt.Sprintf(
+						"GET %s returned %d task(s) without authentication. This exposes task IDs, "+
+							"context IDs, and potentially conversation history for sessions the caller "+
+							"has no claim to.", le, n),
+					Evidence: fmt.Sprintf("HTTP %d from %s\ntasks returned to an unauthenticated caller: %d\n%s",
+						listResp.StatusCode, le, n, snippet(listResp.Body, 400)),
+					Remediation: e.rule.Remediation,
+					TargetURL:   le,
+				}}, reached
+			}
 		}
 	}
 	return nil, reached

--- a/internal/attack/a2a/task_idor_test.go
+++ b/internal/attack/a2a/task_idor_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/calbebop/batesian/internal/attack"
@@ -299,5 +300,72 @@ func TestTaskIDOR_UnauthTaskList(t *testing.T) {
 	}
 	if findings[0].Severity != "critical" {
 		t.Errorf("want critical severity, got %q", findings[0].Severity)
+	}
+}
+
+// taskListServer serves an A2A card and answers the REST task-list paths with body.
+// Everything else is a JSON-RPC method-not-found, so the rule reaches the list probe.
+func taskListServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/.well-known/") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"name":"List Agent","description":"d","version":"1.0.0",`+
+				`"protocolVersion":"1.0","capabilities":{},"skills":[],`+
+				`"supportedInterfaces":[{"url":"http://`+r.Host+`/","protocolBinding":"JSONRPC","protocolVersion":"1.0"}]}`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/tasks" || r.URL.Path == "/v1/tasks" {
+			_, _ = io.WriteString(w, body)
+			return
+		}
+		_, _ = io.WriteString(w, `{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}`)
+	}))
+}
+
+// A server that scopes its task list correctly and returns nothing to an anonymous
+// caller has disclosed nothing. This reported "server-wide task disclosure" at
+// critical/confirmed, because the oracle matched the KEY NAME "tasks" in an empty
+// envelope.
+func TestTaskIDOR_EmptyTaskListIsNotDisclosure(t *testing.T) {
+	srv := taskListServer(t, `{"tasks":[],"totalSize":0}`)
+	defer srv.Close()
+
+	exec := a2a.NewTaskIDORExecutor(attack.RuleContext{ID: "a2a-task-idor-001", Severity: "high"})
+	findings, _ := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+	for _, f := range findings {
+		if strings.Contains(f.Title, "tasks/list") {
+			t.Fatalf("an empty list is the secure answer, not a critical disclosure: %s\n%s",
+				f.Title, f.Evidence)
+		}
+	}
+}
+
+// The true positive must survive the fix: a list that really does hand another
+// caller's tasks to an anonymous request is the finding, and the count is evidence.
+func TestTaskIDOR_PopulatedTaskListIsDisclosure(t *testing.T) {
+	srv := taskListServer(t, `{"tasks":[{"id":"t1","contextId":"c1"},{"id":"t2","contextId":"c2"}],"totalSize":2}`)
+	defer srv.Close()
+
+	exec := a2a.NewTaskIDORExecutor(attack.RuleContext{ID: "a2a-task-idor-001", Severity: "high"})
+	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var found *attack.Finding
+	for i := range findings {
+		if strings.Contains(findings[i].Title, "tasks/list") {
+			found = &findings[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected the unauthenticated task-list disclosure, got %d finding(s)", len(findings))
+	}
+	if found.Severity != "critical" || found.Confidence != attack.ConfirmedExploit {
+		t.Errorf("want critical/confirmed, got %s/%s", found.Severity, found.Confidence)
+	}
+	if !strings.Contains(found.Evidence, "tasks returned to an unauthenticated caller: 2") {
+		t.Errorf("evidence should count what was disclosed; got:\n%s", found.Evidence)
 	}
 }

--- a/internal/attack/a2a/taskref.go
+++ b/internal/attack/a2a/taskref.go
@@ -1,6 +1,9 @@
 package a2a
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // resultReferencesTask reports whether a JSON-RPC result really is the task
 // identified by taskID/contextID, by comparing the identifiers rather than
@@ -70,4 +73,48 @@ func resultReferencesTask(body []byte, taskID, contextID string) bool {
 		}
 	}
 	return false
+}
+
+// countListedTasks returns how many tasks a task-list response actually carried.
+//
+// The oracle it replaced was ContainsAny(`"tasks"`, `"contextId"`, `"history"`) over
+// the raw body, which are KEY NAMES. A server that scopes its list correctly and
+// answers an anonymous caller with {"tasks":[],"totalSize":0} contains `"tasks"`, so
+// it matched, and a2a-task-idor-001 reported "server-wide task disclosure" at
+// critical/confirmed against a server that disclosed nothing at all. That is the same
+// vacuous-needle class as the checks corrected in PR #163 and PR #169, and the
+// highest-severity instance of it.
+//
+// Both shapes are counted: the documented {"tasks":[...]} envelope, and the bare
+// array some REST bindings return. An element counts only when it is an object with
+// at least one non-empty field, so an empty list, a list of empty objects, and a
+// bare count all fail to qualify. Something has to have been disclosed before this
+// says something was disclosed.
+func countListedTasks(body []byte) int {
+	var envelope struct {
+		Tasks []map[string]json.RawMessage `json:"tasks"`
+	}
+	if json.Unmarshal(body, &envelope) == nil && envelope.Tasks != nil {
+		return countNonEmpty(envelope.Tasks)
+	}
+	var bare []map[string]json.RawMessage
+	if json.Unmarshal(body, &bare) == nil {
+		return countNonEmpty(bare)
+	}
+	return 0
+}
+
+// countNonEmpty counts objects carrying at least one field with a non-empty value.
+func countNonEmpty(items []map[string]json.RawMessage) int {
+	n := 0
+	for _, item := range items {
+		for _, v := range item {
+			s := strings.TrimSpace(string(v))
+			if s != "" && s != "null" && s != `""` && s != "{}" && s != "[]" {
+				n++
+				break
+			}
+		}
+	}
+	return n
 }

--- a/internal/attack/a2a/taskref_test.go
+++ b/internal/attack/a2a/taskref_test.go
@@ -100,3 +100,80 @@ func TestResultReferencesTask(t *testing.T) {
 		})
 	}
 }
+
+// The oracle this replaced was ContainsAny(`"tasks"`, `"contextId"`, `"history"`) over
+// the raw body: key names, present in a correctly scoped EMPTY response. That made
+// a2a-task-idor-001 report "server-wide task disclosure" at critical/confirmed against
+// a server that disclosed nothing, which is the highest-severity instance of the
+// vacuous-needle class corrected in #163 and #169.
+func TestCountListedTasks(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want int
+	}{
+		{
+			// The live false positive: correctly scoped, nothing disclosed.
+			name: "an empty list discloses nothing",
+			body: `{"tasks":[],"totalSize":0}`,
+			want: 0,
+		},
+		{
+			name: "one task in the documented envelope",
+			body: `{"tasks":[{"id":"t1","contextId":"c1"}],"totalSize":1}`,
+			want: 1,
+		},
+		{
+			name: "several tasks",
+			body: `{"tasks":[{"id":"t1"},{"id":"t2"},{"id":"t3"}]}`,
+			want: 3,
+		},
+		{
+			// Some REST bindings answer with a bare array.
+			name: "a bare array counts too",
+			body: `[{"id":"t1"},{"id":"t2"}]`,
+			want: 2,
+		},
+		{
+			name: "an empty bare array discloses nothing",
+			body: `[]`,
+			want: 0,
+		},
+		{
+			// A count without the tasks is not the tasks. It may hint at a scoping
+			// problem, but nothing was disclosed that can be named.
+			name: "a total with no tasks discloses nothing",
+			body: `{"totalSize":42,"tasks":[]}`,
+			want: 0,
+		},
+		{
+			name: "placeholder objects disclose nothing",
+			body: `{"tasks":[{},{"id":""},{"history":[]}]}`,
+			want: 0,
+		},
+		{
+			// No id, but a status was disclosed: something about a task came back.
+			name: "an element with any real field counts",
+			body: `{"tasks":[{"status":{"state":"working"}}]}`,
+			want: 1,
+		},
+		{
+			name: "a body that is not a list at all",
+			body: `{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}`,
+			want: 0,
+		},
+		{
+			name: "unparseable body",
+			body: `not json`,
+			want: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := countListedTasks([]byte(tc.body)); got != tc.want {
+				t.Errorf("countListedTasks(%s) = %d, want %d", tc.body, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`a2a-task-idor-001` probes the REST task-list paths unauthenticated, and decided a
server had disclosed tasks with `ContainsAny("tasks", "contextId", "history")` over the
raw body. Those are **key names**. A server that scopes its list correctly and answers
an anonymous caller with `{"tasks":[],"totalSize":0}` contains `"tasks"`, so it matched.

Measured against exactly that server:

```
FINDING critical/confirmed: A2A server exposes tasks/list without authentication
                            - server-wide task disclosure
```

Nothing was disclosed. An empty list is the *secure* answer to that probe, and this is
the highest-severity instance of the vacuous-needle class corrected in #163 and #169.

`countListedTasks` counts what actually came back, in both the documented
`{"tasks":[...]}` envelope and the bare array some REST bindings return. An element
counts only when it is an object carrying at least one non-empty field, so an empty
list, a list of placeholder objects, and a bare `totalSize` with no tasks all fail to
qualify — something has to have been disclosed before the rule says something was
disclosed.

A `totalSize` of 42 beside an empty array may well indicate unscoped counting, but it
is not a task that can be named, so it is deliberately not this finding.

The count is now evidence too: the finding says how many tasks an unauthenticated
caller received, rather than quoting a body snippet and leaving the reader to judge.

Found while verifying the premise of a proposed `ListTasks` enumeration rule — a
different surface (an *authenticated* caller seeing another principal's tasks, on the
JSON-RPC method), which remains unbuilt.

Verification:

- 10 table cases over the shapes, including the empty envelope, a bare array, and
  placeholder objects
- an end-to-end pair: the empty list must produce no finding, a populated one must still
  produce critical/confirmed **with its count**
- both confirmed by restoring the key-name oracle, which fails the empty-list test
- 46-case fixture sweep against the previous binary: no finding or skip changed