### PR TITLE
docs: point the README spec links at 2026-07-28 and note the CI validation gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ Rules and code are welcome under [Apache 2.0](LICENSE). See [CONTRIBUTING.md](CO
 ## References
 
 - [A2A Protocol Specification](https://a2a-protocol.org/latest/specification/)
-- [MCP Authorization Specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
-- [MCP Security Best Practices](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices)
+- [MCP Authorization Specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)
+- [MCP Security Best Practices](https://modelcontextprotocol.io/docs/2026-07-28/tutorials/security/security_best_practices)
 - [Unit 42: Agent Session Smuggling in A2A Systems](https://unit42.paloaltonetworks.com/agent-session-smuggling-in-agent2agent-systems/)
 - [OWASP GenAI Security Project](https://genai.owasp.org)
 

--- a/docs/validation-results.md
+++ b/docs/validation-results.md
@@ -12,6 +12,14 @@ This document records what happens when the rules are pointed at **third-party
 reference implementations** instead: servers written by the protocol maintainers,
 with no knowledge of Batesian.
 
+The fixture and third-party validation are now automated in CI.
+`.github/workflows/validation.yml` runs nightly and on dispatch, and exercises the
+A2A false-positive gate against the auth-enforcing secured-agent fixture; the MCP
+property fixtures (probe-honesty, log opt-in, body size, session-as-credential);
+a third-party FastMCP server for MCP false-positive and true-positive coverage;
+and the OAuth DCR cleanup-and-report-leftovers gate. The per-rule outcomes below
+are the manual runs that established those gates.
+
 ---
 
 ## Why this matters


### PR DESCRIPTION
Two reference-currency fixes that had been waiting on a code PR to ride along on:

- The README linked the MCP Authorization and Security Best Practices specs at the `2025-11-25` revision. The current revision is `2026-07-28`, and Security Best Practices moved out of `/specification/` to `/docs/tutorials/`. Both new URLs verified to resolve.
- `docs/validation-results.md` described the validation as manual runs only. It now notes that the fixture and third-party validation are automated in CI (`validation.yml`, nightly + dispatch): the A2A false-positive, MCP property, FastMCP, and OAuth DCR gates.

## Verification

Both target URLs fetched and resolve:
- https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization
- https://modelcontextprotocol.io/docs/2026-07-28/tutorials/security/security_best_practices
