### PR TITLE
fix: bump the toolchain to go1.25.13 to clear the 2026-08 stdlib advisories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/calbebop/batesian
 
-go 1.25.12
+go 1.25.13
 
 retract (
 	// Superseded by v1.1.0.


### PR DESCRIPTION
The Vulnerability Scan job fails on every ci.yml run since the August Go security release landed in the advisory database — first visible on the rebased dependabot PRs (#198, #199), because the last ci.yml run on main predates the advisories and the nightly Validation workflow has no govulncheck job. Any new PR hits the same wall.

govulncheck reports six standard-library vulnerabilities on called paths, all present in the pinned toolchain and all fixed in its patch successor:

```
GO-2026-6218  net/url          quadratic complexity in resolvePath
GO-2026-6091  html/template
GO-2026-6090  crypto/tls
GO-2026-6089  net/http         ReadHeaderTimeout on the unencrypted HTTP/2 check
GO-2026-5972  encoding/asn1    unbounded recursion depth
GO-2026-5026  net/http         ASCII-only punycode labels via x/net/idna
```

Three of those (crypto/tls, net/http, encoding/asn1) sit directly under this tool's scan-path HTTP clients, so the released binaries carry them too — this is a shipped-binary fix, not just a CI unblock.

## The change

One line: the `go` directive in go.mod. Every job installs Go with `go-version-file: go.mod`, so the bump reaches build, test, lint, CodeQL, govulncheck, and the goreleaser release build in one move. Nothing else pins a Go version (README says 1.25+, which still holds).

## Verification

Reproduced locally with `GOTOOLCHAIN=go1.25.12 govulncheck ./...`: the same six findings, exit status 3. After the bump, `GOTOOLCHAIN=go1.25.13 govulncheck -show verbose ./...` reports "No vulnerabilities found" across all 9 modules, exit 0. `go build ./...` and the full `go test ./...` suite pass on the 1.25.13 toolchain.