### PR TITLE
fix(probe): offer the current protocol revision in the recon client

### DIFF
--- a/internal/protocol/mcp/client.go
+++ b/internal/protocol/mcp/client.go
@@ -1,6 +1,6 @@
 // Package mcp provides a lightweight MCP protocol client for reconnaissance.
 // It handles the initialize handshake, SSE response parsing, and session ID
-// threading required by the MCP 2025-03-26 specification.
+// threading required by the MCP specification.
 package mcp
 
 import (
@@ -297,7 +297,7 @@ func (c *Client) tryInitialize(ctx context.Context, ep string) (*Session, error)
 		"id":      1,
 		"method":  "initialize",
 		"params": map[string]interface{}{
-			"protocolVersion": "2025-03-26",
+			"protocolVersion": "2025-11-25", // matches the scan path's latestStable
 			"capabilities": map[string]interface{}{
 				"tools":     map[string]interface{}{},
 				"resources": map[string]interface{}{},


### PR DESCRIPTION
The recon client (`protocol/mcp/client.go`) hardcoded `2025-03-26`, two revisions behind the scan path's `2025-11-25` (`latestStable`). A version-strict current server rejects the stale probe and reports the target as not speaking MCP.

One-line fix: `2025-03-26` to `2025-11-25`, matching the scan path. Stale doc comment updated. `golangci-lint` clean.
