### PR TITLE
rule(mcp): detect log notifications sent without a per-request opt-in

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -147,7 +147,7 @@ release:
     ## Batesian {{.Version}}
 
     Adversarial red-team CLI for AI agent protocols (A2A and MCP).
-    38 bundled attack rules (18 A2A + 20 MCP). Single binary. No runtime dependencies.
+    39 bundled attack rules (18 A2A + 21 MCP). Single binary. No runtime dependencies.
 
     Every release is published with a cosign signature over `checksums.txt`, a
     CycloneDX SBOM per archive, and SLSA build provenance.

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ CLI for adversarial testing of [A2A](https://a2a-protocol.org) and [MCP](https:/
 
 ## What ships
 
-Bundled rules: **18 A2A, 20 MCP (38 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
+Bundled rules: **18 A2A, 21 MCP (39 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
 
 - [A2A rules](docs/rules-a2a.md) (18)
-- [MCP rules](docs/rules-mcp.md) (20)
+- [MCP rules](docs/rules-mcp.md) (21)
 
 Rules are validated against third-party reference implementations, not only against the bundled fixtures. [Validation results](docs/validation-results.md) records what fires, what correctly stays silent on a server with no authentication at all, and the scanner defects that exercise has found.
 

--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -1,6 +1,6 @@
 # MCP Attack Rules
 
-Batesian ships **20 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
+Batesian ships **21 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
 Every rule is an active probe: it sends crafted protocol traffic and judges the
 server's actual response. Rules are deliberately scoped to MCP-specific semantics
 (OAuth 2.1 authorization, DCR, audience binding, discovery-chain metadata-fetch
@@ -123,6 +123,11 @@ travel in `params._meta`, the method is mirrored into `Mcp-Method`, and for
 `Mcp-Name`. Every one of those is mandatory, and a mismatch or omission earns
 `-32020`.
 
+`mcp-log-optin-001` runs on the 2026-07-28 wire **only**, because the requirement
+it tests was introduced by that revision and has no equivalent on an earlier one.
+Against a target serving no such wire it reports itself not applicable rather than
+clean.
+
 ## Endpoint discovery
 
 A target that names a path is probed as given; otherwise `/mcp`, `/`, `/api` and
@@ -153,6 +158,7 @@ candidate answers does a rule report that it could not test.
 | `mcp-dns-rebind-origin-001` | [Origin Validation / DNS Rebinding](#mcp-dns-rebind-origin-001) | High | confirmed | CWE-350 |
 | `mcp-jsonrpc-batch-bypass-001` | [JSON-RPC Batch Authentication Bypass](#mcp-jsonrpc-batch-bypass-001) | High | confirmed | CWE-288 |
 | `mcp-session-as-credential-001` | [Session ID Accepted as a Credential](#mcp-session-as-credential-001) | High | confirmed | CWE-287 / CWE-565 |
+| `mcp-log-optin-001` | [Log Notifications Without a Per-Request Opt-In](#mcp-log-optin-001) | Medium | confirmed | CWE-200 / CWE-532 |
 
 ---
 
@@ -717,3 +723,55 @@ Currency: `Mcp-Session-Id` is normative in revisions 2025-03-26 through
 2025-11-25. The 2026-07-28 revision removes protocol-level sessions, so a server
 on that revision returns no session id and the rule reports itself not applicable
 at step 1.
+
+---
+
+### mcp-log-optin-001
+
+**MCP Server Emits Log Notifications Without a Per-Request Opt-In** | Severity:
+Medium | CWE-200 / CWE-532
+
+Tests whether a server sends log notifications to a request that never asked for
+them. `2026-07-28` removed `logging/setLevel` and replaced it with a per-request
+opt-in, and the logging page is explicit: "To receive log messages for a specific
+request, include `io.modelcontextprotocol/logLevel` in the request's `_meta`. The
+server MUST NOT emit `notifications/message` for a request that does not include
+this field."
+
+That is the bug the revision created. A server carried over from the `setLevel`
+era holds a connection-global level and emits unconditionally, so a client that
+never opted in receives server-side log content. The same page requires that log
+messages carry no credentials, personal data or internal system details, which is
+an acknowledgement of what they usually do carry, and an MCP client feeds what the
+server sends into a model's context.
+
+Emitting logs is a MAY, so **absence proves nothing**: a server that never logs is
+indistinguishable from one that respects the gate. Two probes, in this order:
+
+1. Control: `tools/list` **with** `io.modelcontextprotocol/logLevel` = `debug` in
+   `_meta`. At least one `notifications/message` frame must come back, otherwise
+   the server does not log on this surface and the probe below could not tell
+   compliance from silence. The rule then reports **not tested**, never clean.
+2. Probe: the identical `tools/list` with **no** `logLevel` in `_meta`. Any
+   `notifications/message` frame is the finding.
+
+Only positive evidence is reported. A server that stays silent for the control is
+left alone; a server that logs for the control and not for the probe is a genuine
+clean result, because it demonstrably logs here and withheld the frames when they
+were not requested. The probe is a read: `tools/list` creates nothing, calls no
+tool and modifies no state. The evidence also records whether the server declares
+the `logging` capability, which it MUST when it emits log notifications, so one
+that emits them unasked and undeclared is breaking two requirements.
+
+The frames are only visible on the raw stream, so this rule reads the SSE stream
+itself rather than through the shared client, which collapses a stream to its
+JSON-RPC response event and would discard exactly the frames being looked for.
+
+**Currency.** The field and its MUST NOT exist only in `2026-07-28`, so the rule
+runs on that wire alone and reports itself not applicable against a target serving
+no such wire. The Logging feature as a whole is also deprecated as of the same
+revision (SEP-2577): it stays in the specification for at least twelve months and
+is eligible for removal in the first revision released on or after `2027-07-28`,
+with new implementations told to log to stderr or use OpenTelemetry instead. The
+requirement is normative until then, and the servers most likely to break it are
+the ones migrating off `logging/setLevel`.

--- a/internal/attack/mcp/log_optin.go
+++ b/internal/attack/mcp/log_optin.go
@@ -1,0 +1,289 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/calbebop/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/sse"
+)
+
+// LogOptInExecutor tests whether an MCP server emits log notifications to a request
+// that never asked for them (rule mcp-log-optin-001).
+//
+// The 2026-07-28 revision removed logging/setLevel and replaced it with a per-request
+// opt-in. The logging page is explicit: "To receive log messages for a specific
+// request, include io.modelcontextprotocol/logLevel in the request's _meta. The server
+// MUST NOT emit notifications/message for a request that does not include this field."
+//
+// That is the bug the revision created. A server carried over from the setLevel era
+// holds a connection-global level and emits unconditionally, so a client that never
+// opted in receives server-side log content. Log frames are where internal detail
+// lives, which the same page acknowledges by requiring that they contain no
+// credentials, personal data or internal system details, and an MCP client feeds what
+// the server sends into a model's context.
+//
+// Two properties of this surface shape the rule:
+//
+// Emitting is a MAY, so ABSENCE PROVES NOTHING. A server that never logs is
+// indistinguishable from one that respects the gate. The control probe below settles
+// that by asking WITH the field first: only a server that logs when asked can be
+// judged on whether it logs when not asked.
+//
+// The frames are only visible on the raw stream. The shared client collapses an SSE
+// response to its JSON-RPC response event by design (see readSSEResponse), which
+// discards exactly the notification frames this rule is looking for, so the probes
+// here read the stream themselves.
+//
+// Currency: the field, and the MUST NOT, exist only in 2026-07-28, so the rule runs
+// on that wire alone. It is also worth knowing that the whole Logging feature is
+// deprecated as of the same revision (SEP-2577), eligible for removal in the first
+// revision released on or after 2027-07-28, with new implementations told to use
+// stderr or OpenTelemetry instead. The requirement is normative until then, and the
+// servers most likely to break it are the ones migrating off setLevel.
+type LogOptInExecutor struct {
+	rule attack.RuleContext
+}
+
+func init() {
+	attack.Register("mcp-log-optin", func(rc attack.RuleContext) attack.Executor {
+		return NewLogOptInExecutor(rc)
+	})
+}
+
+func NewLogOptInExecutor(r attack.RuleContext) *LogOptInExecutor {
+	return &LogOptInExecutor{rule: r}
+}
+
+// metaLogLevel is the reserved _meta key that opts a single request in to log
+// notifications. It is absent from modernMeta on purpose: not asking is the default,
+// and it is what the probe below relies on.
+const metaLogLevel = "io.modelcontextprotocol/logLevel"
+
+// logProbeLevel is the level the control probe asks for. debug is the most permissive
+// of the RFC 5424 set the specification enumerates, so a server that logs at all has
+// something at or above it.
+const logProbeLevel = "debug"
+
+func (e *LogOptInExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
+	vars := attack.NewVars(target, opts.OOBListenerURL)
+	client := attack.NewHTTPClient(opts, vars)
+	raw := rawSSEClient(opts)
+
+	sessions, err := openSessions(ctx, client, vars.BaseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	modernSeen := false
+	notObserved := ""
+	var findings []attack.Finding
+	for _, session := range sessions {
+		if session.Era != EraModern {
+			continue
+		}
+		modernSeen = true
+
+		// Control: ask for logs. A server that sends none when asked does not log on
+		// this surface, so the probe below cannot tell compliance from silence.
+		//
+		// That case is reported as NOT OBSERVED rather than clean, and the distinction
+		// is the whole point of the control. Falling through to clean would make the
+		// control dead logic: silent-control and silent-probe would produce the same
+		// verdict, and the rule would claim a server gates its log notifications on the
+		// strength of never having seen one. Removing the control then changed no
+		// output at all, which is how this was caught.
+		switch e.emitsLogFrame(ctx, raw, client, session, opts, true) {
+		case logNone:
+			notObserved = fmt.Sprintf("%s emitted no notifications/message even for a request that "+
+				"asked for them with %s=%s, so whether it gates them on the opt-in could not be "+
+				"established; emitting is a MAY, and silence is not evidence of the gate",
+				session.Endpoint, metaLogLevel, logProbeLevel)
+			continue
+		case logUnreadable:
+			notObserved = fmt.Sprintf("the log-level probe at %s produced no readable response stream, "+
+				"and only a stream can carry a notifications/message frame, so the opt-in gate was "+
+				"never exercised", session.Endpoint)
+			continue
+		}
+
+		// Probe: the same request with no logLevel in _meta. Any notifications/message
+		// frame here is the violation, and no interpretation stands between the
+		// observation and the claim.
+		if e.emitsLogFrame(ctx, raw, client, session, opts, false) == logEmitted {
+			findings = append(findings, labelEra(session, []attack.Finding{
+				e.finding(session, e.advertisesLogging(session)),
+			})...)
+		}
+	}
+
+	if len(findings) > 0 {
+		return findings, nil
+	}
+	if !modernSeen {
+		// The field and its MUST NOT arrived with 2026-07-28. On an earlier wire the
+		// mechanism is logging/setLevel, which this rule is not about, so there is no
+		// requirement here to violate.
+		return nil, fmt.Errorf("%w: the per-request log opt-in exists only in MCP %s, and %s serves "+
+			"no wire on that revision", attack.ErrInconclusive, modernEraVersion, vars.BaseURL)
+	}
+	if notObserved != "" {
+		return nil, fmt.Errorf("%w: %s", attack.ErrInconclusive, notObserved)
+	}
+	// The control logged and the probe did not: the server demonstrably logs here and
+	// withheld the frames when they were not asked for. That is a tested clean result.
+	return nil, nil
+}
+
+// logOutcome is what a single probe saw on the response stream.
+type logOutcome int
+
+const (
+	// logNone: the stream carried no log notification. On the control probe that
+	// means the server does not log here; on the real probe it means the gate held.
+	logNone logOutcome = iota
+	// logEmitted: at least one notifications/message frame was present.
+	logEmitted
+	// logUnreadable: the request did not produce a stream that could be read.
+	logUnreadable
+)
+
+// emitsLogFrame sends one tools/list on this wire and reports whether the response
+// stream carried a log notification. optIn adds the logLevel field to _meta.
+//
+// tools/list is the body because it is a read that every server implements, and this
+// rule needs the server to do a unit of work rather than to do anything in
+// particular. Nothing is created, called or modified.
+func (e *LogOptInExecutor) emitsLogFrame(ctx context.Context, raw *http.Client, client *attack.HTTPClient,
+	session mcpSession, opts attack.Options, optIn bool) logOutcome {
+	headers, body := session.request(4, "tools/list", nil)
+	if optIn {
+		addMeta(body, metaLogLevel, logProbeLevel)
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return logUnreadable
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, session.Endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return logUnreadable
+	}
+	req.Header.Set("Content-Type", "application/json")
+	// Both content types, because the server chooses: a single JSON object carries no
+	// notifications at all, and only a stream can.
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("User-Agent", "batesian/"+attack.Version+" (https://github.com/calbebop/batesian)")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	// The raw client bypasses the shared client's token injection, so the decision is
+	// delegated back to it: PresentsCredential answers the same question the injection
+	// site asks, including the off-host guard, so this cannot drift from it.
+	if client.PresentsCredential(session.Endpoint) {
+		req.Header.Set("Authorization", "Bearer "+opts.Token)
+	}
+
+	resp, err := raw.Do(req)
+	if err != nil {
+		return logUnreadable
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode/100 != 2 {
+		return logUnreadable
+	}
+	if !strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
+		// A single JSON object cannot carry a notification frame, so nothing about the
+		// gate follows from it either way.
+		return logUnreadable
+	}
+
+	// One matching frame is all the oracle needs: the question is whether ANY log
+	// notification was sent, so the scan stops at the first.
+	if _, found, err := sse.FirstMatching(resp.Body, maxLogStream, isLogNotification); err == nil && found {
+		return logEmitted
+	}
+	return logNone
+}
+
+// maxLogStream bounds the stream read. A response stream ends with the response, so
+// this only guards against a server that streams without terminating.
+const maxLogStream = 1 << 20
+
+// addMeta sets one key inside a request's _meta block, which request() has already
+// built for the era. Legacy requests carry no _meta and are left untouched.
+func addMeta(body map[string]interface{}, key string, value interface{}) {
+	params, ok := body["params"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	meta, ok := params["_meta"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	meta[key] = value
+}
+
+// isLogNotification reports whether an SSE payload is a notifications/message frame.
+//
+// It keys on the method name, not on the presence of "level" or "logger", because
+// those are field names that appear in plenty of unrelated payloads and this rule's
+// whole claim rests on the frame being a log notification.
+func isLogNotification(payload []byte) bool {
+	var frame struct {
+		Method string `json:"method"`
+	}
+	if json.Unmarshal(payload, &frame) != nil {
+		return false
+	}
+	return frame.Method == "notifications/message"
+}
+
+// advertisesLogging reports whether the server's discover result declares the logging
+// capability. A server that emits log notifications MUST declare it, so a server
+// emitting them unasked AND undeclared is breaking two requirements, which is worth
+// saying in the evidence rather than leaving the reader to check.
+func (e *LogOptInExecutor) advertisesLogging(session mcpSession) bool {
+	return session.ServerSupports("logging")
+}
+
+func (e *LogOptInExecutor) finding(session mcpSession, declared bool) attack.Finding {
+	capability := "the server also does not declare the logging capability, which it MUST when it " +
+		"emits log notifications, so two requirements are broken here"
+	if declared {
+		capability = "the server does declare the logging capability, so the defect is the opt-in " +
+			"gate rather than the declaration"
+	}
+	return attack.Finding{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "medium",
+		Confidence: attack.ConfirmedExploit,
+		Title:      "MCP server emits log notifications to a request that did not opt in",
+		Description: fmt.Sprintf(
+			"At %s, a tools/list request whose _meta carried no %s was answered with a stream "+
+				"containing a notifications/message frame. MCP %s replaced logging/setLevel with a "+
+				"per-request opt-in and requires that a server MUST NOT emit notifications/message for "+
+				"a request that does not include that field. The same page requires that log messages "+
+				"carry no credentials, personal data or internal system details, which is an "+
+				"acknowledgement of what they usually do carry, and an MCP client feeds what the server "+
+				"sends into a model's context. So a client that never asked for logs receives "+
+				"server-side detail it did not request and cannot anticipate. A control request that DID "+
+				"carry the field produced log frames too, which is what establishes that this server "+
+				"logs on this surface and that the unasked-for frames are not an artefact of the probe.",
+			session.Endpoint, metaLogLevel, modernEraVersion),
+		// No wire line here: this rule only ever reports on the modern wire, so labelEra
+		// always prepends one, and naming it twice is how the live fixture run read.
+		Evidence: fmt.Sprintf(
+			"endpoint: %s\ncontrol, _meta WITH %s=%s: notifications/message observed, so the "+
+				"server logs here\nprobe, _meta WITHOUT %s: notifications/message observed anyway "+
+				"(MUST NOT)\n%s",
+			session.Endpoint, metaLogLevel, logProbeLevel, metaLogLevel, capability),
+		Remediation: e.rule.Remediation,
+		TargetURL:   session.Endpoint,
+	}
+}

--- a/internal/attack/mcp/log_optin_test.go
+++ b/internal/attack/mcp/log_optin_test.go
@@ -1,0 +1,345 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+// mcp-log-optin-001 tests one MUST NOT: "The server MUST NOT emit
+// notifications/message for a request that does not include this field."
+//
+// Emitting logs is a MAY, so absence proves nothing, and the control probe is what
+// makes the rule honest: only a server that logs WHEN ASKED can be judged on whether
+// it logs when not asked. Every case below turns on that asymmetry.
+
+// logMode decides how the fixture treats the per-request opt-in.
+type logMode int
+
+const (
+	// logAlways emits log frames whether or not logLevel was requested: the finding.
+	logAlways logMode = iota
+	// logOnOptIn emits only when logLevel is present: compliant.
+	logOnOptIn
+	// logNever emits nothing at all, so the rule cannot judge the gate.
+	logNever
+	// logAlwaysUndeclared is logAlways, and also omits the logging capability.
+	logAlwaysUndeclared
+	// logJSONOnly answers with a single JSON object rather than a stream, so no
+	// notification frame is possible either way.
+	logJSONOnly
+	// logDecoy emits a NON-log notification that mentions a level, and lists a tool
+	// called logLevel, so the payloads contain every word a text search would look
+	// for while carrying no notifications/message at all. It exists to pin the oracle
+	// to the METHOD NAME: matching on field names instead reports this server, which
+	// gates its log notifications correctly, as a violation.
+	logDecoy
+)
+
+// logOptInServer serves the 2026-07-28 wire only, so the rule's era gate is exercised
+// as well. requestLogLevel records what each tools/list carried, so a test can assert
+// the control probe really did ask.
+func logOptInServer(t *testing.T, mode logMode, sawOptIn *[]bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method, _ := body["method"].(string)
+		params, _ := body["params"].(map[string]interface{})
+		meta, _ := params["_meta"].(map[string]interface{})
+		id := body["id"]
+
+		// Modern wire only: refuse the handshake so the rule arrives via discovery.
+		if r.Header.Get("MCP-Protocol-Version") != "2026-07-28" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": -32022, "message": "UnsupportedProtocolVersion"},
+			})
+			return
+		}
+
+		if method == "server/discover" {
+			caps := map[string]interface{}{"tools": map[string]interface{}{}}
+			if mode != logAlwaysUndeclared {
+				caps["logging"] = map[string]interface{}{}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{
+					"supportedVersions": []string{"2026-07-28"},
+					"capabilities":      caps,
+				},
+			})
+			return
+		}
+
+		if method != "tools/list" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": -32601, "message": "Method not found"},
+			})
+			return
+		}
+
+		_, optedIn := meta["io.modelcontextprotocol/logLevel"]
+		if sawOptIn != nil {
+			*sawOptIn = append(*sawOptIn, optedIn)
+		}
+
+		result := map[string]interface{}{"tools": []interface{}{map[string]interface{}{"name": "echo"}}}
+		if mode == logDecoy {
+			// Every needle a text search might use, in a payload that is not a log frame.
+			result = map[string]interface{}{"tools": []interface{}{
+				map[string]interface{}{"name": "logLevel", "description": "set the level"},
+			}}
+		}
+		if mode == logJSONOnly {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id, "result": result,
+			})
+			return
+		}
+
+		emitLog := mode == logAlways || mode == logAlwaysUndeclared || (mode == logOnOptIn && optedIn)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		if mode == logDecoy {
+			// A progress notification, not a log one, mentioning a level.
+			decoy, _ := json.Marshal(map[string]interface{}{
+				"jsonrpc": "2.0", "method": "notifications/progress",
+				"params": map[string]interface{}{"level": "debug", "logger": "decoy", "progress": 1},
+			})
+			fmt.Fprintf(w, "data: %s\n\n", decoy)
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		if emitLog {
+			// A log notification ahead of the response, which is where the binding
+			// says request-scoped notifications flow.
+			note, _ := json.Marshal(map[string]interface{}{
+				"jsonrpc": "2.0", "method": "notifications/message",
+				"params": map[string]interface{}{
+					"level": "debug", "logger": "fixture",
+					"data": map[string]interface{}{"msg": "listing tools"},
+				},
+			})
+			fmt.Fprintf(w, "data: %s\n\n", note)
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		reply, _ := json.Marshal(map[string]interface{}{
+			"jsonrpc": "2.0", "id": id, "result": result,
+		})
+		fmt.Fprintf(w, "data: %s\n\n", reply)
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}))
+}
+
+func logOptInRC() attack.RuleContext {
+	return attack.RuleContext{
+		ID: "mcp-log-optin-001", Name: "MCP Log Opt-In", Severity: "medium",
+		Remediation: "Gate notifications/message on the request's own logLevel.",
+	}
+}
+
+func runLogOptIn(t *testing.T, ts *httptest.Server) ([]attack.Finding, error) {
+	t.Helper()
+	return mcpattack.NewLogOptInExecutor(logOptInRC()).
+		Execute(context.Background(), ts.URL, testOpts())
+}
+
+// The finding: log frames arrive for a request that carried no logLevel, and the
+// control proved the server logs here.
+func TestLogOptIn_EmitsWithoutOptIn(t *testing.T) {
+	var sawOptIn []bool
+	ts := logOptInServer(t, logAlways, &sawOptIn)
+	defer ts.Close()
+
+	findings, err := runLogOptIn(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected the opt-in violation, got %d: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Severity != "medium" || f.Confidence != attack.ConfirmedExploit {
+		t.Errorf("want medium/ConfirmedExploit, got %s/%s", f.Severity, f.Confidence)
+	}
+	if !strings.Contains(f.Title, "2026-07-28 wire") {
+		t.Errorf("a modern-wire finding should be labelled as such, got %q", f.Title)
+	}
+	// The control has to have actually asked, or the finding rests on nothing.
+	if len(sawOptIn) < 2 || !sawOptIn[0] || sawOptIn[1] {
+		t.Errorf("expected a control request WITH the field then a probe WITHOUT it, saw %v", sawOptIn)
+	}
+	if !strings.Contains(f.Evidence, "notifications/message observed, so the server logs here") {
+		t.Errorf("evidence should record the control that makes the claim meaningful; got:\n%s", f.Evidence)
+	}
+	if !strings.Contains(f.Evidence, "does declare the logging capability") {
+		t.Errorf("evidence should record the capability declaration; got:\n%s", f.Evidence)
+	}
+	// labelEra prepends the wire line, and this rule only ever reports on that wire, so
+	// stating it in the finding too printed it twice. Caught by running the fixture, not
+	// by these tests, which is the argument for running the fixture.
+	if n := strings.Count(f.Evidence, "wire: MCP"); n != 1 {
+		t.Errorf("the wire should be named exactly once, got %d times:\n%s", n, f.Evidence)
+	}
+}
+
+// A server that logs only when asked is compliant, and the control proves the rule
+// actually exercised the surface rather than finding silence.
+func TestLogOptIn_EmitsOnlyOnOptInIsClean(t *testing.T) {
+	ts := logOptInServer(t, logOnOptIn, nil)
+	defer ts.Close()
+
+	findings, err := runLogOptIn(t, ts)
+	if err != nil {
+		t.Fatalf("a server that respects the gate is a real clean result: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings, got %d: %+v", len(findings), findings)
+	}
+}
+
+// A server that never logs cannot be judged: silence is indistinguishable from
+// compliance. It must be reported as NOT OBSERVED, never as clean, or the rule would
+// claim the server gates its log notifications on the strength of never having seen
+// one. This is what makes the control probe load-bearing: without it, silent-control
+// and silent-probe produce the same verdict and removing the control changes nothing.
+func TestLogOptIn_NeverLogsIsNotObserved(t *testing.T) {
+	ts := logOptInServer(t, logNever, nil)
+	defer ts.Close()
+
+	findings, err := runLogOptIn(t, ts)
+	if len(findings) != 0 {
+		t.Fatalf("silence is not evidence of anything; got %d: %+v", len(findings), findings)
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "silence is not evidence of the gate") {
+		t.Errorf("the reason should say why silence settles nothing; got %q", err)
+	}
+}
+
+// A single JSON object cannot carry a notification frame, so the gate was never
+// exercised and the honest answer is not observed rather than clean.
+func TestLogOptIn_NonStreamingResponseIsNotObserved(t *testing.T) {
+	ts := logOptInServer(t, logJSONOnly, nil)
+	defer ts.Close()
+
+	findings, err := runLogOptIn(t, ts)
+	if len(findings) != 0 {
+		t.Fatalf("expected zero findings, got %d: %+v", len(findings), findings)
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "no readable response stream") {
+		t.Errorf("the reason should name the missing stream; got %q", err)
+	}
+}
+
+// Emitting log notifications without declaring the logging capability breaks a second
+// requirement, and the evidence should say so rather than leave it to the reader.
+func TestLogOptIn_UndeclaredCapabilityIsNamed(t *testing.T) {
+	ts := logOptInServer(t, logAlwaysUndeclared, nil)
+	defer ts.Close()
+
+	findings, err := runLogOptIn(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected the opt-in violation, got %d", len(findings))
+	}
+	if !strings.Contains(findings[0].Evidence, "two requirements are broken") {
+		t.Errorf("evidence should name the undeclared capability; got:\n%s", findings[0].Evidence)
+	}
+}
+
+// The field and its MUST NOT exist only in 2026-07-28. A handshake-era server has no
+// such requirement, so the rule reports not applicable and names the revision rather
+// than reporting a clean pass about a surface that does not exist there.
+func TestLogOptIn_LegacyOnlyIsNotApplicable(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method, _ := body["method"].(string)
+		id := body["id"]
+		w.Header().Set("Content-Type", "application/json")
+		switch method {
+		case "initialize":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{
+					"protocolVersion": "2025-11-25",
+					"serverInfo":      map[string]interface{}{"name": "legacy", "version": "1"},
+					"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}, "logging": map[string]interface{}{}},
+				},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": -32601, "message": "Method not found"},
+			})
+		}
+	}))
+	defer ts.Close()
+
+	findings, err := runLogOptIn(t, ts)
+	if len(findings) != 0 {
+		t.Fatalf("expected zero findings, got %d", len(findings))
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive on a legacy-only target, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "2026-07-28") {
+		t.Errorf("the reason should name the revision that introduced the field, got %q", err)
+	}
+}
+
+// The oracle keys on the METHOD NAME, not on field names. This server gates its log
+// notifications correctly and never sends notifications/message, but every payload it
+// does send mentions a level and a logger, and one of its tools is called logLevel. A
+// text search over the stream reports it; the method-name check does not.
+//
+// Matching on field names instead of the method name is the vacuous-needle mistake
+// corrected in #163, #169 and #181, and this is the case that pins it here.
+func TestLogOptIn_DecoyPayloadsAreNotLogFrames(t *testing.T) {
+	ts := logOptInServer(t, logDecoy, nil)
+	defer ts.Close()
+
+	findings, err := runLogOptIn(t, ts)
+	if len(findings) != 0 {
+		t.Fatalf("a progress notification mentioning a level is not a log frame; got %d: %+v",
+			len(findings), findings)
+	}
+	// It never sends a log frame at all, so the control cannot establish the gate and
+	// the honest answer is not observed.
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive, got %v", err)
+	}
+}

--- a/rules/mcp/log-optin-001.yaml
+++ b/rules/mcp/log-optin-001.yaml
@@ -1,0 +1,85 @@
+id: mcp-log-optin-001
+info:
+  name: MCP Server Emits Log Notifications Without a Per-Request Opt-In
+  author: batesian
+  severity: medium
+  description: |
+    Tests whether a server sends log notifications to a request that never asked for
+    them. The 2026-07-28 revision removed logging/setLevel and replaced it with a
+    per-request opt-in, and the logging page is explicit: "To receive log messages
+    for a specific request, include io.modelcontextprotocol/logLevel in the request's
+    _meta. The server MUST NOT emit notifications/message for a request that does not
+    include this field."
+
+    That is the bug the revision created. A server carried over from the setLevel era
+    holds a connection-global level and emits unconditionally, so a client that never
+    opted in receives server-side log content. The same page requires that log
+    messages carry no credentials, personal data or internal system details, which is
+    an acknowledgement of what they usually do carry, and an MCP client feeds what the
+    server sends into a model's context. So the harm is unrequested server-internal
+    detail arriving somewhere it was not expected.
+
+    Emitting logs is a MAY, so ABSENCE PROVES NOTHING: a server that never logs is
+    indistinguishable from one that respects the gate. Two probes, in this order:
+
+      1. Control: tools/list with io.modelcontextprotocol/logLevel = debug in _meta.
+         The server must answer with at least one notifications/message frame,
+         otherwise it does not log on this surface and the probe below could not tell
+         compliance from silence. The rule then judges nothing.
+      2. Probe: the identical tools/list with NO logLevel in _meta. Any
+         notifications/message frame is the finding.
+
+    Only positive evidence is ever reported. A server that stays silent for the
+    control is left alone, and a server that logs for the control and not for the
+    probe is a genuine clean result: it demonstrably logs here, and it withheld the
+    frames when they were not requested.
+
+    The probe is a read. tools/list creates nothing, calls no tool and modifies no
+    state; the rule needs the server to do a unit of work, not to do anything in
+    particular.
+
+    The evidence also records whether the server declares the logging capability,
+    because a server that emits notifications MUST declare it, so one that emits them
+    unasked and undeclared is breaking two requirements rather than one.
+
+    Currency: the field, and the MUST NOT, exist only in 2026-07-28, so the rule runs
+    on that wire alone and reports not applicable against a target serving no such
+    wire. Note also that the whole Logging feature is deprecated as of the same
+    revision (SEP-2577): it remains in the specification for at least twelve months
+    and is eligible for removal in the first revision released on or after
+    2027-07-28, with new implementations told to log to stderr or use OpenTelemetry
+    instead. The requirement is normative until then, and the servers most likely to
+    break it are precisely the ones migrating off logging/setLevel.
+
+  references:
+    - https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/logging
+    - https://modelcontextprotocol.io/specification/2026-07-28/basic/index
+    - https://modelcontextprotocol.io/specification/2026-07-28/changelog
+    - https://cwe.mitre.org/data/definitions/200.html
+    - https://cwe.mitre.org/data/definitions/532.html
+
+  tags:
+    - mcp
+    - logging
+    - information-disclosure
+    - cwe-200
+    - cwe-532
+
+attack:
+  protocol: mcp
+  type: mcp-log-optin
+
+remediation: |
+  1. Gate every notifications/message on the requesting call's own
+     io.modelcontextprotocol/logLevel. A request that does not carry the field gets no
+     log notifications at all.
+  2. Do not keep a connection-global or server-global log level. The 2026-07-28
+     revision removed logging/setLevel precisely because the level is now a property
+     of a single request, and a level held anywhere broader is what causes this.
+  3. Keep notifications/message on the response stream of the request that set the
+     level. It must not be delivered on a subscriptions/listen stream or on any other
+     stream.
+  4. Declare the logging capability whenever the server emits log notifications.
+  5. Keep credentials, personal data and internal system details out of log messages
+     regardless. A client feeds server output into a model's context, so log content
+     is not an internal channel.

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -31,7 +31,7 @@ a run that treats it as a clean result is reporting coverage it does not have.
 
 ## Server Registry
 
-The bundled rule set is **18 A2A + 20 MCP = 38 rules**. Every rule's primary
+The bundled rule set is **18 A2A + 21 MCP = 39 rules**. Every rule's primary
 validation is an in-process `net/http/httptest` harness in its Go
 `*_test.go` (multiple server postures: vulnerable must fire / patched / open /
 benign must stay silent). The Python servers below are optional standalone
@@ -71,8 +71,9 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_large_body_server.py` | 7801 | the unauth family at responses past the body read limit, see below |
 | `mcp_transient_failure_server.py` | 7802 | the unauth family when a probe fails without refusing, see below |
 | `mcp_session_as_credential_server.py` | 7803 | `mcp-session-as-credential-001` (needs `--token tok-a`; four postures, see below) |
+| `mcp_log_optin_server.py` | 7804 | `mcp-log-optin-001` must fire on `always`; stay silent on `on-optin`; report not tested on `never` (three postures, see below) |
 
-**Coverage.** 37 of the 38 rules have a standalone Python fixture above, and each
+**Coverage.** 38 of the 39 rules have a standalone Python fixture above, and each
 of those was checked by actually running it rather than by reading this table. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
 (`internal/attack/mcp/token_replay_test.go`); the same is true of the per-rule
@@ -273,6 +274,25 @@ official MCP C# SDK's stateful sample, which this rule reported as vulnerable
 until the anonymous-handshake control was added. Without `--token` the rule
 reports inconclusive against all three, since it cannot ask whether a session id
 substitutes for a credential it was never given.
+
+**`mcp_log_optin_server.py` takes a posture argument**, defaulting to `always`, and
+speaks the 2026-07-28 wire only:
+
+```sh
+python testdata/mcp_log_optin_server.py always    # rule must fire
+python testdata/mcp_log_optin_server.py on-optin  # rule must stay silent
+python testdata/mcp_log_optin_server.py never     # rule must report NOT TESTED
+```
+
+The third posture is the one worth having. Emitting log notifications is a MAY, so a
+server that never emits any is indistinguishable from one that gates them correctly,
+and reporting it clean would be a pass with no evidence behind it. That is why the
+rule sends a control request asking for logs before it sends the probe that does not.
+While the rule was being written that control was briefly dead logic: silent-control
+and silent-probe both fell through to clean, so removing the control changed no
+output at all. `never` is what pins the difference, and `on-optin` is what keeps the
+clean verdict a real one, since the control proves the server logs on this surface
+and it withheld the frames when they were not asked for.
 
 The multi-tenant and delegation fixtures exercise the chained rules: they require
 two principals supplied with `--principal name=...,token=...,tenant=...` (or a

--- a/testdata/mcp_log_optin_server.py
+++ b/testdata/mcp_log_optin_server.py
@@ -1,0 +1,135 @@
+"""
+Batesian MCP validation target: per-request log opt-in (mcp-log-optin-001).
+
+MCP 2026-07-28 removed logging/setLevel and replaced it with a per-request opt-in.
+The logging page is explicit: "To receive log messages for a specific request,
+include io.modelcontextprotocol/logLevel in the request's _meta. The server MUST NOT
+emit notifications/message for a request that does not include this field."
+
+This server speaks the 2026-07-28 wire ONLY (it refuses the handshake), answers
+server/discover, and streams its tools/list reply as SSE so notification frames are
+possible at all.
+
+Three postures, selected by the first argument:
+
+    always    emits a notifications/message frame whether or not logLevel was
+              requested. THE RULE MUST FIRE. This is the shape of a server carried
+              over from the setLevel era, holding a connection-global level.
+    on-optin  emits only when logLevel is present. The rule must report CLEAN, and
+              that clean result is a real one: the control request proves the server
+              logs here, and it withheld the frames when they were not asked for.
+    never     emits nothing at all. The rule must report NOT OBSERVED, never clean:
+              emitting is a MAY, so silence is indistinguishable from the gate
+              working, and claiming otherwise would be a pass with no evidence.
+
+The `never` posture is the one worth keeping. It is the reason the rule sends a
+control request at all, and while writing that rule the control was briefly dead
+logic: silent-control and silent-probe both fell through to clean, so removing the
+control changed no output. This posture is what pins the difference.
+
+Run:
+    python testdata/mcp_log_optin_server.py always
+    python testdata/mcp_log_optin_server.py on-optin
+    python testdata/mcp_log_optin_server.py never
+
+Scan:
+    batesian scan --target http://127.0.0.1:7804/mcp \\
+        --rule-ids mcp-log-optin-001 -v
+
+Endpoint: http://127.0.0.1:7804/mcp
+"""
+import json
+import sys
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response, StreamingResponse
+from starlette.routing import Route
+import uvicorn
+
+PORT = 7804
+MODERN_VERSION = "2026-07-28"
+LOG_LEVEL_KEY = "io.modelcontextprotocol/logLevel"
+
+POSTURES = ("always", "on-optin", "never")
+POSTURE = sys.argv[1] if len(sys.argv) > 1 else "always"
+
+
+def _rpc_error(req_id, code, message, status=200):
+    return JSONResponse({"jsonrpc": "2.0", "id": req_id,
+                         "error": {"code": code, "message": message}},
+                        status_code=status)
+
+
+def _sse(frames):
+    """One SSE data event per frame, in order."""
+    def gen():
+        for frame in frames:
+            yield f"data: {json.dumps(frame)}\n\n"
+    return StreamingResponse(gen(), media_type="text/event-stream")
+
+
+async def mcp_endpoint(request: Request) -> Response:
+    try:
+        body = await request.json()
+    except Exception:
+        return _rpc_error(None, -32700, "Parse error")
+
+    method = body.get("method", "")
+    req_id = body.get("id")
+    params = body.get("params") or {}
+    meta = params.get("_meta") or {}
+
+    # Modern wire only: a handshake request is refused, so the scanner can only reach
+    # this server through server/discover.
+    if request.headers.get("mcp-protocol-version") != MODERN_VERSION:
+        return _rpc_error(req_id, -32022, "UnsupportedProtocolVersion", status=400)
+
+    if method == "server/discover":
+        return JSONResponse({"jsonrpc": "2.0", "id": req_id, "result": {
+            "supportedVersions": [MODERN_VERSION],
+            # Declared, because this server does emit log notifications. A server that
+            # emits them without declaring the capability breaks a second requirement,
+            # and the rule reports that in its evidence.
+            "capabilities": {"tools": {}, "logging": {}},
+            "serverInfo": {"name": "log-optin-target", "version": "1.0"},
+        }})
+
+    if method != "tools/list":
+        return _rpc_error(req_id, -32601, "Method not found")
+
+    opted_in = LOG_LEVEL_KEY in meta
+    emit = POSTURE == "always" or (POSTURE == "on-optin" and opted_in)
+
+    frames = []
+    if emit:
+        # Request-scoped, on the response stream, ahead of the response: where the
+        # binding says notifications/message flows.
+        frames.append({
+            "jsonrpc": "2.0",
+            "method": "notifications/message",
+            "params": {"level": "debug", "logger": "log-optin-target",
+                       "data": {"msg": "listing tools", "optedIn": opted_in}},
+        })
+    frames.append({"jsonrpc": "2.0", "id": req_id,
+                   "result": {"tools": [{"name": "echo", "description": "Echo input"}]}})
+    return _sse(frames)
+
+
+app = Starlette(routes=[Route("/mcp", mcp_endpoint, methods=["POST"])])
+
+if __name__ == "__main__":
+    if POSTURE not in POSTURES:
+        sys.exit(f"unknown posture {POSTURE!r}; expected one of {', '.join(POSTURES)}")
+    print(f"[*] MCP per-request log opt-in target ({POSTURE}) on "
+          f"http://127.0.0.1:{PORT}/mcp", flush=True)
+    if POSTURE == "always":
+        print("[*] Violation: emits notifications/message with no logLevel in _meta "
+              "(MUST NOT). The rule must fire.", flush=True)
+    elif POSTURE == "on-optin":
+        print("[*] Expected: no finding. Logs only when asked, which is the gate "
+              "working.", flush=True)
+    else:
+        print("[*] Expected: NOT OBSERVED. Never logs, so the gate cannot be "
+              "established either way.", flush=True)
+    print(f"[*] Wire: MCP {MODERN_VERSION} only; the handshake is refused", flush=True)
+    uvicorn.run(app, host="127.0.0.1", port=PORT)


### PR DESCRIPTION
2026-07-28 removed `logging/setLevel` and replaced it with a per-request opt-in. The logging page: "To receive log messages for a specific request, include `io.modelcontextprotocol/logLevel` in the request's `_meta`. The server MUST NOT emit `notifications/message` for a request that does not include this field." Nothing tested that. A server carried over from the setLevel era holds a connection-global level and emits unconditionally, so a client that never opted in receives server-side log content, which an MCP client feeds into a model's context.

New rule `mcp-log-optin-001`, medium, confirmed, 2026-07-28 wire only.

Emitting logs is a MAY, so absence proves nothing. The rule sends a control request **with** the field and reports not tested unless a `notifications/message` frame comes back; only then does it send the identical request without the field, where a frame is the finding. A server that logs for the control and not for the probe is a real clean result. The probe is a read (`tools/list`). The frames are only visible on the raw stream, since `readSSEResponse` collapses a stream to its response event, so the probes read the stream themselves. The oracle keys on the method name, not on a `level` or `logger` field.

Verification: `testdata/mcp_log_optin_server.py` on three postures. Fires on `always`, silent on `on-optin`, not tested on `never`. Seven Go tests.

Two non-vacuity checks initially passed when they should have failed, and both were real defects:

- Removing the control changed no output. Silent-control and silent-probe both fell through to clean, so the control was dead logic and the rule would have called a server that never logs "gated". It now returns not tested.
- Replacing the method-name oracle with a substring match on `"level"` also passed. The fixture grew a decoy posture serving a `notifications/progress` frame carrying `level` and `logger`.

Both checks now fail as they must. Running the fixture also caught the wire being named twice in the evidence, which the Go tests had not; that assertion is now in them.

The 49-case fixture sweep shows no change against the previous binary beyond this rule appearing as not applicable on legacy targets.