### PR TITLE
fix(mcp): stop reading a non-answer as an authorization refusal in five rules

### DIFF
--- a/internal/attack/mcp/era_downgrade.go
+++ b/internal/attack/mcp/era_downgrade.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/calbebop/batesian/internal/attack"
 )
@@ -59,13 +60,31 @@ func (e *EraDowngradeExecutor) Execute(ctx context.Context, target string, opts 
 		return nil, nil
 	}
 
-	legacyOutcome := e.probeList(ctx, client, *legacy)
-	modernOutcome := e.probeList(ctx, client, *modern)
-	if legacyOutcome.method == "" || modernOutcome.method == "" {
+	// ONE method, advertised by BOTH wires. Each wire used to choose its own from its
+	// own advertisement, and nothing then required the two to match: a legacy wire
+	// advertising {resources} and a modern wire advertising {tools} were compared as
+	// though they were the same call. The difference measured was the capability or a
+	// per-method policy, not the era gate, and the finding text rendered one wire's
+	// method for both sides while the evidence printed both, so the two contradicted
+	// each other.
+	legacyMethods := advertisedListMethods(*legacy)
+	modernMethods := advertisedListMethods(*modern)
+	if len(legacyMethods) == 0 || len(modernMethods) == 0 {
 		// A wire advertising nothing listable leaves nothing whose gating could be
 		// compared, and that is a genuine not-applicable.
 		return nil, nil
 	}
+	method := firstCommon(legacyMethods, modernMethods)
+	if method == "" {
+		return nil, fmt.Errorf("%w: the two wires at %s advertise no listable method in common "+
+			"(legacy: %s; %s: %s), so any difference between them would be a capability "+
+			"difference rather than an authorization gate",
+			attack.ErrInconclusive, legacy.Endpoint, strings.Join(legacyMethods, ", "),
+			modernEraVersion, strings.Join(modernMethods, ", "))
+	}
+
+	legacyOutcome := e.probeList(ctx, client, *legacy, method)
+	modernOutcome := e.probeList(ctx, client, *modern, method)
 	if !legacyOutcome.comparable() || !modernOutcome.comparable() {
 		// One wire did not answer: a transport failure, a bare 202, a 429, a 502.
 		// The comparison is unavailable, and calling the silent wire "refused" is
@@ -90,6 +109,39 @@ func (e *EraDowngradeExecutor) Execute(ctx context.Context, target string, opts 
 		open, closed = modernOutcome, legacyOutcome
 	}
 	return []attack.Finding{e.finding(*legacy, open, closed)}, nil
+}
+
+// listableMethods are the read-only listings this rule will compare, in preference
+// order, each with the capability that advertises it.
+var listableMethods = []struct{ capability, method string }{
+	{"tools", "tools/list"},
+	{"resources", "resources/list"},
+	{"prompts", "prompts/list"},
+}
+
+// advertisedListMethods returns the listings this wire advertises, in preference
+// order.
+func advertisedListMethods(session mcpSession) []string {
+	var out []string
+	for _, c := range listableMethods {
+		if session.ServerSupports(c.capability) {
+			out = append(out, c.method)
+		}
+	}
+	return out
+}
+
+// firstCommon returns the first entry of a that also appears in b, preserving a's
+// preference order, or "" when they share nothing.
+func firstCommon(a, b []string) string {
+	for _, x := range a {
+		for _, y := range b {
+			if x == y {
+				return x
+			}
+		}
+	}
+	return ""
 }
 
 // listOutcome is one wire's answer to a read-only list call.
@@ -119,23 +171,9 @@ func (o listOutcome) comparable() bool {
 // experimental, prompts, resources and tools while server/discover reports
 // prompts, resources and tools. Comparing a method one wire does not implement
 // against one it does would measure the capability difference, not the gate.
-func (e *EraDowngradeExecutor) probeList(ctx context.Context, client *attack.HTTPClient, session mcpSession) listOutcome {
-	out := listOutcome{era: session.Era}
-
-	for _, c := range []struct{ capability, method string }{
-		{"tools", "tools/list"},
-		{"resources", "resources/list"},
-		{"prompts", "prompts/list"},
-	} {
-		if !session.ServerSupports(c.capability) {
-			continue
-		}
-		out.method = c.method
-		break
-	}
-	if out.method == "" {
-		return out
-	}
+func (e *EraDowngradeExecutor) probeList(ctx context.Context, client *attack.HTTPClient, session mcpSession,
+	method string) listOutcome {
+	out := listOutcome{era: session.Era, method: method}
 
 	resp, err := session.post(ctx, client, 2, out.method, nil)
 	out.verdict = classifyAccess(resp, err)

--- a/internal/attack/mcp/header_body_split.go
+++ b/internal/attack/mcp/header_body_split.go
@@ -157,7 +157,20 @@ func (e *HeaderBodySplitExecutor) probe(ctx context.Context, client *attack.HTTP
 
 	// Probe 3: mismatched Mcp-Method. A compliant server MUST reject; if it
 	// executes the body's tools/list, header value is not validated.
-	if e.toolsList(ctx, client, session, mismatchMethodHeader) != accessGranted {
+	//
+	// accessUndetermined is graded separately here, exactly as it is for probe 1. It
+	// used to fold into the "value IS validated" branch, which is the rule's own
+	// subject: a 502 or a rate limit on this one request reported the SEP-2243 surface
+	// clean. Worse, it then ran the case-folded follow-up, so an undetermined mismatch
+	// plus a server that ignores the header value outright emitted the CASE-FOLDING
+	// finding, whose text asserts that a mismatched Mcp-Method was rejected - something
+	// this path never observed.
+	switch e.toolsList(ctx, client, session, mismatchMethodHeader) {
+	case accessUndetermined:
+		return nil, "", false, "the tools/list probe whose Mcp-Method disagreed with the body " +
+			"returned neither a result nor a refusal, so whether the server validates the header " +
+			"VALUE could not be established"
+	case accessRefused:
 		// The value IS validated. One narrower way to get it wrong remains: comparing
 		// case-insensitively. This runs only here, because a server that ignores the
 		// value outright already reports above and a second finding would say the same

--- a/internal/attack/mcp/init_downgrade.go
+++ b/internal/attack/mcp/init_downgrade.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -65,12 +66,21 @@ func (e *InitDowngradeExecutor) Execute(ctx context.Context, target string, opts
 	// WITHOUT proper credentials, so the probe must run with no bearer token.
 	client := attack.NewUnauthHTTPClient(opts, vars)
 
-	return probeCandidates(vars.BaseURL, func(ep string) ([]attack.Finding, bool) {
-		return e.probeEndpoint(ctx, client, ep)
+	// Why no candidate could be compared, so an undetermined probe does not surface as
+	// the generic "could not reach a testable endpoint". The endpoint WAS reached; it
+	// answered one of the two baselines with something that refuses nothing.
+	var observed initObservation
+	findings, err := probeCandidates(vars.BaseURL, func(ep string) ([]attack.Finding, bool) {
+		return e.probeEndpoint(ctx, client, ep, &observed)
 	})
+	if errors.Is(err, attack.ErrInconclusive) && observed.rank > rankNothing {
+		return nil, inconclusive(handshakeRefusal{observed.reason})
+	}
+	return findings, err
 }
 
-func (e *InitDowngradeExecutor) probeEndpoint(ctx context.Context, client *attack.HTTPClient, ep string) ([]attack.Finding, bool) {
+func (e *InitDowngradeExecutor) probeEndpoint(ctx context.Context, client *attack.HTTPClient, ep string,
+	observed *initObservation) ([]attack.Finding, bool) {
 	// Legacy path: initialize with the pre-auth version, then probe resources/list.
 	legacyInitOK, legacyAccess, legacyCount := e.initAndList(ctx, client, ep, legacyVersion)
 	if !legacyInitOK {
@@ -92,7 +102,24 @@ func (e *InitDowngradeExecutor) probeEndpoint(ctx context.Context, client *attac
 	// (auth enforced) while the legacy session was GRANTED access. If the modern
 	// session was also granted access, the server has no auth at all (not a
 	// downgrade issue); if legacy was rejected the server is secure.
-	if legacyAccess && modernInitOK && !modernAccess {
+	//
+	// accessUndetermined on EITHER side means there is no comparison to make. It is
+	// reported as not tested rather than folded into either verdict: folded into
+	// "refused" it invents a critical finding against a server with no authorization at
+	// all, and folded into "granted" it hides a real one.
+	if legacyAccess == accessUndetermined || (modernInitOK && modernAccess == accessUndetermined) {
+		version := legacyVersion
+		if legacyAccess != accessUndetermined {
+			version = modernVersion
+		}
+		observed.observe(initObservation{rankStatusOnly, fmt.Sprintf(
+			"resources/list on the session opened at %s with protocol version %s returned neither a "+
+				"result nor a refusal, so the two versions' authorization could not be compared",
+			ep, version)})
+		return nil, false
+	}
+
+	if legacyAccess == accessGranted && modernInitOK && modernAccess == accessRefused {
 		return []attack.Finding{{
 			RuleID:     e.rule.ID,
 			RuleName:   e.rule.Name,
@@ -231,7 +258,7 @@ func jsonRPCErrorMessage(body []byte) string {
 //   - access: resources/list passed authorization (HTTP success, a JSON-RPC
 //     result, and no JSON-RPC error envelope);
 //   - count: number of resources returned (for evidence).
-func (e *InitDowngradeExecutor) initAndList(ctx context.Context, client *attack.HTTPClient, ep, version string) (initOK, access bool, count int) {
+func (e *InitDowngradeExecutor) initAndList(ctx context.Context, client *attack.HTTPClient, ep, version string) (initOK bool, access accessVerdict, count int) {
 	initResp, err := client.POST(ctx, ep, nil, map[string]interface{}{
 		"jsonrpc": "2.0",
 		"id":      1,
@@ -243,15 +270,15 @@ func (e *InitDowngradeExecutor) initAndList(ctx context.Context, client *attack.
 		},
 	})
 	if err != nil || !initResp.IsSuccess() {
-		return false, false, 0
+		return false, accessUndetermined, 0
 	}
 	body := initResp.BodyString()
 	// Explicit version rejection (error without a negotiated version).
 	if strings.Contains(body, `"error"`) && !strings.Contains(body, `"protocolVersion"`) {
-		return false, false, 0
+		return false, accessUndetermined, 0
 	}
 	if !initResp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
-		return false, false, 0
+		return false, accessUndetermined, 0
 	}
 
 	session := mcpSession{Endpoint: ep, SessionID: initResp.Headers.Get("Mcp-Session-Id"), ProtocolVersion: negotiatedVersion(initResp.Body)}
@@ -266,20 +293,25 @@ func (e *InitDowngradeExecutor) initAndList(ctx context.Context, client *attack.
 		"method":  "resources/list",
 		"params":  map[string]interface{}{},
 	})
-	if err != nil || !listResp.IsSuccess() {
-		return true, false, 0
+	// classifyAccess, not err != nil || !IsSuccess(). Deriving "refused" from the
+	// absence of acceptance made a transport failure, a 429 from a rate limiter and a
+	// one-off 502 indistinguishable from an authorization refusal, and "the modern wire
+	// refused" is the finding-enabling half of the comparison below. era_downgrade was
+	// fixed for exactly this; this rule kept the collapsed form.
+	verdict := classifyAccess(listResp, err)
+	if verdict != accessGranted {
+		return true, verdict, 0
 	}
 	var rb map[string]interface{}
 	if jsonErr := json.Unmarshal(listResp.Body, &rb); jsonErr != nil {
-		return true, false, 0
-	}
-	if _, hasErr := rb["error"]; hasErr {
-		return true, false, 0
+		return true, accessUndetermined, 0
 	}
 	result, ok := rb["result"].(map[string]interface{})
 	if !ok {
-		return true, false, 0
+		// Accepted by the transport oracle but carrying no result object: nothing was
+		// refused and nothing was listed.
+		return true, accessUndetermined, 0
 	}
 	resources, _ := result["resources"].([]interface{})
-	return true, true, len(resources)
+	return true, accessGranted, len(resources)
 }

--- a/internal/attack/mcp/session_as_credential.go
+++ b/internal/attack/mcp/session_as_credential.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/calbebop/batesian/internal/attack"
 )
@@ -82,7 +83,14 @@ func (e *SessionAsCredentialExecutor) Execute(ctx context.Context, target string
 
 		// Step 2: the session must actually work when presented with the credential,
 		// or there is nothing to strip.
-		if !e.toolsList(ctx, client, ep, session, authed) {
+		if v := e.toolsList(ctx, client, ep, session, authed); v != accessGranted {
+			if v == accessUndetermined {
+				observed.observe(initObservation{rankStatusOnly, fmt.Sprintf(
+					"the credentialled call presenting the server's own session id at %s returned "+
+						"neither a result nor a refusal, so the session was never shown to work and "+
+						"there was nothing to strip", ep)})
+				return nil, false
+			}
 			return nil, true
 		}
 
@@ -113,11 +121,17 @@ func (e *SessionAsCredentialExecutor) Execute(ctx context.Context, target string
 				// session. Report nothing rather than guess.
 				return nil, true
 			}
-			if e.toolsList(ctx, client, ep, anonSession, nil) {
+			switch e.toolsList(ctx, client, ep, anonSession, nil) {
+			case accessGranted:
 				// A caller who presented no credential at any point reads the tool list.
 				// The server implements no authorization, the MUST NOT above does not
 				// bind on it, and mcp-tools-unauth-001 owns that surface.
 				return nil, true
+			case accessUndetermined:
+				observed.observe(initObservation{rankStatusOnly, fmt.Sprintf(
+					"the anonymous-session control at %s returned neither a result nor a refusal, so "+
+						"whether this server authorizes anything could not be established", ep)})
+				return nil, false
 			}
 			// The anonymous session was refused while the credentialed one was
 			// accepted, on the same call with the same headers. That is the asymmetry
@@ -130,21 +144,41 @@ func (e *SessionAsCredentialExecutor) Execute(ctx context.Context, target string
 		// Step 4: control. No session, no credential. A server that answers this is
 		// open on the surface under test, so a later success cannot be attributed to
 		// the session id.
-		if e.toolsList(ctx, client, ep, "", nil) {
+		switch e.toolsList(ctx, client, ep, "", nil) {
+		case accessGranted:
 			return nil, true
+		case accessUndetermined:
+			observed.observe(initObservation{rankStatusOnly, fmt.Sprintf(
+				"the no-session no-credential control at %s returned neither a result nor a "+
+					"refusal, so whether this surface is simply open could not be established",
+				ep)})
+			return nil, false
 		}
 
 		// Step 5: control. A random never-issued session id, no credential. A server
 		// that accepts this treats the presence of the header as authorization, so the
 		// issued id was not what decided it.
 		bogus := "batesian-never-issued-" + vars.RandID
-		if e.toolsList(ctx, client, ep, bogus, nil) {
+		switch e.toolsList(ctx, client, ep, bogus, nil) {
+		case accessGranted:
 			return nil, true
+		case accessUndetermined:
+			observed.observe(initObservation{rankStatusOnly, fmt.Sprintf(
+				"the never-issued session-id control at %s returned neither a result nor a refusal, "+
+					"so whether the server accepts any session id could not be established", ep)})
+			return nil, false
 		}
 
 		// Step 6: the real session id, no credential.
-		if !e.toolsList(ctx, client, ep, session, nil) {
+		switch e.toolsList(ctx, client, ep, session, nil) {
+		case accessRefused:
 			return nil, true // the session carries no authority: secure
+		case accessUndetermined:
+			observed.observe(initObservation{rankStatusOnly, fmt.Sprintf(
+				"the credential-stripped call presenting the real session id at %s returned neither "+
+					"a result nor a refusal, so whether the session alone authorizes was never "+
+					"observed", ep)})
+			return nil, false
 		}
 
 		return []attack.Finding{e.finding(ep, session, bogus, anonSession)}, true
@@ -198,7 +232,7 @@ func (e *SessionAsCredentialExecutor) initialize(ctx context.Context, client *at
 // a JSON-RPC error at HTTP 200 has refused it, and reading that as success is the
 // mistake that produced fabricated findings elsewhere in this package.
 func (e *SessionAsCredentialExecutor) toolsList(ctx context.Context, client *attack.HTTPClient,
-	endpoint, session string, headers map[string]string) bool {
+	endpoint, session string, headers map[string]string) accessVerdict {
 	h := map[string]string{"Mcp-Protocol-Version": latestStable}
 	for k, v := range headers {
 		h[k] = v
@@ -212,10 +246,22 @@ func (e *SessionAsCredentialExecutor) toolsList(ctx context.Context, client *att
 		"method":  "tools/list",
 		"params":  map[string]interface{}{},
 	})
-	if err != nil {
-		return false
+	// classifyAccess, not err != nil -> false. Steps 4 and 5 are SUPPRESSION controls,
+	// so "refused" is the direction that lets the finding through: a transport failure
+	// or a 429 on either of them used to read as "this server does gate the surface",
+	// and the rule then attributed a step-6 success to the session id.
+	verdict := classifyAccess(resp, err)
+	// One session-specific amendment. HTTP 404 is the shape the transport prescribes
+	// for a missing or unknown session id, and it commonly carries no JSON-RPC body, so
+	// classifyAccess grades it undetermined. Here it is a real refusal: every call this
+	// helper makes goes to an endpoint that has already completed a handshake, so a 404
+	// is this server declining this request rather than a path that does not exist.
+	// Without this a compliant server reports not tested at the controls instead of
+	// being assessed.
+	if verdict == accessUndetermined && resp != nil && resp.StatusCode == http.StatusNotFound {
+		return accessRefused
 	}
-	return resp.IsAccepted()
+	return verdict
 }
 
 func (e *SessionAsCredentialExecutor) finding(endpoint, session, bogus, anonSession string) attack.Finding {

--- a/internal/attack/mcp/session_fixation.go
+++ b/internal/attack/mcp/session_fixation.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/calbebop/batesian/internal/attack"
@@ -99,15 +100,26 @@ func (e *SessionFixationExecutor) ExecuteChained(ctx context.Context, target str
 	})
 
 	// Step 2: present the attacker-chosen id on a follow-up call.
-	if !e.sessionAccepted(ctx, client, ep, fixed, nil) {
+	switch e.sessionAccepted(ctx, client, ep, fixed, nil) {
+	case accessRefused:
 		return nil, nil // server did not adopt the pre-seeded id - secure
+	case accessUndetermined:
+		return nil, fmt.Errorf("%w: the follow-up call presenting the client-chosen session id at %s "+
+			"returned neither a result nor a refusal, so whether the server adopted it was never "+
+			"observed", attack.ErrInconclusive, ep)
 	}
 
 	// Step 3 (control): a never-initialized random id. A spec-compliant server
 	// rejects it (404). If it is ALSO accepted, the server tracks no sessions at
 	// all - not fixation - so suppress.
-	if e.sessionAccepted(ctx, client, ep, unseeded, nil) {
+	switch e.sessionAccepted(ctx, client, ep, unseeded, nil) {
+	case accessGranted:
 		return nil, nil
+	case accessUndetermined:
+		return nil, fmt.Errorf("%w: the never-initialized control id at %s returned neither a result "+
+			"nor a refusal, so whether this server enforces sessions at all could not be established, "+
+			"and without that a client-chosen id being accepted proves nothing",
+			attack.ErrInconclusive, ep)
 	}
 
 	// Confirmed: sessions ARE enforced (unseeded id rejected) yet the server
@@ -125,7 +137,7 @@ func (e *SessionFixationExecutor) ExecuteChained(ctx context.Context, target str
 		o := opts
 		o.Token = p.Token
 		pClient := attack.NewHTTPClient(o, vars)
-		if e.sessionAccepted(ctx, pClient, ep, fixed, p.Headers) {
+		if e.sessionAccepted(ctx, pClient, ep, fixed, p.Headers) == accessGranted {
 			crossPrincipal = p.Name
 			chain = append(chain, attack.ChainStep{
 				Hop:       4,
@@ -173,7 +185,7 @@ func (e *SessionFixationExecutor) initWithSession(ctx context.Context, client *a
 // UNLESS it carries a JSON-RPC error that references the session (e.g. "session
 // not found"); a method-not-found error still means the session passed
 // validation and reached method dispatch.
-func (e *SessionFixationExecutor) sessionAccepted(ctx context.Context, client *attack.HTTPClient, ep, sessionID string, extraHeaders map[string]string) bool {
+func (e *SessionFixationExecutor) sessionAccepted(ctx context.Context, client *attack.HTTPClient, ep, sessionID string, extraHeaders map[string]string) accessVerdict {
 	headers := map[string]string{"Mcp-Session-Id": sessionID, "Mcp-Protocol-Version": latestStable}
 	for k, v := range extraHeaders {
 		headers[k] = v
@@ -184,17 +196,34 @@ func (e *SessionFixationExecutor) sessionAccepted(ctx context.Context, client *a
 		"method":  "tools/list",
 		"params":  map[string]interface{}{},
 	})
-	if err != nil || !resp.IsSuccess() {
-		return false
+	if err != nil || resp == nil {
+		return accessUndetermined
 	}
 	body := resp.BodyString()
+	sessionRefusal := false
 	if isJSONRPCError(body) {
 		low := strings.ToLower(body)
-		if strings.Contains(low, "session") || strings.Contains(low, "not initialized") {
-			return false
-		}
+		sessionRefusal = strings.Contains(low, "session") || strings.Contains(low, "not initialized")
 	}
-	return true
+	if !resp.IsSuccess() {
+		// 404 is the shape the transport prescribes for an unknown session; an auth
+		// status, or any status carrying a session-flavoured error, is also a real
+		// refusal. Anything else - a 429, a 502, an empty 400 - refused nothing, and
+		// grading it as a refusal is what let this rule fabricate: BOTH of its
+		// suppression controls read a non-answer as "the server enforces sessions",
+		// which is the direction that enables the finding.
+		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusUnauthorized ||
+			resp.StatusCode == http.StatusForbidden || sessionRefusal {
+			return accessRefused
+		}
+		return accessUndetermined
+	}
+	if sessionRefusal {
+		return accessRefused
+	}
+	// A JSON-RPC error that is not about the session still means the session was
+	// accepted: the request reached dispatch.
+	return accessGranted
 }
 
 // finding builds the confirmed session-fixation finding.

--- a/internal/attack/mcp/transient_honesty_test.go
+++ b/internal/attack/mcp/transient_honesty_test.go
@@ -1,0 +1,501 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcpattack "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+// Four MCP rules compared two probes, or gated a finding on a control, while deriving
+// "refused" from the absence of acceptance. A transport failure, a 429 from a rate
+// limiter, a one-off 502 and a bare 202 all read as an authorization refusal, which in
+// every case is the direction that ENABLES the finding.
+//
+// classifyAccess and classifyProbe exist for this and carry comments describing this
+// exact failure. era_downgrade adopted them; these rules had not.
+//
+// Each case below drives a server with NO authorization anywhere, so any finding is
+// fabricated, and makes exactly one probe answer with something that refuses nothing.
+
+// mcp-init-downgrade-001: the modern baseline's listing hits a 429. The rule read that
+// as "authorization enforced under the modern version" and, since the legacy listing
+// succeeded, emitted a critical downgrade bypass against a server gating nothing.
+func TestTransient_InitDowngradeUndeterminedModernBaseline(t *testing.T) {
+	// The listing succeeds on a session opened with the legacy version and answers 429
+	// on one opened with the modern version. Keyed on the version rather than on a
+	// request counter, because the endpoint walk probes several candidate paths and a
+	// counter makes only one of them see the failure.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method, _ := body["method"].(string)
+		params, _ := body["params"].(map[string]interface{})
+		id := body["id"]
+
+		if strings.HasPrefix(method, "notifications/") {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if method == "initialize" {
+			offered, _ := params["protocolVersion"].(string)
+			// Echo the offered version back, so the follow-up carries it.
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{
+					"protocolVersion": offered,
+					"serverInfo":      map[string]interface{}{"name": "open", "version": "1.0"},
+					"capabilities":    map[string]interface{}{"resources": map[string]interface{}{}},
+				},
+			})
+			return
+		}
+		if method == "resources/list" {
+			if r.Header.Get("Mcp-Protocol-Version") != "2024-11-05" {
+				w.WriteHeader(http.StatusTooManyRequests) // refuses nothing
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{"resources": []interface{}{
+					map[string]interface{}{"uri": "file:///a", "name": "a"},
+				}},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": id,
+			"error": map[string]interface{}{"code": -32601, "message": "Method not found"},
+		})
+	}))
+	defer ts.Close()
+
+	findings, err := mcpattack.NewInitDowngradeExecutor(attack.RuleContext{ID: "mcp-init-downgrade-001"}).
+		Execute(context.Background(), ts.URL, testOpts())
+	if len(findings) != 0 {
+		t.Fatalf("a 429 refuses nothing, so no downgrade bypass may be claimed; got %d: %+v",
+			len(findings), findings)
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("the comparison was unavailable, so this is not tested; got %v", err)
+	}
+}
+
+// The same rule must still fire when the modern baseline is genuinely refused.
+func TestTransient_InitDowngradeStillFiresOnARealRefusal(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method, _ := body["method"].(string)
+		params, _ := body["params"].(map[string]interface{})
+		id := body["id"]
+		version, _ := params["protocolVersion"].(string)
+
+		if strings.HasPrefix(method, "notifications/") {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if method == "initialize" {
+			w.Header().Set("Mcp-Session-Id", "sess-"+version)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{
+					"protocolVersion": version,
+					"serverInfo":      map[string]interface{}{"name": "downgradable", "version": "1.0"},
+					"capabilities":    map[string]interface{}{"resources": map[string]interface{}{}},
+				},
+			})
+			return
+		}
+		// Authorization enforced only when the session was opened on a modern version.
+		if strings.HasPrefix(r.Header.Get("Mcp-Session-Id"), "sess-2024") {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{"resources": []interface{}{
+					map[string]interface{}{"uri": "file:///secret", "name": "secret"},
+				}},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer ts.Close()
+
+	findings, err := mcpattack.NewInitDowngradeExecutor(attack.RuleContext{ID: "mcp-init-downgrade-001"}).
+		Execute(context.Background(), ts.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("a real refusal on the modern version IS the bypass; got %d: %+v", len(findings), findings)
+	}
+	if findings[0].Severity != "critical" {
+		t.Errorf("want critical, got %s", findings[0].Severity)
+	}
+}
+
+// mcp-header-body-split-001: the MISMATCH probe is the rule's own subject. When it
+// returned no verdict the rule folded it into "the value IS validated" and reported
+// the SEP-2243 surface clean.
+func TestTransient_HeaderBodySplitUndeterminedMismatchProbe(t *testing.T) {
+	// Probe order on a legacy wire: omit (refused), match (granted), mismatch.
+	calls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method, _ := body["method"].(string)
+		id := body["id"]
+
+		if strings.HasPrefix(method, "notifications/") {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if method == "initialize" {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{
+					"protocolVersion": "2025-11-25",
+					"serverInfo":      map[string]interface{}{"name": "split", "version": "1.0"},
+					"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+				},
+			})
+			return
+		}
+		if method != "tools/list" {
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": -32601, "message": "Method not found"},
+			})
+			return
+		}
+		switch hdr := r.Header.Get("Mcp-Method"); hdr {
+		case "":
+			// Presence enforced: the rule's precondition.
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": -32020, "message": "HeaderMismatch"},
+			})
+		case "tools/list":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{"tools": []interface{}{map[string]interface{}{"name": "echo"}}},
+			})
+		default:
+			// The mismatch probe, and anything after it: no verdict at all.
+			calls++
+			w.WriteHeader(http.StatusBadGateway)
+		}
+	}))
+	defer ts.Close()
+
+	findings, err := mcpattack.NewHeaderBodySplitExecutor(hbsRuleCtx()).
+		Execute(context.Background(), ts.URL, testOpts())
+	if len(findings) != 0 {
+		t.Fatalf("nothing was observed about the header value; got %d: %+v", len(findings), findings)
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("an unobserved mismatch probe is not a clean SEP-2243 result; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "header") {
+		t.Errorf("the reason should name the header probe; got %v", err)
+	}
+}
+
+// mcp-session-fixation-001: the never-initialized control decides whether the server
+// enforces sessions at all, and it is what licenses the finding. A control that
+// produced no verdict read as "sessions ARE enforced".
+func TestTransient_SessionFixationUndeterminedControl(t *testing.T) {
+	// The server adopts ANY session id, so it tracks no sessions and the rule must
+	// stay silent. The control request is made to answer 502 instead of succeeding,
+	// which is what used to flip the verdict.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method, _ := body["method"].(string)
+		id := body["id"]
+
+		if strings.HasPrefix(method, "notifications/") {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if method == "initialize" {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{
+					"protocolVersion": "2025-11-25",
+					"serverInfo":      map[string]interface{}{"name": "sessionless", "version": "1.0"},
+					"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+				},
+			})
+			return
+		}
+		// The never-initialized control carries the batesian-generated id; the seeded
+		// one carries the rule's own fixed id. Answer the control with no verdict.
+		if strings.Contains(r.Header.Get("Mcp-Session-Id"), "never") ||
+			strings.Contains(r.Header.Get("Mcp-Session-Id"), "unseeded") {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": id,
+			"result": map[string]interface{}{"tools": []interface{}{map[string]interface{}{"name": "echo"}}},
+		})
+	}))
+	defer ts.Close()
+
+	findings, err := mcpattack.NewSessionFixationExecutor(attack.RuleContext{ID: "mcp-session-fixation-001"}).
+		Execute(context.Background(), ts.URL, testOpts())
+	if len(findings) != 0 {
+		t.Fatalf("the control never established that sessions are enforced; got %d: %+v",
+			len(findings), findings)
+	}
+	if err != nil && !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("want nil or ErrInconclusive, got %v", err)
+	}
+}
+
+// mcp-era-downgrade-001: the two wires must be compared on the SAME method. A legacy
+// wire advertising only resources and a modern wire advertising only tools have no
+// common listing, so any difference between them is a capability difference.
+func TestTransient_EraDowngradeNeedsACommonMethod(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method, _ := body["method"].(string)
+		id := body["id"]
+		isModern := r.Header.Get("MCP-Protocol-Version") == "2026-07-28"
+
+		if strings.HasPrefix(method, "notifications/") {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch method {
+		case "initialize":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{
+					"protocolVersion": "2025-11-25",
+					"serverInfo":      map[string]interface{}{"name": "split-caps", "version": "1.0"},
+					// Legacy wire: resources only.
+					"capabilities": map[string]interface{}{"resources": map[string]interface{}{}},
+				},
+			})
+		case "server/discover":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{
+					"supportedVersions": []string{"2026-07-28"},
+					// Modern wire: tools only.
+					"capabilities": map[string]interface{}{"tools": map[string]interface{}{}},
+				},
+			})
+		case "resources/list":
+			if isModern {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{"resources": []interface{}{
+					map[string]interface{}{"uri": "file:///a", "name": "a"},
+				}},
+			})
+		case "tools/list":
+			// Answered on the modern wire, refused on the legacy one: the shape that
+			// used to be reported as an era gate on a method never sent to both.
+			if !isModern {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{"tools": []interface{}{map[string]interface{}{"name": "echo"}}},
+			})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"error": map[string]interface{}{"code": -32601, "message": "Method not found"},
+			})
+		}
+	}))
+	defer ts.Close()
+
+	findings, err := mcpattack.NewEraDowngradeExecutor(attack.RuleContext{ID: "mcp-era-downgrade-001"}).
+		Execute(context.Background(), ts.URL, testOpts())
+	if len(findings) != 0 {
+		t.Fatalf("the wires share no listable method, so no era gate can be claimed; got %d: %+v",
+			len(findings), findings)
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("want ErrInconclusive naming the capability difference, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "in common") {
+		t.Errorf("the reason should say the wires share no method; got %v", err)
+	}
+}
+
+// mcp-session-as-credential-001: steps 4 and 5 are SUPPRESSION controls, so a
+// non-answer on either used to read as "this server does gate the surface", and the
+// rule then attributed a step-6 success to the session id.
+//
+// The server below REFUSES the anonymous handshake, so the anonymous-session
+// discriminator cannot settle the question and the later controls run. Its no-session
+// control then answers 502, establishing nothing. Without grading that, the rule
+// treats it as "the surface is gated" and proceeds toward a finding.
+func TestTransient_SessionAsCredentialUndeterminedControl(t *testing.T) {
+	issued := map[string]bool{}
+	n := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method, _ := body["method"].(string)
+		id := body["id"]
+		credentialled := r.Header.Get("Authorization") != ""
+
+		if strings.HasPrefix(method, "notifications/") {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if method == "initialize" {
+			// The handshake requires a credential, so the anonymous-session control
+			// cannot run and the no-session control below is what the rule relies on.
+			if !credentialled {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			n++
+			sid := "sess-" + strings.Repeat("x", n)
+			issued[sid] = true
+			w.Header().Set("Mcp-Session-Id", sid)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{
+					"protocolVersion": "2025-11-25",
+					"serverInfo":      map[string]interface{}{"name": "flaky-control", "version": "1.0"},
+					"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+				},
+			})
+			return
+		}
+		sid := r.Header.Get("Mcp-Session-Id")
+		if sid == "" {
+			// The no-session no-credential control: answers nothing conclusive.
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		if !issued[sid] {
+			w.WriteHeader(http.StatusNotFound) // never-issued id: a real refusal
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": id,
+			"result": map[string]interface{}{"tools": []interface{}{map[string]interface{}{"name": "echo"}}},
+		})
+	}))
+	defer ts.Close()
+
+	opts := testOpts()
+	opts.Token = "tok-a"
+	findings, err := mcpattack.NewSessionAsCredentialExecutor(
+		attack.RuleContext{ID: "mcp-session-as-credential-001"}).
+		Execute(context.Background(), ts.URL, opts)
+	if len(findings) != 0 {
+		t.Fatalf("the no-session control established nothing, so a session-id success cannot be "+
+			"attributed to the session; got %d: %+v", len(findings), findings)
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("want ErrInconclusive, got %v", err)
+	}
+	// Pinned to the no-session control specifically. Without this the never-issued-id
+	// control catches the same server for a different reason and the assertion passes
+	// whether or not step 4 grades its outcome.
+	if !strings.Contains(err.Error(), "no-session") {
+		t.Errorf("the reason should name the no-session control; got %v", err)
+	}
+}
+
+// A bare HTTP 404 is the shape the transport prescribes for an unknown session id, and
+// it commonly carries no JSON-RPC body, so classifyAccess grades it undetermined. On a
+// request that PRESENTED a session id that is a real refusal, and the never-issued-id
+// control must read it as one: taking it as undetermined makes a compliant server
+// report not tested where the rule should have proceeded.
+//
+// This server IS vulnerable, and answers every session refusal with a bodyless 404.
+func TestTransient_SessionAsCredentialBare404IsARefusal(t *testing.T) {
+	issued := map[string]bool{}
+	n := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		method, _ := body["method"].(string)
+		id := body["id"]
+
+		if strings.HasPrefix(method, "notifications/") {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		if method == "initialize" {
+			if r.Header.Get("Authorization") == "" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			n++
+			sid := "sess-" + strings.Repeat("y", n)
+			issued[sid] = true
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Mcp-Session-Id", sid)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{
+					"protocolVersion": "2025-11-25",
+					"serverInfo":      map[string]interface{}{"name": "bare404", "version": "1.0"},
+					"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+				},
+			})
+			return
+		}
+		sid := r.Header.Get("Mcp-Session-Id")
+		if sid == "" || !issued[sid] {
+			// Bodyless 404 for both the no-session and never-issued controls.
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		// The defect: an issued session id alone authorizes, with no credential.
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": id,
+			"result": map[string]interface{}{"tools": []interface{}{map[string]interface{}{"name": "echo"}}},
+		})
+	}))
+	defer ts.Close()
+
+	opts := testOpts()
+	opts.Token = "tok-a"
+	findings, err := mcpattack.NewSessionAsCredentialExecutor(
+		attack.RuleContext{ID: "mcp-session-as-credential-001"}).
+		Execute(context.Background(), ts.URL, opts)
+	if err != nil {
+		t.Fatalf("a bodyless 404 on a session-bearing request is a refusal, so both controls "+
+			"resolved and the rule was testable: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("the session id alone authorized, which is the finding; got %d: %+v",
+			len(findings), findings)
+	}
+}

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -190,6 +190,12 @@ indistinguishable from a 401 and both reported the surfaces clean. An operator
 could not tell "this server enforces auth" from "the scanner could not tell". If
 the 401 and 502 runs ever agree again, that conflation is back.
 
+The same conflation lived in four rules that compare two probes or gate a finding on
+a control, and `mcp-init-downgrade-001` is now covered by this fixture too: on the
+`502` posture it reports not tested, naming the version whose listing returned no
+verdict, where it used to read the gateway error as "authorization enforced under the
+modern version" and emit a critical downgrade bypass.
+
 **`mcp_era_downgrade_server.py` takes a posture argument**, defaulting to
 `vulnerable`:
 


### PR DESCRIPTION
Four rules compared two probes, or gated a finding on a control, while deriving "refused" from the *absence* of acceptance. A transport failure, a 429, a one-off 502 and a bare 202 all read as an authorization refusal — and in every case that is the direction which **enables** the finding. `classifyAccess`/`classifyProbe` exist for exactly this and carry comments describing it; `era_downgrade` adopted them, these had not.

| Rule | Was | Now |
|---|---|---|
| `mcp-init-downgrade-001` | 429 on the modern baseline read as "auth enforced" → **critical confirmed** downgrade bypass against a server gating nothing | not tested, naming the version whose listing was silent |
| `mcp-header-body-split-001` | undetermined **mismatch** probe (the rule's own subject) folded into "the value IS validated" → clean; then ran the case-fold follow-up, so it could emit the **case-folding** finding asserting a rejection it never saw | not tested |
| `mcp-session-fixation-001` | boolean control: no verdict read as "sessions ARE enforced", licensing the finding | not tested |
| `mcp-session-as-credential-001` | same, on both suppression controls | not tested |
| `mcp-era-downgrade-001` | each wire chose its own method with nothing requiring them to match, so `{resources}` vs `{tools}` were compared as one call — measuring the capability, not the gate, with the description rendering one method and the evidence printing both | probes one method both wires advertise; not tested when they share none |

**The sweep found a third false clean on a real fixture.** `mcp_header_body_split_server.py` refuses a session-bearing `tools/list` for *header* reasons, and `mcp-session-fixation-001` read that as "the server did not adopt the pre-seeded id — secure". Now not tested.

**One amendment came out of testing.** HTTP 404 is the transport's prescribed shape for a missing or unknown session id and commonly carries no JSON-RPC body, so `classifyAccess` grades it undetermined. Every call in these two session helpers goes to an endpoint that already completed a handshake, so a 404 there is a refusal — without that, a compliant server would newly report not tested. Pinned by its own test.

`mcp-init-downgrade-001` also threads its reason out rather than falling back to "could not reach a testable endpoint", which would blame the network for a server that answered:

```
not tested: resources/list on the session opened at http://127.0.0.1:7802/mcp with
protocol version 2024-11-05 returned neither a result nor a refusal, so the two
versions' authorization could not be compared
```

Six non-vacuity checks, one per fix. **Two initially passed**, and both were my error rather than the code's: the init-downgrade fixture keyed its failure on a request counter, which the endpoint walk spreads across candidate paths so only one saw it; and the session-as-credential assertion matched any inconclusive result, so a different control caught the same server and the check proved nothing. Worth recording — that's three times this session a revert has looked like a pass.