### PR TITLE
fix: cut evidence and dry-run snippets on a UTF-8 rune boundary

### DIFF
--- a/internal/attack/mcp/oauth_audience.go
+++ b/internal/attack/mcp/oauth_audience.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/calbebop/batesian/internal/attack"
 )
@@ -620,8 +621,15 @@ func summarizeAudience(expected string) string {
 func oneLine(s string) string {
 	s = strings.ReplaceAll(s, "\n", " ")
 	s = strings.ReplaceAll(s, "\r", " ")
-	if len(s) > 200 {
-		s = s[:200] + "..."
+	if len(s) <= 200 {
+		return s
 	}
-	return s
+	// Back the cut to a rune boundary so a multi-byte character is never split.
+	// The result ends up in Finding.Evidence, which is marshalled to JSON/SARIF,
+	// where a trailing partial rune is silently rewritten to U+FFFD.
+	cut := 200
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + "..."
 }

--- a/internal/attack/mcp/secret_canary.go
+++ b/internal/attack/mcp/secret_canary.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/calbebop/batesian/internal/attack"
 )
@@ -133,6 +134,16 @@ func snippetAround(body, needle string) string {
 	end := idx + len(needle) + 40
 	if end > len(body) {
 		end = len(body)
+	}
+	// Both window edges are byte offsets into arbitrary response text. Move each
+	// to a rune boundary so a multi-byte character is never split: the snippet
+	// ends up in Finding.Evidence, which is marshalled to JSON/SARIF, where a
+	// partial rune is silently rewritten to U+FFFD.
+	for start < end && !utf8.RuneStart(body[start]) {
+		start++
+	}
+	for end > start && end < len(body) && !utf8.RuneStart(body[end]) {
+		end--
 	}
 	prefix, suffix := "", ""
 	if start > 0 {

--- a/internal/attack/mcp/snippet_utf8_test.go
+++ b/internal/attack/mcp/snippet_utf8_test.go
@@ -1,0 +1,60 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// oneLine and snippetAround build Finding.Evidence from the scanned target's raw
+// response, which is marshalled to JSON and SARIF. A byte-offset cut that splits
+// a multibyte rune becomes U+FFFD there, corrupting the evidence. These pin the
+// rune-safety that the #90 truncation fix established and that the two helpers
+// had re-introduced by slicing on a raw byte index.
+
+func TestOneLine_NeverSplitsRune(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		s    string
+	}{
+		{"ascii under limit", strings.Repeat("a", 50)},
+		{"ascii over limit", strings.Repeat("a", 250)},
+		// "a" + 100 "é" (2 bytes each) is 201 bytes, so the cut at 200 lands on a
+		// continuation byte unless it is backed to a rune boundary.
+		{"multibyte cut mid-rune", "a" + strings.Repeat("é", 100)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := oneLine(tc.s)
+			if !utf8.ValidString(got) {
+				t.Errorf("oneLine produced invalid UTF-8: %x", got)
+			}
+			if len(tc.s) > 200 && !strings.HasSuffix(got, "...") {
+				t.Errorf("oneLine dropped the truncation marker on a long input: %q", got)
+			}
+		})
+	}
+}
+
+func TestSnippetAround_NeverSplitsRune(t *testing.T) {
+	const needle = "CANARY"
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"multibyte both sides", strings.Repeat("é", 30) + needle + strings.Repeat("é", 30)},
+		// Even-length prefix + 2-byte chars put the start edge on a continuation
+		// byte; 3-byte suffix chars put the end edge on one too, so both window
+		// edges land mid-rune.
+		{"both edges mid-rune", "aa" + strings.Repeat("é", 25) + needle + strings.Repeat("世", 25)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := snippetAround(tc.body, needle)
+			if got == "" {
+				t.Fatal("snippetAround returned empty for a present needle")
+			}
+			if !utf8.ValidString(got) {
+				t.Errorf("snippetAround produced invalid UTF-8: %x", got)
+			}
+		})
+	}
+}

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	batesian "github.com/calbebop/batesian"
 	attackpkg "github.com/calbebop/batesian/internal/attack"
@@ -635,10 +636,16 @@ func significantHeaderKeys(h map[string]string) []string {
 // oneLine collapses whitespace runs and truncates s for single-line display.
 func oneLine(s string, max int) string {
 	s = strings.Join(strings.Fields(s), " ")
-	if len(s) > max {
-		return s[:max] + "..."
+	if len(s) <= max {
+		return s
 	}
-	return s
+	// Back the cut to a rune boundary so a multi-byte character is never split.
+	// Dry-run plan bodies are display text that may carry non-ASCII content.
+	cut := max
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + "..."
 }
 
 // buildScanJSON creates the JSON representation of scan results.


### PR DESCRIPTION
`oneLine` (mcp-oauth-audience), `snippetAround` (mcp-secret-canary), and the dry-run `oneLine` (cli scan) truncated on a raw byte index. All three build `Finding.Evidence` (or the dry-run preview) from the target's raw response, which is marshalled to JSON and SARIF — where a trailing partial rune is rewritten to U+FFFD. For any target returning non-ASCII text, the reported evidence is corrupted.

This is the #90 truncation class. `oauth_dcr.snippetMCP`, `extcard.snippet`, and `report.truncateRunes` already back the cut to a rune boundary; these were the copies that did not.

```
oneLine        s[:200] + "..."
snippetAround  body[start:end]            // start = idx-40, end = idx+len(needle)+40
```

## Backed to a rune boundary

Each cut now backs to the nearest `utf8.RuneStart`, matching `snippetMCP`. `report.truncateRunes` is unexported, and the mcp package keeps its snippet helpers inline (`snippetMCP`, `extcard.snippet`), so the fix follows that precedent rather than importing the report layer.

## Verification

`snippet_utf8_test.go` feeds inputs where the cut and both window edges land on continuation bytes; under the old byte-slice the window starts mid-rune and `utf8.ValidString` fails, so the guard is non-vacuous. `golangci-lint` clean.
