### PR TITLE
fix(probe): surface SSE read errors instead of silently reporting no MCP server

### DIFF
--- a/internal/protocol/mcp/client.go
+++ b/internal/protocol/mcp/client.go
@@ -418,7 +418,7 @@ func (c *Client) newRequest(ctx context.Context, ep string, body []byte) (*http.
 func readBody(resp *http.Response) ([]byte, error) {
 	ct := resp.Header.Get("Content-Type")
 	if strings.Contains(ct, "text/event-stream") {
-		return readFirstSSEData(resp.Body), nil
+		return readFirstSSEData(resp.Body)
 	}
 	// Read one byte past the limit so exceeding it is detectable, matching the
 	// scan client. A plain LimitReader at the limit returns a truncated body and no
@@ -446,9 +446,9 @@ func readBody(resp *http.Response) ([]byte, error) {
 //
 // A read error still maps to a nil body here. The recon path treats a nil body as
 // "no usable answer" throughout, and changing that is a wider change than this.
-func readFirstSSEData(r io.Reader) []byte {
-	payload, _, _ := sse.FirstMatching(r, maxBodyBytes, sse.IsJSONRPCResponse)
-	return payload
+func readFirstSSEData(r io.Reader) ([]byte, error) {
+	payload, _, err := sse.FirstMatching(r, maxBodyBytes, sse.IsJSONRPCResponse)
+	return payload, err
 }
 
 // HasCapability returns true if the session's capability map includes the key.


### PR DESCRIPTION
`readFirstSSEData` discarded the error from `sse.FirstMatching` with `_, _, _`. A read failure or the 64-event cap mapped to a nil body, and the recon path reported the target as not speaking MCP rather than naming the read problem.

`readFirstSSEData` now returns its error, and `readBody`'s SSE branch propagates it. The callers (`tryInitialize`, `post`) already handle `readBody` errors, so the error surfaces correctly to `probe`.

`golangci-lint` clean.
