### PR TITLE
fix(mcp): report not-tested when the session-as-credential premise fails

### DIFF
--- a/internal/attack/mcp/session_as_credential.go
+++ b/internal/attack/mcp/session_as_credential.go
@@ -91,7 +91,15 @@ func (e *SessionAsCredentialExecutor) Execute(ctx context.Context, target string
 						"there was nothing to strip", ep)})
 				return nil, false
 			}
-			return nil, true
+			// accessRefused: the credentialed call was refused. The premise that
+			// the credential works on this surface was never established, so the
+			// session-only test could not run. Reporting clean here claimed the
+			// server was tested when it was not; the operator's credential may
+			// simply be stale or lack the right scope for this surface.
+			observed.observe(initObservation{rankStatusOnly, fmt.Sprintf(
+				"the credentialed tools/list at %s was refused, so the credential was "+
+					"never shown to work and the session-only test could not run", ep)})
+			return nil, false
 		}
 
 		// Step 3: control. Does this server implement authorization at all? The

--- a/internal/attack/mcp/session_as_credential_test.go
+++ b/internal/attack/mcp/session_as_credential_test.go
@@ -70,7 +70,7 @@ func sessionCredServer(t *testing.T, mode string) *httptest.Server {
 		case "initialize":
 			switch mode {
 			case "no-auth", "no-auth-session-required", "open-init-session-auth",
-				"open-init-no-anon-session":
+				"open-init-no-anon-session", "open-init-header-refuses":
 				// Handshake is ungated in these postures.
 			default:
 				if !authed {
@@ -118,6 +118,18 @@ func sessionCredServer(t *testing.T, mode string) *httptest.Server {
 				// The handshake is open, but the session remembers who opened it and
 				// that memory is what authorizes the call.
 				ok = authed || bornAuthed[sid]
+			case "open-init-header-refuses":
+				// The auth middleware rejects any request whose Authorization
+				// header carries a token it does not recognize, even when the
+				// session is valid. A request with no header but a valid session
+				// is accepted. This models a server where the operator's stale
+				// token makes the credentialed call fail while the session-only
+				// path (the vulnerability) would succeed.
+				if r.Header.Get("Authorization") != "" && !authed {
+					refuse()
+					return
+				}
+				ok = authed || issued[sid]
 			default: // token-required, stateless
 				ok = authed
 			}
@@ -332,5 +344,23 @@ func TestSessionAsCredential_NoAnonymousSessionIsSuppressed(t *testing.T) {
 	if len(findings) != 0 {
 		t.Errorf("no anonymous session was available to attribute the refusals to the "+
 			"missing credential; got %d finding(s)", len(findings))
+	}
+}
+
+// TestSessionAsCredential_RefusedCredentialNotClean: the operator's token is
+// rejected on the credentialed tools/list (stale, wrong scope). The rule used
+// to report clean, claiming the server was tested when the premise (the
+// credential works) was never established. It must report not-tested instead.
+func TestSessionAsCredential_RefusedCredentialNotClean(t *testing.T) {
+	srv := sessionCredServer(t, "open-init-header-refuses")
+	defer srv.Close()
+
+	exec := mcpattack.NewSessionAsCredentialExecutor(attack.RuleContext{ID: "mcp-session-as-credential-001"})
+	_, err := exec.Execute(context.Background(), srv.URL, attack.Options{
+		TimeoutSeconds: 5, Token: "stale-token",
+	})
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("a refused credentialed call must report not-tested, not clean; "+
+			"want ErrInconclusive, got %v", err)
 	}
 }


### PR DESCRIPTION
`mcp-session-as-credential-001` reported clean when the operator's credential was refused on the credentialed `tools/list` (step 2). The rule's premise is that the credential works on this surface; a refusal means it was never established, so clean was a false claim.

```
operator passes stale token:
  step 1 (initialize, ungated): session minted
  step 2 (tools/list + stale token): refused
  before: return (nil, true) -> probeCandidates reports CLEAN
  after:  return (nil, false) -> probeCandidates reports NOT TESTED
```

A server where the session alone authorizes `tools/list` (the vulnerability) but the operator's bad token prevents the credentialed call from succeeding would be reported clean. This fix makes that report honest.

## Scope: minimal fix

This PR converts the false-clean to not-tested. It does not make the rule CATCH the vulnerability when the operator's token is bad (the rule still bails at step 2 before reaching step 6, the session-only test). A deeper redesign that tries step 6 regardless of step 2's outcome is a follow-up. The minimal fix is correct: do not claim clean when you did not test.

## Verification

`TestSessionAsCredential_RefusedCredentialNotClean`: a new `open-init-header-refuses` posture where the credentialed `tools/list` is refused (bad token in header) but a session-only call would succeed. Runs with a stale token and asserts `ErrInconclusive`. Before the fix, the rule returned clean (nil error). `golangci-lint` clean.
