### PR TITLE
fix(mcp): three confirmed defects from a review pass

### DIFF
--- a/internal/attack/mcp/dns_rebind_origin.go
+++ b/internal/attack/mcp/dns_rebind_origin.go
@@ -98,10 +98,9 @@ func (e *DNSRebindOriginExecutor) originAccepted(ctx context.Context, client *at
 	}
 
 	// legacyHandshakeBody, not mcpInitBody: the baseline this is paired against is the
-	// wire-opening handshake, and mcpInitBody offers a different protocol revision with
-	// different capabilities and clientInfo. A server that refuses the older revision
-	// refused this probe for a reason that has nothing to do with Origin, and the rule
-	// read that as Origin validation.
+	// wire-opening handshake, and mcpInitBody carries different capabilities and
+	// clientInfo. A server that refused this probe did so for a reason that had nothing
+	// to do with Origin, and the rule read that as Origin validation.
 	headers := map[string]string{"Content-Type": "application/json", "Origin": foreignOrigin}
 	resp, err := client.POST(ctx, session.Endpoint, headers, legacyHandshakeBody())
 	if err != nil {

--- a/internal/attack/mcp/init_downgrade.go
+++ b/internal/attack/mcp/init_downgrade.go
@@ -81,9 +81,10 @@ func (e *InitDowngradeExecutor) Execute(ctx context.Context, target string, opts
 
 func (e *InitDowngradeExecutor) probeEndpoint(ctx context.Context, client *attack.HTTPClient, ep string,
 	observed *initObservation) ([]attack.Finding, bool) {
-	// Legacy path: initialize with the pre-auth version, then probe resources/list.
-	legacyInitOK, legacyAccess, legacyCount := e.initAndList(ctx, client, ep, legacyVersion)
-	if !legacyInitOK {
+	// Legacy path: initialize with the pre-auth version. The probe method is
+	// chosen below from the server's advertised capabilities, not hardcoded.
+	legacyOK, legacySession := e.handshake(ctx, client, ep, legacyVersion)
+	if !legacyOK {
 		// The legacy initialize did not succeed. Distinguish "not an MCP
 		// endpoint" from "a server that speaks MCP but rejects this version" by
 		// probing whether the endpoint answers initialize with a JSON-RPC
@@ -96,30 +97,66 @@ func (e *InitDowngradeExecutor) probeEndpoint(ctx context.Context, client *attac
 	}
 
 	// Modern baseline: does the server enforce auth under the post-auth version?
-	modernInitOK, modernAccess, _ := e.initAndList(ctx, client, ep, modernVersion)
+	// A server that does not speak the modern revision has no modern baseline to
+	// compare against; an old server that only supports the legacy version is not a
+	// downgrade bypass. The rule requires the modern path to exist and be rejected
+	// while the legacy path is granted.
+	modernOK, modernSession := e.handshake(ctx, client, ep, modernVersion)
+	if !modernOK {
+		return nil, true
+	}
 
-	// Confirmed downgrade bypass: the modern baseline must exist and be REJECTED
-	// (auth enforced) while the legacy session was GRANTED access. If the modern
-	// session was also granted access, the server has no auth at all (not a
-	// downgrade issue); if legacy was rejected the server is secure.
+	// ONE list method, advertised by BOTH versions, so the comparison measures the
+	// authorization gate and not a capability difference between revisions. A
+	// tools-only or prompts-only server has a real downgrade surface on that method;
+	// the old hardcoded resources/list probe silently missed it because
+	// resources/list returned method-not-found under both versions. era_downgrade
+	// compares two wires the same way; here the two versions of one server play
+	// that role.
+	legacyMethods := advertisedListMethods(legacySession)
+	modernMethods := advertisedListMethods(modernSession)
+	method := firstCommon(legacyMethods, modernMethods)
+	if method == "" {
+		if len(legacyMethods) == 0 && len(modernMethods) == 0 {
+			// Nothing listable is advertised under either version, so the downgrade
+			// concept (a listing gated under one version, open under the other) does
+			// not apply here.
+			return nil, true
+		}
+		observed.observe(initObservation{rankStatusOnly, fmt.Sprintf(
+			"the legacy (%s) and modern (%s) versions at %s advertise no listable method in common "+
+				"(legacy: %s; modern: %s), so any difference between them would be a capability "+
+				"difference rather than an authorization gate",
+			legacyVersion, modernVersion, ep, strings.Join(legacyMethods, ", "), strings.Join(modernMethods, ", "))})
+		return nil, false
+	}
+
+	legacyAccess, legacyCount := e.probeList(ctx, client, legacySession, method)
+	modernAccess, _ := e.probeList(ctx, client, modernSession, method)
+
+	// Confirmed downgrade bypass: the modern baseline must be REJECTED (auth
+	// enforced) while the legacy session was GRANTED access. If the modern session
+	// was also granted access, the server has no auth at all (not a downgrade
+	// issue); if legacy was rejected the server is secure.
 	//
 	// accessUndetermined on EITHER side means there is no comparison to make. It is
 	// reported as not tested rather than folded into either verdict: folded into
 	// "refused" it invents a critical finding against a server with no authorization at
 	// all, and folded into "granted" it hides a real one.
-	if legacyAccess == accessUndetermined || (modernInitOK && modernAccess == accessUndetermined) {
+	if legacyAccess == accessUndetermined || modernAccess == accessUndetermined {
 		version := legacyVersion
 		if legacyAccess != accessUndetermined {
 			version = modernVersion
 		}
 		observed.observe(initObservation{rankStatusOnly, fmt.Sprintf(
-			"resources/list on the session opened at %s with protocol version %s returned neither a "+
+			"%s on the session opened at %s with protocol version %s returned neither a "+
 				"result nor a refusal, so the two versions' authorization could not be compared",
-			ep, version)})
+			method, ep, version)})
 		return nil, false
 	}
 
-	if legacyAccess == accessGranted && modernInitOK && modernAccess == accessRefused {
+	if legacyAccess == accessGranted && modernAccess == accessRefused {
+		noun := strings.TrimSuffix(method, "/list") // resource, tool, prompt
 		return []attack.Finding{{
 			RuleID:     e.rule.ID,
 			RuleName:   e.rule.Name,
@@ -128,15 +165,15 @@ func (e *InitDowngradeExecutor) probeEndpoint(ctx context.Context, client *attac
 			Title: fmt.Sprintf(
 				"MCP protocol downgrade to %q bypasses auth enforced under %q", legacyVersion, modernVersion),
 			Description: fmt.Sprintf(
-				"At %s, resources/list was REJECTED when the session was initialized with the "+
+				"At %s, %s was REJECTED when the session was initialized with the "+
 					"modern protocol version %q (authorization enforced), but SUCCEEDED (returned %d "+
-					"resource(s)) when the session was initialized with the legacy pre-auth version %q. "+
+					"%s(s)) when the session was initialized with the legacy pre-auth version %q. "+
 					"This confirms that advertising the outdated protocol version bypasses the server's "+
 					"authorization checks.",
-				ep, modernVersion, legacyCount, legacyVersion),
+				ep, method, modernVersion, legacyCount, noun, legacyVersion),
 			Evidence: fmt.Sprintf(
-				"Endpoint: %s\nModern (%s) resources/list: rejected\nLegacy (%s) resources/list: %d resource(s) returned",
-				ep, modernVersion, legacyVersion, legacyCount),
+				"Endpoint: %s\nModern (%s) %s: rejected\nLegacy (%s) %s: %d %s(s) returned",
+				ep, modernVersion, method, legacyVersion, method, legacyCount, noun),
 			Remediation: e.rule.Remediation,
 			TargetURL:   ep,
 		}}, true
@@ -252,13 +289,12 @@ func jsonRPCErrorMessage(body []byte) string {
 	return envelope.Error.Message
 }
 
-// initAndList performs an MCP initialize with the given protocol version, sends
-// notifications/initialized, then calls resources/list. It returns:
-//   - initOK: the initialize produced a valid MCP response (not a version rejection);
-//   - access: resources/list passed authorization (HTTP success, a JSON-RPC
-//     result, and no JSON-RPC error envelope);
-//   - count: number of resources returned (for evidence).
-func (e *InitDowngradeExecutor) initAndList(ctx context.Context, client *attack.HTTPClient, ep, version string) (initOK bool, access accessVerdict, count int) {
+// handshake opens an MCP session at ep with the given protocol version and
+// returns it with the server's advertised capabilities captured in RawInit, so
+// the probe method can be chosen from what the server actually implements.
+// initOK is false when the initialize was rejected (version unsupported) or did
+// not yield a valid MCP response.
+func (e *InitDowngradeExecutor) handshake(ctx context.Context, client *attack.HTTPClient, ep, version string) (bool, mcpSession) {
 	initResp, err := client.POST(ctx, ep, nil, map[string]interface{}{
 		"jsonrpc": "2.0",
 		"id":      1,
@@ -270,48 +306,60 @@ func (e *InitDowngradeExecutor) initAndList(ctx context.Context, client *attack.
 		},
 	})
 	if err != nil || !initResp.IsSuccess() {
-		return false, accessUndetermined, 0
+		return false, mcpSession{}
 	}
 	body := initResp.BodyString()
 	// Explicit version rejection (error without a negotiated version).
 	if strings.Contains(body, `"error"`) && !strings.Contains(body, `"protocolVersion"`) {
-		return false, accessUndetermined, 0
+		return false, mcpSession{}
 	}
 	if !initResp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
-		return false, accessUndetermined, 0
+		return false, mcpSession{}
 	}
-
-	session := mcpSession{Endpoint: ep, SessionID: initResp.Headers.Get("Mcp-Session-Id"), ProtocolVersion: negotiatedVersion(initResp.Body)}
+	session := mcpSession{
+		Endpoint:        ep,
+		SessionID:       initResp.Headers.Get("Mcp-Session-Id"),
+		ProtocolVersion: negotiatedVersion(initResp.Body),
+		RawInit:         initResp.Body,
+	}
 	_, _ = client.POST(ctx, ep, session.header(), map[string]interface{}{
 		"jsonrpc": "2.0",
 		"method":  "notifications/initialized",
 	})
+	return true, session
+}
 
-	listResp, err := client.POST(ctx, ep, session.header(), map[string]interface{}{
+// probeList calls a read-only listing on session and reports its access verdict
+// and the number of items returned. The result array is keyed by the capability:
+// resources/list -> "resources", tools/list -> "tools", prompts/list -> "prompts".
+//
+// classifyAccess, not err != nil || !IsSuccess(). Deriving "refused" from the
+// absence of acceptance made a transport failure, a 429 from a rate limiter and a
+// one-off 502 indistinguishable from an authorization refusal, and "the modern
+// version refused" is the finding-enabling half of the comparison in probeEndpoint.
+// era_downgrade was fixed for exactly this; this rule kept the collapsed form until
+// the probe method became selectable.
+func (e *InitDowngradeExecutor) probeList(ctx context.Context, client *attack.HTTPClient, session mcpSession, method string) (accessVerdict, int) {
+	resp, err := client.POST(ctx, session.Endpoint, session.header(), map[string]interface{}{
 		"jsonrpc": "2.0",
 		"id":      2,
-		"method":  "resources/list",
+		"method":  method,
 		"params":  map[string]interface{}{},
 	})
-	// classifyAccess, not err != nil || !IsSuccess(). Deriving "refused" from the
-	// absence of acceptance made a transport failure, a 429 from a rate limiter and a
-	// one-off 502 indistinguishable from an authorization refusal, and "the modern wire
-	// refused" is the finding-enabling half of the comparison below. era_downgrade was
-	// fixed for exactly this; this rule kept the collapsed form.
-	verdict := classifyAccess(listResp, err)
+	verdict := classifyAccess(resp, err)
 	if verdict != accessGranted {
-		return true, verdict, 0
+		return verdict, 0
 	}
 	var rb map[string]interface{}
-	if jsonErr := json.Unmarshal(listResp.Body, &rb); jsonErr != nil {
-		return true, accessUndetermined, 0
+	if jsonErr := json.Unmarshal(resp.Body, &rb); jsonErr != nil {
+		return accessUndetermined, 0
 	}
 	result, ok := rb["result"].(map[string]interface{})
 	if !ok {
 		// Accepted by the transport oracle but carrying no result object: nothing was
 		// refused and nothing was listed.
-		return true, accessUndetermined, 0
+		return accessUndetermined, 0
 	}
-	resources, _ := result["resources"].([]interface{})
-	return true, accessGranted, len(resources)
+	items, _ := result[strings.TrimSuffix(method, "/list")].([]interface{})
+	return accessGranted, len(items)
 }

--- a/internal/attack/mcp/init_downgrade_test.go
+++ b/internal/attack/mcp/init_downgrade_test.go
@@ -315,3 +315,86 @@ func TestInitDowngrade_OldServerRejectingModernIsNotABypass(t *testing.T) {
 			"downgrade bypass; got %d finding(s): %v", len(findings), findings)
 	}
 }
+
+// toolsOnlyDowngradeServer advertises ONLY tools (no resources capability) and
+// gates tools/list under the modern version while leaving it open under the
+// legacy version. This is the false negative the hardcoded resources/list probe
+// caused: resources/list returned method-not-found under both versions, so the
+// rule reported clean against a server with a real downgrade bypass on its tools
+// surface. Picking the probe method from advertised capabilities surfaces it.
+func toolsOnlyDowngradeServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	var mu sync.Mutex
+	sessions := map[string]string{} // sessionID -> protocolVersion
+	counter := 0
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		method, _ := req["method"].(string)
+		id := req["id"]
+		w.Header().Set("Content-Type", "application/json")
+
+		switch method {
+		case "initialize":
+			params, _ := req["params"].(map[string]interface{})
+			version, _ := params["protocolVersion"].(string)
+			mu.Lock()
+			counter++
+			sid := fmt.Sprintf("sess-%d", counter)
+			sessions[sid] = version
+			mu.Unlock()
+			w.Header().Set("Mcp-Session-Id", sid)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{
+					"protocolVersion": version,
+					"serverInfo":      map[string]interface{}{"name": "tools-only", "version": "1.0"},
+					"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+				},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			mu.Lock()
+			version := sessions[r.Header.Get("Mcp-Session-Id")]
+			mu.Unlock()
+			if version != legacyVer {
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"jsonrpc": "2.0", "id": id,
+					"error": map[string]interface{}{"code": -32001, "message": "Unauthorized"},
+				})
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]interface{}{"tools": []interface{}{
+					map[string]interface{}{"name": "search", "description": "internal search"},
+				}},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// TestInitDowngrade_ToolsOnlyServer: a tools-only server with a real downgrade
+// bypass on tools/list must be reported, not silently cleaned. Under the old
+// hardcoded resources/list probe this returned no finding.
+func TestInitDowngrade_ToolsOnlyServer(t *testing.T) {
+	srv := toolsOnlyDowngradeServer(t)
+	defer srv.Close()
+
+	exec := mcpattack.NewInitDowngradeExecutor(attack.RuleContext{ID: "mcp-init-downgrade-001"})
+	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding for a tools-only downgrade bypass (resources/list probe "+
+			"silently missed it), got %d: %v", len(findings), findings)
+	}
+	if findings[0].Severity != "critical" || findings[0].Confidence != attack.ConfirmedExploit {
+		t.Errorf("expected critical/ConfirmedExploit, got %q/%q", findings[0].Severity, findings[0].Confidence)
+	}
+}

--- a/internal/attack/mcp/oauth_audience.go
+++ b/internal/attack/mcp/oauth_audience.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/calbebop/batesian/internal/attack"
 )
@@ -620,8 +621,15 @@ func summarizeAudience(expected string) string {
 func oneLine(s string) string {
 	s = strings.ReplaceAll(s, "\n", " ")
 	s = strings.ReplaceAll(s, "\r", " ")
-	if len(s) > 200 {
-		s = s[:200] + "..."
+	if len(s) <= 200 {
+		return s
 	}
-	return s
+	// Back the cut to a rune boundary so a multi-byte character is never split.
+	// The result ends up in Finding.Evidence, which is marshalled to JSON/SARIF,
+	// where a trailing partial rune is silently rewritten to U+FFFD.
+	cut := 200
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + "..."
 }

--- a/internal/attack/mcp/reachability_test.go
+++ b/internal/attack/mcp/reachability_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -129,5 +130,28 @@ func TestOAuthGatedRules_NotMCPServerIsInconclusive(t *testing.T) {
 				t.Errorf("a server that does not implement MCP must be not-tested, not clean; got err=%v", err)
 			}
 		})
+	}
+}
+
+// mcpInitBody is a raw JSON template and cannot reference latestStable, so when
+// latestStable moved from 2025-06-18 to 2025-11-25 the template was left two
+// revisions behind: a strict server then rejected every forged-token initialize as
+// "Unsupported protocol version" and the OAuth rules reported clean on a server
+// they had not tested (a silent false negative). latestStable has its own guard
+// (TestOffersCurrentHandshakeRevision); this one pins the version embedded in the
+// template to latestStable so the two cannot drift again.
+func TestMcpInitBodyOffersCurrentRevision(t *testing.T) {
+	var body struct {
+		Params struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		} `json:"params"`
+	}
+	if err := json.Unmarshal([]byte(mcpInitBody), &body); err != nil {
+		t.Fatalf("mcpInitBody is not valid JSON: %v", err)
+	}
+	if body.Params.ProtocolVersion != latestStable {
+		t.Fatalf("mcpInitBody offers protocolVersion %q; latestStable is %q "+
+			"(a stale offered version is rejected by current servers as a silent false negative)",
+			body.Params.ProtocolVersion, latestStable)
 	}
 }

--- a/internal/attack/mcp/secret_canary.go
+++ b/internal/attack/mcp/secret_canary.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/calbebop/batesian/internal/attack"
 )
@@ -133,6 +134,16 @@ func snippetAround(body, needle string) string {
 	end := idx + len(needle) + 40
 	if end > len(body) {
 		end = len(body)
+	}
+	// Both window edges are byte offsets into arbitrary response text. Move each
+	// to a rune boundary so a multi-byte character is never split: the snippet
+	// ends up in Finding.Evidence, which is marshalled to JSON/SARIF, where a
+	// partial rune is silently rewritten to U+FFFD.
+	for start < end && !utf8.RuneStart(body[start]) {
+		start++
+	}
+	for end > start && end < len(body) && !utf8.RuneStart(body[end]) {
+		end--
 	}
 	prefix, suffix := "", ""
 	if start > 0 {

--- a/internal/attack/mcp/secret_canary.go
+++ b/internal/attack/mcp/secret_canary.go
@@ -63,7 +63,7 @@ func (e *SecretCanaryExecutor) probe(ctx context.Context, client *attack.HTTPCli
 		"id":      1,
 		"method":  "initialize",
 		"params": map[string]interface{}{
-			"protocolVersion": "2025-06-18",
+			"protocolVersion": latestStable,
 			"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
 			"clientInfo":      map[string]interface{}{"name": "batesian", "version": "1.0"},
 		},

--- a/internal/attack/mcp/session.go
+++ b/internal/attack/mcp/session.go
@@ -155,10 +155,10 @@ const latestStable = "2025-11-25"
 // the baseline sent. mcp-dns-rebind-origin-001 needs exactly that: it establishes a
 // baseline by opening the wire, then repeats it carrying a foreign Origin, and the
 // claim it makes rests on the pair differing in the Origin header alone. It was
-// built by hand from mcpInitBody instead, which offers 2025-06-18 with different
-// capabilities and clientInfo, so the pair differed three ways and a server that
-// refuses the older revision refused the probe for reasons that had nothing to do
-// with Origin. That reads as Origin validation.
+// built by hand rather than reusing mcpInitBody, which carries different
+// capabilities and clientInfo, so the pair differed in more than Origin and a
+// server that refused the probe did so for reasons that had nothing to do with
+// Origin. That reads as Origin validation.
 //
 // Any rule pairing a probe against the wire-opening handshake should use this rather
 // than assembling its own.

--- a/internal/attack/mcp/snippet_utf8_test.go
+++ b/internal/attack/mcp/snippet_utf8_test.go
@@ -1,0 +1,60 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// oneLine and snippetAround build Finding.Evidence from the scanned target's raw
+// response, which is marshalled to JSON and SARIF. A byte-offset cut that splits
+// a multibyte rune becomes U+FFFD there, corrupting the evidence. These pin the
+// rune-safety that the #90 truncation fix established and that the two helpers
+// had re-introduced by slicing on a raw byte index.
+
+func TestOneLine_NeverSplitsRune(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		s    string
+	}{
+		{"ascii under limit", strings.Repeat("a", 50)},
+		{"ascii over limit", strings.Repeat("a", 250)},
+		// "a" + 100 "é" (2 bytes each) is 201 bytes, so the cut at 200 lands on a
+		// continuation byte unless it is backed to a rune boundary.
+		{"multibyte cut mid-rune", "a" + strings.Repeat("é", 100)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := oneLine(tc.s)
+			if !utf8.ValidString(got) {
+				t.Errorf("oneLine produced invalid UTF-8: %x", got)
+			}
+			if len(tc.s) > 200 && !strings.HasSuffix(got, "...") {
+				t.Errorf("oneLine dropped the truncation marker on a long input: %q", got)
+			}
+		})
+	}
+}
+
+func TestSnippetAround_NeverSplitsRune(t *testing.T) {
+	const needle = "CANARY"
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"multibyte both sides", strings.Repeat("é", 30) + needle + strings.Repeat("é", 30)},
+		// Even-length prefix + 2-byte chars put the start edge on a continuation
+		// byte; 3-byte suffix chars put the end edge on one too, so both window
+		// edges land mid-rune.
+		{"both edges mid-rune", "aa" + strings.Repeat("é", 25) + needle + strings.Repeat("世", 25)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := snippetAround(tc.body, needle)
+			if got == "" {
+				t.Fatal("snippetAround returned empty for a present needle")
+			}
+			if !utf8.ValidString(got) {
+				t.Errorf("snippetAround produced invalid UTF-8: %x", got)
+			}
+		})
+	}
+}

--- a/internal/attack/mcp/sse_resume_replay.go
+++ b/internal/attack/mcp/sse_resume_replay.go
@@ -135,7 +135,7 @@ func (e *SSEResumeReplayExecutor) initialize(ctx context.Context, client *attack
 		"id":      1,
 		"method":  "initialize",
 		"params": map[string]interface{}{
-			"protocolVersion": "2025-06-18",
+			"protocolVersion": latestStable,
 			"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
 			"clientInfo":      map[string]interface{}{"name": "batesian", "version": "1.0"},
 		},

--- a/internal/attack/mcp/token_replay.go
+++ b/internal/attack/mcp/token_replay.go
@@ -50,8 +50,11 @@ func NewTokenReplayExecutor(r attack.RuleContext) *TokenReplayExecutor {
 // mcpInitBody is the standard MCP initialize request used as the probe body. The
 // offered protocolVersion mirrors latestStable: a stale offered version here is
 // rejected as "Unsupported protocol version" by current servers (a silent false
-// negative). Shared by token_replay, dns_rebind_origin, and oauth_audience.
-const mcpInitBody = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"batesian","version":"dev"}}}`
+// negative). mcpInitBody is a raw JSON template and cannot reference latestStable
+// directly, so TestMcpInitBodyOffersCurrentRevision pins the two together. Shared
+// by token_replay and oauth_audience (the legacy wire); dns_rebind_origin pairs
+// against the wire-opening handshake and uses legacyHandshakeBody instead.
+const mcpInitBody = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"batesian","version":"dev"}}}`
 
 // Execute runs the token replay / audience validation test.
 func (e *TokenReplayExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	batesian "github.com/calbebop/batesian"
 	attackpkg "github.com/calbebop/batesian/internal/attack"
@@ -635,10 +636,16 @@ func significantHeaderKeys(h map[string]string) []string {
 // oneLine collapses whitespace runs and truncates s for single-line display.
 func oneLine(s string, max int) string {
 	s = strings.Join(strings.Fields(s), " ")
-	if len(s) > max {
-		return s[:max] + "..."
+	if len(s) <= max {
+		return s
 	}
-	return s
+	// Back the cut to a rune boundary so a multi-byte character is never split.
+	// Dry-run plan bodies are display text that may carry non-ASCII content.
+	cut := max
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + "..."
 }
 
 // buildScanJSON creates the JSON representation of scan results.


### PR DESCRIPTION
Three code-confirmed defects surfaced in a full review pass. Each ships with a
regression test. Local gate green on all three: build, full MCP suite under
-race, gofmt, golangci-lint.

1. Stale protocol version on initialize probes
mcpInitBody, sse_resume_replay, and secret_canary still offered 2025-06-18
after latestStable moved to 2025-11-25. A version-strict current server rejected
the initialize and the OAuth rules reported clean on a server they never tested.
The two inline bodies now reference latestStable directly; mcpInitBody is bumped
and TestMcpInitBodyOffersCurrentRevision pins the template to latestStable so it
cannot drift again.

2. Evidence snippets cut on a byte index
oneLine (oauth_audience), snippetAround (secret_canary), and the dry-run oneLine
(cli scan) sliced on a raw byte offset, so a multi-byte character at the cut or
window edge split a rune and JSON/SARIF marshalling rewrote it to U+FFFD. Each
cut is now backed to utf8.RuneStart, matching oauth_dcr.snippetMCP. New
snippet_utf8_test.go pins oneLine and snippetAround to valid UTF-8 with inputs
that force a mid-rune cut.

3. init-downgrade hardcoded resources/list
A tools- or prompts-only server with a real version-downgrade auth bypass
returned method-not-found under both versions, so the comparison never fired and
the rule reported clean. The probe method is now chosen from the capabilities
advertised under both versions (mirroring era_downgrade), so the comparison
measures the authorization gate rather than a capability difference. New
TestInitDowngrade_ToolsOnlyServer is the regression guard; it fails under the old
resources/list hardcode.

Note: the branch name predates these commits, which are independent of the
in-flight oauth audience work still in the working tree.
