### PR TITLE
fix: surface errored rules instead of hiding them behind "appears clean"

### DIFF
--- a/internal/cli/json_errors_test.go
+++ b/internal/cli/json_errors_test.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/engine"
+	"github.com/calbebop/batesian/internal/rules"
+)
+
+// TestBuildScanJSON_ErroredRulesAppear: a rule whose RunResult carries an error
+// must appear in the JSON output's "errors" array, not vanish. Before this fix,
+// errored rules produced no finding and no skip entry, so they were entirely
+// absent from the machine-readable output.
+func TestBuildScanJSON_ErroredRulesAppear(t *testing.T) {
+	doc := buildScanJSON("https://target.example.com", []engine.RunResult{
+		{Rule: &rules.Rule{ID: "mcp-x"}, Err: errors.New("executor panicked: nil pointer dereference")},
+	})
+	errs, ok := doc["errors"].([]map[string]string)
+	if !ok {
+		t.Fatalf("expected an errors array, got %T: %v", doc["errors"], doc["errors"])
+	}
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 errored rule, got %d", len(errs))
+	}
+	if errs[0]["rule_id"] != "mcp-x" {
+		t.Errorf("expected rule_id mcp-x, got %q", errs[0]["rule_id"])
+	}
+	if errs[0]["error"] == "" {
+		t.Error("error message should not be empty")
+	}
+}

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -671,6 +671,7 @@ func buildScanJSON(target string, results []engine.RunResult) map[string]interfa
 
 	findings := make([]jsonFinding, 0)
 	skipped := make([]map[string]string, 0)
+	ruleErrors := make([]map[string]string, 0)
 
 	for _, r := range results {
 		for _, f := range r.Findings {
@@ -706,12 +707,19 @@ func buildScanJSON(target string, results []engine.RunResult) map[string]interfa
 				"reason":  r.SkipMsg,
 			})
 		}
+		if r.Err != nil {
+			ruleErrors = append(ruleErrors, map[string]string{
+				"rule_id": r.Rule.ID,
+				"error":   r.Err.Error(),
+			})
+		}
 	}
 
 	return map[string]interface{}{
 		"target":   target,
 		"findings": findings,
 		"skipped":  skipped,
+		"errors":   ruleErrors,
 		"summary": map[string]int{
 			"total":    engine.TotalFindings(results),
 			"critical": len(engine.FindingsBySeverity(results)["critical"]),

--- a/internal/report/inconclusive_test.go
+++ b/internal/report/inconclusive_test.go
@@ -2,6 +2,7 @@ package report_test
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 
@@ -23,8 +24,8 @@ func TestPrintScanSummary_InconclusiveNotClean(t *testing.T) {
 	if strings.Contains(out, "appears clean") {
 		t.Errorf("must not claim 'appears clean' when no rule was exercised:\n%s", out)
 	}
-	if !strings.Contains(out, "were not exercised") {
-		t.Errorf("expected an inconclusive note, got:\n%s", out)
+	if !strings.Contains(out, "not exercised") {
+		t.Errorf("expected an incompleteness note, got:\n%s", out)
 	}
 }
 
@@ -126,5 +127,26 @@ func TestPrintScanSummary_GroupingIsDeterministic(t *testing.T) {
 		if got := build(); got != first {
 			t.Fatalf("output differed between runs (iteration %d); grouping is not deterministic", i)
 		}
+	}
+}
+
+// TestPrintScanSummary_ErroredNotClean: when a rule errored (not skipped, not
+// inconclusive) and there are no findings and no skips, the summary must NOT
+// claim the target "appears clean". An errored rule means the scan's coverage
+// is incomplete, and the operator must see that.
+func TestPrintScanSummary_ErroredNotClean(t *testing.T) {
+	var buf bytes.Buffer
+	report.New(&buf, false).PrintScanSummary([]engine.RunResult{
+		{Rule: &rules.Rule{ID: "mcp-x"}, Err: errors.New("executor panicked: nil pointer dereference")},
+	})
+	out := buf.String()
+	if strings.Contains(out, "appears clean") {
+		t.Errorf("must not claim 'appears clean' when a rule errored:\n%s", out)
+	}
+	if !strings.Contains(out, "errored") {
+		t.Errorf("expected the summary to mention the errored rule, got:\n%s", out)
+	}
+	if !strings.Contains(out, "ERROR running mcp-x") {
+		t.Errorf("expected an ERROR line for the rule, got:\n%s", out)
 	}
 }

--- a/internal/report/printer.go
+++ b/internal/report/printer.go
@@ -294,9 +294,13 @@ func (p *Printer) PrintScanSummary(results []engine.RunResult) {
 	fmt.Fprintln(p.w)
 
 	notExercised := 0
+	errored := 0
 	for _, r := range results {
 		if r.Skipped {
 			notExercised++
+		}
+		if r.Err != nil {
+			errored++
 		}
 	}
 
@@ -307,10 +311,17 @@ func (p *Printer) PrintScanSummary(results []engine.RunResult) {
 	// "could not reach a testable endpoint" for all of them sent operators looking
 	// for a network fault. The per-rule reason is on each SKIP line, which -v shows.
 	if total == 0 {
-		if notExercised > 0 {
+		if notExercised > 0 || errored > 0 {
+			parts := []string{}
+			if notExercised > 0 {
+				parts = append(parts, fmt.Sprintf("%d not exercised", notExercised))
+			}
+			if errored > 0 {
+				parts = append(parts, fmt.Sprintf("%d errored", errored))
+			}
 			fmt.Fprintf(p.w, "  %s\n\n", Yellow(fmt.Sprintf(
-				"No findings, but %d of %d rule(s) were not exercised, so the target was not fully tested. Run with -v to see why each was skipped.",
-				notExercised, len(results))))
+				"No findings, but %d of %d rule(s) did not complete (%s). The target was not fully tested. Run with -v for details.",
+				notExercised+errored, len(results), strings.Join(parts, ", "))))
 			// The per-rule reasons have to print here too. This branch used to
 			// return before reaching the loop below, so on a scan with no findings,
 			// which is exactly when an operator needs to know what went untested,
@@ -365,10 +376,17 @@ func (p *Printer) PrintScanSummary(results []engine.RunResult) {
 
 	p.printSkipsAndErrors(results)
 
-	if notExercised > 0 {
+	if notExercised > 0 || errored > 0 {
+		parts := []string{}
+		if notExercised > 0 {
+			parts = append(parts, fmt.Sprintf("%d not exercised", notExercised))
+		}
+		if errored > 0 {
+			parts = append(parts, fmt.Sprintf("%d errored", errored))
+		}
 		fmt.Fprintf(p.w, "\n  %s\n", Yellow(fmt.Sprintf(
-			"Note: %d of %d rule(s) were not exercised. Run with -v to see why each was skipped.",
-			notExercised, len(results))))
+			"Note: %d of %d rule(s) did not complete (%s).",
+			notExercised+errored, len(results), strings.Join(parts, ", "))))
 	}
 }
 


### PR DESCRIPTION
A rule whose executor returned an error (panic, transport failure) produced `Err!=nil, Skipped=false`. Both output paths dropped it silently.

```
text:  zero findings + zero skips + errored rule(s) -> "Target appears clean" + return
json:  errored rule -> no finding, no skip -> vanishes from findings/skipped/summary
```

The operator sees a clean scan when part of it crashed, with no signal that coverage is incomplete.

## Fix

- **Text** (`PrintScanSummary`): count errored rules alongside skipped. The zero-findings branch now triggers when `notExercised > 0 || errored > 0`, so "appears clean" requires every rule to have actually run. The message breaks down `(N not exercised, M errored)`.
- **JSON** (`buildScanJSON`): add an `errors` array (`[{"rule_id":..., "error":...}]`). Additive key; existing consumers ignore it.

## Verification

`TestPrintScanSummary_ErroredNotClean`: a single errored rule, no findings, no skips. Before the fix the output said "appears clean"; now it names the error and says "not fully tested."

`TestBuildScanJSON_ErroredRulesAppear`: the same rule appears in the `errors` array with its error message.

Both existing `TestPrintScanSummary_InconclusiveNotClean` and `_CleanWhenAllRan` still pass (the skipped-only and all-ran cases are unchanged). `golangci-lint` clean.
