### PR TITLE
ci: gate the MCP OAuth DCR cleanup and report-leftovers behaviour

### DIFF
--- a/.github/scripts/validate_oauth_dcr.py
+++ b/.github/scripts/validate_oauth_dcr.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""CI validation harness for testdata/mcp_oauth_dcr_server.py.
+
+The DCR rules (mcp-oauth-dcr-001, mcp-confused-deputy-001,
+mcp-oauth-metadata-ssrf-001) each register a client to test what dynamic client
+registration accepts, so a scan necessarily changes the target's state. RFC 7592
+client management is how they clean it up. This fixture has two postures that
+turn on whether the server implements that management:
+
+  managed    returns registration_client_uri + token, so each rule deletes its
+             client. After a scan, GET /__clients must report 0.
+  unmanaged  returns neither, so the clients remain. After a scan, GET /__clients
+             must report the 3 the rules registered (batesian-cd, batesian-probe,
+             batesian-ssrf).
+
+The property under test is the cleanup-and-report-leftovers behaviour: the
+scanner must leave no state behind when the server lets it clean up, and must say
+so when it cannot.
+
+The two postures run on separate ports (the fixture takes an optional port
+argument) so a process that did not shut down cleanly between them cannot hold
+the second posture's port. Run by .github/workflows/validation.yml.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+
+FIXTURE = os.environ.get("BATESIAN_FIXTURE", "testdata/mcp_oauth_dcr_server.py")
+BINARY = os.environ.get("BATESIAN_BIN", "./batesian")
+# Separate ports per posture: a leaked process from one cannot confound the other.
+PORTS = {"managed": 7788, "unmanaged": 7789}
+
+
+def _read(log):
+    log.flush()
+    log.seek(0)
+    return log.read()
+
+
+def wait_meta(base, proc, log, deadline_s=30):
+    deadline = time.time() + deadline_s
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(f"fixture exited early (code {proc.returncode}); log:\n{_read(log)}")
+        try:
+            with urllib.request.urlopen(f"{base}/.well-known/oauth-authorization-server", timeout=2) as r:
+                if r.status == 200:
+                    return
+        except Exception:  # noqa: BLE001 - not ready yet
+            time.sleep(0.5)
+    raise RuntimeError(f"fixture did not serve metadata within {deadline_s}s; log:\n{_read(log)}")
+
+
+def start(posture):
+    port = PORTS[posture]
+    base = f"http://127.0.0.1:{port}"
+    log = tempfile.NamedTemporaryFile("w+", suffix="-dcr.log", delete=False, encoding="utf-8")
+    proc = subprocess.Popen([sys.executable, FIXTURE, posture, str(port)],
+                            stdout=log, stderr=subprocess.STDOUT, text=True)
+    try:
+        wait_meta(base, proc, log)
+    except Exception:
+        stop(proc, log)
+        raise
+    return proc, log, base
+
+
+def stop(proc, log=None):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+    if log is not None:
+        try:
+            log.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def scan_count(base):
+    """Run batesian, then GET /__clients and return (leftover client count, fired rules)."""
+    out = subprocess.run([BINARY, "scan", "--target", base, "--output", "json", "--timeout", "20"],
+                         capture_output=True, text=True, timeout=180)
+    if out.returncode != 0:
+        raise RuntimeError(f"batesian exited {out.returncode}:\nstdout:\n{out.stdout}\nstderr:\n{out.stderr}")
+    findings = sorted({f["rule_id"] for f in json.loads(out.stdout).get("findings", [])})
+    with urllib.request.urlopen(f"{base}/__clients", timeout=5) as r:
+        doc = json.loads(r.read())
+    return doc.get("count", 0), findings
+
+
+def check(name, ok, detail):
+    print(f"[{'PASS' if ok else 'FAIL'}] {name}: {detail}")
+    return ok
+
+
+def main():
+    ok = True
+    for posture, expected in [("managed", 0), ("unmanaged", 3)]:
+        proc, log, base = start(posture)
+        try:
+            count, findings = scan_count(base)
+        finally:
+            stop(proc, log)
+        detail = "scan leaves 0 clients via RFC 7592 cleanup" if posture == "managed" \
+            else "3 registered clients left behind (oauth-dcr, confused-deputy, metadata-ssrf)"
+        ok &= check(f"oauth-dcr {posture} ({detail})", count == expected,
+                    f"count={count} (expected {expected}); findings={findings}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -131,3 +131,35 @@ jobs:
         run: python .github/scripts/validate_fastmcp.py
         env:
           BATESIAN_BIN: ./batesian
+
+  oauth-dcr-fixture:
+    name: MCP OAuth DCR cleanup + report-leftovers gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install fixture dependencies
+        run: pip install starlette uvicorn
+
+      - name: Build batesian
+        run: go build -o batesian ./cmd/batesian
+
+      - name: Run the OAuth DCR validation
+        run: python .github/scripts/validate_oauth_dcr.py
+        env:
+          BATESIAN_BIN: ./batesian

--- a/testdata/mcp_oauth_dcr_server.py
+++ b/testdata/mcp_oauth_dcr_server.py
@@ -43,13 +43,16 @@ from starlette.routing import Route
 
 POSTURES = ("managed", "unmanaged")
 POSTURE = sys.argv[1] if len(sys.argv) > 1 else "managed"
+# Optional second argument lets the CI harness run the two postures on separate
+# ports, so a leaked process from one posture cannot hold the other's port.
+PORT = int(sys.argv[2]) if len(sys.argv) > 2 else 7788
 
 # client_id -> {client_name, scope, token}. Registrations this server currently holds.
 CLIENTS: dict = {}
 
 
 async def oauth_metadata(request: Request) -> JSONResponse:
-    base = "http://localhost:7788"
+    base = f"http://localhost:{PORT}"
     return JSONResponse({
         "issuer": base,
         "authorization_endpoint": f"{base}/authorize",
@@ -134,7 +137,7 @@ app = Starlette(routes=routes)
 if __name__ == "__main__":
     if POSTURE not in POSTURES:
         sys.exit(f"unknown posture {POSTURE!r}; expected one of {', '.join(POSTURES)}")
-    print(f"Starting vulnerable OAuth DCR server ({POSTURE}) on http://localhost:7788")
+    print(f"Starting vulnerable OAuth DCR server ({POSTURE}) on http://localhost:{PORT}")
     print("  GET  /.well-known/oauth-authorization-server")
     print("  POST /register  (no auth, accepts any scopes and redirect URIs)")
     if POSTURE == "managed":
@@ -143,4 +146,4 @@ if __name__ == "__main__":
     else:
         print("  no RFC 7592 management: a scan CANNOT clean up, and must report that")
     print("  GET  /__clients  (validation helper: what is still registered)")
-    uvicorn.run(app, host="127.0.0.1", port=7788)
+    uvicorn.run(app, host="127.0.0.1", port=PORT)


### PR DESCRIPTION
The DCR rules (oauth-dcr, confused-deputy, metadata-ssrf) each register a client to test what dynamic client registration accepts, so a scan changes the target's state. RFC 7592 client management is how they clean it up, and the rule reports leftovers when the server does not implement it. Neither behaviour had a CI gate.

A new nightly (+ dispatch) job boots `mcp_oauth_dcr_server.py` in its two postures and asserts `GET /__clients` after each scan:

```
managed    -> 0 clients (each rule deleted its client via RFC 7592)
unmanaged  -> 3 clients (batesian-cd, batesian-probe, batesian-ssrf left behind)
```

## Separate ports per posture

The fixture takes an optional port argument now (backward-compatible default 7788) so the harness runs the two postures on 7788 and 7789. On Windows, a uvicorn subprocess can survive `proc.terminate()`; with both postures on one port the leaked managed process held the port and the unmanaged scan hit it, accumulating clients (6, 9). Separate ports keep a leaked process from one posture from confounding the other. ubuntu (CI) has no such leak.

## Verification

Validated locally after the port fix: managed 0, unmanaged 3. `golangci-lint` clean (no Go changed).
