### PR TITLE
fix(engine): fold findings to canonical severity before bucketing

### DIFF
--- a/internal/engine/coalesce_test.go
+++ b/internal/engine/coalesce_test.go
@@ -75,3 +75,25 @@ func TestCoalesce_SingleRuleMultipleFindings(t *testing.T) {
 		t.Errorf("expected both single-rule findings kept, got %d", got)
 	}
 }
+
+// TestFindingsBySeverity_FoldsToCanonical: a capitalized severity must fold into
+// its canonical (lowercase) bucket. The JSON summary keys FindingsBySeverity by
+// lowercase, so without folding a "High" finding lands in its own bucket and the
+// summary count disagrees with the findings list.
+func TestFindingsBySeverity_FoldsToCanonical(t *testing.T) {
+	results := []RunResult{
+		mkResult("r1", attackpkg.Finding{RuleID: "a", Severity: "High"}),
+		mkResult("r2", attackpkg.Finding{RuleID: "b", Severity: "high"}),
+		mkResult("r3", attackpkg.Finding{RuleID: "c", Severity: "CRITICAL"}),
+	}
+	got := FindingsBySeverity(results)
+	if len(got["high"]) != 2 {
+		t.Errorf("\"High\" and \"high\" must fold into one canonical \"high\" bucket; got %d", len(got["high"]))
+	}
+	if len(got["critical"]) != 1 {
+		t.Errorf("\"CRITICAL\" must fold into \"critical\"; got %d", len(got["critical"]))
+	}
+	if _, ok := got["High"]; ok {
+		t.Error("a capitalized severity key must not survive canonicalization")
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/calbebop/batesian/internal/attack/a2a"
 	_ "github.com/calbebop/batesian/internal/attack/mcp"
 	"github.com/calbebop/batesian/internal/rules"
+	"github.com/calbebop/batesian/internal/severity"
 )
 
 // RunResult holds the findings and any error from executing a single rule.
@@ -259,12 +260,17 @@ func TotalFindings(results []RunResult) int {
 	return n
 }
 
-// FindingsBySeverity groups findings by severity level.
+// FindingsBySeverity groups findings by severity level, folded to canonical
+// (lowercase) spelling. The JSON summary buckets it by lowercase key, while the
+// table printer canonicalizes on its own end, so bucketing by raw f.Severity left
+// a capitalized severity ("High") in its own bucket and the summary count
+// disagreeing with the findings list. Canonical is idempotent, so a finding
+// already carrying a lowercase severity is unchanged.
 func FindingsBySeverity(results []RunResult) map[string][]attackpkg.Finding {
 	out := make(map[string][]attackpkg.Finding)
 	for _, r := range results {
 		for _, f := range r.Findings {
-			out[f.Severity] = append(out[f.Severity], f)
+			out[severity.Canonical(f.Severity)] = append(out[severity.Canonical(f.Severity)], f)
 		}
 	}
 	return out


### PR DESCRIPTION
The JSON summary keys `FindingsBySeverity` by lowercase (`summary["high"]`), but `FindingsBySeverity` bucketed by raw `f.Severity`. A finding carrying a capitalized severity ("High") landed in its own bucket, so the summary count disagreed with the findings list it sat next to.

The table printer already canonicalizes on its own end (`severity.Canonical(key)`, printer.go:355); this was the one path that did not.

```
finding Severity "High":
  before: FindingsBySeverity["high"] = 0, ["High"] = 1   (summary misses it)
  after:  FindingsBySeverity["high"] = 1                  (summary counts it)
```

## Fix

Bucket by `severity.Canonical(f.Severity)`. Canonical is idempotent, so a finding already carrying a lowercase severity is unchanged and the printer's re-canonicalization is a no-op. Latent today (every rule emits lowercase), but it is the one summary path that could disagree with the displayed table.

## Verification

`TestFindingsBySeverity_FoldsToCanonical` feeds "High", "high", and "CRITICAL" and asserts they fold into the canonical "high" (2) and "critical" (1) buckets with no capitalized key surviving. `golangci-lint` clean.
