### PR TITLE
fix(probe): stop the recon clients following redirects and silently truncating

### DIFF
--- a/internal/protocol/a2a/card_test.go
+++ b/internal/protocol/a2a/card_test.go
@@ -420,6 +420,40 @@ func TestFetchAgentCard_RealV1SecuredCard(t *testing.T) {
 	}
 }
 
+// TestFetchAgentCard_DoesNotFollowRedirect: a 302 on the card path must surface,
+// not be followed to whatever it points at. Following redirects lets a server mask
+// a missing or gated card behind a 200 login page, the same class the scan client
+// was hardened against in #79. The card path returns 302; the redirect target
+// returns 200. Before the guard the client followed and read the 200 body; now the
+// 302 is the response.
+func TestFetchAgentCard_DoesNotFollowRedirect(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/login" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("login page"))
+			return
+		}
+		http.Redirect(w, r, "/login", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(srv.URL)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	_, result, err := client.FetchAgentCard(context.Background())
+	if err == nil {
+		t.Fatal("a 302 on the card path must surface as an error, not be followed to a 200")
+	}
+	got := 0
+	if result != nil {
+		got = result.StatusCode
+	}
+	if got != http.StatusFound {
+		t.Errorf("expected HTTP 302 to surface (redirect not followed), got %d", got)
+	}
+}
+
 // TestAgentCard_RequiresAuth covers what probe reports in its Authentication
 // block. Reading only the v1.0 securityRequirements field described every v0.3
 // agent as "no (unauthenticated access)", including ones that reject anonymous

--- a/internal/protocol/a2a/client.go
+++ b/internal/protocol/a2a/client.go
@@ -111,8 +111,12 @@ func NewClient(baseURL string, opts ...ClientOption) (*Client, error) {
 
 	c := &Client{
 		http: &http.Client{
-			Timeout:   defaultTimeout,
-			Transport: &http.Transport{TLSClientConfig: &tls.Config{}, Proxy: http.ProxyFromEnvironment}, //nolint:gosec
+			Timeout: defaultTimeout,
+			// Do not follow redirects. Matches the scan client (attack/http.go): a
+			// server that 302s the agent card to a login page would otherwise have a
+			// probe report the login page as the card.
+			CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+			Transport:     &http.Transport{TLSClientConfig: &tls.Config{}, Proxy: http.ProxyFromEnvironment}, //nolint:gosec
 		},
 		baseURL: base,
 		headers: map[string]string{
@@ -230,10 +234,16 @@ func (c *Client) do(req *http.Request) (*ProbeResult, error) {
 	result.StatusCode = resp.StatusCode
 	result.Headers = resp.Header
 
-	lr := io.LimitReader(resp.Body, maxBodyBytes)
-	body, err := io.ReadAll(lr)
+	// Read one byte past the limit so exceeding it is detectable, matching the
+	// scan client. A plain LimitReader at the limit returns a truncated body and no
+	// error, which reads downstream as malformed JSON from the server rather than a
+	// body this client declined to finish reading.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes+1))
 	if err != nil {
 		return result, fmt.Errorf("reading response body from %s: %w", req.URL, err)
+	}
+	if len(body) > maxBodyBytes {
+		return result, fmt.Errorf("response body from %s exceeds the %d byte read limit", req.URL, maxBodyBytes)
 	}
 	result.Body = body
 	return result, nil

--- a/internal/protocol/mcp/client.go
+++ b/internal/protocol/mcp/client.go
@@ -97,8 +97,12 @@ func NewClient(baseURL string, opts ...ClientOption) (*Client, error) {
 	}
 	c := &Client{
 		http: &http.Client{
-			Timeout:   defaultTimeout,
-			Transport: &http.Transport{TLSClientConfig: &tls.Config{}, Proxy: http.ProxyFromEnvironment}, //nolint:gosec
+			Timeout: defaultTimeout,
+			// Do not follow redirects. Matches the scan client (attack/http.go): a
+			// redirect on initialize or server/discover would otherwise be followed
+			// and the final response read as the MCP server's.
+			CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+			Transport:     &http.Transport{TLSClientConfig: &tls.Config{}, Proxy: http.ProxyFromEnvironment}, //nolint:gosec
 		},
 		baseURL: strings.TrimRight(u.String(), "/"),
 	}
@@ -319,7 +323,10 @@ func (c *Client) tryInitialize(ctx context.Context, ep string) (*Session, error)
 	}
 
 	sessionID := resp.Header.Get("Mcp-Session-Id")
-	respBody := readBody(resp)
+	respBody, err := readBody(resp)
+	if err != nil {
+		return nil, err
+	}
 
 	var parsed map[string]interface{}
 	if err := json.Unmarshal(respBody, &parsed); err != nil {
@@ -384,7 +391,11 @@ func (c *Client) post(ctx context.Context, s *Session, payload interface{}) ([]b
 		return nil, err
 	}
 	defer resp.Body.Close()
-	return readBody(resp), nil
+	b, err := readBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // newRequest builds an HTTP POST with the standard MCP headers.
@@ -404,13 +415,23 @@ func (c *Client) newRequest(ctx context.Context, ep string, body []byte) (*http.
 
 // readBody reads the response body, handling both plain JSON and SSE streams.
 // For SSE, it extracts the payload from the first "data:" line.
-func readBody(resp *http.Response) []byte {
+func readBody(resp *http.Response) ([]byte, error) {
 	ct := resp.Header.Get("Content-Type")
 	if strings.Contains(ct, "text/event-stream") {
-		return readFirstSSEData(resp.Body)
+		return readFirstSSEData(resp.Body), nil
 	}
-	b, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
-	return b
+	// Read one byte past the limit so exceeding it is detectable, matching the
+	// scan client. A plain LimitReader at the limit returns a truncated body and no
+	// error, which reads downstream as malformed JSON from the server rather than a
+	// body this client declined to finish reading.
+	b, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+	if len(b) > maxBodyBytes {
+		return nil, fmt.Errorf("response body exceeds the %d byte read limit", maxBodyBytes)
+	}
+	return b, nil
 }
 
 // readFirstSSEData returns the JSON-RPC response carried on an SSE stream,


### PR DESCRIPTION
The recon clients (`batesian probe`) followed up to 10 redirects and read bodies through a plain `LimitReader` that truncates silently at 32 MB. The scan client (`attack/http.go`) was hardened against both: `CheckRedirect: ErrUseLastResponse` (#79, so an auth rejection masked as a 2xx login page is not followed) and read-one-byte-past-the-limit overflow detection (#90/S8, so an oversized body is named, not misread as malformed JSON). The recon path had neither.

Probe-only: no scan rule routes through these clients. The cost is probe honesty, where a redirect or a huge response reads as "not an A2A/MCP server" rather than what happened.

```
a2a + mcp recon clients:
  CheckRedirect:  (Go default, follow 10)         ->  ErrUseLastResponse
  body read:      LimitReader(maxBody), no error  ->  LimitReader(maxBody+1), error on overflow
```

## Why not just reuse the scan client

`attack/http.go` withholds the operator token from off-host targets and is shared across rules; importing it would pull rule-layer concerns into recon. The recon clients keep their own `http.Client`, now with the same two guards.

## Verification

`TestFetchAgentCard_DoesNotFollowRedirect`: a server that 302s the card path to a 200 login page. Before the guard the client followed and read the 200 body; now the 302 surfaces. Non-vacuous: removing `CheckRedirect` fails it (`got 200`). `internal/protocol/{a2a,mcp}` and `internal/cli` (probe) tests pass. `golangci-lint` clean.
