### PR TITLE
feat(mcp): probe Mcp-Name and header-value case, not only Mcp-Method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,11 @@ env/
 *.key
 secrets.yaml
 secrets.json
+# Per-developer agent settings. This file holds an auth token in cleartext, and
+# nothing under .claude/ is tracked, so it was one `git add .` away from being
+# published. Only the local file is ignored: a shared .claude/settings.json remains
+# committable if the project ever wants one.
+.claude/settings.local.json
 
 # IDE
 .vscode/

--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -516,6 +516,28 @@ server that enforces header presence is tested whatever version it advertises, a
 one on 2026-07-28 or later that ignores the header reports clean, since this rule's
 subject is the mismatch rather than the absence.
 
+**Two more dimensions of the same requirement.** `Mcp-Name` is a second REQUIRED
+header, sourced from `params.name` or `params.uri` on `tools/call`, `resources/read`
+and `prompts/get`, carrying the same MUST and the same `-32020`. A server can validate
+`Mcp-Method` and ignore it, and this is the higher-impact instance: an intermediary
+blocklisting a dangerous **tool or resource** inspects the name, not the method. It is
+probed as its own dimension, with the same precondition logic (omission establishes
+whether presence is enforced; it is not itself reported, for consistency with the
+`Mcp-Method` path).
+
+The subject asked for deliberately does not exist, which keeps that dimension
+**read-only**: the oracle is which error comes back, and a server that does not
+validate the header is precisely one that would otherwise act on the body. `tools/call`
+is never used for it, because probing there would invite a non-validating server to
+execute a tool. `Mcp-Param-{Name}` carries the same requirement and is deliberately not
+probed at all, for the same reason: those headers come from `x-mcp-header` annotations
+on a specific tool's schema, so testing one means calling that real annotated tool.
+
+A fourth probe runs only when the plain mismatch was correctly rejected: header names
+are case-insensitive but **values are not**, so `Mcp-Method: TOOLS/LIST` against a body
+of `tools/list` must also be refused. A server that executes it validates the value but
+folds case, and an exact-match intermediary is walked past.
+
 ---
 
 ### mcp-sse-resume-replay-001

--- a/internal/attack/mcp/header_body_split.go
+++ b/internal/attack/mcp/header_body_split.go
@@ -40,6 +40,12 @@ func (e *HeaderBodySplitExecutor) Execute(ctx context.Context, target string, op
 	// merits and never sets this.
 	unawareAt := ""
 	blockedReason := ""
+	// Kept apart from blockedReason so an undetermined Mcp-Name probe can never
+	// override a verdict the Mcp-Method dimension actually reasoned its way to. That
+	// dimension is the rule's headline subject; the name dimension is additive, and an
+	// additive probe that could not decide anything must not turn a considered clean
+	// result into "not tested". It is used only when nothing else had anything to say.
+	nameBlockedReason := ""
 	anyTested := false
 	var findings []attack.Finding
 	for _, session := range sessions {
@@ -53,6 +59,18 @@ func (e *HeaderBodySplitExecutor) Execute(ctx context.Context, target string, op
 		}
 		if blocked != "" && blockedReason == "" {
 			blockedReason = blocked
+		}
+
+		// Mcp-Name is a separate required header on the name-bearing methods, with the
+		// same MUST behind it, and a server can validate Mcp-Method while ignoring it.
+		// It is probed independently so one dimension passing does not hide the other.
+		nf, nameTested, nameBlocked := e.probeName(ctx, client, session)
+		findings = append(findings, labelEra(session, nf)...)
+		if nameTested {
+			anyTested = true
+		}
+		if nameBlocked != "" && nameBlockedReason == "" {
+			nameBlockedReason = nameBlocked
 		}
 	}
 	if len(findings) > 0 {
@@ -89,6 +107,14 @@ func (e *HeaderBodySplitExecutor) Execute(ctx context.Context, target string, op
 	// being sent.
 	if blockedReason != "" {
 		return nil, fmt.Errorf("%w: %s", attack.ErrInconclusive, blockedReason)
+	}
+	// Last resort, and the guard on unawareAt is the point: a wire that carries the
+	// requirement and ignores the header is a REASONED clean result (the observation
+	// was made, it is simply not this rule's subject), so the name dimension failing to
+	// decide must not convert it into "not tested". Only when the Mcp-Method dimension
+	// reached no conclusion whatsoever does the name dimension get to explain the run.
+	if nameBlockedReason != "" && unawareAt == "" {
+		return nil, fmt.Errorf("%w: %s", attack.ErrInconclusive, nameBlockedReason)
 	}
 	return nil, nil
 }
@@ -131,8 +157,21 @@ func (e *HeaderBodySplitExecutor) probe(ctx context.Context, client *attack.HTTP
 
 	// Probe 3: mismatched Mcp-Method. A compliant server MUST reject; if it
 	// executes the body's tools/list, header value is not validated.
-	if e.toolsList(ctx, client, session, mismatchMethodHeader) == accessGranted {
-		return []attack.Finding{{
+	if e.toolsList(ctx, client, session, mismatchMethodHeader) != accessGranted {
+		// The value IS validated. One narrower way to get it wrong remains: comparing
+		// case-insensitively. This runs only here, because a server that ignores the
+		// value outright already reports above and a second finding would say the same
+		// thing twice.
+		if e.toolsList(ctx, client, session, caseFoldedMethodHeader) == accessGranted {
+			return []attack.Finding{e.caseFoldedFinding(session)}, "", true, ""
+		}
+		return nil, "", true, ""
+	}
+
+	// The value is not validated at all: the server executed the body under a header
+	// naming a different method.
+	return []attack.Finding{
+		{
 			RuleID:     e.rule.ID,
 			RuleName:   e.rule.Name,
 			Severity:   "high",
@@ -153,9 +192,8 @@ func (e *HeaderBodySplitExecutor) probe(ctx context.Context, client *attack.HTTP
 				session.Endpoint),
 			Remediation: e.rule.Remediation,
 			TargetURL:   session.Endpoint,
-		}}, "", true, ""
-	}
-	return nil, "", true, ""
+		},
+	}, "", true, ""
 }
 
 // The two deliberate malformations. Omitting the header tests whether presence is
@@ -201,4 +239,203 @@ func (e *HeaderBodySplitExecutor) toolsList(ctx context.Context, client *attack.
 		return accessUndetermined
 	}
 	return accessGranted
+}
+
+// headerMismatchCode is the JSON-RPC error a server MUST answer a header/body
+// validation failure with. SEP-2243 specified -32001; the specification renumbered
+// it into the range reserved for protocol-defined errors, and this rule keys on the
+// spec value. It is the oracle for the Mcp-Name probes below, which unlike the
+// Mcp-Method ones cannot use "did the body execute": their subject deliberately does
+// not exist, so a compliant and a non-compliant server both answer with an error and
+// only the CODE separates them.
+const headerMismatchCode = -32020
+
+// nameProbeSubject is the resource URI and prompt name the Mcp-Name probes ask for.
+// It is deliberately absent from every server: the point is to compare which error
+// comes back, and a subject that does not exist cannot be executed. That is what
+// keeps these probes read-only.
+const nameProbeSubject = "batesian-nonexistent-subject"
+
+// nameBearingProbe is one method that carries a subject in its params, and the
+// params field the subject travels in.
+//
+// tools/call is deliberately absent. Testing Mcp-Name on it would mean sending a
+// tools/call whose header disagrees with its body, and a server that does not
+// validate the header is exactly a server that would then EXECUTE the tool. A
+// scanner must not invoke a tool to find out. resources/read and prompts/get are
+// reads, and with a subject that does not exist there is nothing to read.
+type nameBearingProbe struct {
+	method string
+	field  string
+}
+
+var nameBearingProbes = []nameBearingProbe{
+	{"resources/read", "uri"},
+	{"prompts/get", "name"},
+}
+
+// probeName tests the Mcp-Name header on one wire.
+//
+// Mcp-Name is REQUIRED for tools/call, resources/read and prompts/get, its value
+// MUST match params.name or params.uri, and a missing or mismatched value MUST earn
+// 400 with -32020. The rule covered only Mcp-Method, so a server that validated the
+// method and ignored the name passed: an intermediary blocklisting a dangerous tool
+// or resource by name inspects Mcp-Name, and that is the header this exercises.
+func (e *HeaderBodySplitExecutor) probeName(ctx context.Context, client *attack.HTTPClient,
+	session mcpSession) (findings []attack.Finding, tested bool, blocked string) {
+	for _, np := range nameBearingProbes {
+		params := map[string]interface{}{np.field: nameProbeSubject}
+
+		// Control: omit Mcp-Name. A dispatch here means presence is not enforced.
+		omitted := e.nameVerdict(ctx, client, session, np, params, func(h map[string]string) {
+			delete(h, "Mcp-Name")
+		})
+		switch omitted {
+		case nameNotImplemented:
+			continue // this server does not offer the method; try the next one
+		case nameUndetermined:
+			blocked = "the " + np.method + " probe with no Mcp-Name header returned neither a " +
+				"header-mismatch error nor a dispatched answer, so whether the server enforces " +
+				"Mcp-Name presence could not be established"
+			continue
+		case nameDispatched:
+			// Presence is not enforced, so a mismatch here would prove nothing about
+			// value validation and this method is not a surface for the dimension.
+			//
+			// Deliberately NOT a finding, for consistency with how the Mcp-Method
+			// dimension treats the same observation: omission is the PRECONDITION
+			// detector for both, and this rule's subject is whether the value is
+			// validated. The binding does list "a required standard header
+			// (MCP-Protocol-Version, Mcp-Method, Mcp-Name) is missing" as its own
+			// validation failure, so a server that dispatches without one is violating
+			// something, and reporting that is a separate rule with its own oracle
+			// rather than a second verdict smuggled into this one. Reporting it here for
+			// Mcp-Name while the Mcp-Method path called the identical observation
+			// "not SEP-2243-aware" was incoherent, which the existing tests caught.
+			continue
+		}
+
+		// Presence is enforced. Now the value: same body, a name that disagrees.
+		mismatched := e.nameVerdict(ctx, client, session, np, params, func(h map[string]string) {
+			h["Mcp-Name"] = nameProbeSubject + "-different"
+		})
+		switch mismatched {
+		case nameRejected:
+			return nil, true, "" // validated: the mismatch was refused with -32020
+		case nameDispatched:
+			return []attack.Finding{e.nameMismatchFinding(session, np)}, true, ""
+		default:
+			blocked = "the " + np.method + " probe with a mismatched Mcp-Name header returned " +
+				"neither a header-mismatch error nor a dispatched answer, so the value check " +
+				"could not be established"
+		}
+	}
+	return nil, false, blocked
+}
+
+// nameVerdict grades one shaped name-bearing call by which error came back.
+type nameVerdict int
+
+const (
+	// nameUndetermined: a transport failure, or an answer that settles nothing.
+	nameUndetermined nameVerdict = iota
+	// nameRejected: -32020 HeaderMismatch, so the header was validated.
+	nameRejected
+	// nameDispatched: the server acted on the body rather than rejecting the
+	// header, whether it answered a result or a subject-not-found error.
+	nameDispatched
+	// nameNotImplemented: -32601, so this method is not a surface here.
+	nameNotImplemented
+)
+
+func (e *HeaderBodySplitExecutor) nameVerdict(ctx context.Context, client *attack.HTTPClient,
+	session mcpSession, np nameBearingProbe, params map[string]interface{},
+	shape func(map[string]string)) nameVerdict {
+	resp, err := session.postShaping(ctx, client, 3, np.method, params, shape)
+	if err != nil || resp == nil {
+		return nameUndetermined
+	}
+	if resp.IsAccepted() {
+		// A result for a subject that does not exist is odd, but it is still the
+		// server acting on the body rather than rejecting the header.
+		return nameDispatched
+	}
+	code, hasErr := jsonRPCErrorCode(resp.Body)
+	if !hasErr {
+		return nameUndetermined
+	}
+	switch code {
+	case headerMismatchCode:
+		return nameRejected
+	case mcpMethodNotFound:
+		return nameNotImplemented
+	}
+	// Any other error is the server having dispatched far enough to complain about
+	// the subject, the params or authorization, none of which is a header rejection.
+	return nameDispatched
+}
+
+// caseFoldedMethodHeader spells the body's method in upper case. Header VALUES are
+// case-sensitive per the specification ("Header values (such as method names) are
+// case-sensitive"), so a server that treats this as equal to the body's tools/list
+// is comparing case-insensitively, and an intermediary matching an exact method name
+// can be walked past with a different spelling.
+func caseFoldedMethodHeader(h map[string]string) { h["Mcp-Method"] = "TOOLS/LIST" }
+
+// nameMismatchFinding: the header said one subject, the body another, and the server
+// acted on the body. Same class and severity as the Mcp-Method split, because the
+// bypass is the same: an intermediary inspecting the header sees a value the server
+// never used.
+func (e *HeaderBodySplitExecutor) nameMismatchFinding(session mcpSession, np nameBearingProbe) attack.Finding {
+	return attack.Finding{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "high",
+		Confidence: attack.ConfirmedExploit,
+		Title:      "MCP server does not validate Mcp-Name against the request body (SEP-2243 split-brain)",
+		Description: fmt.Sprintf(
+			"At %s, a %s request was REJECTED when the Mcp-Name header was omitted (the server "+
+				"enforces header presence), but a request whose Mcp-Name disagreed with params.%s was "+
+				"acted on rather than refused. The Streamable HTTP binding makes Mcp-Name REQUIRED for "+
+				"tools/call, resources/read and prompts/get, requires its value to match the body, and "+
+				"requires a mismatch to be rejected with 400 and -32020 (HeaderMismatch). An "+
+				"intermediary that blocklists or routes on the named subject, which is how a gateway "+
+				"gates a dangerous tool or resource, inspects a value this server does not enforce, so "+
+				"the body can name something else.",
+			session.Endpoint, np.method, np.field),
+		Evidence: fmt.Sprintf(
+			"endpoint: %s\nmethod: %s\nomit Mcp-Name: rejected with -32020 (presence enforced)\n"+
+				"Mcp-Name disagreeing with params.%s: acted on the body (should be 400/-32020)\n"+
+				"subject probed: %s (deliberately absent, so nothing was executed)",
+			session.Endpoint, np.method, np.field, nameProbeSubject),
+		Remediation: e.rule.Remediation,
+		TargetURL:   session.Endpoint,
+	}
+}
+
+// caseFoldedFinding: the server validates the Mcp-Method value but compares it
+// case-insensitively, so an exact-match intermediary can be walked past.
+func (e *HeaderBodySplitExecutor) caseFoldedFinding(session mcpSession) attack.Finding {
+	return attack.Finding{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "high",
+		Confidence: attack.ConfirmedExploit,
+		Title:      "MCP server compares the Mcp-Method value case-insensitively (SEP-2243)",
+		Description: fmt.Sprintf(
+			"At %s, a tools/list request was rejected when Mcp-Method disagreed with the body, so the "+
+				"value is validated, but the same request with Mcp-Method: TOOLS/LIST was executed. The "+
+				"binding states that header names are case-insensitive while header VALUES, such as "+
+				"method names, are case-sensitive, so the two spellings are different values and the "+
+				"mismatch MUST be rejected. An intermediary matching an exact method name sees a "+
+				"spelling it does not recognize while the server executes the body regardless.",
+			session.Endpoint),
+		Evidence: fmt.Sprintf(
+			"endpoint: %s\nMcp-Method: tools/call (mismatch): rejected, so the value is validated\n"+
+				"Mcp-Method: TOOLS/LIST (case-folded) + body tools/list: EXECUTED body "+
+				"(should be 400/-32020)",
+			session.Endpoint),
+		Remediation: e.rule.Remediation,
+		TargetURL:   session.Endpoint,
+	}
 }

--- a/internal/attack/mcp/header_body_split_name_test.go
+++ b/internal/attack/mcp/header_body_split_name_test.go
@@ -1,0 +1,257 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+// The Mcp-Name and case-sensitivity dimensions of mcp-header-body-split-001.
+//
+// The rule covered Mcp-Method only, so a server that validated the method and ignored
+// the name passed. The binding makes Mcp-Name REQUIRED for tools/call, resources/read
+// and prompts/get, requires its value to match params.name or params.uri, and requires
+// a mismatch to earn 400 with -32020. An intermediary gating a dangerous tool or
+// resource by name inspects Mcp-Name, so that is the header worth spoofing.
+//
+// Every probe here asks for a subject that does not exist, which is what keeps the
+// dimension read-only: a server that does not validate the header is precisely one
+// that would otherwise act on the body, and the rule must never let that be a tool
+// call.
+
+// nameSplitServer serves ONLY the 2026-07-28 wire and validates Mcp-Method fully, so
+// the method dimension is clean and these tests measure the name dimension alone.
+//
+//	"validates" reject a missing or mismatched Mcp-Name with -32020
+//	"ignores"   enforce presence but not value: the split this dimension catches
+//	"absent"    enforce neither, so the dimension has no precondition
+//	"nomethod"  answer -32601, so the method is not a surface here
+func nameSplitServer(t *testing.T, nameMode string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method, _ := body["method"].(string)
+		params, _ := body["params"].(map[string]interface{})
+		id := body["id"]
+		w.Header().Set("Content-Type", "application/json")
+
+		rpcErr := func(status, code int, msg string) {
+			w.WriteHeader(status)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": code, "message": msg},
+			})
+		}
+
+		// Modern wire only: refuse the handshake so the rule arrives via discovery.
+		if r.Header.Get("MCP-Protocol-Version") != "2026-07-28" {
+			rpcErr(http.StatusBadRequest, -32022, "UnsupportedProtocolVersion")
+			return
+		}
+		if h := r.Header.Get("Mcp-Method"); h != method {
+			rpcErr(http.StatusBadRequest, -32020, "HeaderMismatch: Mcp-Method")
+			return
+		}
+
+		switch method {
+		case "server/discover":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{
+					"supportedVersions": []string{"2026-07-28"},
+					"capabilities": map[string]interface{}{
+						"tools": map[string]interface{}{}, "resources": map[string]interface{}{},
+					},
+				},
+			})
+		case "tools/list":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{"tools": []interface{}{map[string]interface{}{"name": "echo"}}},
+			})
+		case "resources/read", "prompts/get":
+			if nameMode == "nomethod" {
+				rpcErr(http.StatusOK, -32601, "Method not found")
+				return
+			}
+			subject, _ := params["uri"].(string)
+			if subject == "" {
+				subject, _ = params["name"].(string)
+			}
+			hdr := r.Header.Get("Mcp-Name")
+			switch nameMode {
+			case "validates":
+				if hdr != subject {
+					rpcErr(http.StatusBadRequest, -32020, "HeaderMismatch: Mcp-Name")
+					return
+				}
+			case "ignores":
+				if hdr == "" { // presence enforced, value ignored
+					rpcErr(http.StatusBadRequest, -32020, "HeaderMismatch: Mcp-Name missing")
+					return
+				}
+			case "absent":
+				// Neither presence nor value is enforced.
+			}
+			// Dispatched: the subject does not exist, so nothing was executed.
+			rpcErr(http.StatusOK, -32002, "Resource not found: "+subject)
+		default:
+			rpcErr(http.StatusOK, -32601, "Method not found")
+		}
+	}))
+}
+
+func runSplitRule(t *testing.T, ts *httptest.Server) ([]attack.Finding, error) {
+	t.Helper()
+	return mcpattack.NewHeaderBodySplitExecutor(hbsRuleCtx()).
+		Execute(context.Background(), ts.URL, testOpts())
+}
+
+// The gap this closes: Mcp-Method is validated perfectly, so the rule reported clean,
+// while Mcp-Name is enforced for presence and not for value.
+func TestSplit_McpNameValueNotValidated(t *testing.T) {
+	ts := nameSplitServer(t, "ignores")
+	defer ts.Close()
+
+	findings, err := runSplitRule(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly the Mcp-Name finding, got %d: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Severity != "high" || f.Confidence != attack.ConfirmedExploit {
+		t.Errorf("want high/ConfirmedExploit, got %s/%s", f.Severity, f.Confidence)
+	}
+	if !strings.Contains(f.Title, "Mcp-Name") {
+		t.Errorf("the finding should name the header it is about, got %q", f.Title)
+	}
+	if !strings.Contains(f.Title, "2026-07-28 wire") {
+		t.Errorf("a modern-wire finding should be labelled as such, got %q", f.Title)
+	}
+	// The evidence has to record that the probe was read-only.
+	if !strings.Contains(f.Evidence, "deliberately absent, so nothing was executed") {
+		t.Errorf("evidence should record that no subject was executed; got:\n%s", f.Evidence)
+	}
+}
+
+// A server that validates Mcp-Name against the body is clean, and must not be reported
+// merely because the rule asked for a subject that does not exist.
+func TestSplit_McpNameValidatedIsClean(t *testing.T) {
+	ts := nameSplitServer(t, "validates")
+	defer ts.Close()
+
+	findings, err := runSplitRule(t, ts)
+	if err != nil {
+		t.Fatalf("a server validating both headers is a real clean result: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings, got %d: %+v", len(findings), findings)
+	}
+}
+
+// Presence is not enforced, so a mismatch would prove nothing about value validation.
+// Deliberately not a finding: omission is the precondition detector for both
+// dimensions, and reporting it here while the Mcp-Method path calls the identical
+// observation "not SEP-2243-aware" would be incoherent.
+func TestSplit_McpNamePresenceNotEnforcedIsNotAFinding(t *testing.T) {
+	ts := nameSplitServer(t, "absent")
+	defer ts.Close()
+
+	findings, err := runSplitRule(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("omission is the precondition, not the subject; got %d: %+v", len(findings), findings)
+	}
+}
+
+// Neither name-bearing method exists, so the dimension has no surface and must fall
+// through to the Mcp-Method verdict rather than blocking the rule.
+func TestSplit_NoNameBearingMethodStillReportsTheMethodVerdict(t *testing.T) {
+	ts := nameSplitServer(t, "nomethod")
+	defer ts.Close()
+
+	findings, err := runSplitRule(t, ts)
+	if err != nil {
+		t.Fatalf("the Mcp-Method dimension tested fine, so this is clean: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings, got %d: %+v", len(findings), findings)
+	}
+}
+
+// caseFoldServer validates the Mcp-Method value but compares it case-insensitively,
+// which the binding forbids: header names are case-insensitive, header VALUES are not.
+func caseFoldServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method, _ := body["method"].(string)
+		id := body["id"]
+		w.Header().Set("Content-Type", "application/json")
+
+		write := func(result map[string]interface{}) {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id, "result": result,
+			})
+		}
+		rpcErr := func(status, code int, msg string) {
+			w.WriteHeader(status)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": code, "message": msg},
+			})
+		}
+
+		if r.Header.Get("MCP-Protocol-Version") != "2026-07-28" {
+			rpcErr(http.StatusBadRequest, -32022, "UnsupportedProtocolVersion")
+			return
+		}
+		// The bug under test: compared with EqualFold rather than exactly.
+		if !strings.EqualFold(r.Header.Get("Mcp-Method"), method) {
+			rpcErr(http.StatusBadRequest, -32020, "HeaderMismatch")
+			return
+		}
+		switch method {
+		case "server/discover":
+			write(map[string]interface{}{
+				"supportedVersions": []string{"2026-07-28"},
+				"capabilities":      map[string]interface{}{"tools": map[string]interface{}{}},
+			})
+		case "tools/list":
+			write(map[string]interface{}{"tools": []interface{}{map[string]interface{}{"name": "echo"}}})
+		default:
+			rpcErr(http.StatusOK, -32601, "Method not found")
+		}
+	}))
+}
+
+// A server that rejects a plain mismatch looks compliant to the first three probes.
+// Folding case is the narrower way to get it wrong, and an intermediary matching an
+// exact method name is walked past by a different spelling of the same method.
+func TestSplit_CaseFoldedMethodValueIsAFinding(t *testing.T) {
+	ts := caseFoldServer(t)
+	defer ts.Close()
+
+	findings, err := runSplitRule(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected the case-folding finding, got %d: %+v", len(findings), findings)
+	}
+	if !strings.Contains(findings[0].Title, "case-insensitively") {
+		t.Errorf("the finding should say the comparison folded case, got %q", findings[0].Title)
+	}
+}

--- a/rules/mcp/header-body-split-001.yaml
+++ b/rules/mcp/header-body-split-001.yaml
@@ -25,10 +25,49 @@ info:
       3. Mcp-Method: tools/call (mismatch). A compliant server MUST reject (400 /
          -32020). If it executes the body's tools/list anyway, the server enforces
          header PRESENCE but not header/body CONSISTENCY - reported CONFIRMED.
+      4. Only when probe 3 was correctly REJECTED: Mcp-Method: TOOLS/LIST. Header
+         names are case-insensitive but header VALUES are not ("Header values (such
+         as method names) are case-sensitive"), so the two spellings are different
+         values and the mismatch must be rejected. A server that executes this
+         validates the value but folds case, and an intermediary matching an exact
+         method name is walked past. Probe 4 runs only here, because a server that
+         ignores the value outright already reports at probe 3.
+
+    Mcp-Name is a SECOND required header with the same MUST behind it, and a server
+    can validate Mcp-Method while ignoring it, so it is probed as its own dimension.
+    The binding makes Mcp-Name REQUIRED for tools/call, resources/read and
+    prompts/get, sourced from params.name or params.uri, and requires a mismatch to
+    earn the same 400 / -32020. This is the higher-impact instance: an intermediary
+    that blocklists a dangerous TOOL OR RESOURCE inspects the name, not the method.
+
+      1. Omit Mcp-Name on a name-bearing method. A dispatch means presence is not
+         enforced, so a mismatch would prove nothing and the dimension does not
+         apply. Exactly as for Mcp-Method, omission is the precondition detector and
+         not the subject; a server dispatching without a required header does
+         violate the binding, but reporting that belongs to its own rule rather than
+         being a second verdict smuggled into this one.
+      2. Same body, an Mcp-Name that disagrees with it. Rejected with -32020 means
+         validated. Anything else means the server acted on the body under a header
+         naming something else - reported CONFIRMED.
+
+    The subject asked for is deliberately one that does not exist, which is what
+    keeps the dimension READ-ONLY: the oracle is which error comes back, and a
+    server that does not validate the header is precisely a server that would
+    otherwise act on the body. tools/call is never used for this reason - probing
+    Mcp-Name on it would mean inviting a non-validating server to execute a tool.
+    resources/read and prompts/get are reads, and a subject that does not exist
+    cannot be read.
+
+    Mcp-Param-{Name} carries the same requirement and is deliberately NOT probed.
+    Those headers come from x-mcp-header annotations on a specific tool's
+    inputSchema, so a header is only "recognized" for that tool, and testing a
+    mismatch would require calling a real annotated tool - the tenant or region
+    parameter of, say, an execute_sql. A scanner must not invoke a tool to learn
+    whether the header is validated.
 
   references:
     - https://modelcontextprotocol.io/seps/2243-http-standardization
-    - https://modelcontextprotocol.io/specification/draft/basic/transports/streamable-http
+    - https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http
     - https://cwe.mitre.org/data/definitions/444.html
     - https://cwe.mitre.org/data/definitions/436.html
 


### PR DESCRIPTION
`mcp-header-body-split-001` tested one instance of the header/body requirement. The
binding makes **`Mcp-Name` a second REQUIRED header** — sourced from `params.name` or
`params.uri` on `tools/call`, `resources/read`, `prompts/get` — with the same MUST and
the same `-32020`, and a server can validate `Mcp-Method` while ignoring it. That is the
higher-impact instance: an intermediary blocklisting a dangerous **tool or resource**
inspects the name, not the method.

A fourth `Mcp-Method` probe covers a narrower failure. Header names are case-insensitive
but *"Header values (such as method names) are case-sensitive"*, so `Mcp-Method:
TOOLS/LIST` against a body of `tools/list` must also be refused. It runs **only** when
the plain mismatch was correctly rejected — a server that ignores the value outright
already reports at probe 3.

**The Mcp-Name dimension is read-only by construction.** Its oracle cannot be "did the
body execute", because the subject it asks for deliberately does not exist: a compliant
and a non-compliant server both answer with an error, and only the *code* separates them
(`-32020` = validated; anything else = acted on the body). `tools/call` is never used for
it, because a server that does not validate the header is exactly one that would then
**execute the tool**, and a scanner must not invoke one to find out.

`Mcp-Param-{Name}` carries the same requirement and is **deliberately not probed** —
those headers come from `x-mcp-header` annotations on a specific tool's schema, so a
header is only recognized for that tool, and testing a mismatch means calling that real
annotated tool (the tenant/region parameter of something like an `execute_sql`).

**Two design errors the existing tests caught**, both worth reading:

My first cut reported an *omitted* `Mcp-Name` as a finding on a modern wire. That was
incoherent — the `Mcp-Method` path calls the identical observation "not SEP-2243-aware"
and uses it as the precondition detector. Omission is now the precondition for both. (A
server dispatching without a required header *does* violate the binding, which lists a
missing required header as its own validation failure; that belongs to its own rule
rather than a second verdict smuggled into this one.)

An *undetermined* `Mcp-Name` probe was overriding a **reasoned** clean result. A wire
that carries the requirement and ignores the header is a real observation that simply
isn't this rule's subject, and an additive dimension failing to decide must not convert
that into "not tested". The name dimension's blocked reason is now kept apart and used
only when the `Mcp-Method` dimension reached no conclusion at all.

Also folded in: `.gitignore` now covers `.claude/settings.local.json`, which holds an
auth token in cleartext while nothing under `.claude/` is tracked — one `git add .` from
being published. Only the local file is ignored; a shared `.claude/settings.json` stays
committable.

Verification:

- 5 new tests: the split, the validated case, the presence-not-enforced precondition, an
  agent with no name-bearing method, and the case-folding server
- each dimension confirmed non-vacuous by removal, failing only its own test
- all 14 existing split tests still pass, including the two that caught the errors above
- 46-case fixture sweep against the previous binary: no finding or skip changed