### PR TITLE
fix(mcp): probe Origin validation on both wires, and require a real handshake

### DIFF
--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -112,6 +112,10 @@ need not be gated alike: a server can enforce authorization on one and not the
 other. Each wire is capability-gated on its own advertisement, so a surface the
 server exposes on only one era is probed only there.
 
+`mcp-dns-rebind-origin-001` is exercised on each wire for the same reason, with the
+request each one speaks. Origin validation is normally middleware, so a server can
+serve the two wires through different handlers and fix only one.
+
 Findings from the 2026-07-28 wire carry a `[MCP 2026-07-28 wire]` suffix and name
 the wire in their evidence, so a surface exposed on both produces two
 distinguishable results rather than what looks like a duplicate. A legacy-only
@@ -632,17 +636,32 @@ finding.
 
 The Streamable HTTP transport requires servers to validate the Origin header on
 every connection and respond `HTTP 403 Forbidden` to a present, invalid Origin,
-to prevent DNS rebinding. The rule first POSTs a normal `initialize` with no
-Origin (baseline: it must be accepted, confirming a responsive MCP endpoint),
-then POSTs the same `initialize` with a foreign Origin
-(`https://dns-rebind.batesian.invalid`, a non-resolving RFC 6761 host no server
-should allowlist) - the only difference is the Origin header. A **confirmed**
-finding is raised when the server still returns a JSON-RPC result for the
-foreign-Origin request instead of rejecting it with 403. DNS-rebinding
-exploitation additionally requires the server to be reachable from a victim's
-browser (a local or same-network bind), which the operator confirms for the
-deployment; this is the class behind the MCP Inspector RCE (CVE-2025-49596). A
-server that answers the foreign Origin with 403 produces no finding.
+to prevent DNS rebinding. The rule opens each wire the server serves, which is a
+request with no Origin that the server accepted, then repeats that exact request
+with a foreign Origin (`https://dns-rebind.batesian.invalid`, a non-resolving RFC
+6761 host no server should allowlist). The pair differs in the Origin header and
+nothing else, and is credential-symmetric, so a refusal cannot be about a missing
+token. A **confirmed** finding is raised when the server still returns a JSON-RPC
+result for the foreign-Origin request instead of rejecting it with 403.
+DNS-rebinding exploitation additionally requires the server to be reachable from a
+victim's browser (a local or same-network bind), which the operator confirms for
+the deployment; this is the class behind the MCP Inspector RCE (CVE-2025-49596). A
+server that answers the foreign Origin with 403 produces no finding, and a probe
+that never got an answer is reported as not tested rather than clean.
+
+Requiring a completed handshake, rather than any HTTP 200 carrying a JSON-RPC
+result, is load-bearing. An A2A agent answers any method with a Task result, so
+scanning one used to produce this finding against a server that speaks no MCP.
+
+**Currency.** The requirement is byte-identical in `2026-07-28`, where it moved to
+the transports/streamable-http page. It is stated for "all incoming connections",
+is not scoped to a method, and is not conditioned on the server being local; only
+the bind-to-localhost SHOULD beside it is. So **both wires are probed**, with the
+request each one speaks: `initialize` on the handshake wires, `server/discover` on
+2026-07-28, which every server MUST implement. The two are reported separately,
+because Origin checking is normally middleware and a server can serve the wires
+through different handlers, so a server that has fixed one and not the other reads
+as clean if only the fixed one is probed.
 
 ---
 

--- a/internal/attack/mcp/dns_rebind_origin.go
+++ b/internal/attack/mcp/dns_rebind_origin.go
@@ -18,6 +18,14 @@ import (
 // instead of rejecting it does not validate Origin; a local or same-network
 // server is then reachable from a malicious website that rebinds DNS to it
 // (driving tool calls and, on some servers, command execution).
+//
+// Both wires are probed. The requirement is byte-identical in 2026-07-28, where it
+// moved to the transports/streamable-http page, is stated for "all incoming
+// connections" with no per-method scoping, and is not conditioned on the server
+// being local: only the bind-to-localhost SHOULD beside it is. So the rule has the
+// same question to ask of a modern-only server, and the wires need not answer it
+// alike, since Origin checking is usually middleware and the two wires can sit
+// behind different handlers.
 type DNSRebindOriginExecutor struct {
 	rule attack.RuleContext
 }
@@ -40,73 +48,94 @@ func (e *DNSRebindOriginExecutor) Execute(ctx context.Context, target string, op
 	vars := attack.NewVars(target, opts.OOBListenerURL)
 	client := attack.NewHTTPClient(opts, vars)
 
-	// Why the baseline never succeeded, classified from the responses this loop
-	// already has. Without it a server that answers and refuses the handshake reads
-	// the same as a host that is not there.
-	var observed initObservation
-	for _, ep := range endpointCandidates(vars.BaseURL) {
-		// Baseline: a normal initialize with no Origin must be accepted, so we know
-		// this endpoint is a responsive MCP server and the probe is meaningful.
-		accepted, baseline := e.initAccepted(ctx, client, ep, "")
+	// The handshake IS the baseline. Opening a wire means the server accepted, at
+	// this endpoint, the very request the probe below repeats with one header added,
+	// so the pair differs in the Origin header and nothing else. It is also
+	// credential-symmetric: the same client sends both, so a rejection cannot be
+	// about a missing token when the baseline it is paired with carried the same one.
+	//
+	// Reaching the wires through openSessions is also what makes the rule honest
+	// about a modern-only server. It used to run its own initialize loop, and a
+	// 2026-07-28 server has no initialize at all, so every candidate failed and the
+	// rule reported a bare "could not test" against a server it could in fact have
+	// probed.
+	return runOnEachWire(ctx, client, vars.BaseURL, func(session mcpSession) ([]attack.Finding, bool) {
+		accepted, resp := e.originAccepted(ctx, client, session)
+		if resp == nil {
+			// Nothing answered, so this wire yielded no verdict either way. Reporting
+			// it clean would credit a server with validation on the strength of a
+			// request that never arrived.
+			return nil, false
+		}
 		if !accepted {
-			if baseline != nil {
-				observed.observe(classifyInitFailure(ep, client.PresentsCredential(ep), baseline))
-			}
-			continue
+			// Refused. The specification asks for 403 specifically, and anything else
+			// is a lesser kind of compliant, but the security question is only whether
+			// the server PROCESSED a foreign-Origin request. It did not, so there is no
+			// rebinding exposure to report.
+			return nil, true
 		}
-		// Probe: the same initialize with a foreign Origin. A compliant server
-		// rejects it with HTTP 403; a server that still processes it does not
-		// validate Origin. The only difference from the baseline is the Origin
-		// header, so acceptance isolates Origin handling.
-		if forged, _ := e.initAccepted(ctx, client, ep, foreignOrigin); forged {
-			return []attack.Finding{{
-				RuleID:     e.rule.ID,
-				RuleName:   e.rule.Name,
-				Severity:   e.rule.Severity,
-				Confidence: attack.ConfirmedExploit,
-				Title:      "MCP server does not validate the Origin header (DNS rebinding protection missing)",
-				Description: fmt.Sprintf(
-					"The MCP endpoint processed an initialize request carrying a foreign Origin header (%s) "+
-						"and returned a JSON-RPC result, instead of rejecting it with HTTP 403. The Streamable "+
-						"HTTP transport requires servers to validate the Origin header on every connection and "+
-						"respond 403 to an invalid Origin, to prevent DNS rebinding. A server bound to a local "+
-						"or private address is then reachable from a victim's browser via a malicious website "+
-						"that rebinds DNS to it, which can drive tool calls and, on some servers, reach command "+
-						"execution. Validate Origin against an allowlist and bind local servers to localhost.",
-					foreignOrigin),
-				Evidence: fmt.Sprintf(
-					"endpoint: %s\nbaseline initialize (no Origin): accepted\ninitialize with Origin %s: accepted (should be HTTP 403)",
-					ep, foreignOrigin),
-				Remediation: e.rule.Remediation,
-				TargetURL:   ep,
-			}}, nil
-		}
-		// Baseline accepted but the foreign-Origin probe was rejected: Origin is
-		// validated. No finding, and no need to try other endpoints.
-		return nil, nil
-	}
-	// No candidate accepted a baseline initialize: not a testable MCP endpoint. Say
-	// which of those it was where the target explained itself.
-	if observed.rank > rankNothing {
-		return nil, inconclusive(handshakeRefusal{observed.reason})
-	}
-	return nil, attack.ErrInconclusive
+		return []attack.Finding{e.finding(session)}, true
+	})
 }
 
-// initAccepted sends an MCP initialize to ep (optionally with an Origin header)
-// and reports whether the server accepted it (HTTP 200 with a JSON-RPC result
-// rather than an error envelope or a 403).
-// The response is returned alongside the verdict so a failed baseline can be
-// explained rather than only counted. It is nil when the request never got an
-// answer, which is the one case there is nothing to explain.
-func (e *DNSRebindOriginExecutor) initAccepted(ctx context.Context, client *attack.HTTPClient, ep, origin string) (bool, *attack.Response) {
-	headers := map[string]string{"Content-Type": "application/json"}
-	if origin != "" {
-		headers["Origin"] = origin
+// originAccepted repeats this wire's own handshake request with a foreign Origin
+// header and reports whether the server processed it anyway.
+//
+// The request is chosen per era so that it matches what the baseline was: initialize
+// on the handshake wires, server/discover on 2026-07-28, which every server MUST
+// implement and which is what opened the modern session in the first place.
+//
+// The response is returned alongside the verdict so that "refused" can be told from
+// "never answered". It is nil only in the second case.
+func (e *DNSRebindOriginExecutor) originAccepted(ctx context.Context, client *attack.HTTPClient,
+	session mcpSession) (bool, *attack.Response) {
+	if session.Era == EraModern {
+		resp, err := session.postShaping(ctx, client, "batesian-origin", "server/discover", nil,
+			func(h map[string]string) { h["Origin"] = foreignOrigin })
+		if err != nil {
+			return false, nil
+		}
+		return resp.IsAccepted(), resp
 	}
-	resp, err := client.POST(ctx, ep, headers, json.RawMessage(mcpInitBody))
+
+	headers := map[string]string{"Content-Type": "application/json", "Origin": foreignOrigin}
+	resp, err := client.POST(ctx, session.Endpoint, headers, json.RawMessage(mcpInitBody))
 	if err != nil {
 		return false, nil
 	}
 	return resp.IsAccepted(), resp
+}
+
+// probeMethod names the request the probe sent, for the finding text. The two wires
+// are asked the same question with the request each one actually speaks.
+func probeMethod(session mcpSession) string {
+	if session.Era == EraModern {
+		return "server/discover"
+	}
+	return "initialize"
+}
+
+func (e *DNSRebindOriginExecutor) finding(session mcpSession) attack.Finding {
+	method := probeMethod(session)
+	return attack.Finding{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   e.rule.Severity,
+		Confidence: attack.ConfirmedExploit,
+		Title:      "MCP server does not validate the Origin header (DNS rebinding protection missing)",
+		Description: fmt.Sprintf(
+			"The MCP endpoint processed a %s request carrying a foreign Origin header (%s) "+
+				"and returned a JSON-RPC result, instead of rejecting it with HTTP 403. The Streamable "+
+				"HTTP transport requires servers to validate the Origin header on every connection and "+
+				"respond 403 to an invalid Origin, to prevent DNS rebinding. A server bound to a local "+
+				"or private address is then reachable from a victim's browser via a malicious website "+
+				"that rebinds DNS to it, which can drive tool calls and, on some servers, reach command "+
+				"execution. Validate Origin against an allowlist and bind local servers to localhost.",
+			method, foreignOrigin),
+		Evidence: fmt.Sprintf(
+			"endpoint: %s\nbaseline %s (no Origin): accepted\n%s with Origin %s: accepted (should be HTTP 403)",
+			session.Endpoint, method, method, foreignOrigin),
+		Remediation: e.rule.Remediation,
+		TargetURL:   session.Endpoint,
+	}
 }

--- a/internal/attack/mcp/dns_rebind_origin_modern_test.go
+++ b/internal/attack/mcp/dns_rebind_origin_modern_test.go
@@ -1,0 +1,303 @@
+package mcp_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+// The 2026-07-28 wire for mcp-dns-rebind-origin-001.
+//
+// The requirement is byte-identical in that revision, where it moved to the
+// transports/streamable-http page: servers MUST validate Origin on all incoming
+// connections and MUST answer an invalid one with 403. It is not scoped to a method
+// and not conditioned on the server being local. The rule ran its own initialize
+// loop, so against a modern-only server every candidate failed and it reported a bare
+// "could not test" about a server it could have probed.
+//
+// The case that justifies probing per wire rather than once is
+// TestDNSRebindModern_WiresCanDisagree: Origin checking is usually middleware, and a
+// server can put the two wires behind different handlers.
+
+// originWireServer serves whichever wires are asked for and validates Origin
+// independently on each.
+//
+// legacy/modern select which wires exist; legacyChecks/modernChecks select whether
+// that wire answers 403 to a request carrying an Origin.
+type originWireServer struct {
+	legacy, modern             bool
+	legacyChecks, modernChecks bool
+}
+
+func (s originWireServer) start(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method, _ := body["method"].(string)
+		id := body["id"]
+
+		// Which wire this request belongs to, by the header the modern revision
+		// requires on every request.
+		isModern := r.Header.Get("MCP-Protocol-Version") == "2026-07-28"
+
+		rpcErr := func(status, code int, msg string) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(status)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": code, "message": msg},
+			})
+		}
+		result := func(v map[string]interface{}) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id, "result": v,
+			})
+		}
+
+		// Origin validation, per wire, before anything else: it is a transport-level
+		// check, which is exactly why the two wires can differ.
+		if origin := r.Header.Get("Origin"); origin != "" {
+			if (isModern && s.modernChecks) || (!isModern && s.legacyChecks) {
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+		}
+
+		switch {
+		case method == "server/discover":
+			if !s.modern {
+				rpcErr(http.StatusBadRequest, -32022, "UnsupportedProtocolVersion")
+				return
+			}
+			result(map[string]interface{}{
+				"supportedVersions": []string{"2026-07-28"},
+				"capabilities":      map[string]interface{}{"tools": map[string]interface{}{}},
+				"serverInfo":        map[string]interface{}{"name": "origin-wire", "version": "1.0"},
+			})
+		case method == "initialize":
+			if !s.legacy {
+				rpcErr(http.StatusBadRequest, -32022, "UnsupportedProtocolVersion")
+				return
+			}
+			result(map[string]interface{}{
+				"protocolVersion": "2025-11-25",
+				"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+				"serverInfo":      map[string]interface{}{"name": "origin-wire", "version": "1.0"},
+			})
+		case strings.HasPrefix(method, "notifications/"):
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			rpcErr(http.StatusOK, -32601, "Method not found")
+		}
+	}))
+}
+
+func runOriginRule(t *testing.T, ts *httptest.Server) ([]attack.Finding, error) {
+	t.Helper()
+	return mcpattack.NewDNSRebindOriginExecutor(dnsRebindRC()).
+		Execute(t.Context(), ts.URL, testOpts())
+}
+
+// A modern-only server that ignores Origin. Before the port this reported a bare
+// "could not test", because the rule only knew how to send initialize.
+func TestDNSRebindModern_ModernOnlyIgnoresOrigin(t *testing.T) {
+	ts := originWireServer{modern: true}.start(t)
+	defer ts.Close()
+
+	findings, err := runOriginRule(t, ts)
+	if err != nil {
+		t.Fatalf("a modern-only server is testable on this surface: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected the Origin finding, got %d: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Severity != "high" || f.Confidence != attack.ConfirmedExploit {
+		t.Errorf("want high/ConfirmedExploit, got %s/%s", f.Severity, f.Confidence)
+	}
+	if !strings.Contains(f.Title, "2026-07-28 wire") {
+		t.Errorf("a modern-wire finding should be labelled as such, got %q", f.Title)
+	}
+	// The probe must name the request it actually sent. Saying "initialize" here
+	// would describe a method this revision does not have.
+	if !strings.Contains(f.Evidence, "server/discover with Origin") {
+		t.Errorf("evidence should name the request the modern wire was probed with; got:\n%s", f.Evidence)
+	}
+	if strings.Contains(f.Evidence, "initialize") {
+		t.Errorf("the modern wire has no initialize; evidence should not claim one:\n%s", f.Evidence)
+	}
+}
+
+// A modern-only server that answers 403 is clean, and clean rather than not tested:
+// the session was opened by the same request with no Origin, so the refusal is
+// attributable to the header.
+func TestDNSRebindModern_ModernOnlyValidatesIsClean(t *testing.T) {
+	ts := originWireServer{modern: true, modernChecks: true}.start(t)
+	defer ts.Close()
+
+	findings, err := runOriginRule(t, ts)
+	if err != nil {
+		t.Fatalf("a server that validates Origin is a real clean result: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings, got %d: %+v", len(findings), findings)
+	}
+}
+
+// The case the port exists for. Origin checking is middleware, and a server can
+// serve both wires through different handlers, so a single probe on one wire
+// generalises to a claim it has not tested.
+func TestDNSRebindModern_WiresCanDisagree(t *testing.T) {
+	ts := originWireServer{legacy: true, modern: true, legacyChecks: true}.start(t)
+	defer ts.Close()
+
+	findings, err := runOriginRule(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly the modern-wire finding, got %d: %+v", len(findings), findings)
+	}
+	if !strings.Contains(findings[0].Title, "2026-07-28 wire") {
+		t.Errorf("the unvalidated wire is the modern one, and the finding should say so: %q",
+			findings[0].Title)
+	}
+}
+
+// The reverse asymmetry, so the test above is not passing because the rule only ever
+// looks at the modern wire.
+func TestDNSRebindModern_LegacyBrokenModernFixed(t *testing.T) {
+	ts := originWireServer{legacy: true, modern: true, modernChecks: true}.start(t)
+	defer ts.Close()
+
+	findings, err := runOriginRule(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly the legacy-wire finding, got %d: %+v", len(findings), findings)
+	}
+	if strings.Contains(findings[0].Title, "2026-07-28 wire") {
+		t.Errorf("the unvalidated wire is the legacy one, so the finding must not be labelled "+
+			"modern: %q", findings[0].Title)
+	}
+	if !strings.Contains(findings[0].Evidence, "initialize with Origin") {
+		t.Errorf("evidence should name the legacy probe; got:\n%s", findings[0].Evidence)
+	}
+}
+
+// A false positive the port removed, found by running the A2A fixtures.
+//
+// An A2A agent answers any JSON-RPC method with a Task result, so a raw initialize
+// got HTTP 200 and a result envelope, the rule called that a responsive MCP endpoint,
+// and a scan of an A2A agent reported a high-severity MCP DNS-rebinding finding
+// against a server that speaks no MCP at all. Requiring a real handshake, rather than
+// any 200 carrying a result, is what settles it.
+func TestDNSRebindModern_EchoServerIsNotAnMCPEndpoint(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.Header().Set("Content-Type", "application/json")
+		// A result envelope for anything, carrying none of protocolVersion,
+		// serverInfo or capabilities: the shape of an A2A agent, not an MCP server.
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": body["id"],
+			"result": map[string]interface{}{
+				"id": "task-1", "contextId": "ctx-1", "status": "working",
+			},
+		})
+	}))
+	defer ts.Close()
+
+	findings, err := runOriginRule(t, ts)
+	if len(findings) != 0 {
+		t.Fatalf("an endpoint that echoes a result for any method is not an MCP server, "+
+			"got %d finding(s): %+v", len(findings), findings)
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Errorf("want ErrInconclusive naming the incomplete handshake, got %v", err)
+	}
+}
+
+// A probe that never got an answer has tested nothing, and must not be reported as
+// Origin validation. The handshake succeeded, so the target is plainly reachable;
+// only the request carrying the Origin died, which is the one shape that could
+// otherwise be mistaken for a server rejecting it.
+func TestDNSRebindModern_TransportFailureIsNotClean(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method, _ := body["method"].(string)
+
+		if r.Header.Get("Origin") != "" {
+			// Hang up without answering, rather than refusing.
+			conn, _, err := w.(http.Hijacker).Hijack()
+			if err == nil {
+				_ = conn.Close()
+			}
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch method {
+		case "server/discover":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": body["id"],
+				"result": map[string]interface{}{
+					"supportedVersions": []string{"2026-07-28"},
+					"capabilities":      map[string]interface{}{"tools": map[string]interface{}{}},
+				},
+			})
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": body["id"],
+				"error": map[string]interface{}{"code": -32022, "message": "UnsupportedProtocolVersion"},
+			})
+		}
+	}))
+	defer ts.Close()
+
+	findings, err := runOriginRule(t, ts)
+	if len(findings) != 0 {
+		t.Fatalf("a probe that never landed cannot produce a finding, got %d: %+v", len(findings), findings)
+	}
+	if err == nil {
+		t.Fatal("a probe that never got an answer must report not tested, not a clean pass")
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Errorf("want ErrInconclusive, got %v", err)
+	}
+}
+
+// Both wires unvalidated: two findings, one per wire, distinguishable. A server can
+// only be fixed one handler at a time, so collapsing them would hide half the work.
+func TestDNSRebindModern_BothWiresReportSeparately(t *testing.T) {
+	ts := originWireServer{legacy: true, modern: true}.start(t)
+	defer ts.Close()
+
+	findings, err := runOriginRule(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("expected one finding per wire, got %d: %+v", len(findings), findings)
+	}
+	modern := 0
+	for _, f := range findings {
+		if strings.Contains(f.Title, "2026-07-28 wire") {
+			modern++
+		}
+	}
+	if modern != 1 {
+		t.Errorf("expected exactly one of the two to be labelled modern, got %d: %+v",
+			modern, findings)
+	}
+}

--- a/rules/mcp/dns-rebind-origin-001.yaml
+++ b/rules/mcp/dns-rebind-origin-001.yaml
@@ -13,25 +13,38 @@ info:
     drives its tools (the class behind the MCP Inspector RCE, CVE-2025-49596, and
     the TypeScript/Python SDK DNS-rebinding advisories).
 
-    Detection (deterministic, black-box):
+    Detection (deterministic, black-box), on each wire the server serves:
 
-      1. Baseline: POST a normal `initialize` with NO Origin header. It must be
-         accepted (HTTP 200 + a JSON-RPC result), confirming a responsive MCP
-         endpoint; otherwise the rule does not apply.
-      2. Probe: POST the same `initialize` with a foreign Origin
+      1. Baseline: open the wire, which is a request carrying NO Origin header that
+         the server accepted (HTTP 200 + a JSON-RPC result). A wire that does not
+         open is not probed.
+      2. Probe: repeat that exact request with a foreign Origin
          (`https://dns-rebind.batesian.invalid`, a non-resolving RFC 6761 host no
          server should allowlist). The only difference from the baseline is the
-         Origin header.
+         Origin header, and both carry the same credential, so a refusal cannot be
+         about a missing token.
 
     A CONFIRMED finding is raised when the server still returns a JSON-RPC result
     for the foreign-Origin request instead of rejecting it with HTTP 403, i.e. it
     does not validate Origin. A server that answers the foreign Origin with 403
-    produces no finding. DNS-rebinding exploitation additionally requires the
+    produces no finding, and a probe that never got an answer is reported as not
+    tested rather than clean. DNS-rebinding exploitation additionally requires the
     server to be reachable from a victim's browser (a local or same-network bind),
     which the operator should confirm for the deployment.
 
+    Currency: the requirement is byte-identical in 2026-07-28, where it moved to
+    the transports/streamable-http page. It is stated for "all incoming
+    connections", is not scoped to a method, and is not conditioned on the server
+    being local; only the bind-to-localhost SHOULD beside it is. So both wires are
+    probed, with the request each speaks: `initialize` on the handshake wires,
+    `server/discover` on 2026-07-28, which every server MUST implement. They are
+    reported separately, because Origin checking is normally middleware and a
+    server can serve the two wires through different handlers, so one that has
+    fixed only one of them reads as clean if only that one is probed.
+
   references:
     - https://modelcontextprotocol.io/specification/2025-11-25/basic/transports
+    - https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http
     - https://www.oligo.security/blog/critical-rce-vulnerability-in-anthropic-mcp-inspector-cve-2025-49596
     - https://nvd.nist.gov/vuln/detail/CVE-2025-49596
     - https://cwe.mitre.org/data/definitions/350.html

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -61,7 +61,7 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_oauth_metadata_ssrf_server.py` | 7791 | `mcp-oauth-metadata-ssrf-001` |
 | `mcp_secret_canary_server.py` | 7792 | `mcp-secret-canary-001` |
 | `mcp_confused_deputy_server.py` | 7793 | `mcp-confused-deputy-001` |
-| `mcp_dns_rebind_origin_server.py` | 7794 | `mcp-dns-rebind-origin-001` |
+| `mcp_dns_rebind_origin_server.py` | 7794 | `mcp-dns-rebind-origin-001` (two postures, see below) |
 | `mcp_batch_bypass_server.py` | 7795 | `mcp-jsonrpc-batch-bypass-001` |
 | `mcp_completion_unauth_server.py` | 7796 | `mcp-completion-unauth-001` |
 | `mcp_logging_unauth_server.py` | 7797 | `mcp-logging-unauth-001` |
@@ -274,6 +274,20 @@ official MCP C# SDK's stateful sample, which this rule reported as vulnerable
 until the anonymous-handshake control was added. Without `--token` the rule
 reports inconclusive against all three, since it cannot ask whether a session id
 substitutes for a credential it was never given.
+
+**`mcp_dns_rebind_origin_server.py` takes a posture argument**, defaulting to
+`vulnerable`:
+
+```sh
+python testdata/mcp_dns_rebind_origin_server.py vulnerable  # one finding, handshake wire
+python testdata/mcp_dns_rebind_origin_server.py wire-split  # one finding, and it must name the 2026-07-28 wire
+```
+
+`wire-split` serves both wires and validates Origin on the handshake wire only. The
+rule used to send only `initialize`, so it could see neither half of this: a
+2026-07-28 server has no `initialize` at all, and a server that has fixed one wire
+reads as clean if only the fixed one is probed. Origin checking is normally
+middleware, and the two wires can sit behind different handlers.
 
 **`mcp_log_optin_server.py` takes a posture argument**, defaulting to `always`, and
 speaks the 2026-07-28 wire only:

--- a/testdata/mcp_dns_rebind_origin_server.py
+++ b/testdata/mcp_dns_rebind_origin_server.py
@@ -5,17 +5,33 @@ Deliberately vulnerable MCP Streamable HTTP test server for validating:
     HTTP 403. A local/private-bound server is then reachable from a victim's
     browser via DNS rebinding (CWE-350 / CWE-346; the class behind CVE-2025-49596).
 
-Flow the scanner drives:
-  - POST {/, /mcp} initialize with no Origin -> 200 + JSON-RPC result (baseline)
-  - POST initialize with Origin: https://...invalid -> 200 + result (VULNERABLE;
-    a compliant server returns HTTP 403 Forbidden for a present, invalid Origin)
+Two postures, selected by the first argument:
+
+    vulnerable  serves the handshake wire only and validates nothing. ONE finding.
+    wire-split  serves BOTH wires and validates Origin on the handshake wire ONLY.
+                ONE finding, on the 2026-07-28 wire, labelled as such. The rule
+                used to send only initialize, so it could not see this at all: a
+                2026-07-28 server has no initialize, and a server that has fixed
+                one wire and not the other reads as clean if you only probe the
+                fixed one. Origin checking is normally middleware, and the two
+                wires can sit behind different handlers.
+
+The requirement is byte-identical in 2026-07-28, where it moved to the
+transports/streamable-http page. It is stated for "all incoming connections", is
+not scoped to a method, and is not conditioned on the server being local; only the
+bind-to-localhost SHOULD beside it is.
+
+Flow the scanner drives on each wire:
+  - handshake with no Origin -> 200 + JSON-RPC result (this is the baseline)
+  - the same request with Origin: https://...invalid -> 200 + result is the finding
+    (a compliant server returns HTTP 403 Forbidden for a present, invalid Origin)
 
 Validate against it:
-  python testdata/mcp_dns_rebind_origin_server.py
+  python testdata/mcp_dns_rebind_origin_server.py vulnerable
+  python testdata/mcp_dns_rebind_origin_server.py wire-split
   batesian scan --target http://127.0.0.1:7794 --rule-ids mcp-dns-rebind-origin-001 -v
-
-Run: python testdata/mcp_dns_rebind_origin_server.py
 """
+import sys
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
@@ -23,15 +39,45 @@ from starlette.routing import Route
 import uvicorn
 
 PORT = 7794
+MODERN_VERSION = "2026-07-28"
+
+POSTURES = ("vulnerable", "wire-split")
+POSTURE = sys.argv[1] if len(sys.argv) > 1 else "vulnerable"
 
 
 async def mcp(request: Request) -> Response:
     body = await request.json()
     req_id = body.get("id")
     method = body.get("method", "")
-    # VULNERABLE: the Origin header is never checked; the request is processed
-    # regardless of its value (a compliant server returns HTTP 403 for a present,
-    # invalid Origin).
+
+    # Which wire this request belongs to, by the header every 2026-07-28 request
+    # must carry.
+    is_modern = request.headers.get("mcp-protocol-version") == MODERN_VERSION
+
+    # Origin validation, per wire, ahead of any dispatch: it is a transport-level
+    # check, which is what lets the two wires disagree.
+    #
+    # In wire-split the handshake wire is FIXED and the modern one is not. The
+    # asymmetry is the point: a rule that probes one wire and reports for the server
+    # generalises from what it tested to what it did not.
+    if request.headers.get("origin") and POSTURE == "wire-split" and not is_modern:
+        return Response(status_code=403)
+
+    if method == "server/discover":
+        if POSTURE != "wire-split":
+            # No modern wire here. Answering server/discover without advertising the
+            # revision is what a handshake-era server does, and the scanner must not
+            # read the mere answer as a modern wire.
+            return JSONResponse({"jsonrpc": "2.0", "id": req_id, "error": {
+                "code": -32601, "message": "Method not found"}}, status_code=200)
+        return JSONResponse({"jsonrpc": "2.0", "id": req_id, "result": {
+            "supportedVersions": [MODERN_VERSION],
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "rebind-fixture", "version": "1.0"},
+        }})
+
+    # VULNERABLE (in the posture above): the Origin header is never checked; the
+    # request is processed regardless of its value.
     if method == "initialize":
         return JSONResponse({"jsonrpc": "2.0", "id": req_id, "result": {
             "protocolVersion": "2025-06-18",
@@ -47,6 +93,15 @@ app = Starlette(routes=[
 ])
 
 if __name__ == "__main__":
-    print(f"[*] MCP DNS-rebinding (no Origin validation) vulnerable server on port {PORT}", flush=True)
-    print("[*] Vulnerability: processes any Origin instead of returning HTTP 403", flush=True)
+    if POSTURE not in POSTURES:
+        sys.exit(f"unknown posture {POSTURE!r}; expected one of {', '.join(POSTURES)}")
+    print(f"[*] MCP DNS-rebinding (no Origin validation) server ({POSTURE}) on port {PORT}",
+          flush=True)
+    if POSTURE == "vulnerable":
+        print("[*] Vulnerability: processes any Origin instead of returning HTTP 403",
+              flush=True)
+    else:
+        print(f"[*] Wires: handshake + MCP {MODERN_VERSION}. Origin is validated on the "
+              "handshake wire ONLY, so the one finding must name the modern wire.",
+              flush=True)
     uvicorn.run(app, host="127.0.0.1", port=PORT)


### PR DESCRIPTION
Stacked on #184; base retargets to `main` when that merges.

`mcp-dns-rebind-origin-001` ran its own `initialize` loop. A 2026-07-28 server has no `initialize`, so every candidate failed and the rule reported a bare "could not test" against a server it could have probed. The requirement is byte-identical in that revision, where it moved to the transports/streamable-http page: stated for "all incoming connections", not scoped to a method, and not conditioned on the server being local, since only the bind-to-localhost SHOULD beside it is.

The rule now goes through `openSessions` and probes each wire with the request that wire speaks, `initialize` or `server/discover`. Opening a wire **is** the baseline, so the pair differs in the Origin header and nothing else and both carry the same credential. Findings are per wire, because Origin checking is normally middleware and a server can serve the two through different handlers, so one that had fixed only one of them read as clean when only that one was probed. A probe that never got an answer is now not tested rather than clean.

**It also removes a false positive**, found by running the A2A fixtures rather than by reading the code. An A2A agent answers any JSON-RPC method with a Task result, so a raw `initialize` returned 200 with a result envelope, the old rule read that as a responsive MCP endpoint, and scanning an A2A agent produced a high-severity MCP DNS-rebinding finding against a server that speaks no MCP:

```
before: FINDING  MCP server does not validate the Origin header ...
after:  SKIP     not tested: ... answered the handshake with HTTP 200 but the reply
                 carried no protocolVersion, serverInfo or capabilities
```

Verification: the fixture grew a `wire-split` posture (both wires, Origin validated on the handshake wire only, so the one finding must name the modern wire). Checked on a socket in both postures; the `vulnerable` posture's evidence is unchanged. Seven new tests. Three non-vacuity checks, each confirmed to fail when its control is reverted: era-blind probe fails three tests, era-blind method name in the evidence fails one, treating a transport failure as clean fails one. The 50-case fixture sweep shows no change beyond this rule.