### PR TITLE
fix(mcp): pair the Origin probe with its own baseline, and grade an unobserved log probe

### DIFF
--- a/internal/attack/mcp/dns_rebind_origin.go
+++ b/internal/attack/mcp/dns_rebind_origin.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/calbebop/batesian/internal/attack"
@@ -98,8 +97,13 @@ func (e *DNSRebindOriginExecutor) originAccepted(ctx context.Context, client *at
 		return resp.IsAccepted(), resp
 	}
 
+	// legacyHandshakeBody, not mcpInitBody: the baseline this is paired against is the
+	// wire-opening handshake, and mcpInitBody offers a different protocol revision with
+	// different capabilities and clientInfo. A server that refuses the older revision
+	// refused this probe for a reason that has nothing to do with Origin, and the rule
+	// read that as Origin validation.
 	headers := map[string]string{"Content-Type": "application/json", "Origin": foreignOrigin}
-	resp, err := client.POST(ctx, session.Endpoint, headers, json.RawMessage(mcpInitBody))
+	resp, err := client.POST(ctx, session.Endpoint, headers, legacyHandshakeBody())
 	if err != nil {
 		return false, nil
 	}

--- a/internal/attack/mcp/dns_rebind_origin_modern_test.go
+++ b/internal/attack/mcp/dns_rebind_origin_modern_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -299,5 +300,85 @@ func TestDNSRebindModern_BothWiresReportSeparately(t *testing.T) {
 	if modern != 1 {
 		t.Errorf("expected exactly one of the two to be labelled modern, got %d: %+v",
 			modern, findings)
+	}
+}
+
+// The baseline and the Origin probe must be the SAME request.
+//
+// The rule's whole claim is that the pair differs in the Origin header alone. When it
+// started taking its baseline from openSessions, the probe still built its own body
+// offering a different protocol revision with different capabilities and clientInfo,
+// so the pair differed three ways. A server that refuses that revision refused the
+// probe for reasons unrelated to Origin, and the rule reported Origin validation.
+//
+// Asserting the bodies match, rather than asserting a particular revision, keeps this
+// test correct across a legitimate bump of the offered revision.
+func TestDNSRebindModern_ProbeIsTheBaselineRequestPlusOrigin(t *testing.T) {
+	type seen struct {
+		body   map[string]interface{}
+		origin string
+	}
+	var inits []seen
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method, _ := body["method"].(string)
+		id := body["id"]
+		w.Header().Set("Content-Type", "application/json")
+
+		if strings.HasPrefix(method, "notifications/") {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		if method != "initialize" {
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": -32601, "message": "Method not found"},
+			})
+			return
+		}
+		inits = append(inits, seen{body: body, origin: r.Header.Get("Origin")})
+		// Origin is never validated, so the rule must report a finding.
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": id,
+			"result": map[string]interface{}{
+				"protocolVersion": "2025-11-25",
+				"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+				"serverInfo":      map[string]interface{}{"name": "symmetry", "version": "1.0"},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	findings, err := runOriginRule(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("a server that ignores Origin must be reported, got %d: %+v", len(findings), findings)
+	}
+
+	if len(inits) != 2 {
+		t.Fatalf("expected a baseline handshake and one Origin-bearing repeat, got %d", len(inits))
+	}
+	withOrigin, withoutOrigin := 0, 0
+	for _, in := range inits {
+		if in.origin == "" {
+			withoutOrigin++
+		} else {
+			withOrigin++
+		}
+	}
+	if withOrigin != 1 || withoutOrigin != 1 {
+		t.Fatalf("the pair should be one request with Origin and one without, got %d/%d",
+			withOrigin, withoutOrigin)
+	}
+	if !reflect.DeepEqual(inits[0].body, inits[1].body) {
+		a, _ := json.Marshal(inits[0].body)
+		b, _ := json.Marshal(inits[1].body)
+		t.Errorf("the Origin probe must repeat the baseline request verbatim, so a refusal is "+
+			"attributable to the header.\nbaseline: %s\nprobe:    %s", a, b)
 	}
 }

--- a/internal/attack/mcp/log_optin.go
+++ b/internal/attack/mcp/log_optin.go
@@ -114,10 +114,21 @@ func (e *LogOptInExecutor) Execute(ctx context.Context, target string, opts atta
 		// Probe: the same request with no logLevel in _meta. Any notifications/message
 		// frame here is the violation, and no interpretation stands between the
 		// observation and the claim.
-		if e.emitsLogFrame(ctx, raw, client, session, opts, false) == logEmitted {
+		//
+		// logUnreadable is graded separately from logNone. Both used to fall through to
+		// the clean tail, so a probe that died in transport after a control which HAD
+		// established that the server logs here was reported as "it withheld the frames
+		// when they were not asked for" - a clean verdict resting on a request that
+		// produced no observation. Only logNone is evidence the gate held.
+		switch e.emitsLogFrame(ctx, raw, client, session, opts, false) {
+		case logEmitted:
 			findings = append(findings, labelEra(session, []attack.Finding{
 				e.finding(session, e.advertisesLogging(session)),
 			})...)
+		case logUnreadable:
+			notObserved = fmt.Sprintf("the control at %s established that the server emits log "+
+				"notifications, but the probe that omits %s produced no readable response stream, so "+
+				"whether the opt-in gate held was never observed", session.Endpoint, metaLogLevel)
 		}
 	}
 

--- a/internal/attack/mcp/log_optin_test.go
+++ b/internal/attack/mcp/log_optin_test.go
@@ -42,6 +42,14 @@ const (
 	// to the METHOD NAME: matching on field names instead reports this server, which
 	// gates its log notifications correctly, as a violation.
 	logDecoy
+	// logProbeUnreadable streams a log frame for the CONTROL and answers the PROBE
+	// with a plain JSON object, so the probe yields no readable stream at all.
+	//
+	// It pins the one asymmetry the two legs must not share. The control establishes
+	// that this server logs here, so silence on the probe would be evidence the gate
+	// held; a probe that produced no stream is not silence, it is no observation. Both
+	// used to fall through to the same clean verdict.
+	logProbeUnreadable
 )
 
 // logOptInServer serves the 2026-07-28 wire only, so the rule's era gate is exercised
@@ -105,7 +113,10 @@ func logOptInServer(t *testing.T, mode logMode, sawOptIn *[]bool) *httptest.Serv
 				map[string]interface{}{"name": "logLevel", "description": "set the level"},
 			}}
 		}
-		if mode == logJSONOnly {
+		// The probe leg gets no stream, only the control does. Answering the probe with
+		// a plain JSON object is the cheapest way to produce "no observation" without
+		// also killing the connection.
+		if mode == logJSONOnly || (mode == logProbeUnreadable && !optedIn) {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"jsonrpc": "2.0", "id": id, "result": result,
@@ -113,7 +124,8 @@ func logOptInServer(t *testing.T, mode logMode, sawOptIn *[]bool) *httptest.Serv
 			return
 		}
 
-		emitLog := mode == logAlways || mode == logAlwaysUndeclared || (mode == logOnOptIn && optedIn)
+		emitLog := mode == logAlways || mode == logAlwaysUndeclared ||
+			(mode == logOnOptIn && optedIn) || (mode == logProbeUnreadable && optedIn)
 
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
@@ -341,5 +353,32 @@ func TestLogOptIn_DecoyPayloadsAreNotLogFrames(t *testing.T) {
 	// the honest answer is not observed.
 	if !errors.Is(err, attack.ErrInconclusive) {
 		t.Fatalf("expected ErrInconclusive, got %v", err)
+	}
+}
+
+// The control logged and the probe produced no readable stream. That is NOT a clean
+// pass: the control proved the server logs here, so silence on the probe would have
+// been evidence, but no stream is not silence. Both legs used to fall through to the
+// same clean verdict, which reported "it withheld the frames when they were not asked
+// for" about a request that produced no observation at all.
+func TestLogOptIn_UnreadableProbeIsNotClean(t *testing.T) {
+	ts := logOptInServer(t, logProbeUnreadable, nil)
+	defer ts.Close()
+
+	findings, err := runLogOptIn(t, ts)
+	if len(findings) != 0 {
+		t.Fatalf("a probe that produced no stream cannot yield a finding, got %d: %+v",
+			len(findings), findings)
+	}
+	if err == nil {
+		t.Fatal("an unobserved probe must report not tested, not a clean pass")
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("want ErrInconclusive, got %v", err)
+	}
+	// The reason has to say which leg failed, or an operator cannot tell this from a
+	// server that simply does not log.
+	if !strings.Contains(err.Error(), "no readable response stream") {
+		t.Errorf("the skip reason should name the unreadable probe; got: %v", err)
 	}
 }

--- a/internal/attack/mcp/resources_unauth.go
+++ b/internal/attack/mcp/resources_unauth.go
@@ -258,16 +258,7 @@ func initializeMCP(ctx context.Context, client *attack.HTTPClient, baseURL strin
 	// responses this loop already has, so it costs no extra requests.
 	var observed initObservation
 	for _, ep := range endpoints {
-		initResp, err := client.POST(ctx, ep, nil, map[string]interface{}{
-			"jsonrpc": "2.0",
-			"id":      1,
-			"method":  "initialize",
-			"params": map[string]interface{}{
-				"protocolVersion": latestStable,
-				"capabilities":    map[string]interface{}{"resources": map[string]interface{}{}},
-				"clientInfo":      map[string]interface{}{"name": "batesian", "version": "1.0"},
-			},
-		})
+		initResp, err := client.POST(ctx, ep, nil, legacyHandshakeBody())
 		if err != nil {
 			continue // transport failure: nothing answered, so nothing to explain
 		}

--- a/internal/attack/mcp/session.go
+++ b/internal/attack/mcp/session.go
@@ -149,6 +149,32 @@ func (s mcpSession) header() map[string]string {
 // TestOffersCurrentHandshakeRevision, which fails if it drifts again.
 const latestStable = "2025-11-25"
 
+// legacyHandshakeBody is the initialize request the handshake wire is opened with.
+//
+// It exists so a rule that repeats the handshake as a probe sends the SAME request
+// the baseline sent. mcp-dns-rebind-origin-001 needs exactly that: it establishes a
+// baseline by opening the wire, then repeats it carrying a foreign Origin, and the
+// claim it makes rests on the pair differing in the Origin header alone. It was
+// built by hand from mcpInitBody instead, which offers 2025-06-18 with different
+// capabilities and clientInfo, so the pair differed three ways and a server that
+// refuses the older revision refused the probe for reasons that had nothing to do
+// with Origin. That reads as Origin validation.
+//
+// Any rule pairing a probe against the wire-opening handshake should use this rather
+// than assembling its own.
+func legacyHandshakeBody() map[string]interface{} {
+	return map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]interface{}{
+			"protocolVersion": latestStable,
+			"capabilities":    map[string]interface{}{"resources": map[string]interface{}{}},
+			"clientInfo":      map[string]interface{}{"name": "batesian", "version": "1.0"},
+		},
+	}
+}
+
 // negotiatedVersion reads the protocolVersion the server chose from its
 // initialize result body, falling back to latestStable if the server did not
 // echo one. The negotiated value is sent in the Mcp-Protocol-Version header on


### PR DESCRIPTION
Two false cleans I introduced in #185 and #184. Both were found by reviewing what shipped, not by a failing test.

**`mcp-dns-rebind-origin-001`.** #185 moved the baseline onto `openSessions`, which offers the current handshake revision, while the Origin probe kept building its own body from `mcpInitBody` — 2025-06-18, with different capabilities and clientInfo. The pair differed three ways, not one. A server that refuses the older revision refused the probe *on the version*, and the rule read that as Origin validation. The comment above it asserted the pair "differs in the Origin header and nothing else", which made it harder to spot rather than easier.

The wire-opening body is now a single `legacyHandshakeBody()` shared by `initializeMCP` and the probe, so the symmetry is structural. The test asserts the **two request bodies are equal** rather than asserting a particular revision, so it survives the next legitimate bump and cannot pass by coincidence.

**`mcp-log-optin-001`.** The probe leg tested only for `logEmitted`, so a probe that produced no readable stream fell through to the same clean tail as one that was legitimately silent. Since the control had already established the server logs here, the rule reported "it withheld the frames when they were not asked for" about a request that produced no observation. Silence is evidence; no stream is not. `logUnreadable` on the probe now reports not tested and names which leg failed.

Verification: new `logProbeUnreadable` fixture posture (log frames for the control, plain JSON for the probe). Non-vacuity confirmed per fix — restoring `mcpInitBody` fails the symmetry test, collapsing the probe leg fails the unreadable-probe test.

No fixture exhibits either defect, so the 50-case sweep is unchanged. That's also why neither is pinned by a fixture posture: a version-strict target only shows the symptom, whereas asserting the bodies match tests the property.