### PR TITLE
fix(mcp): offer the current protocol version on every initialize probe

### DIFF
--- a/internal/attack/mcp/dns_rebind_origin.go
+++ b/internal/attack/mcp/dns_rebind_origin.go
@@ -98,10 +98,9 @@ func (e *DNSRebindOriginExecutor) originAccepted(ctx context.Context, client *at
 	}
 
 	// legacyHandshakeBody, not mcpInitBody: the baseline this is paired against is the
-	// wire-opening handshake, and mcpInitBody offers a different protocol revision with
-	// different capabilities and clientInfo. A server that refuses the older revision
-	// refused this probe for a reason that has nothing to do with Origin, and the rule
-	// read that as Origin validation.
+	// wire-opening handshake, and mcpInitBody carries different capabilities and
+	// clientInfo. A server that refused this probe did so for a reason that had nothing
+	// to do with Origin, and the rule read that as Origin validation.
 	headers := map[string]string{"Content-Type": "application/json", "Origin": foreignOrigin}
 	resp, err := client.POST(ctx, session.Endpoint, headers, legacyHandshakeBody())
 	if err != nil {

--- a/internal/attack/mcp/reachability_test.go
+++ b/internal/attack/mcp/reachability_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -129,5 +130,28 @@ func TestOAuthGatedRules_NotMCPServerIsInconclusive(t *testing.T) {
 				t.Errorf("a server that does not implement MCP must be not-tested, not clean; got err=%v", err)
 			}
 		})
+	}
+}
+
+// mcpInitBody is a raw JSON template and cannot reference latestStable, so when
+// latestStable moved from 2025-06-18 to 2025-11-25 the template was left two
+// revisions behind: a strict server then rejected every forged-token initialize as
+// "Unsupported protocol version" and the OAuth rules reported clean on a server
+// they had not tested (a silent false negative). latestStable has its own guard
+// (TestOffersCurrentHandshakeRevision); this one pins the version embedded in the
+// template to latestStable so the two cannot drift again.
+func TestMcpInitBodyOffersCurrentRevision(t *testing.T) {
+	var body struct {
+		Params struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		} `json:"params"`
+	}
+	if err := json.Unmarshal([]byte(mcpInitBody), &body); err != nil {
+		t.Fatalf("mcpInitBody is not valid JSON: %v", err)
+	}
+	if body.Params.ProtocolVersion != latestStable {
+		t.Fatalf("mcpInitBody offers protocolVersion %q; latestStable is %q "+
+			"(a stale offered version is rejected by current servers as a silent false negative)",
+			body.Params.ProtocolVersion, latestStable)
 	}
 }

--- a/internal/attack/mcp/secret_canary.go
+++ b/internal/attack/mcp/secret_canary.go
@@ -63,7 +63,7 @@ func (e *SecretCanaryExecutor) probe(ctx context.Context, client *attack.HTTPCli
 		"id":      1,
 		"method":  "initialize",
 		"params": map[string]interface{}{
-			"protocolVersion": "2025-06-18",
+			"protocolVersion": latestStable,
 			"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
 			"clientInfo":      map[string]interface{}{"name": "batesian", "version": "1.0"},
 		},

--- a/internal/attack/mcp/session.go
+++ b/internal/attack/mcp/session.go
@@ -155,10 +155,10 @@ const latestStable = "2025-11-25"
 // the baseline sent. mcp-dns-rebind-origin-001 needs exactly that: it establishes a
 // baseline by opening the wire, then repeats it carrying a foreign Origin, and the
 // claim it makes rests on the pair differing in the Origin header alone. It was
-// built by hand from mcpInitBody instead, which offers 2025-06-18 with different
-// capabilities and clientInfo, so the pair differed three ways and a server that
-// refuses the older revision refused the probe for reasons that had nothing to do
-// with Origin. That reads as Origin validation.
+// built by hand rather than reusing mcpInitBody, which carries different
+// capabilities and clientInfo, so the pair differed in more than Origin and a
+// server that refused the probe did so for reasons that had nothing to do with
+// Origin. That reads as Origin validation.
 //
 // Any rule pairing a probe against the wire-opening handshake should use this rather
 // than assembling its own.

--- a/internal/attack/mcp/sse_resume_replay.go
+++ b/internal/attack/mcp/sse_resume_replay.go
@@ -135,7 +135,7 @@ func (e *SSEResumeReplayExecutor) initialize(ctx context.Context, client *attack
 		"id":      1,
 		"method":  "initialize",
 		"params": map[string]interface{}{
-			"protocolVersion": "2025-06-18",
+			"protocolVersion": latestStable,
 			"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
 			"clientInfo":      map[string]interface{}{"name": "batesian", "version": "1.0"},
 		},

--- a/internal/attack/mcp/token_replay.go
+++ b/internal/attack/mcp/token_replay.go
@@ -50,8 +50,11 @@ func NewTokenReplayExecutor(r attack.RuleContext) *TokenReplayExecutor {
 // mcpInitBody is the standard MCP initialize request used as the probe body. The
 // offered protocolVersion mirrors latestStable: a stale offered version here is
 // rejected as "Unsupported protocol version" by current servers (a silent false
-// negative). Shared by token_replay, dns_rebind_origin, and oauth_audience.
-const mcpInitBody = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"batesian","version":"dev"}}}`
+// negative). mcpInitBody is a raw JSON template and cannot reference latestStable
+// directly, so TestMcpInitBodyOffersCurrentRevision pins the two together. Shared
+// by token_replay and oauth_audience (the legacy wire); dns_rebind_origin pairs
+// against the wire-opening handshake and uses legacyHandshakeBody instead.
+const mcpInitBody = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"batesian","version":"dev"}}}`
 
 // Execute runs the token replay / audience validation test.
 func (e *TokenReplayExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {


### PR DESCRIPTION
Three initialize-as-probe sites still offered `2025-06-18` after `latestStable` moved to `2025-11-25`. Their own comments claimed they tracked `latestStable` while they sat two revisions behind.

A version-strict current server rejects an unsupported offered version at the JSON-RPC layer (`-32600`), and the OAuth rules read that rejection as the token check holding — the same silent clean #179 fixed on the handshake wire. Against such a server the forged-token probes never landed, and the rule reported audience validation sound about a target it had not tested.

```
mcpInitBody        "2025-06-18"  ->  latestStable (2025-11-25)
sse_resume_replay  "2025-06-18"  ->  latestStable
secret_canary      "2025-06-18"  ->  latestStable
```

## Two drift-proof, one guarded

The two inline bodies reference `latestStable` directly, so they cannot drift again. `mcpInitBody` is a raw JSON template and cannot reference the const, so it is bumped and `TestMcpInitBodyOffersCurrentRevision` parses the version out of it and asserts it equals `latestStable` — the same const-plus-guard shape `latestStable` itself uses. The bump that moved `latestStable` (#102) added that guard for the handshake wire but never covered these three sites, which is how they slipped.

## Left alone

`init_downgrade` offers `2024-11-05` and `jsonrpc_batch_bypass` offers `2025-03-26` on purpose (each rule's premise is the old version). Both are intentional and untouched.

## Verification

Non-vacuity: forcing `mcpInitBody` back to `2025-06-18` fails `TestMcpInitBodyOffersCurrentRevision`. `golangci-lint` clean.
