### PR TITLE
rule(a2a): detect ListTasks enumerating another principal's tasks

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -147,7 +147,7 @@ release:
     ## Batesian {{.Version}}
 
     Adversarial red-team CLI for AI agent protocols (A2A and MCP).
-    37 bundled attack rules (17 A2A + 20 MCP). Single binary. No runtime dependencies.
+    38 bundled attack rules (18 A2A + 20 MCP). Single binary. No runtime dependencies.
 
     Every release is published with a cosign signature over `checksums.txt`, a
     CycloneDX SBOM per archive, and SLSA build provenance.

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ CLI for adversarial testing of [A2A](https://a2a-protocol.org) and [MCP](https:/
 
 ## What ships
 
-Bundled rules: **17 A2A, 20 MCP (37 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
+Bundled rules: **18 A2A, 20 MCP (38 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
 
-- [A2A rules](docs/rules-a2a.md) (17)
+- [A2A rules](docs/rules-a2a.md) (18)
 - [MCP rules](docs/rules-mcp.md) (20)
 
 Rules are validated against third-party reference implementations, not only against the bundled fixtures. [Validation results](docs/validation-results.md) records what fires, what correctly stays silent on a server with no authentication at all, and the scanner defects that exercise has found.
@@ -33,7 +33,7 @@ Coverage spans:
 - **OAuth & token validation** - OAuth 2.1 / DCR scope escalation, audience binding, token replay, version-downgrade bypass, forged-token acceptance, redirect_uri confused deputy
 - **Agent-card trust (A2A)** - JWS signatures, canonicalization, cache/freshness, required-extension downgrade, host-header injection, unauthenticated extended card, declared-but-unenforced auth
 - **Request & task integrity** - task IDOR, agent-role injection, artifact tampering, SEP-2243 header/body routing, SSE resumption replay
-- **Multi-party isolation** - cross-tenant isolation, session/context fixation, session id accepted as a credential, delegation chain-of-custody, cross-principal task cancellation, cross-context MCP task and result access
+- **Multi-party isolation** - cross-tenant isolation, cross-principal task enumeration, session/context fixation, session id accepted as a credential, delegation chain-of-custody, cross-principal task cancellation, cross-context MCP task and result access
 - **SSRF & secret leakage** - push-notification SSRF, push control-plane binding, OAuth discovery/metadata SSRF, credential leakage into responses
 - **Unauthenticated & cross-origin access** - exposed MCP tools, resources, prompt templates, completion suggestions, and log-level control, Streamable HTTP Origin validation (DNS rebinding)
 

--- a/docs/rules-a2a.md
+++ b/docs/rules-a2a.md
@@ -1,6 +1,6 @@
 # A2A Attack Rules
 
-Batesian ships **17 rules** targeting the [Agent-to-Agent (A2A) protocol](https://a2a-protocol.org/).
+Batesian ships **18 rules** targeting the [Agent-to-Agent (A2A) protocol](https://a2a-protocol.org/).
 Every rule is an active probe: it sends crafted protocol traffic and judges the
 server's actual response. Rules are deliberately scoped to A2A-specific semantics
 (agent cards, JWS card signatures, tasks/contexts, push notifications, peer
@@ -77,14 +77,15 @@ evidence. A card rule with no card has nothing to say either way.
 
 ### Rules that need a task first
 
-Eight rules cannot say anything until they have created a task: `a2a-task-idor-001`,
+Nine rules cannot say anything until they have created a task: `a2a-task-idor-001`,
 `a2a-push-ssrf-001`, `a2a-session-smuggle-001`, `a2a-context-fixation-001`,
 `a2a-delegation-integrity-001`, `a2a-multitenant-isolation-001`,
-`a2a-push-binding-001` and `a2a-task-cancel-idor-001`. Against an agent that
-enforces authorization, whether they can depends on the credential the scan was
-given, so a failure to create one is reported as **not tested**, naming the refusal
-and whether the request carried a credential at all. A clean result there would
-claim the agent does not leak tasks across principals when no task ever existed.
+`a2a-push-binding-001`, `a2a-task-cancel-idor-001` and `a2a-task-enumeration-001`.
+Against an agent that enforces authorization, whether they can depends on the
+credential the scan was given, so a failure to create one is reported as **not
+tested**, naming the refusal and whether the request carried a credential at all. A
+clean result there would claim the agent does not leak tasks across principals when no
+task ever existed.
 
 Two things stay clean, deliberately. An agent that does not implement the surface
 (`-32601`, or A2A's own `-32003` push-not-supported and `-32004`
@@ -117,6 +118,7 @@ report them not tested against a secured agent, and say so.
 | `a2a-push-binding-001` | [Push/Webhook Control-Plane Not Bound to Task Owner](#a2a-push-binding-001) | High | confirmed | CWE-639 |
 | `a2a-jsonrpc-batch-bypass-001` | [JSON-RPC Batch Authentication Bypass](#a2a-jsonrpc-batch-bypass-001) | High | confirmed | CWE-288 |
 | `a2a-task-cancel-idor-001` | [Cross-Principal Task Cancellation](#a2a-task-cancel-idor-001) | High | confirmed | CWE-639 / CWE-862 |
+| `a2a-task-enumeration-001` | [ListTasks Enumerates Another Principal's Tasks](#a2a-task-enumeration-001) | High | confirmed | CWE-639 / CWE-200 |
 | `a2a-card-security-unenforced-001` | [Agent Card Declares Unenforced Authentication](#a2a-card-security-unenforced-001) | High | confirmed | CWE-287 / CWE-306 |
 
 ---
@@ -499,3 +501,55 @@ case, but only when the card promised authentication, making it an attributable
 contract violation (CWE-287 / CWE-306). It is distinct from `a2a-extcard-unauth-001`
 (the extended-card endpoint) and `a2a-card-trust-001` / `a2a-jws-algconf-001` (card
 signatures).
+
+---
+
+### a2a-task-enumeration-001
+
+**ListTasks Enumerates Another Principal's Tasks** | Severity: High | CWE-639 / CWE-200
+
+Tests whether one authenticated principal can enumerate another's tasks through
+`ListTasks`. The specification requires the opposite twice: section 3.1.4, on
+`ListTasks` itself, states that "Implementations **MUST** implement appropriate
+authorization scoping to ensure clients can only access authorized tasks", and section
+13.1 that "Servers **MUST** return only tasks visible to the authenticated client".
+
+Enumeration is worse than reading a task by id, because it needs no prior knowledge.
+One valid credential yields every task identifier on the server, and those identifiers
+are what the per-task read, cancel and push-notification-config surfaces take as input.
+
+**A distinct surface**, not a second look at an existing one.
+`a2a-multitenant-isolation-001` reads a task **by id**, so it only shows that a caller
+who already knows an identifier can fetch it. `a2a-task-idor-001` probes the REST list
+paths **anonymously**, so a server that correctly requires a credential passes it and
+can still hand every tenant's tasks to any authenticated caller. The listing is
+separate code from the per-task fetch, and a server can scope one and not the other:
+the fetch has an obvious owner to compare against, while the list has to be filtered.
+
+Two principals are required, and three controls keep it off servers where the listing
+is not what decided the outcome:
+
+1. Principal A creates a task. A refused creation is reported as **not tested**, naming
+   the refusal, rather than as a scoped listing that was never given anything to leak.
+2. Control: A lists its own tasks and must see the task it just created. No list method
+   at all (`-32601` on every spelling) is **clean**, the surface being absent. A refused
+   listing, or one that omits the owner's own task, is **not tested**: B seeing nothing
+   would prove nothing.
+3. Control: an **unauthenticated** `ListTasks`. If it returns A's task, the server
+   enforces no authorization on this surface at all, which is `a2a-task-idor-001`'s
+   finding; reporting it here too would count one defect twice.
+4. Principal B lists. A's task id appearing in B's response is the **confirmed**
+   finding.
+
+Identifiers are compared, never key names, and history is deliberately not requested
+(`historyLength` 0): the failure is that the identifiers came back, and pulling another
+tenant's conversation content to prove it would be gratuitous. `pageSize` is set high
+so a scoped server has no pagination excuse for omitting a task.
+
+Currency: `ListTasks` is a v1.0 JSON-RPC method. v0.3 defines `tasks/get`,
+`tasks/cancel`, `tasks/resubscribe` and the push-notification-config methods, and no
+list method, so a v0.3-only agent answers `-32601` and this reports not applicable. The
+v0.3 REST binding's list path is covered anonymously by `a2a-task-idor-001`; the
+authenticated case on that binding is not probed, because its prefix belongs to the
+deployment and guessing it is how earlier rules came to post at paths that never
+existed.

--- a/internal/attack/a2a/posture_matrix_test.go
+++ b/internal/attack/a2a/posture_matrix_test.go
@@ -114,6 +114,8 @@ func (a *matrixAgent) serve(w http.ResponseWriter, r *http.Request) {
 		a.get(w, id, params, caller, method == "GetTask")
 	case "CancelTask", "tasks/cancel":
 		a.cancel(w, id, params, caller, method == "CancelTask")
+	case "ListTasks", "tasks/list":
+		a.list(w, id, caller, method == "ListTasks")
 	case "CreateTaskPushNotificationConfig", "tasks/pushNotificationConfig/set":
 		a.setPush(w, id, params, caller)
 	default:
@@ -207,6 +209,31 @@ func (a *matrixAgent) cancel(w http.ResponseWriter, id, params interface{}, call
 	a.writeTask(w, id, t, v1, false)
 }
 
+// list is ListTasks: scoped to the caller under secured, every task under idor. The
+// specification requires scoping twice, in sections 3.1.4 and 13.1.
+func (a *matrixAgent) list(w http.ResponseWriter, id interface{}, caller string, v1 bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	visible := []interface{}{}
+	for _, t := range a.tasks {
+		if !a.mayTouch(t, caller) {
+			continue
+		}
+		state := t.state
+		if v1 {
+			state = "TASK_STATE_" + strings.ToUpper(t.state)
+		}
+		visible = append(visible, map[string]interface{}{
+			"id": t.id, "contextId": t.ctxID,
+			"status": map[string]interface{}{"state": state},
+		})
+	}
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"jsonrpc": "2.0", "id": id,
+		"result": map[string]interface{}{"tasks": visible, "totalSize": len(visible)},
+	})
+}
+
 func (a *matrixAgent) setPush(w http.ResponseWriter, id, params interface{}, caller string) {
 	p, _ := params.(map[string]interface{})
 	taskID, _ := p["taskId"].(string)
@@ -294,6 +321,9 @@ func TestA2APostureMatrix(t *testing.T) {
 		}, true},
 		{"a2a-push-binding-001", func(rc attack.RuleContext) attack.Executor {
 			return a2aattack.NewPushBindingExecutor(rc)
+		}, true},
+		{"a2a-task-enumeration-001", func(rc attack.RuleContext) attack.Executor {
+			return a2aattack.NewTaskEnumerationExecutor(rc)
 		}, true},
 		// Not ownership-sensitive: its oracle is an ANONYMOUS read, which both
 		// postures refuse. It is here as a false-positive control, since it is the

--- a/internal/attack/a2a/task_enumeration.go
+++ b/internal/attack/a2a/task_enumeration.go
@@ -1,0 +1,265 @@
+package a2a
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// TaskEnumerationExecutor tests whether one authenticated principal can enumerate
+// another's tasks through ListTasks (rule a2a-task-enumeration-001).
+//
+// The specification is explicit twice over. Section 3.1.4, on ListTasks itself:
+// "Implementations MUST implement appropriate authorization scoping to ensure clients
+// can only access authorized tasks." Section 13.1: "Servers MUST return only tasks
+// visible to the authenticated client."
+//
+// This is a different surface from the rules that already exist, not a second look at
+// the same one:
+//
+//   - a2a-multitenant-isolation-001 reads a task BY ID, so it only proves a caller
+//     who already knows an identifier can fetch it. Enumeration needs no prior
+//     knowledge, which is what makes it worse: an attacker with one valid credential
+//     learns every task id on the server and then has everything the read rules need.
+//   - a2a-task-idor-001 probes the REST list paths ANONYMOUSLY. A server that
+//     correctly requires a credential passes that and can still hand every tenant's
+//     tasks to any authenticated caller.
+//   - The listing endpoint is separate code from the per-task fetch, so a server can
+//     scope one and not the other, and commonly does: the fetch has an obvious owner
+//     to compare against while the list has to be filtered.
+//
+// Currency: ListTasks is a v1.0 JSON-RPC method. The v0.3 revision defines
+// tasks/get, tasks/cancel, tasks/resubscribe and the push-notification-config
+// methods, and no list method at all, so a v0.3-only agent answers -32601 and the
+// rule reports itself not applicable. The v0.3 REST binding's list path is covered
+// anonymously by a2a-task-idor-001; the authenticated cross-principal case on that
+// binding is not probed here, deliberately, because the prefix belongs to the
+// deployment and guessing it is how earlier rules came to POST at paths that never
+// existed.
+type TaskEnumerationExecutor struct {
+	rule attack.RuleContext
+}
+
+func init() {
+	attack.Register("a2a-task-enumeration", func(rc attack.RuleContext) attack.Executor {
+		return NewTaskEnumerationExecutor(rc)
+	})
+}
+
+func NewTaskEnumerationExecutor(r attack.RuleContext) *TaskEnumerationExecutor {
+	return &TaskEnumerationExecutor{rule: r}
+}
+
+func (e *TaskEnumerationExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
+	// Two distinct identities are the premise: the question is whether B sees A's
+	// task, which cannot be asked with one principal. See twoPrincipals.
+	a, b, err := twoPrincipals(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	vars := attack.NewVars(target, opts.OOBListenerURL)
+	endpoint, ok := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
+	if !ok {
+		return nil, attack.ErrInconclusive
+	}
+
+	clientA := principalClient(opts, vars, a)
+	clientB := principalClient(opts, vars, b)
+	unauthClient := attack.NewUnauthHTTPClient(opts, attack.NewVars(target, opts.OOBListenerURL))
+
+	// Step 1: A owns a task. Without one there is nothing for B to find, and a clean
+	// result would claim the listing is scoped having never given it anything to leak.
+	taskID, _, _, obs := e.createTask(ctx, clientA, endpoint, a, vars.RandID)
+	if taskID == "" {
+		return nil, obs.err()
+	}
+
+	// Step 2: is the listing implemented at all? Asked as A, who owns a task and so
+	// should see at least one, which also confirms the surface works before any
+	// conclusion is drawn about B.
+	ownList, ownOutcome := e.listTasks(ctx, clientA, endpoint, a.Headers, vars.RandID)
+	switch ownOutcome {
+	case listAbsent:
+		// No list method here. Nothing to scope, and nothing wrong: the same call the
+		// OAuth-gated rules make for a server exposing no OAuth.
+		return nil, nil
+	case listRefused:
+		return nil, fmt.Errorf("%w: ListTasks at %s was refused for the task's own owner (%s), "+
+			"so whether the listing is scoped to the caller could not be established",
+			attack.ErrInconclusive, endpoint, a.Name)
+	}
+	if !containsTaskID(ownList, taskID) {
+		// The owner cannot see their own task, so this listing does not enumerate what
+		// the rule assumes it enumerates and B seeing nothing would prove nothing.
+		return nil, fmt.Errorf("%w: ListTasks at %s did not return principal %s's own task %s, "+
+			"so the listing does not enumerate the tasks this rule compares against",
+			attack.ErrInconclusive, endpoint, a.Name, taskID)
+	}
+
+	// Step 3: open-server discriminator. If an UNAUTHENTICATED list returns A's task,
+	// the server enforces no authorization on this surface at all. That is a2a-task-
+	// idor-001's finding, not a scoping failure between two valid principals, and
+	// reporting it here would double-count one defect as two.
+	if anonList, anonOutcome := e.listTasks(ctx, unauthClient, endpoint, nil, vars.RandID); anonOutcome == listOK &&
+		containsTaskID(anonList, taskID) {
+		return nil, nil
+	}
+
+	// Step 4: B lists. A's task appearing in it is the finding: B is authenticated,
+	// holds no claim to A's task, and was handed its identifier anyway.
+	otherList, otherOutcome := e.listTasks(ctx, clientB, endpoint, b.Headers, vars.RandID)
+	if otherOutcome != listOK {
+		// B cannot list at all, which is one legitimate way to scope the surface.
+		return nil, nil
+	}
+	if !containsTaskID(otherList, taskID) {
+		return nil, nil // scoped: B's listing does not include A's task
+	}
+
+	return []attack.Finding{e.finding(endpoint, a, b, taskID, otherList)}, nil
+}
+
+// listOutcome distinguishes the three answers a listing attempt can give, because
+// they mean different things: absent is not applicable, refused is untested, and only
+// an answered list can be judged.
+type listOutcome int
+
+const (
+	listOK listOutcome = iota
+	// listAbsent is -32601 on every spelling tried: the method is not implemented.
+	listAbsent
+	// listRefused is any other failure, including an authorization refusal.
+	listRefused
+)
+
+// listTasks asks for the caller's tasks and returns the identifiers it received.
+//
+// pageSize is set high enough that a scoped server has no pagination excuse for
+// omitting a task, and historyLength is zero because this rule needs identifiers
+// rather than conversation content: enumerating ids is the failure, and pulling
+// another tenant's message history to prove it would be gratuitous.
+func (e *TaskEnumerationExecutor) listTasks(ctx context.Context, c *attack.HTTPClient, endpoint string,
+	extraHeaders map[string]string, randID string) ([]string, listOutcome) {
+	attempts := []struct {
+		method  string
+		headers map[string]string
+	}{
+		{"ListTasks", withV1Version(extraHeaders)},
+		// v0.3 defines no list method, so this only reaches an implementation that
+		// chose the slash spelling anyway. It costs one request on a path that would
+		// otherwise report the surface absent.
+		{"tasks/list", extraHeaders},
+	}
+
+	absentEverywhere := true
+	for _, at := range attempts {
+		resp, err := c.POST(ctx, endpoint, at.headers, map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      "batesian-enum-" + randID,
+			"method":  at.method,
+			"params":  map[string]interface{}{"pageSize": 100, "historyLength": 0},
+		})
+		if err != nil {
+			absentEverywhere = false
+			continue
+		}
+		if resp.IsAccepted() {
+			return listedTaskIDs(resp.Body), listOK
+		}
+		if code, hasErr := jsonRPCErrorCode(resp.Body); !hasErr || code != jsonRPCMethodNotFound {
+			// Something other than "no such method": a refusal that says nothing about
+			// scoping.
+			absentEverywhere = false
+		}
+	}
+	if absentEverywhere {
+		return nil, listAbsent
+	}
+	return nil, listRefused
+}
+
+// withV1Version adds the v1.0 revision header to a principal's own headers without
+// mutating them.
+func withV1Version(extra map[string]string) map[string]string {
+	h := map[string]string{"A2A-Version": "1.0"}
+	for k, v := range extra {
+		h[k] = v
+	}
+	return h
+}
+
+// createTask establishes a task owned by p, trying the v1.0 method name then the v0.3
+// one. The observation is returned so a caller that got no task can say why rather
+// than reporting a scoped listing it never tested.
+func (e *TaskEnumerationExecutor) createTask(ctx context.Context, c *attack.HTTPClient, endpoint string,
+	p attack.Principal, randID string) (taskID, contextID string, accepted bool, obs setupObservation) {
+	resp, err := c.POST(ctx, endpoint, withV1Version(p.Headers), map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      "batesian-enum-create-" + p.Name + "-" + randID,
+		"method":  "SendMessage",
+		"params": map[string]interface{}{
+			"message": map[string]interface{}{
+				"role":      1, // ROLE_USER
+				"parts":     []interface{}{map[string]string{"text": "batesian enumeration probe " + randID}},
+				"messageId": "batesian-enum-" + p.Name + "-" + randID,
+			},
+		},
+	})
+	if err != nil || !resp.IsAccepted() {
+		obs.observe(classifyTaskSetup("creating a probe task as principal "+p.Name, endpoint,
+			c.PresentsCredential(endpoint), resp))
+		resp, err = c.POST(ctx, endpoint, p.Headers, map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      "batesian-enum-create-" + p.Name + "-" + randID,
+			"method":  "message/send",
+			"params": map[string]interface{}{
+				"message": map[string]interface{}{
+					"role":      "user",
+					"parts":     []interface{}{map[string]string{"kind": "text", "text": "batesian enumeration probe " + randID}},
+					"messageId": "batesian-enum-" + p.Name + "-" + randID,
+				},
+			},
+		})
+	}
+	if err != nil || !resp.IsAccepted() {
+		obs.observe(classifyTaskSetup("creating a probe task as principal "+p.Name, endpoint,
+			c.PresentsCredential(endpoint), resp))
+		return "", "", false, obs
+	}
+	taskID, contextID = extractTaskContext(resp.Body)
+	if taskID == "" {
+		obs.observe(classifyTaskSetup("creating a probe task as principal "+p.Name, endpoint,
+			c.PresentsCredential(endpoint), resp))
+	}
+	return taskID, contextID, taskID != "", obs
+}
+
+func (e *TaskEnumerationExecutor) finding(endpoint string, a, b attack.Principal,
+	taskID string, otherList []string) attack.Finding {
+	return attack.Finding{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "high",
+		Confidence: attack.ConfirmedExploit,
+		Title:      "A2A ListTasks enumerates another principal's tasks (broken authorization scoping)",
+		Description: fmt.Sprintf(
+			"ListTasks at %s returned principal %s's task to principal %s, who has no claim to it. "+
+				"The specification requires the opposite twice: section 3.1.4 states that "+
+				"implementations MUST implement appropriate authorization scoping so clients can only "+
+				"access authorized tasks, and section 13.1 that servers MUST return only tasks visible "+
+				"to the authenticated client. Enumeration is worse than reading a task by id, because "+
+				"it needs no prior knowledge: one valid credential yields every task identifier on the "+
+				"server, and those identifiers are what the per-task read, cancel and push-config "+
+				"surfaces take as input.", endpoint, a.Name, b.Name),
+		Evidence: fmt.Sprintf(
+			"endpoint: %s\ntask owner: %s (tenant %s)\nenumerating principal: %s (tenant %s)\n"+
+				"task created by %s: %s\ntask ids returned to %s: %v\n"+
+				"unauthenticated ListTasks: did not return the task, so authorization is enforced "+
+				"and the failure is scoping between valid principals",
+			endpoint, a.Name, a.Tenant, b.Name, b.Tenant, a.Name, taskID, b.Name, otherList),
+		Remediation: e.rule.Remediation,
+		TargetURL:   endpoint,
+	}
+}

--- a/internal/attack/a2a/task_enumeration_test.go
+++ b/internal/attack/a2a/task_enumeration_test.go
@@ -1,0 +1,333 @@
+package a2a_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	a2aattack "github.com/calbebop/batesian/internal/attack/a2a"
+)
+
+// a2a-task-enumeration-001 asks whether one authenticated principal can enumerate
+// another's tasks. Both directions are covered by the posture matrix; these are the
+// controls it cannot reach, each of which is a way for the rule to be wrong without
+// the matrix noticing.
+
+// enumBehaviour decides how the fixture answers ListTasks.
+type enumBehaviour int
+
+const (
+	// enumUnscoped returns every task to any authenticated caller: the finding.
+	enumUnscoped enumBehaviour = iota
+	// enumAbsent implements no list method at all.
+	enumAbsent
+	// enumRefused answers the list with an authorization error.
+	enumRefused
+	// enumOwnerBlind implements the list but never returns the caller's own task.
+	enumOwnerBlind
+	// enumWideOpen returns every task to ANYONE, including an anonymous caller.
+	enumWideOpen
+)
+
+// enumAgent is an A2A agent whose ListTasks behaviour is configurable. Task creation
+// always works for a known token, so a failure here is about the listing.
+func enumAgent(t *testing.T, behaviour enumBehaviour) *httptest.Server {
+	t.Helper()
+	type task struct{ id, ctxID, owner string }
+	tasks := map[string]*task{}
+	n := 0
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/.well-known/") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"name":"Enum Agent","description":"d","version":"1.0.0",`+
+				`"protocolVersion":"1.0","capabilities":{},"skills":[],`+
+				`"supportedInterfaces":[{"url":"http://`+r.Host+`/","protocolBinding":"JSONRPC","protocolVersion":"1.0"}]}`)
+			return
+		}
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		method, _ := req["method"].(string)
+		id := req["id"]
+		w.Header().Set("Content-Type", "application/json")
+
+		caller := ""
+		switch r.Header.Get("Authorization") {
+		case "Bearer tok-a":
+			caller = "a"
+		case "Bearer tok-b":
+			caller = "b"
+		}
+
+		rpcErr := func(code int, msg string) {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": code, "message": msg},
+			})
+		}
+
+		switch method {
+		case "SendMessage", "message/send":
+			if caller == "" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			n++
+			tk := &task{id: "task-" + string(rune('0'+n)), ctxID: "ctx", owner: caller}
+			tasks[tk.id] = tk
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{"task": map[string]interface{}{
+					"id": tk.id, "contextId": tk.ctxID,
+					"status": map[string]interface{}{"state": "TASK_STATE_SUBMITTED"},
+				}},
+			})
+		case "ListTasks", "tasks/list":
+			if behaviour == enumAbsent {
+				rpcErr(-32601, "Method not found")
+				return
+			}
+			if behaviour == enumRefused {
+				rpcErr(-32600, "not authorized to list tasks")
+				return
+			}
+			if caller == "" && behaviour != enumWideOpen {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			out := []interface{}{}
+			for _, tk := range tasks {
+				if behaviour == enumOwnerBlind {
+					continue // implements the list, never returns anything
+				}
+				out = append(out, map[string]interface{}{"id": tk.id, "contextId": tk.ctxID})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{"tasks": out, "totalSize": len(out)},
+			})
+		default:
+			rpcErr(-32601, "Method not found")
+		}
+	}))
+}
+
+func enumOpts() attack.Options {
+	return attack.Options{
+		TimeoutSeconds: 5,
+		Principals: []attack.Principal{
+			{Name: "a", Token: "tok-a", Tenant: "A"},
+			{Name: "b", Token: "tok-b", Tenant: "B"},
+		},
+	}
+}
+
+func runEnum(t *testing.T, srv *httptest.Server, opts attack.Options) ([]attack.Finding, error) {
+	t.Helper()
+	exec := a2aattack.NewTaskEnumerationExecutor(attack.RuleContext{
+		ID: "a2a-task-enumeration-001", Severity: "high",
+	})
+	return exec.Execute(context.Background(), srv.URL, opts)
+}
+
+// The finding: B is authenticated, has no claim to A's task, and its identifier comes
+// back in B's listing.
+func TestTaskEnumeration_UnscopedListingFires(t *testing.T) {
+	srv := enumAgent(t, enumUnscoped)
+	defer srv.Close()
+
+	findings, err := runEnum(t, srv, enumOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected the enumeration finding, got %d", len(findings))
+	}
+	f := findings[0]
+	if f.Severity != "high" || f.Confidence != attack.ConfirmedExploit {
+		t.Errorf("want high/ConfirmedExploit, got %s/%s", f.Severity, f.Confidence)
+	}
+	// The evidence has to name both principals and the task, or the claim is not
+	// checkable by the person reading it.
+	for _, want := range []string{"task owner: a", "enumerating principal: b", "task ids returned to b"} {
+		if !strings.Contains(f.Evidence, want) {
+			t.Errorf("evidence missing %q; got:\n%s", want, f.Evidence)
+		}
+	}
+}
+
+// An agent that implements no list method has nothing to scope. That is not
+// applicable rather than insecure, the same call the OAuth-gated rules make for a
+// server exposing no OAuth, and it must not be reported as either a finding or a
+// failure to test.
+func TestTaskEnumeration_NoListMethodIsClean(t *testing.T) {
+	srv := enumAgent(t, enumAbsent)
+	defer srv.Close()
+
+	findings, err := runEnum(t, srv, enumOpts())
+	if err != nil {
+		t.Fatalf("an agent without ListTasks is not applicable, not untested: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected no findings, got %d", len(findings))
+	}
+}
+
+// The listing is refused even for the owner, so whether it is scoped was never
+// established. Reporting that clean would claim a property this rule did not test.
+func TestTaskEnumeration_RefusedListingIsNotTested(t *testing.T) {
+	srv := enumAgent(t, enumRefused)
+	defer srv.Close()
+
+	findings, err := runEnum(t, srv, enumOpts())
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "refused for the task's own owner") {
+		t.Errorf("the reason should say the owner's own listing was refused; got: %v", err)
+	}
+}
+
+// The agent implements ListTasks and returns nothing, even to the task's owner. B
+// seeing nothing then proves nothing about scoping, so this is not tested rather than
+// clean: without this control, any server with a broken listing would look scoped.
+func TestTaskEnumeration_OwnerCannotSeeOwnTaskIsNotTested(t *testing.T) {
+	srv := enumAgent(t, enumOwnerBlind)
+	defer srv.Close()
+
+	findings, err := runEnum(t, srv, enumOpts())
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "did not return principal a's own task") {
+		t.Errorf("the reason should name the owner's missing task; got: %v", err)
+	}
+}
+
+// A server that lists every task to an ANONYMOUS caller enforces no authorization on
+// this surface at all. That is a2a-task-idor-001's finding, and reporting it here as
+// well would count one defect twice.
+func TestTaskEnumeration_WideOpenBelongsToTaskIDOR(t *testing.T) {
+	srv := enumAgent(t, enumWideOpen)
+	defer srv.Close()
+
+	findings, err := runEnum(t, srv, enumOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("a server with no authorization at all is task-idor's finding, not this "+
+			"rule's; got %d: %+v", len(findings), findings)
+	}
+}
+
+// Two identities are the premise: the question is whether B sees A's task. With one
+// principal, or none, there is no comparison to make and the rule must say so rather
+// than call the target clean.
+func TestTaskEnumeration_NeedsTwoPrincipals(t *testing.T) {
+	srv := enumAgent(t, enumUnscoped)
+	defer srv.Close()
+
+	for _, tc := range []struct {
+		name string
+		opts attack.Options
+	}{
+		{"no principals", attack.Options{TimeoutSeconds: 5}},
+		{"one principal", attack.Options{TimeoutSeconds: 5, Principals: []attack.Principal{
+			{Name: "a", Token: "tok-a", Tenant: "A"},
+		}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			findings, err := runEnum(t, srv, tc.opts)
+			if len(findings) != 0 {
+				t.Fatalf("expected no findings, got %d", len(findings))
+			}
+			if !errors.Is(err, attack.ErrInconclusive) {
+				t.Fatalf("expected ErrInconclusive, got %v", err)
+			}
+		})
+	}
+}
+
+// Identifiers, never key names. A scoped server returns a NON-EMPTY list to B
+// containing only B's own task, which is the case a key-name oracle would fire on:
+// the body contains "tasks" and a task id, just not A's.
+func TestTaskEnumeration_ScopedListingWithOwnTasksIsClean(t *testing.T) {
+	// Each caller sees exactly their own task, so both lists are non-empty.
+	type task struct{ id, owner string }
+	tasks := map[string]*task{}
+	n := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/.well-known/") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"name":"Scoped","description":"d","version":"1.0.0",`+
+				`"protocolVersion":"1.0","capabilities":{},"skills":[],`+
+				`"supportedInterfaces":[{"url":"http://`+r.Host+`/","protocolBinding":"JSONRPC","protocolVersion":"1.0"}]}`)
+			return
+		}
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		method, _ := req["method"].(string)
+		id := req["id"]
+		caller := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer tok-")
+		w.Header().Set("Content-Type", "application/json")
+		if caller != "a" && caller != "b" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		switch method {
+		case "SendMessage", "message/send":
+			n++
+			tk := &task{id: "t" + string(rune('0'+n)), owner: caller}
+			tasks[tk.id] = tk
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{"task": map[string]interface{}{
+					"id": tk.id, "contextId": "ctx-" + caller,
+				}},
+			})
+		case "ListTasks", "tasks/list":
+			out := []interface{}{}
+			for _, tk := range tasks {
+				if tk.owner == caller {
+					out = append(out, map[string]interface{}{"id": tk.id, "contextId": "ctx-" + caller})
+				}
+			}
+			// B's own task, so B can list and gets a non-empty answer.
+			if caller == "b" && len(out) == 0 {
+				out = append(out, map[string]interface{}{"id": "t-b-own", "contextId": "ctx-b"})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{"tasks": out, "totalSize": len(out)},
+			})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": -32601, "message": "Method not found"},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	findings, err := runEnum(t, srv, enumOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("B's listing contains only B's own task, so the surface is scoped; got %d: %+v",
+			len(findings), findings)
+	}
+}

--- a/internal/attack/a2a/taskref.go
+++ b/internal/attack/a2a/taskref.go
@@ -118,3 +118,66 @@ func countNonEmpty(items []map[string]json.RawMessage) int {
 	}
 	return n
 }
+
+// listedTaskIDs returns the task identifiers a list response carried.
+//
+// Identifiers, never key names: a2a-task-enumeration-001 asks whether one
+// principal's task appears in another principal's listing, and that question can only
+// be answered by comparing ids. The same body-shape knowledge as countListedTasks
+// lives here so the two cannot disagree about what a list looks like.
+//
+// Three envelopes are read. ListTasks over JSON-RPC answers {"result":{"tasks":[...]}}
+// and, unlike a send-style reply, is not a oneof, so the tasks sit directly under
+// result. The other two are the bare {"tasks":[...]} and the plain array that REST
+// bindings return.
+func listedTaskIDs(body []byte) []string {
+	type task struct {
+		ID     string `json:"id"`
+		TaskID string `json:"taskId"`
+	}
+	collect := func(tasks []task) []string {
+		out := make([]string, 0, len(tasks))
+		for _, t := range tasks {
+			switch {
+			case t.ID != "":
+				out = append(out, t.ID)
+			case t.TaskID != "":
+				out = append(out, t.TaskID)
+			}
+		}
+		return out
+	}
+
+	var wrapped struct {
+		Result *struct {
+			Tasks []task `json:"tasks"`
+		} `json:"result"`
+		Tasks []task `json:"tasks"`
+	}
+	if json.Unmarshal(body, &wrapped) == nil {
+		if wrapped.Result != nil && wrapped.Result.Tasks != nil {
+			return collect(wrapped.Result.Tasks)
+		}
+		if wrapped.Tasks != nil {
+			return collect(wrapped.Tasks)
+		}
+	}
+	var bare []task
+	if json.Unmarshal(body, &bare) == nil {
+		return collect(bare)
+	}
+	return nil
+}
+
+// containsTaskID reports whether ids includes want.
+func containsTaskID(ids []string, want string) bool {
+	if want == "" {
+		return false
+	}
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}

--- a/rules/a2a/task-enumeration-001.yaml
+++ b/rules/a2a/task-enumeration-001.yaml
@@ -1,0 +1,96 @@
+id: a2a-task-enumeration-001
+info:
+  name: A2A ListTasks Enumerates Another Principal's Tasks
+  author: batesian
+  severity: high
+  description: |
+    Tests whether one authenticated principal can enumerate another's tasks through
+    ListTasks. The specification requires the opposite twice. Section 3.1.4, on
+    ListTasks itself: "Implementations MUST implement appropriate authorization
+    scoping to ensure clients can only access authorized tasks." Section 13.1:
+    "Servers MUST return only tasks visible to the authenticated client."
+
+    Enumeration is worse than reading a task by id, because it needs no prior
+    knowledge. One valid credential yields every task identifier on the server, and
+    those identifiers are exactly what the per-task read, cancel and
+    push-notification-config surfaces take as input. A tenant that can list becomes a
+    tenant that can act.
+
+    This is a distinct surface from the rules that already exist, not a second look
+    at the same one:
+
+      - a2a-multitenant-isolation-001 reads a task BY ID, so it only shows that a
+        caller who already knows an identifier can fetch it.
+      - a2a-task-idor-001 probes the REST list paths ANONYMOUSLY. A server that
+        correctly requires a credential passes that check and can still hand every
+        tenant's tasks to any authenticated caller.
+      - The listing endpoint is separate code from the per-task fetch, and a server
+        can scope one and not the other. The fetch has an obvious owner to compare
+        against; the list has to be filtered, which is the step implementations miss.
+
+    The rule needs two principals, and confirms the failure with three controls so it
+    cannot fire on a server that implements no listing, one whose listing is broken
+    for its own owner, or one that enforces no authorization at all:
+
+      1. Principal A creates a task. Without one there is nothing for B to find, and
+         reporting the listing scoped would claim a property never tested. A refused
+         creation is reported as not tested, naming the refusal.
+      2. Control: A lists its own tasks and must see the task it just created. If
+         ListTasks is not implemented (-32601 on every spelling) the surface is absent
+         and the rule does not apply. If it is refused, or does not return the owner's
+         own task, the listing is not the thing this rule compares against and the
+         result is not tested rather than clean.
+      3. Control: an UNAUTHENTICATED ListTasks. If it returns A's task the server
+         enforces no authorization on this surface at all, which is
+         a2a-task-idor-001's finding; reporting it here would count one defect twice.
+      4. Principal B lists. A's task id appearing in B's response is the finding: B is
+         authenticated, holds no claim to the task, and was handed its identifier.
+
+    Identifiers are compared, never key names. An earlier version of a sibling check
+    matched the key name "tasks" and so fired on an empty list; the oracle here is
+    whether A's specific task id appears among the ids B received.
+
+    History is deliberately not requested (historyLength 0). The failure is that the
+    identifiers came back at all, and pulling another tenant's conversation content to
+    prove it would be gratuitous. pageSize is set high so a scoped server has no
+    pagination excuse for omitting a task.
+
+    Currency: ListTasks is a v1.0 JSON-RPC method. The v0.3 revision defines
+    tasks/get, tasks/cancel, tasks/resubscribe and the push-notification-config
+    methods, and no list method, so a v0.3-only agent answers -32601 and this reports
+    not applicable. The v0.3 REST binding's list path is covered anonymously by
+    a2a-task-idor-001; the authenticated case on that binding is not probed, because
+    its prefix belongs to the deployment and guessing it is how earlier rules came to
+    post at paths that never existed.
+
+  references:
+    - https://a2a-protocol.org/latest/specification/
+    - https://cwe.mitre.org/data/definitions/639.html
+    - https://cwe.mitre.org/data/definitions/200.html
+    - https://owasp.org/API-Security/editions/2023/en/0xa1-broken-object-level-authorization/
+
+  tags:
+    - a2a
+    - authorization
+    - multi-tenant
+    - enumeration
+    - cwe-639
+    - cwe-200
+
+attack:
+  protocol: a2a
+  type: a2a-task-enumeration
+
+remediation: |
+  1. Filter ListTasks by the authenticated principal. Resolve the caller's identity
+     from the credential on the request and return only tasks that identity owns, in
+     the query itself rather than after the fact.
+  2. Do not treat a task store as shared by default. Scope it per tenant or per
+     principal, so a listing that forgets to filter returns nothing rather than
+     everything.
+  3. Apply the same rule to the count and pagination fields. A totalSize computed over
+     every task discloses the volume of other tenants' work even when the returned
+     page is filtered correctly.
+  4. Test the listing separately from the per-task fetch. They are different code
+     paths, and scoping one does not scope the other; the fetch has an owner to
+     compare against, the list has to be filtered.

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -31,7 +31,7 @@ a run that treats it as a clean result is reporting coverage it does not have.
 
 ## Server Registry
 
-The bundled rule set is **17 A2A + 20 MCP = 37 rules**. Every rule's primary
+The bundled rule set is **18 A2A + 20 MCP = 38 rules**. Every rule's primary
 validation is an in-process `net/http/httptest` harness in its Go
 `*_test.go` (multiple server postures: vulnerable must fire / patched / open /
 benign must stay silent). The Python servers below are optional standalone
@@ -50,7 +50,7 @@ fixtures for live-validation / manual smoke testing.
 | `a2a_batch_bypass_server.py` | 3108 | `a2a-jsonrpc-batch-bypass-001` |
 | `a2a_task_cancel_server.py` | 3109 | `a2a-task-cancel-idor-001` (two principals; needs two `--principal`s) |
 | `a2a_card_security_unenforced_server.py` | 3110 | `a2a-card-security-unenforced-001` |
-| `a2a_secured_agent.py` | 3111 | negative control, two postures: NO rule may fire on `secured`; `a2a-multitenant-isolation-001`, `a2a-delegation-integrity-001`, `a2a-task-cancel-idor-001` and `a2a-push-binding-001` must all fire on `idor` (needs `--token tok-a` and two principals, see below) |
+| `a2a_secured_agent.py` | 3111 | negative control, two postures: NO rule may fire on `secured`; `a2a-multitenant-isolation-001`, `a2a-delegation-integrity-001`, `a2a-task-cancel-idor-001`, `a2a-push-binding-001` and `a2a-task-enumeration-001` must all fire on `idor` (needs `--token tok-a` and two principals, see below) |
 | `mcp_unauth_resources_server.py` | 7787 | `mcp-resources-unauth-001` |
 | `mcp_oauth_dcr_server.py` | 7788 | `mcp-oauth-dcr-001` (two postures, see below; tracks registrations at `/__clients`) |
 | `mcp_oauth_audience_server.py` | 7785 | `mcp-oauth-audience-002` (four sub-paths, one per bug class; target each, not the root) |
@@ -72,7 +72,7 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_transient_failure_server.py` | 7802 | the unauth family when a probe fails without refusing, see below |
 | `mcp_session_as_credential_server.py` | 7803 | `mcp-session-as-credential-001` (needs `--token tok-a`; four postures, see below) |
 
-**Coverage.** 36 of the 37 rules have a standalone Python fixture above, and each
+**Coverage.** 37 of the 38 rules have a standalone Python fixture above, and each
 of those was checked by actually running it rather than by reading this table. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
 (`internal/attack/mcp/token_replay_test.go`); the same is true of the per-rule
@@ -231,7 +231,7 @@ this directory.
 
 ```sh
 python testdata/a2a_secured_agent.py secured  # NO rule may fire: any finding is a false positive
-python testdata/a2a_secured_agent.py idor     # the four ownership rules must all fire
+python testdata/a2a_secured_agent.py idor     # the five ownership rules must all fire
 ```
 
 Ownership enforcement is the only difference between the two postures, which is what

--- a/testdata/a2a_secured_agent.py
+++ b/testdata/a2a_secured_agent.py
@@ -22,9 +22,11 @@ Postures, selected by the first argument:
             continuations, cancels and push-config writes. Any finding here is a
             FALSE POSITIVE.
   idor      a bearer token is required but ownership is NOT enforced: any valid
-            token may act on any task. a2a-multitenant-isolation-001,
-            a2a-delegation-integrity-001, a2a-task-cancel-idor-001 and
-            a2a-push-binding-001 MUST fire. Silence here is a false negative.
+            token may act on any task, and ListTasks returns every task rather than
+            the caller's. a2a-multitenant-isolation-001,
+            a2a-delegation-integrity-001, a2a-task-cancel-idor-001,
+            a2a-push-binding-001 and a2a-task-enumeration-001 MUST fire. Silence here
+            is a false negative.
 
 Ownership is the only difference between the two, which is what makes a diff
 between them mean something.
@@ -178,6 +180,30 @@ def _cancel(req_id, params, caller, v1):
                          "result": _task_body(task_id, v1, nest=False)})
 
 
+def _list(req_id, params, caller, v1):
+    """ListTasks. Scoped to the caller under `secured`, unscoped under `idor`.
+
+    The specification requires scoping twice: section 3.1.4 ("clients can only access
+    authorized tasks") and section 13.1 ("servers MUST return only tasks visible to
+    the authenticated client"). Under `idor` this returns every task, which is what
+    a2a-task-enumeration-001 must catch.
+    """
+    visible = [
+        {
+            "id": task_id,
+            "contextId": t["ctx"],
+            "status": {"state": f"TASK_STATE_{t['state'].upper()}" if v1 else t["state"]},
+        }
+        for task_id, t in TASKS.items()
+        if POSTURE == "idor" or t["owner"] == caller
+    ]
+    return JSONResponse({"jsonrpc": "2.0", "id": req_id, "result": {
+        "tasks": visible,
+        "totalSize": len(visible),
+        "pageSize": (params or {}).get("pageSize", len(visible)),
+    }})
+
+
 def _set_push(req_id, params, caller):
     task_id = (params or {}).get("taskId") or ""
     if task_id not in TASKS:
@@ -231,6 +257,8 @@ async def jsonrpc(request: Request) -> Response:
         return _get(req_id, params, caller, v1=method == "GetTask")
     if method in ("CancelTask", "tasks/cancel"):
         return _cancel(req_id, params, caller, v1=method == "CancelTask")
+    if method in ("ListTasks", "tasks/list"):
+        return _list(req_id, params, caller, v1=method == "ListTasks")
     if method in ("CreateTaskPushNotificationConfig", "tasks/pushNotificationConfig/set"):
         return _set_push(req_id, params, caller)
     return _error(req_id, -32601, "Method not found")
@@ -250,6 +278,6 @@ if __name__ == "__main__":
         print("[*] Expected: no findings. Any finding is a false positive.", flush=True)
     else:
         print("[*] Expected: multitenant-isolation, delegation-integrity, "
-              "task-cancel-idor and push-binding all fire.", flush=True)
+              "task-cancel-idor, push-binding and task-enumeration all fire.", flush=True)
     print("[*] Credentials: --token tok-a plus two principals (tok-a, tok-b)", flush=True)
     uvicorn.run(app, host="127.0.0.1", port=PORT)


### PR DESCRIPTION
Nothing tested whether one authenticated principal can enumerate another's tasks, though
the specification requires the opposite **twice**:

- §3.1.4, on `ListTasks` itself: *"Implementations MUST implement appropriate
  authorization scoping to ensure clients can only access authorized tasks."*
- §13.1: *"Servers MUST return only tasks visible to the authenticated client."*

Enumeration is worse than reading a task by id, because it needs no prior knowledge: one
valid credential yields every task identifier on the server, and those identifiers are
what the per-task read, cancel and push-config surfaces take as input. A tenant that can
list becomes a tenant that can act.

**A distinct surface**, not a second look at an existing one:

| existing rule | what it actually tests | gap |
|---|---|---|
| `a2a-multitenant-isolation-001` | reads a task **by id** | needs the id already |
| `a2a-task-idor-001` | REST list paths **anonymously** | a server that requires a credential passes, and can still hand every tenant's tasks to any authenticated caller |

The listing is separate code from the per-task fetch, and a server can scope one and not
the other — the fetch has an obvious owner to compare against, while the list has to be
filtered.

Two principals are the premise, and **three controls** keep it off servers where the
listing was not what decided the outcome:

1. A lists its own tasks and must see the task it just created. No list method at all is
   **clean** (surface absent); a refused listing, or one omitting the owner's own task, is
   **not tested** — B seeing nothing would prove nothing.
2. An **unauthenticated** `ListTasks` returning A's task means no authorization on this
   surface at all: that is `a2a-task-idor-001`'s finding, and reporting it here would
   count one defect twice.
3. B's listing must contain **A's specific task id**, compared as an identifier. The
   sibling check fixed in #181 matched the key name `"tasks"` and fired on an empty list.

History is deliberately not requested: the failure is that the identifiers came back, and
pulling another tenant's conversation content to prove it would be gratuitous. `pageSize`
is set high so a scoped server has no pagination excuse.

Currency: `ListTasks` is v1.0. v0.3 defines no list method, so a v0.3-only agent answers
`-32601` and this reports not applicable. The v0.3 REST binding's list path is covered
anonymously by `a2a-task-idor-001`; the authenticated case there is not probed, because
its prefix belongs to the deployment and guessing it is how earlier rules came to post at
paths that never existed.

Rule count 37 → 38 (18 A2A, 20 MCP).

Verification:

- 9 cases over the finding and every control; each control confirmed non-vacuous by
  removal. One revert had to be redone: the first attempt left a variable unused, so it
  was a compile error and proved nothing
- both directions in CI via the posture matrix, which now serves `ListTasks` scoped or
  unscoped by posture
- live against `testdata/a2a_secured_agent.py`: silent on `secured`, fires on `idor` with
  evidence naming both principals and the leaked id
- 46-case fixture sweep: the only findings delta is that intended one, and a wide-open
  fixture correctly reports not applicable because it implements no listing