### PR TITLE
fix(mcp): detect downgrade bypasses enforced via result-level filtering

### DIFF
--- a/internal/attack/mcp/era_downgrade.go
+++ b/internal/attack/mcp/era_downgrade.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -96,10 +97,19 @@ func (e *EraDowngradeExecutor) Execute(ctx context.Context, target string, opts 
 			undeterminedStatus(legacyOutcome, modernOutcome))
 	}
 
-	// Both granted means the server gates nothing, which is
-	// mcp-resources-unauth-001 and mcp-tools-unauth-001 territory rather than a
-	// difference between wires. Both refused is the secure outcome. Either way
-	// there is no asymmetry to report.
+	// Both granted: if both return data, no auth at all (tools-unauth territory).
+	// But if one returned data and the other an empty list, the empty side
+	// enforces via result-level filtering that the non-empty side bypasses.
+	if legacyOutcome.granted() && modernOutcome.granted() {
+		if legacyOutcome.count > 0 && modernOutcome.count == 0 {
+			return []attack.Finding{e.finding(*legacy, legacyOutcome, modernOutcome)}, nil
+		}
+		if modernOutcome.count > 0 && legacyOutcome.count == 0 {
+			return []attack.Finding{e.finding(*legacy, modernOutcome, legacyOutcome)}, nil
+		}
+		return nil, nil
+	}
+	// Both refused is the secure outcome. No asymmetry to report.
 	if legacyOutcome.granted() == modernOutcome.granted() {
 		return nil, nil
 	}
@@ -153,6 +163,10 @@ type listOutcome struct {
 	// verdict is what the probe established: granted, refused, or neither. It used
 	// to be a bool derived from IsAccepted, which made every non-answer a refusal.
 	verdict accessVerdict
+	// count is the number of items in a granted listing. Zero on a granted call
+	// means the server enforced authorization via result-level filtering (empty
+	// list) rather than hard-refusing. Non-zero means data was returned.
+	count int
 }
 
 // granted reports whether the wire answered the unauthenticated call.
@@ -187,10 +201,26 @@ func (e *EraDowngradeExecutor) probeList(ctx context.Context, client *attack.HTT
 	}
 	out.status = resp.StatusCode
 	out.body = resp.BodyString()
+	if out.verdict == accessGranted {
+		var rb map[string]interface{}
+		if json.Unmarshal([]byte(out.body), &rb) == nil {
+			if result, ok := rb["result"].(map[string]interface{}); ok {
+				if items, ok := result[strings.TrimSuffix(method, "/list")].([]interface{}); ok {
+					out.count = len(items)
+				}
+			}
+		}
+	}
 	return out
 }
 
 func (e *EraDowngradeExecutor) finding(session mcpSession, open, closed listOutcome) attack.Finding {
+	closedDesc := "was REFUSED"
+	closedEvidence := "refused"
+	if closed.verdict == accessGranted {
+		closedDesc = "returned 0 items (authorization enforced via result-level filtering)"
+		closedEvidence = "0 items returned (filtered)"
+	}
 	return attack.Finding{
 		RuleID:     e.rule.ID,
 		RuleName:   e.rule.Name,
@@ -199,15 +229,15 @@ func (e *EraDowngradeExecutor) finding(session mcpSession, open, closed listOutc
 		Title: fmt.Sprintf("MCP authorization enforced on the %s wire but not the %s wire (era downgrade bypass)",
 			closed.era, open.era),
 		Description: fmt.Sprintf(
-			"At %s, an unauthenticated %s was REFUSED on the %s wire but ANSWERED on the %s wire. "+
+			"At %s, an unauthenticated %s %s on the %s wire but ANSWERED on the %s wire. "+
 				"The server serves both protocol eras on one endpoint and applies its authorization "+
 				"check to only one of them, so a caller reaches protected functionality by asking on "+
 				"the other. Nothing about the two eras changes who is allowed to read what.",
-			session.Endpoint, open.method, closed.era, open.era),
+			session.Endpoint, open.method, closedDesc, closed.era, open.era),
 		Evidence: fmt.Sprintf(
-			"endpoint: %s\n%s wire: %s -> HTTP %d, refused\n%s wire: %s -> HTTP %d, answered\nanswered body: %.300s",
+			"endpoint: %s\n%s wire: %s -> HTTP %d, %s\n%s wire: %s -> HTTP %d, answered\nanswered body: %.300s",
 			session.Endpoint,
-			closed.era, closed.method, closed.status,
+			closed.era, closed.method, closed.status, closedEvidence,
 			open.era, open.method, open.status, open.body),
 		Remediation: e.rule.Remediation,
 		TargetURL:   session.Endpoint,

--- a/internal/attack/mcp/init_downgrade.go
+++ b/internal/attack/mcp/init_downgrade.go
@@ -132,7 +132,7 @@ func (e *InitDowngradeExecutor) probeEndpoint(ctx context.Context, client *attac
 	}
 
 	legacyAccess, legacyCount := e.probeList(ctx, client, legacySession, method)
-	modernAccess, _ := e.probeList(ctx, client, modernSession, method)
+	modernAccess, modernCount := e.probeList(ctx, client, modernSession, method)
 
 	// Confirmed downgrade bypass: the modern baseline must be REJECTED (auth
 	// enforced) while the legacy session was GRANTED access. If the modern session
@@ -155,8 +155,17 @@ func (e *InitDowngradeExecutor) probeEndpoint(ctx context.Context, client *attac
 		return nil, false
 	}
 
-	if legacyAccess == accessGranted && modernAccess == accessRefused {
+	modernEnforced := modernAccess == accessRefused ||
+		(modernAccess == accessGranted && modernCount == 0)
+	if legacyAccess == accessGranted && legacyCount > 0 && modernEnforced {
 		noun := strings.TrimSuffix(method, "/list") // resource, tool, prompt
+		modernClause := fmt.Sprintf("%s was REJECTED (authorization enforced)", method)
+		modernEvidence := "rejected"
+		if modernAccess == accessGranted {
+			modernClause = fmt.Sprintf("%s returned 0 %s(s) (authorization enforced via "+
+				"result-level filtering)", method, noun)
+			modernEvidence = fmt.Sprintf("0 %s(s) returned (filtered)", noun)
+		}
 		return []attack.Finding{{
 			RuleID:     e.rule.ID,
 			RuleName:   e.rule.Name,
@@ -165,15 +174,14 @@ func (e *InitDowngradeExecutor) probeEndpoint(ctx context.Context, client *attac
 			Title: fmt.Sprintf(
 				"MCP protocol downgrade to %q bypasses auth enforced under %q", legacyVersion, modernVersion),
 			Description: fmt.Sprintf(
-				"At %s, %s was REJECTED when the session was initialized with the "+
-					"modern protocol version %q (authorization enforced), but SUCCEEDED (returned %d "+
+				"At %s, %s, but SUCCEEDED (returned %d "+
 					"%s(s)) when the session was initialized with the legacy pre-auth version %q. "+
 					"This confirms that advertising the outdated protocol version bypasses the server's "+
 					"authorization checks.",
-				ep, method, modernVersion, legacyCount, noun, legacyVersion),
+				ep, modernClause, legacyCount, noun, legacyVersion),
 			Evidence: fmt.Sprintf(
-				"Endpoint: %s\nModern (%s) %s: rejected\nLegacy (%s) %s: %d %s(s) returned",
-				ep, modernVersion, method, legacyVersion, method, legacyCount, noun),
+				"Endpoint: %s\nModern (%s) %s: %s\nLegacy (%s) %s: %d %s(s) returned",
+				ep, modernVersion, method, modernEvidence, legacyVersion, method, legacyCount, noun),
 			Remediation: e.rule.Remediation,
 			TargetURL:   ep,
 		}}, true

--- a/internal/attack/mcp/init_downgrade_test.go
+++ b/internal/attack/mcp/init_downgrade_test.go
@@ -398,3 +398,75 @@ func TestInitDowngrade_ToolsOnlyServer(t *testing.T) {
 		t.Errorf("expected critical/ConfirmedExploit, got %q/%q", findings[0].Severity, findings[0].Confidence)
 	}
 }
+
+// TestInitDowngrade_ResultFilteringBypass: the modern version returns an empty
+// list (auth enforced via result-level filtering) while the legacy version
+// returns data. The oracle used to require a hard refuse (accessRefused) on the
+// modern side and missed this entirely; now it also fires when the modern side
+// returns an empty result.
+func TestInitDowngrade_ResultFilteringBypass(t *testing.T) {
+	var mu sync.Mutex
+	sessions := map[string]string{}
+	counter := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		method, _ := req["method"].(string)
+		params, _ := req["params"].(map[string]interface{})
+		version, _ := params["protocolVersion"].(string)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch method {
+		case "initialize":
+			mu.Lock()
+			counter++
+			sid := fmt.Sprintf("sess-%d", counter)
+			sessions[sid] = version
+			mu.Unlock()
+			w.Header().Set("Mcp-Session-Id", sid)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req["id"],
+				"result": map[string]interface{}{
+					"protocolVersion": version,
+					"serverInfo":      map[string]interface{}{"name": "filter", "version": "1"},
+					"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+				},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			mu.Lock()
+			v := sessions[r.Header.Get("Mcp-Session-Id")]
+			mu.Unlock()
+			if v == legacyVer {
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"jsonrpc": "2.0", "id": req["id"],
+					"result": map[string]interface{}{"tools": []interface{}{
+						map[string]interface{}{"name": "tool1"},
+					}},
+				})
+			} else {
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"jsonrpc": "2.0", "id": req["id"],
+					"result": map[string]interface{}{"tools": []interface{}{}},
+				})
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	exec := mcpattack.NewInitDowngradeExecutor(attack.RuleContext{ID: "mcp-init-downgrade-001"})
+	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{TimeoutSeconds: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding for result-level filtering bypass, got %d: %+v", len(findings), findings)
+	}
+	if findings[0].Severity != "critical" || findings[0].Confidence != attack.ConfirmedExploit {
+		t.Errorf("want critical/ConfirmedExploit, got %q/%q", findings[0].Severity, findings[0].Confidence)
+	}
+}


### PR DESCRIPTION
Both downgrade rules required the enforced side to hard-refuse the listing call (`accessRefused`). A server that enforces authorization via **result-level filtering** (returning 200 with an empty list under the enforced version, data under the downgraded version) defeated both oracles.

```
modern tools/list -> 200, {"tools": []}        -> accessGranted, count=0
legacy tools/list -> 200, {"tools": [t1, t2]}  -> accessGranted, count=2

before: both accessGranted -> "no auth at all" -> clean
after:  legacy count>0 + modern count=0 -> filtering bypass -> confirmed
```

## init_downgrade

The oracle already tracked counts (for evidence). It now also fires when the modern side returns `accessGranted` with count 0, not just on hard-refuse. The finding text distinguishes "REJECTED" from "returned 0 items (filtered)".

## era_downgrade

`listOutcome` gains a `count` field, populated in `probeList`. The oracle checks for a data-vs-empty asymmetry when both wires are granted, before the "both granted = no auth" early return. The finding text is conditional on whether the closed wire refused or filtered.

## Verification

`TestInitDowngrade_ResultFilteringBypass`: a server where the modern version returns `{"tools":[]}` and the legacy version returns data. Before the fix, the rule reported clean; now it fires critical/ConfirmedExploit. All existing postures (hard-refuse, both-granted, both-refused, version-rejected, tools-only) are unchanged. `golangci-lint` clean.
