### PR TITLE
fix(a2a): judge the task read by identifier, and take the REST base from the card

### DIFF
--- a/internal/attack/a2a/task_idor.go
+++ b/internal/attack/a2a/task_idor.go
@@ -93,7 +93,7 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 	if !accepted {
 		// Not a responsive A2A server, or our credentials were rejected: there
 		// is no owner-created task to test ownership against.
-		f, restReached := e.probeTaskList(ctx, unauthClient, vars)
+		f, restReached := e.probeTaskList(ctx, unauthClient, authedClient, vars)
 		if len(f) > 0 {
 			return f, nil
 		}
@@ -110,7 +110,7 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 	}
 	taskID, contextID := extractTaskContext(ownerResp.Body)
 	if taskID == "" {
-		f, restReached := e.probeTaskList(ctx, unauthClient, vars)
+		f, restReached := e.probeTaskList(ctx, unauthClient, authedClient, vars)
 		if len(f) > 0 {
 			return f, nil
 		}
@@ -148,8 +148,17 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 			"params":  getParams,
 		})
 	}
+	// resultReferencesTask, not a text search. The needles used here were
+	// ContainsAny(`"history"`, `"contextId"`, taskID, contextID), and ContainsAny is
+	// OR: the first two are KEY NAMES carried by virtually every A2A Task envelope, so
+	// the check reduced to "the caller got some accepted result". A server that hides
+	// a task it will not disclose by answering with a redacted or empty Task stub
+	// matched on `"contextId"` alone, and the rule reported it at high/confirmed with
+	// the owner's real identifiers printed in the evidence as though they had come
+	// back. taskref.go removed this exact expression from two sibling rules; this was
+	// the third and last instance.
 	unauthReadSucceeded := err == nil && getResp.IsAccepted() &&
-		getResp.ContainsAny(`"history"`, `"contextId"`, taskID, contextID)
+		resultReferencesTask(getResp.Body, taskID, contextID)
 
 	if authEnforcedOnCreate && unauthReadSucceeded {
 		findings = append(findings, attack.Finding{
@@ -170,20 +179,40 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 		})
 	}
 
-	listFindings, _ := e.probeTaskList(ctx, unauthClient, vars)
+	listFindings, _ := e.probeTaskList(ctx, unauthClient, authedClient, vars)
 	findings = append(findings, listFindings...)
 	return findings, nil
 }
 
-// probeTaskList probes tasks/list - some implementations expose this as
-// GET /v1/tasks or /tasks. An unauthenticated response that lists tasks
-// discloses every session's task IDs (and often history) server-wide, which is
-// the strongest form of the same broken-authorization failure. It runs over the
-// unauthenticated client and is independent of the per-task IDOR check above.
-func (e *TaskIDORExecutor) probeTaskList(ctx context.Context, unauthClient *attack.HTTPClient, vars attack.Vars) ([]attack.Finding, bool) {
-	listEndpoints := []string{
-		vars.BaseURL + "/v1/tasks",
-		vars.BaseURL + "/tasks",
+// probeTaskList probes the REST binding's task listing. An unauthenticated response
+// that lists tasks discloses every session's task IDs (and often history)
+// server-wide, which is the strongest form of the same broken-authorization failure.
+// It runs over the unauthenticated client and is independent of the per-task IDOR
+// check above.
+//
+// The base comes from the card, via resolveHTTPJSONBase, and not from a guess. This
+// probed vars.BaseURL+"/v1/tasks" and +"/tasks" only, while endpoint.go says plainly
+// that the REST prefix cannot be guessed: the deployment chooses it and chooses which
+// protocol version sits under it. A deployment mounting its HTTP+JSON binding
+// anywhere else 404'd both guesses, and the strongest finding this rule can emit was
+// silently never raised. The guessed paths are kept as a fallback, because an agent
+// that advertises no HTTP+JSON interface may still serve one, but the advertised base
+// is tried first and its own /v1/tasks and /tasks are what get probed.
+func (e *TaskIDORExecutor) probeTaskList(ctx context.Context, unauthClient, cardClient *attack.HTTPClient,
+	vars attack.Vars) ([]attack.Finding, bool) {
+	// The card is fetched with the operator's credential because an agent may gate
+	// its own card; the LISTING probes below stay unauthenticated, which is the whole
+	// point of the check.
+	bases := []string{}
+	if restBase := resolveHTTPJSONBase(ctx, cardClient, vars.BaseURL); restBase != "" {
+		bases = append(bases, restBase)
+	}
+	if len(bases) == 0 || bases[0] != vars.BaseURL {
+		bases = append(bases, vars.BaseURL)
+	}
+	var listEndpoints []string
+	for _, b := range bases {
+		listEndpoints = append(listEndpoints, b+"/v1/tasks", b+"/tasks")
 	}
 	reached := false
 	for _, le := range listEndpoints {

--- a/internal/attack/a2a/task_idor_oracle_test.go
+++ b/internal/attack/a2a/task_idor_oracle_test.go
@@ -1,0 +1,301 @@
+package a2a_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/attack/a2a"
+)
+
+// Two defects in a2a-task-idor-001, both of which the existing suite could not see.
+//
+// The read oracle was ContainsAny(`"history"`, `"contextId"`, taskID, contextID).
+// ContainsAny is OR and the first two are key names present in virtually every A2A
+// Task envelope, so it reduced to "the caller got some accepted result". taskref.go
+// removed this exact expression from two sibling rules and documents it as a live
+// false positive; this rule was the third instance.
+//
+// The tasks/list probe guessed vars.BaseURL+"/v1/tasks" and +"/tasks". endpoint.go
+// states plainly that the REST prefix cannot be guessed, and resolveHTTPJSONBase
+// exists for it and is used by push_ssrf.go.
+
+// redactingAgent gates task creation, and answers an unauthenticated GetTask with a
+// 200 carrying a Task stub that discloses NOTHING: no id, no contextId, empty
+// history. That is a server refusing to expose the task while still speaking A2A.
+//
+// It must produce no finding. Under the old needles the literal `"contextId"` key
+// matched and the rule reported high/confirmed, printing the owner's real taskId and
+// contextId in the evidence as though the server had returned them.
+func redactingAgent(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/.well-known/") {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"protocolVersion": "0.3.0", "name": "redacting", "description": "d",
+				"url": "http://" + r.Host + "/", "preferredTransport": "JSONRPC",
+				"version": "1.0", "capabilities": map[string]interface{}{},
+				"defaultInputModes": []string{"text"}, "defaultOutputModes": []string{"text"},
+				"skills": []interface{}{},
+			})
+			return
+		}
+		method, id := decodeRPC(r)
+		w.Header().Set("Content-Type", "application/json")
+		enc := func(v map[string]interface{}) {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id, "result": v,
+			})
+		}
+
+		switch method {
+		case "SendMessage", "message/send":
+			if !hasOwnerAuth(r) {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			enc(map[string]interface{}{"task": map[string]interface{}{
+				"id": "task-owner-1", "contextId": "ctx-owner-1",
+				"status": map[string]interface{}{"state": "working"},
+			}})
+		case "GetTask", "tasks/get":
+			if hasOwnerAuth(r) {
+				enc(map[string]interface{}{
+					"id": "task-owner-1", "contextId": "ctx-owner-1",
+					"status":  map[string]interface{}{"state": "working"},
+					"history": []interface{}{map[string]interface{}{"role": "user"}},
+				})
+				return
+			}
+			// Anonymous: a Task-shaped envelope that discloses nothing at all.
+			enc(map[string]interface{}{
+				"id": "", "contextId": "",
+				"status":  map[string]interface{}{"state": "unknown"},
+				"history": []interface{}{},
+			})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": -32601, "message": "Method not found"},
+			})
+		}
+	}))
+}
+
+// A redacted stub is not a disclosure. The identifiers the rule would print are its
+// own, so matching on key names manufactured the evidence.
+func TestA2ATaskIDOR_RedactedStubIsNotADisclosure(t *testing.T) {
+	ts := redactingAgent(t)
+	defer ts.Close()
+
+	findings, err := a2a.NewTaskIDORExecutor(attack.RuleContext{ID: "a2a-task-idor-001"}).
+		Execute(context.Background(), ts.URL, idorOpts())
+	if err != nil {
+		t.Fatalf("the agent answered every probe, so this is a tested clean result: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("an envelope carrying neither the task id nor the context id disclosed "+
+			"nothing; got %d finding(s): %+v", len(findings), findings)
+	}
+}
+
+// The same agent, but the anonymous read really does return the owner's task. The
+// oracle must still fire, or the fix above would have been bought by breaking the rule.
+func TestA2ATaskIDOR_RealDisclosureStillFires(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/.well-known/") {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"protocolVersion": "0.3.0", "name": "leaky", "description": "d",
+				"url": "http://" + r.Host + "/", "preferredTransport": "JSONRPC",
+				"version": "1.0", "capabilities": map[string]interface{}{},
+				"defaultInputModes": []string{"text"}, "defaultOutputModes": []string{"text"},
+				"skills": []interface{}{},
+			})
+			return
+		}
+		method, id := decodeRPC(r)
+		w.Header().Set("Content-Type", "application/json")
+		enc := func(v map[string]interface{}) {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id, "result": v,
+			})
+		}
+		switch method {
+		case "SendMessage", "message/send":
+			if !hasOwnerAuth(r) {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			enc(map[string]interface{}{"task": map[string]interface{}{
+				"id": "task-owner-1", "contextId": "ctx-owner-1",
+				"status": map[string]interface{}{"state": "working"},
+			}})
+		case "GetTask", "tasks/get":
+			// Hands the owner's task to anyone: the real defect.
+			enc(map[string]interface{}{
+				"id": "task-owner-1", "contextId": "ctx-owner-1",
+				"status":  map[string]interface{}{"state": "working"},
+				"history": []interface{}{map[string]interface{}{"role": "user"}},
+			})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": -32601, "message": "Method not found"},
+			})
+		}
+	}))
+	defer ts.Close()
+
+	findings, err := a2a.NewTaskIDORExecutor(attack.RuleContext{ID: "a2a-task-idor-001"}).
+		Execute(context.Background(), ts.URL, idorOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("an anonymous read that returned the owner's task IS the finding, got %d: %+v",
+			len(findings), findings)
+	}
+	if findings[0].Severity != "high" || findings[0].Confidence != attack.ConfirmedExploit {
+		t.Errorf("want high/ConfirmedExploit, got %s/%s", findings[0].Severity, findings[0].Confidence)
+	}
+}
+
+// restMountedAgent serves its HTTP+JSON binding under a prefix the card declares, and
+// leaks every task from GET {prefix}/v1/tasks to an anonymous caller. Nothing answers
+// at the target root, so a rule that guesses vars.BaseURL+"/v1/tasks" finds nothing.
+func restMountedAgent(t *testing.T, prefix string, hits *[]string) *httptest.Server {
+	t.Helper()
+	var mu sync.Mutex
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		*hits = append(*hits, r.URL.Path)
+		mu.Unlock()
+
+		if strings.Contains(r.URL.Path, "/.well-known/") {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"protocolVersion": "1.0", "name": "rest-mounted", "description": "d",
+				"version": "1.0", "capabilities": map[string]interface{}{},
+				"defaultInputModes": []string{"text"}, "defaultOutputModes": []string{"text"},
+				"skills": []interface{}{},
+				"supportedInterfaces": []interface{}{
+					map[string]interface{}{
+						"transport": "JSONRPC", "url": "http://" + r.Host + "/",
+					},
+					map[string]interface{}{
+						"transport": "HTTP+JSON", "url": "http://" + r.Host + prefix,
+					},
+				},
+			})
+			return
+		}
+
+		// The leak, only under the advertised prefix.
+		if r.Method == http.MethodGet && r.URL.Path == prefix+"/v1/tasks" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"tasks": []interface{}{
+					map[string]interface{}{"id": "task-1", "contextId": "ctx-1"},
+					map[string]interface{}{"id": "task-2", "contextId": "ctx-2"},
+				},
+			})
+			return
+		}
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		// The JSON-RPC surface implements nothing, so only the REST probe can find
+		// anything here.
+		_, id := decodeRPC(r)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": id,
+			"error": map[string]interface{}{"code": -32601, "message": "Method not found"},
+		})
+	}))
+}
+
+// The strongest finding this rule can emit must be reachable at the base the CARD
+// declares, not only at two guessed paths off the target root.
+func TestA2ATaskIDOR_RESTBaseComesFromTheCard(t *testing.T) {
+	var hits []string
+	const prefix = "/agents/finance"
+	ts := restMountedAgent(t, prefix, &hits)
+	defer ts.Close()
+
+	findings, err := a2a.NewTaskIDORExecutor(attack.RuleContext{ID: "a2a-task-idor-001"}).
+		Execute(context.Background(), ts.URL, idorOpts())
+	if err != nil {
+		t.Fatalf("the REST listing answered, so the rule reached a testable surface: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("an anonymous REST listing returning 2 tasks is the critical finding; got %d: %+v\n"+
+			"paths probed: %v", len(findings), findings, hits)
+	}
+	f := findings[0]
+	if f.Severity != "critical" {
+		t.Errorf("want critical, got %s", f.Severity)
+	}
+	if !strings.Contains(f.TargetURL, prefix) {
+		t.Errorf("the finding should name the advertised REST base, got %q", f.TargetURL)
+	}
+	// The probe must actually have gone to the advertised prefix.
+	var probedPrefix bool
+	for _, p := range hits {
+		if p == prefix+"/v1/tasks" {
+			probedPrefix = true
+		}
+	}
+	if !probedPrefix {
+		t.Errorf("the advertised REST base was never probed; paths seen: %v", hits)
+	}
+}
+
+// The guessed paths remain a fallback, so an agent that advertises no HTTP+JSON
+// interface but serves one at the root is still found.
+func TestA2ATaskIDOR_RootFallbackStillProbed(t *testing.T) {
+	var hits []string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits = append(hits, r.URL.Path)
+		if strings.Contains(r.URL.Path, "/.well-known/") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/tasks" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"tasks": []interface{}{map[string]interface{}{"id": "task-1", "contextId": "ctx-1"}},
+			})
+			return
+		}
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_, id := decodeRPC(r)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": id,
+			"error": map[string]interface{}{"code": -32601, "message": "Method not found"},
+		})
+	}))
+	defer ts.Close()
+
+	findings, err := a2a.NewTaskIDORExecutor(attack.RuleContext{ID: "a2a-task-idor-001"}).
+		Execute(context.Background(), ts.URL, idorOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("the root fallback must still be probed; got %d: %+v (paths: %v)",
+			len(findings), findings, hits)
+	}
+}

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -50,7 +50,7 @@ fixtures for live-validation / manual smoke testing.
 | `a2a_batch_bypass_server.py` | 3108 | `a2a-jsonrpc-batch-bypass-001` |
 | `a2a_task_cancel_server.py` | 3109 | `a2a-task-cancel-idor-001` (two principals; needs two `--principal`s) |
 | `a2a_card_security_unenforced_server.py` | 3110 | `a2a-card-security-unenforced-001` |
-| `a2a_secured_agent.py` | 3111 | negative control, two postures: NO rule may fire on `secured`; `a2a-multitenant-isolation-001`, `a2a-delegation-integrity-001`, `a2a-task-cancel-idor-001`, `a2a-push-binding-001` and `a2a-task-enumeration-001` must all fire on `idor` (needs `--token tok-a` and two principals, see below) |
+| `a2a_secured_agent.py` | 3111 | negative control, three postures: NO rule may fire on `secured`; `a2a-multitenant-isolation-001`, `a2a-delegation-integrity-001`, `a2a-task-cancel-idor-001`, `a2a-push-binding-001` and `a2a-task-enumeration-001` must all fire on `idor` (needs `--token tok-a` and two principals, see below); `a2a-task-idor-001` must fire on `unauth-read` |
 | `mcp_unauth_resources_server.py` | 7787 | `mcp-resources-unauth-001` |
 | `mcp_oauth_dcr_server.py` | 7788 | `mcp-oauth-dcr-001` (two postures, see below; tracks registrations at `/__clients`) |
 | `mcp_oauth_audience_server.py` | 7785 | `mcp-oauth-audience-002` (four sub-paths, one per bug class; target each, not the root) |
@@ -231,9 +231,18 @@ enforces authorization and has one specific bug, and none of them was reachable 
 this directory.
 
 ```sh
-python testdata/a2a_secured_agent.py secured  # NO rule may fire: any finding is a false positive
-python testdata/a2a_secured_agent.py idor     # the five ownership rules must all fire
+python testdata/a2a_secured_agent.py secured      # NO rule may fire: any finding is a false positive
+python testdata/a2a_secured_agent.py idor         # the five ownership rules must all fire
+python testdata/a2a_secured_agent.py unauth-read  # a2a-task-idor-001 must fire, and only it
 ```
+
+`unauth-read` exists because **no fixture made `a2a-task-idor-001` fire at all**. That
+rule needs creation to be auth-gated, so the finding is broken authorization rather
+than absent authentication, AND the read to answer an anonymous caller. No fixture
+offered that shape, so the rule's disclosure path had zero coverage on a live socket
+and only its Go harness exercised it. In this posture `GetTask`/`tasks/get` are exempt
+from the credential check and hand back the owner's task; everything else still
+enforces.
 
 Ownership enforcement is the only difference between the two postures, which is what
 makes a diff between them mean something. Both require a bearer token, so run it with

--- a/testdata/a2a_secured_agent.py
+++ b/testdata/a2a_secured_agent.py
@@ -61,7 +61,7 @@ import uvicorn
 
 PORT = 3111
 
-POSTURES = ("secured", "idor")
+POSTURES = ("secured", "idor", "unauth-read")
 POSTURE = sys.argv[1] if len(sys.argv) > 1 else "secured"
 
 # The multi-principal fixtures in this directory all expect these two tokens
@@ -110,10 +110,18 @@ def _normalized(message: dict) -> dict:
     return stored
 
 
+# ANON_READER stands in for a caller that presented no credential at all, so the
+# ownership check below can hand it another principal's task in the unauth-read
+# posture without also making it an owner.
+ANON_READER = "__anonymous__"
+
+
 def _may_touch(task: dict, caller: str) -> bool:
     """Whether caller may act on task. The only place the postures differ."""
     if POSTURE == "idor":
         return True  # any authenticated caller: the bug under test
+    if POSTURE == "unauth-read" and caller == ANON_READER:
+        return True  # reads are not bound to the owner: the bug under test
     return task["owner"] == caller
 
 
@@ -246,10 +254,18 @@ async def jsonrpc(request: Request) -> Response:
     req_id = body.get("id")
     params = body.get("params") or {}
 
-    # Authorization first, in both postures.
+    # Authorization first. In unauth-read the READ methods are exempt, which is the
+    # one posture a2a-task-idor-001 can fire on: that rule needs creation to be
+    # auth-gated (so the finding is broken authorization, not absent authentication)
+    # and the read to answer an anonymous caller. No fixture here offered that shape,
+    # so the rule had zero positive coverage on a live socket and only its Go harness
+    # exercised the disclosure path.
     caller = _principal(request)
     if not caller:
-        return _unauthenticated()
+        if POSTURE == "unauth-read" and method in ("GetTask", "tasks/get"):
+            caller = ANON_READER
+        else:
+            return _unauthenticated()
 
     if method in ("SendMessage", "message/send"):
         return _send(req_id, params, caller, v1=method == "SendMessage")
@@ -274,6 +290,10 @@ if __name__ == "__main__":
     if POSTURE not in POSTURES:
         sys.exit(f"unknown posture {POSTURE!r}; expected one of {', '.join(POSTURES)}")
     print(f"[*] A2A authorization-enforcing agent ({POSTURE}) on http://127.0.0.1:{PORT}/", flush=True)
+    if POSTURE == "unauth-read":
+        print("[*] Violation: task creation requires a credential but GetTask/tasks_get "
+              "answers an ANONYMOUS caller with the owner's task. a2a-task-idor-001 "
+              "must fire.", flush=True)
     if POSTURE == "secured":
         print("[*] Expected: no findings. Any finding is a false positive.", flush=True)
     else:


### PR DESCRIPTION
Two defects in `a2a-task-idor-001`, neither visible to the existing suite.

**The read oracle was a vacuous needle.** `ContainsAny("history", "contextId", taskID, contextID)` — `ContainsAny` is OR and the first two are key names carried by virtually every A2A Task envelope, so it reduced to "the caller got some accepted result". A server that declines to expose a task by answering with a redacted or empty Task stub matched on the literal `"contextId"`, and the rule reported high/confirmed **with the owner's real identifiers printed in the evidence as though the server had returned them**. `taskref.go` exists to remove this exact expression and documents it as a live false positive in two sibling rules; this was the third and last instance, and `resultReferencesTask` was already in the same package.

**The tasks/list probe guessed the REST base.** It tried only `vars.BaseURL+"/v1/tasks"` and `+"/tasks"`, while `endpoint.go` states the REST prefix cannot be guessed — the deployment chooses it and chooses which protocol version sits under it — and `resolveHTTPJSONBase` exists for it and is used by `push_ssrf.go`. A deployment mounting its HTTP+JSON binding anywhere else 404'd both guesses, and the **strongest finding this rule can emit was silently never raised**. The advertised base is tried first now; the root paths stay as a fallback since an agent advertising no HTTP+JSON interface may still serve one. The card is fetched with the operator's credential (agents can gate their own card) while the listing probes stay unauthenticated, which is the point of the check.

**This rule had no live coverage at all.** It needs creation auth-gated *and* the read answering anonymously, and no fixture offered that shape — the one fixture listing it has it documented as silent by design. So the disclosure path was only ever exercised in-process. `testdata/a2a_secured_agent.py` gains an `unauth-read` posture exempting only `GetTask`/`tasks/get` from the credential check, and the rule fires against it on **both** the previous binary and this one, so narrowing the oracle kept the true positive:

```
bat_base: high  A2A task readable without owner credentials despite auth-gated creation
bat_new:  high  A2A task readable without owner credentials despite auth-gated creation
```

Non-vacuity: restoring the needles fails the redacted-stub test; dropping the card lookup fails the mounted-REST test. 51-case sweep otherwise unchanged.