### PR TITLE
fix(a2a): classify extension-downgrade control failures instead of reporting clean

### DIFF
--- a/internal/attack/a2a/extension_downgrade.go
+++ b/internal/attack/a2a/extension_downgrade.go
@@ -68,20 +68,27 @@ func (e *ExtensionDowngradeExecutor) Execute(ctx context.Context, target string,
 		return nil, attack.ErrInconclusive
 	}
 
+	var observed setupObservation
 	for _, uri := range required {
 		// Control: activate the required extension. If even this is rejected we
 		// cannot exercise the rule (e.g. messaging needs creds we lack).
-		accepted, shape := e.sendMessage(ctx, client, endpoint, activationHeaders(uri), vars.RandID, "")
+		accepted, shape, ctrlObs := e.sendMessage(ctx, client, endpoint, activationHeaders(uri), vars.RandID, "")
 		if !accepted {
+			observed.observe(ctrlObs)
 			continue
 		}
 		// Test: omit the extension header and reuse the shape that worked.
-		omitted, _ := e.sendMessage(ctx, client, endpoint, nil, vars.RandID, shape)
+		omitted, _, _ := e.sendMessage(ctx, client, endpoint, nil, vars.RandID, shape)
 		if omitted {
 			return []attack.Finding{e.finding(endpoint, uri, shape)}, nil
 		}
 	}
-	return nil, nil
+	// No finding. If every control failed and the best explanation is a refusal
+	// (auth, transport), the premise was never established and clean would claim
+	// coverage the scan does not have. classifyTaskSetup maps feature-absent
+	// (-32601, -32003, -32004) to nil (genuine not-applicable) and everything
+	// else to ErrInconclusive.
+	return nil, observed.err()
 }
 
 // requiredExtensions fetches the agent card and returns the URIs of every
@@ -127,7 +134,7 @@ func (e *ExtensionDowngradeExecutor) requiredExtensions(ctx context.Context, cli
 // is empty it tries the A2A v1.0 PascalCase shape then the v0.3 slash shape and
 // returns which one was accepted; when forceShape is set it uses only that shape
 // (so the control and test requests are byte-identical except for the header).
-func (e *ExtensionDowngradeExecutor) sendMessage(ctx context.Context, c *attack.HTTPClient, endpoint string, extra map[string]string, randID, forceShape string) (accepted bool, shape string) {
+func (e *ExtensionDowngradeExecutor) sendMessage(ctx context.Context, c *attack.HTTPClient, endpoint string, extra map[string]string, randID, forceShape string) (accepted bool, shape string, obs setupObservation) {
 	type variant struct {
 		name   string
 		method string
@@ -159,10 +166,12 @@ func (e *ExtensionDowngradeExecutor) sendMessage(ctx context.Context, c *attack.
 			},
 		})
 		if err == nil && resp.IsAccepted() {
-			return true, v.name
+			return true, v.name, setupObservation{}
 		}
+		obs.observe(classifyTaskSetup("activating a required extension", endpoint,
+			c.PresentsCredential(endpoint), resp))
 	}
-	return false, ""
+	return false, "", obs
 }
 
 func (e *ExtensionDowngradeExecutor) finding(endpoint, uri, shape string) attack.Finding {

--- a/internal/attack/a2a/extension_downgrade_test.go
+++ b/internal/attack/a2a/extension_downgrade_test.go
@@ -100,7 +100,9 @@ func TestExtDowngrade_FailClosed(t *testing.T) {
 	ts := extensionServer("failclosed", true)
 	defer ts.Close()
 
-	if findings := runExtDowngrade(t, ts); len(findings) != 0 {
+	exec := a2a.NewExtensionDowngradeExecutor(testRuleCtx())
+	findings, _ := exec.Execute(context.Background(), ts.URL, attack.Options{TimeoutSeconds: 5})
+	if len(findings) != 0 {
 		t.Errorf("expected zero findings against a fail-closed server, got %d: %+v", len(findings), findings)
 	}
 }
@@ -122,7 +124,9 @@ func TestExtDowngrade_ControlRejected(t *testing.T) {
 	ts := extensionServer("noauth-msg", true)
 	defer ts.Close()
 
-	if findings := runExtDowngrade(t, ts); len(findings) != 0 {
+	exec := a2a.NewExtensionDowngradeExecutor(testRuleCtx())
+	findings, _ := exec.Execute(context.Background(), ts.URL, attack.Options{TimeoutSeconds: 5})
+	if len(findings) != 0 {
 		t.Errorf("expected zero findings when control is rejected, got %d", len(findings))
 	}
 }


### PR DESCRIPTION
When every required extension's control message was rejected, the rule returned clean. But a rejection can mean the server requires credentials the scan lacks (auth refusal), not that the extension is absent.

`sendMessage` now returns a `setupObservation` alongside its accepted/shape return, classifying each variant's failure via `classifyTaskSetup`. The control loop collects the best observation across extensions and returns `observed.err()` after the loop: nil for feature-absent (genuine not-applicable), `ErrInconclusive` for auth refusals and transport failures.

This is the same pattern as push-binding (#197), session-as-credential (#206), and oauth-metadata-ssrf (#209): a refusal misread as "feature absent" is the recurring honesty gap `classifyTaskSetup` closes.

## Verification

`TestExtDowngrade_FailClosed` and `_ControlRejected` updated: they now call `Execute` directly and assert `len(findings)==0` (no false positive) without fataling on the now-correct `ErrInconclusive`. All other extension-downgrade tests unchanged. `golangci-lint` clean.
