### PR TITLE
test(mcp): cover the modern wire for the unauth rules, and close two seams

### DIFF
--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -109,8 +109,16 @@ and 2026-07-28 on the same endpoint. The four unauthenticated-access rules,
 `mcp-resources-unauth-001`, `mcp-tools-unauth-001`, `mcp-prompt-unauth-001` and
 `mcp-completion-unauth-001`, are exercised on each wire it serves, because the two
 need not be gated alike: a server can enforce authorization on one and not the
-other. Each wire is capability-gated on its own advertisement, so a surface the
-server exposes on only one era is probed only there.
+other.
+
+Three of those four read the advertised capability per wire, so a surface the server
+exposes on only one era is probed only there: they follow the listing with a
+state-touching call (`tools/call`, `prompts/get`, `completion/complete`) and gating
+avoids calling a surface the server does not implement.
+`mcp-resources-unauth-001` deliberately does not gate, on either wire. A non-empty
+`resources/list` answered without a credential is direct evidence of the disclosure,
+and what a server advertised is not evidence about what it serves, so gating would
+drop the case of a wire listing resources it never declared.
 
 `mcp-dns-rebind-origin-001` is exercised on each wire for the same reason, with the
 request each one speaks. Origin validation is normally middleware, so a server can

--- a/internal/attack/mcp/era.go
+++ b/internal/attack/mcp/era.go
@@ -303,31 +303,15 @@ func jsonRPCErrorCode(body []byte) (int, bool) {
 // 405, tells us something answered, and absent a modern error that answer is
 // legacy.
 func detectEra(ctx context.Context, client *attack.HTTPClient, endpoint string) Era {
-	headers := map[string]string{
-		// Both are REQUIRED on every modern POST. Omitting them would earn a
-		// -32020 HeaderMismatch, which is itself a modern signal, but sending
-		// them correctly keeps the probe a fair test of the server rather than
-		// of our own request.
-		"MCP-Protocol-Version": modernEraVersion,
-		"Mcp-Method":           "server/discover",
-	}
-	resp, err := client.POST(ctx, endpoint, headers, map[string]interface{}{
-		"jsonrpc": "2.0",
-		"id":      "batesian-era-probe",
-		"method":  "server/discover",
-		"params": map[string]interface{}{
-			"_meta": map[string]interface{}{
-				metaProtocolVersion: modernEraVersion,
-				metaClientInfo: map[string]interface{}{
-					"name":    "batesian",
-					"version": attack.Version,
-				},
-				// Required, and deliberately empty: this probe asks only what
-				// the server is, so it needs no client capability.
-				metaClientCapabilities: map[string]interface{}{},
-			},
-		},
-	})
+	// Built through a modern session rather than by hand. What a modern request
+	// looks like (MCP-Protocol-Version and Mcp-Method, both REQUIRED, and the
+	// mandatory _meta block) is one judgement, and this probe had its own copy of
+	// it. Two copies of a wire format drift, and the era probe is the worst place
+	// for that: a request this server would reject as malformed reads as "not a
+	// modern server" and every modern-wire rule then skips a target it should have
+	// tested.
+	probe := mcpSession{Endpoint: endpoint, Era: EraModern}
+	resp, err := probe.post(ctx, client, "batesian-era-probe", "server/discover", nil)
 	if err != nil {
 		return EraUnknown
 	}

--- a/internal/attack/mcp/era_test.go
+++ b/internal/attack/mcp/era_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -313,5 +315,60 @@ func TestInconclusive(t *testing.T) {
 	}
 	if !errors.Is(plain, attack.ErrInconclusive) {
 		t.Errorf("plain error must be ErrInconclusive, got %v", plain)
+	}
+}
+
+// The era probe must send exactly what a modern session sends.
+//
+// It used to build the MCP-Protocol-Version and Mcp-Method headers and the whole
+// mandatory _meta block by hand, duplicating request(). Two copies of a wire format
+// drift, and this is the worst place for it: a request the server rejects as
+// malformed reads as "not a modern server", and every modern-wire rule then skips a
+// target it should have tested. So the probe goes through a session, and this pins
+// that its request is byte-identical to one.
+//
+// The field-level assertions are in TestDetectEra_SendsRequiredModernFields; this
+// one is only about the two sides agreeing.
+func TestDetectEra_ProbeMatchesAModernSessionRequest(t *testing.T) {
+	var gotHeaders http.Header
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeaders = r.Header.Clone()
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"batesian-era-probe","result":{}}`))
+	}))
+	defer srv.Close()
+
+	if era := detect(t, srv); era != EraLegacy {
+		t.Fatalf("a result that advertises no modern version is legacy, got %v", era)
+	}
+
+	// What a modern session would have sent for the same call.
+	want := mcpSession{Endpoint: srv.URL, Era: EraModern}
+	wantHeaders, wantBody := want.request("batesian-era-probe", "server/discover", nil)
+
+	for k, v := range wantHeaders {
+		if got := gotHeaders.Get(k); got != v {
+			t.Errorf("header %s: probe sent %q, a modern session sends %q", k, got, v)
+		}
+	}
+
+	wantJSON, err := json.Marshal(wantBody)
+	if err != nil {
+		t.Fatalf("marshalling the reference body: %v", err)
+	}
+	// Compared as decoded values, since map key order in the encoded form is not
+	// part of the contract.
+	var gotAny, wantAny interface{}
+	if err := json.Unmarshal(gotBody, &gotAny); err != nil {
+		t.Fatalf("probe body is not JSON: %v", err)
+	}
+	if err := json.Unmarshal(wantJSON, &wantAny); err != nil {
+		t.Fatalf("reference body is not JSON: %v", err)
+	}
+	if !reflect.DeepEqual(gotAny, wantAny) {
+		t.Errorf("the era probe and a modern session disagree on the request body.\nprobe: %s\nsession: %s",
+			gotBody, wantJSON)
 	}
 }

--- a/internal/attack/mcp/unauth_wires_test.go
+++ b/internal/attack/mcp/unauth_wires_test.go
@@ -1,0 +1,343 @@
+package mcp_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+// The 2026-07-28 wire for the four unauthenticated-access rules.
+//
+// They were ported to run on each wire a server serves, but every one of their own
+// test files drives a legacy-only server, so the modern half of that port was
+// exercised only indirectly by the shared wire tests. These are the cases the port
+// exists for, asserted per rule.
+//
+// The one that matters is the asymmetry: a server that enforces authorization on one
+// wire and not the other. Nothing about the two wires forces them to be gated alike,
+// and a rule that probed only the wire that is gated reports the server clean.
+
+// unauthWireServer serves either wire, or both, and gates each independently.
+//
+// legacy/modern select which wires exist. legacyGated/modernGated select whether that
+// wire refuses the listing and completion methods with an auth error. The capabilities
+// advertised on each wire are also selectable, since a surface a server exposes on
+// only one wire must be probed only there.
+type unauthWireServer struct {
+	legacy, modern           bool
+	legacyGated, modernGated bool
+	// When set, the capabilities advertised on that wire; otherwise all four.
+	legacyCaps, modernCaps []string
+}
+
+const authErrCode = -32001
+
+func (s unauthWireServer) capsFor(modern bool) map[string]interface{} {
+	names := s.legacyCaps
+	if modern {
+		names = s.modernCaps
+	}
+	if names == nil {
+		names = []string{"tools", "resources", "prompts", "completions"}
+	}
+	caps := map[string]interface{}{}
+	for _, n := range names {
+		caps[n] = map[string]interface{}{}
+	}
+	return caps
+}
+
+func (s unauthWireServer) start(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method, _ := body["method"].(string)
+		id := body["id"]
+
+		isModern := r.Header.Get("MCP-Protocol-Version") == "2026-07-28"
+		gated := s.legacyGated
+		if isModern {
+			gated = s.modernGated
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		rpcErr := func(status, code int, msg string) {
+			w.WriteHeader(status)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": code, "message": msg},
+			})
+		}
+		result := func(v map[string]interface{}) {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id, "result": v,
+			})
+		}
+
+		switch method {
+		case "server/discover":
+			if !s.modern {
+				rpcErr(http.StatusBadRequest, -32022, "UnsupportedProtocolVersion")
+				return
+			}
+			result(map[string]interface{}{
+				"supportedVersions": []string{"2026-07-28"},
+				"capabilities":      s.capsFor(true),
+				"serverInfo":        map[string]interface{}{"name": "unauth-wire", "version": "1.0"},
+			})
+			return
+		case "initialize":
+			if !s.legacy {
+				rpcErr(http.StatusBadRequest, -32022, "UnsupportedProtocolVersion")
+				return
+			}
+			result(map[string]interface{}{
+				"protocolVersion": "2025-11-25",
+				"capabilities":    s.capsFor(false),
+				"serverInfo":      map[string]interface{}{"name": "unauth-wire", "version": "1.0"},
+			})
+			return
+		}
+		if strings.HasPrefix(method, "notifications/") {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+
+		if gated {
+			rpcErr(http.StatusOK, authErrCode, "Unauthorized")
+			return
+		}
+
+		switch method {
+		case "tools/list":
+			result(map[string]interface{}{"tools": []interface{}{
+				map[string]interface{}{"name": "echo", "description": "Echo input"},
+				map[string]interface{}{"name": "run_query", "description": "Run a database query"},
+			}})
+		case "resources/list":
+			result(map[string]interface{}{"resources": []interface{}{
+				map[string]interface{}{"uri": "file:///etc/passwd", "name": "passwd"},
+			}})
+		case "resources/read":
+			result(map[string]interface{}{"contents": []interface{}{
+				map[string]interface{}{"uri": "file:///etc/passwd", "text": "root:x:0:0:"},
+			}})
+		case "prompts/list":
+			result(map[string]interface{}{"prompts": []interface{}{
+				map[string]interface{}{"name": "summarize", "description": "Summarize text"},
+			}})
+		case "prompts/get":
+			result(map[string]interface{}{"messages": []interface{}{
+				map[string]interface{}{"role": "user", "content": map[string]interface{}{
+					"type": "text", "text": "internal prompt body",
+				}},
+			}})
+		case "completion/complete":
+			result(map[string]interface{}{"completion": map[string]interface{}{
+				"values": []interface{}{"alpha", "beta"},
+			}})
+		default:
+			rpcErr(http.StatusOK, -32601, "Method not found")
+		}
+	}))
+}
+
+// unauthRules is the four rules ported in the both-wires change, each with the
+// capability its surface is gated on.
+var unauthRules = []struct {
+	name string
+	cap  string
+	exec func() attack.Executor
+}{
+	{"tools", "tools", func() attack.Executor {
+		return mcpattack.NewToolsUnauthExecutor(attack.RuleContext{ID: "mcp-tools-unauth-001", Severity: "high"})
+	}},
+	{"resources", "resources", func() attack.Executor {
+		return mcpattack.NewResourcesUnauthExecutor(attack.RuleContext{ID: "mcp-resources-unauth-001", Severity: "high"})
+	}},
+	{"prompts", "prompts", func() attack.Executor {
+		return mcpattack.NewPromptUnauthExecutor(attack.RuleContext{ID: "mcp-prompt-unauth-001", Severity: "medium"})
+	}},
+	{"completions", "completions", func() attack.Executor {
+		return mcpattack.NewCompletionUnauthExecutor(attack.RuleContext{ID: "mcp-completion-unauth-001", Severity: "high"})
+	}},
+}
+
+// A modern-only server with the surface wide open. Each rule must fire and label the
+// wire, since before the port none of them could reach a server with no initialize.
+func TestUnauthWires_ModernOnlyOpen(t *testing.T) {
+	for _, rule := range unauthRules {
+		t.Run(rule.name, func(t *testing.T) {
+			ts := unauthWireServer{modern: true}.start(t)
+			defer ts.Close()
+
+			findings, err := rule.exec().Execute(t.Context(), ts.URL, testOpts())
+			if err != nil {
+				t.Fatalf("a modern-only server is testable: %v", err)
+			}
+			if len(findings) == 0 {
+				t.Fatal("an open surface on the modern wire must be reported")
+			}
+			for _, f := range findings {
+				if !strings.Contains(f.Title, "2026-07-28 wire") {
+					t.Errorf("a modern-wire finding must be labelled as such, got %q", f.Title)
+				}
+				if !strings.Contains(f.Evidence, "2026-07-28") {
+					t.Errorf("evidence should name the wire; got:\n%s", f.Evidence)
+				}
+			}
+		})
+	}
+}
+
+// The asymmetry the port exists for: authorization enforced on the handshake wire and
+// not on the modern one. Probing only the gated wire reports this server clean.
+func TestUnauthWires_LegacyGatedModernOpen(t *testing.T) {
+	for _, rule := range unauthRules {
+		t.Run(rule.name, func(t *testing.T) {
+			ts := unauthWireServer{legacy: true, modern: true, legacyGated: true}.start(t)
+			defer ts.Close()
+
+			findings, err := rule.exec().Execute(t.Context(), ts.URL, testOpts())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(findings) == 0 {
+				t.Fatal("the modern wire is open and must be reported even though the legacy one is gated")
+			}
+			for _, f := range findings {
+				if !strings.Contains(f.Title, "2026-07-28 wire") {
+					t.Errorf("only the modern wire is open here, so every finding must name it: %q", f.Title)
+				}
+			}
+		})
+	}
+}
+
+// The reverse, so the test above is not passing because the rules only look at the
+// modern wire.
+func TestUnauthWires_ModernGatedLegacyOpen(t *testing.T) {
+	for _, rule := range unauthRules {
+		t.Run(rule.name, func(t *testing.T) {
+			ts := unauthWireServer{legacy: true, modern: true, modernGated: true}.start(t)
+			defer ts.Close()
+
+			findings, err := rule.exec().Execute(t.Context(), ts.URL, testOpts())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(findings) == 0 {
+				t.Fatal("the legacy wire is open and must be reported")
+			}
+			for _, f := range findings {
+				if strings.Contains(f.Title, "2026-07-28 wire") {
+					t.Errorf("only the legacy wire is open here, so no finding may be labelled "+
+						"modern: %q", f.Title)
+				}
+			}
+		})
+	}
+}
+
+// Both wires gated is a real clean result, not a skip: both were opened and both
+// refused.
+func TestUnauthWires_BothGatedIsClean(t *testing.T) {
+	for _, rule := range unauthRules {
+		t.Run(rule.name, func(t *testing.T) {
+			ts := unauthWireServer{
+				legacy: true, modern: true, legacyGated: true, modernGated: true,
+			}.start(t)
+			defer ts.Close()
+
+			findings, err := rule.exec().Execute(t.Context(), ts.URL, testOpts())
+			if err != nil {
+				t.Fatalf("a server that enforces authorization on both wires is a clean result: %v", err)
+			}
+			if len(findings) != 0 {
+				t.Errorf("expected zero findings, got %d: %+v", len(findings), findings)
+			}
+		})
+	}
+}
+
+// For the three rules that gate on a capability, the gate is read per wire. A rule
+// must not carry one wire's capabilities across to the other: the surface would be
+// probed where the server does not expose it, and the -32601 that comes back is not
+// evidence about authorization.
+//
+// mcp-resources-unauth-001 is deliberately absent, and TestUnauthWires_ResourcesDoNotGate
+// below is why.
+func TestUnauthWires_CapabilityIsPerWire(t *testing.T) {
+	for _, rule := range unauthRules {
+		if rule.name == "resources" {
+			continue
+		}
+		t.Run(rule.name, func(t *testing.T) {
+			// The surface is advertised on the legacy wire only, and BOTH wires would
+			// answer it if asked. Any modern-labelled finding means the rule probed a
+			// capability that wire never advertised.
+			ts := unauthWireServer{
+				legacy: true, modern: true,
+				legacyCaps: []string{rule.cap},
+				modernCaps: []string{},
+			}.start(t)
+			defer ts.Close()
+
+			findings, err := rule.exec().Execute(t.Context(), ts.URL, testOpts())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(findings) == 0 {
+				t.Fatal("the legacy wire advertises the surface and is open, so it must be reported")
+			}
+			for _, f := range findings {
+				if strings.Contains(f.Title, "2026-07-28 wire") {
+					t.Errorf("the modern wire advertises no capability, so it must not be probed: %q",
+						f.Title)
+				}
+			}
+		})
+	}
+}
+
+// mcp-resources-unauth-001 probes regardless of what was advertised, on either wire,
+// and that is the right behaviour rather than an oversight.
+//
+// A non-empty resources/list answered without a credential is direct evidence of the
+// disclosure. What the server advertised is not evidence about what it serves, so
+// gating on the advertisement would drop exactly the case below: a wire that lists
+// resources it never declared. The other three probe a second, state-touching method
+// (tools/call, prompts/get, completion/complete) and gate to avoid calling a surface
+// the server does not implement, which is a different trade.
+//
+// Written after this test caught the discrepancy: the docs claimed all four gate per
+// wire, which was never true of this one.
+func TestUnauthWires_ResourcesDoNotGate(t *testing.T) {
+	ts := unauthWireServer{
+		modern: true,
+		// Declares nothing at all, and serves resources anyway.
+		modernCaps: []string{},
+	}.start(t)
+	defer ts.Close()
+
+	exec := mcpattack.NewResourcesUnauthExecutor(
+		attack.RuleContext{ID: "mcp-resources-unauth-001", Severity: "high"})
+	findings, err := exec.Execute(t.Context(), ts.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) == 0 {
+		t.Fatal("a wire that lists resources it never advertised is still disclosing them")
+	}
+	for _, f := range findings {
+		if !strings.Contains(f.Title, "2026-07-28 wire") {
+			t.Errorf("the finding is on the modern wire and should say so: %q", f.Title)
+		}
+	}
+}

--- a/internal/attack/mcp/wire.go
+++ b/internal/attack/mcp/wire.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/calbebop/batesian/internal/attack"
@@ -246,21 +245,18 @@ func labelEra(session mcpSession, findings []attack.Finding) []attack.Finding {
 	return findings
 }
 
-// modernResultPayload strips the envelope a modern result wraps its payload in.
+// What a 2026-07-28 result looks like, since the rules here read them.
 //
-// A 2026-07-28 result carries cacheScope, resultType, ttlMs and _meta alongside
-// the fields a legacy result would have had. Rules that read a named field
-// (result.tools, result.resources) are unaffected, but anything that treats the
-// result object as the payload needs the envelope keys removed first.
-func modernResultPayload(body []byte) (map[string]json.RawMessage, error) {
-	var envelope struct {
-		Result map[string]json.RawMessage `json:"result"`
-	}
-	if err := json.Unmarshal(body, &envelope); err != nil {
-		return nil, fmt.Errorf("parsing modern result: %w", err)
-	}
-	for _, k := range []string{"cacheScope", "resultType", "ttlMs", "_meta"} {
-		delete(envelope.Result, k)
-	}
-	return envelope.Result, nil
-}
+// Every result carries resultType ("complete", or "input_required" for an interim
+// multi-round-trip reply), and SHOULD carry _meta with
+// io.modelcontextprotocol/serverInfo. The results of server/discover, tools/list,
+// prompts/list, resources/list, resources/templates/list and resources/read
+// additionally carry ttlMs and cacheScope when resultType is "complete"; a
+// tools/call result does not.
+//
+// None of that needs unwrapping. The envelope fields are SIBLINGS of the payload
+// fields, not a wrapper around them: a tools/list result still has tools at the top
+// level of result. So the rules here, which all read a named field, are unaffected,
+// and a helper that stripped the envelope keys had no caller for exactly that
+// reason. It is recorded rather than kept, because dead code reads as a supported
+// capability.

--- a/internal/attack/mcp/wire_test.go
+++ b/internal/attack/mcp/wire_test.go
@@ -373,30 +373,6 @@ func TestSessionPost_DoesNotMutateCallerParams(t *testing.T) {
 	}
 }
 
-func TestModernResultPayload_StripsTheEnvelope(t *testing.T) {
-	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"cacheScope":"private","resultType":"complete",` +
-		`"ttlMs":0,"_meta":{},"tools":[{"name":"echo"}]}}`)
-
-	payload, err := modernResultPayload(body)
-	if err != nil {
-		t.Fatalf("modernResultPayload: %v", err)
-	}
-	if len(payload) != 1 {
-		t.Fatalf("expected only the payload key to survive, got %v", keysOf(payload))
-	}
-	if _, ok := payload["tools"]; !ok {
-		t.Errorf("payload lost its tools key, got %v", keysOf(payload))
-	}
-}
-
-func keysOf(m map[string]json.RawMessage) []string {
-	out := make([]string, 0, len(m))
-	for k := range m {
-		out = append(out, k)
-	}
-	return out
-}
-
 // A rule ported onto runOnEachWire must exercise both wires of a dual-era server
 // and label the modern findings, so that on a server exposing the same surface
 // twice the two results are distinguishable rather than looking like duplicates.


### PR DESCRIPTION
Stacked on #185. Three loose ends from the both-wires work. **No scan result changes**: the 50-case fixture sweep is identical.

**1. The four unauth rules had no modern-wire test.** They run on each wire a server serves, but every one of their own test files drives a legacy-only server. Adds a shared two-wire fixture that gates each wire independently and asserts, per rule: a modern-only server with the surface open is reported and labelled; a server gated on one wire and open on the other is reported for the open one only, in **both** directions; both wires gated is clean rather than a skip; the capability gate is read per wire. Cutting the wire walk to the first wire fails all four asymmetry cases.

**That last case found a documentation defect.** The docs said all four rules gate on the advertised capability per wire. Three do. `mcp-resources-unauth-001` never has, on either wire, and should not: a non-empty `resources/list` answered without a credential is direct evidence of the disclosure, what a server advertised is not evidence about what it serves, and gating would drop a wire listing resources it never declared. Behaviour stays, docs now say what it is, and a test pins it (adding the gate fails that test).

**2. `detectEra` duplicated the modern wire format**, building the required headers and the whole mandatory `_meta` block by hand. It now goes through a modern session. Two copies of a wire format drift, and this is the worst place for it: a request a server rejects as malformed reads as "not a modern server", and every modern-wire rule then skips a target it should have tested. A test pins the probe's request as byte-identical to a session's; reverting to a hand-rolled request that drops `clientInfo` fails it.

**3. `modernResultPayload` had no caller** outside its own test, and could not have had one: the 2026-07-28 envelope fields are siblings of the payload fields, not a wrapper, so a `tools/list` result still carries `tools` at the top level of `result` and every rule here reads a named field. Removed, with the result shape recorded where the wire facts live. Checking it against the spec corrected it in passing: `resultType` is on every result and `_meta` is a SHOULD on every result, but `ttlMs`/`cacheScope` appear only on the six cacheable operations, so a `tools/call` result has neither.