### PR TITLE
fix(mcp): judge forged tokens where the server actually gates them

### DIFF
--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -221,6 +221,17 @@ It submits a **negative control** plus three trap probes as forged HS256 JWTs:
 - `aud-case-canonicalization-trap` - catches lowercase/URL-canonicalizing matchers.
 - `aud-array-canary-only` - catches validators that skip the array-shape branch.
 
+Every probe rides an MCP `initialize` request, and plenty of servers leave
+`initialize` ungated and authorize the calls that follow - a probe accepted
+there was accepted by a method that never looked at it. When any probe is
+accepted, an anonymous `initialize` control establishes where the gate sits: if
+`initialize` itself refuses the anonymous caller, its verdicts stand; if it
+answers anyone, every probe is re-judged at the server's first advertised
+listing (`ping` when nothing is listable), confirmed to refuse an anonymous
+caller, and the evidence names that method. A server that answers both
+anonymously is reported **not tested** - the unauthenticated-access rules own
+that surface.
+
 **Honest scope.** Because the probes are forged self-signed HS256 tokens,
 acceptance indicates a *compound* failure of signature validation **and** audience
 matching. The negative control disambiguates: if the control is accepted, the
@@ -247,8 +258,19 @@ unsigned (`alg: none`). A compliant OAuth 2.1 resource server verifies the token
 signature and the `aud` claim (RFC 9068, RFC 8707) and rejects all three.
 Acceptance is judged at the protocol layer - HTTP 200 + a JSON-RPC `result` - so a
 200 carrying an `invalid_token` JSON-RPC error is correctly treated as a rejection.
-A **confirmed** finding means a forged or unsigned token was accepted: signature
-validation is absent, which also defeats audience binding and enables replay.
+
+Before a **confirmed** finding is reported, an anonymous `initialize` control
+establishes where the server actually examines tokens: plenty of servers leave
+`initialize` ungated and authorize the calls that follow, and an acceptance by a
+method that never looked at the token says nothing about validation. If
+`initialize` itself refuses the anonymous caller, acceptance there is the
+finding. If it answers anyone, the probes are re-run against the server's first
+advertised listing (`ping` when nothing is listable), confirmed to refuse an
+anonymous caller; only acceptance at that method is a finding. A server that
+answers both anonymously is reported **not tested** - the unauthenticated-access
+rules own that surface. A confirmed finding therefore means a forged or unsigned
+token was accepted on a surface that gates: signature validation is absent,
+which also defeats audience binding and enables replay.
 Audience-matching bugs on signature-valid tokens are isolated by
 `mcp-oauth-audience-002`.
 

--- a/internal/attack/mcp/init_gate.go
+++ b/internal/attack/mcp/init_gate.go
@@ -1,0 +1,175 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// This file backs one control shared by the two forged-token rules
+// (mcp-token-replay-001 and mcp-oauth-audience-002): where on a server can a
+// bearer token actually be judged?
+//
+// Both rules present their forged tokens to `initialize`. That was taken to
+// mean the token was examined, but plenty of servers leave initialize ungated
+// and authorize the calls that follow (session-as-credential documented the
+// same posture for its own controls). On such a server every forged token is
+// "accepted" for a method that never looked at it, and the rules reported
+// absent signature validation - with the operator's own token rules elsewhere
+// in this package relying on that posture being common, the false positive was
+// not hypothetical.
+//
+// The control is an anonymous initialize. If it is refused, initialize itself
+// gates, and forged-token acceptance there is a genuine finding. If it is
+// accepted, initialize proves nothing about tokens; the rule then finds a
+// method that DOES gate - the first listing the server advertises - confirms
+// it refuses an anonymous caller, and judges the forged tokens there instead.
+// A server that answers both anonymously authenticates nothing these rules can
+// reach, which is the unauth rules' territory, not a token-validation verdict.
+
+// initGate is what the anonymous-initialize control established about one
+// endpoint.
+type initGate int
+
+const (
+	// gateUnknown: the control could not run, or its answer was neither a clear
+	// acceptance nor a clear refusal. A forged token accepted at initialize
+	// cannot be attributed either way, so the rule reports not tested rather
+	// than guess.
+	gateUnknown initGate = iota
+	// gateOnInit: initialize itself refuses an anonymous caller, so acceptance
+	// of a forged token at initialize is a genuine finding.
+	gateOnInit
+	// gateAfterInit: initialize accepts anyone, but a method the server serves
+	// (its first advertised listing, or ping when nothing is listable) refuses an
+	// anonymous caller, so forged tokens must be judged at that method.
+	gateAfterInit
+	// gateNowhere: initialize and the advertised listing both answer an
+	// anonymous caller. The server presents no credential-gated surface for
+	// these rules; the unauth rules report the open surface.
+	gateNowhere
+)
+
+// gateProbe is the outcome of probing one endpoint, with everything the
+// follow-up probes need when the gate sits after initialize.
+type gateProbe struct {
+	gate initGate
+	// method is the listing that refused the anonymous caller when
+	// gate == gateAfterInit.
+	method string
+	// session is the anonymous initialize handshake, reusable for follow-ups
+	// (its session id and negotiated protocol version, where the server
+	// supplied them).
+	session mcpSession
+	// reason is the not-tested sentence for gateUnknown and gateNowhere.
+	reason string
+}
+
+// probeInitGate runs the controls that decide where a forged bearer token can
+// be judged at one endpoint. anon must be a client with no ambient credential
+// (attack.NewUnauthHTTPClient): the control's question is what the server does
+// for a caller who presents nothing.
+func probeInitGate(ctx context.Context, anon *attack.HTTPClient, ep string) gateProbe {
+	resp, err := anon.POST(ctx, ep, nil, json.RawMessage(mcpInitBody))
+	if err != nil {
+		return gateProbe{gate: gateUnknown, reason: fmt.Sprintf(
+			"the anonymous initialize control at %s did not answer, so acceptance of a forged token at initialize could not be attributed", ep)}
+	}
+
+	if !resp.IsAccepted() {
+		switch classifyAccess(resp, nil) {
+		case accessRefused:
+			// The endpoint demanded a credential for the handshake itself.
+			return gateProbe{gate: gateOnInit}
+		default:
+			return gateProbe{gate: gateUnknown, reason: fmt.Sprintf(
+				"the anonymous initialize control at %s returned neither a result nor a refusal (HTTP %d), so acceptance of a forged token at initialize could not be attributed", ep, resp.StatusCode)}
+		}
+	}
+
+	// Initialize accepts an anonymous caller. Find a method that gates.
+	session := mcpSession{
+		Endpoint:        ep,
+		SessionID:       resp.Headers.Get("Mcp-Session-Id"),
+		ProtocolVersion: negotiatedVersion(resp.Body),
+		RawInit:         resp.Body,
+	}
+	// The gated-method candidates, in preference order: the listings the
+	// server advertises, and then `ping`, which no capability advertises but
+	// every MCP server must answer. Without the fallback, a server offering
+	// nothing listable had no judgeable surface and the rule reported not
+	// tested even when its middleware gates every method equally.
+	method := "ping"
+	if methods := advertisedListMethods(session); len(methods) > 0 {
+		method = methods[0]
+	}
+
+	// Complete the handshake the same way initializeMCP does, so a stateful
+	// server does not refuse the listing for missing-session reasons that have
+	// nothing to do with the credential.
+	_, _ = anon.POST(ctx, ep, session.header(), map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  "notifications/initialized",
+	})
+
+	listResp, err := session.post(ctx, anon, 9, method, map[string]interface{}{})
+	switch classifyAccess(listResp, err) {
+	case accessRefused:
+		return gateProbe{gate: gateAfterInit, method: method, session: session}
+	case accessGranted:
+		return gateProbe{gate: gateNowhere, reason: fmt.Sprintf(
+			"initialize and %s at %s both answer an anonymous caller, so the server presents no credential-gated surface for this rule (the unauth rules report the open surface)", method, ep)}
+	default:
+		return gateProbe{gate: gateUnknown, reason: fmt.Sprintf(
+			"the anonymous %s control at %s returned neither a result nor a refusal, so no credential-gated surface was confirmed to judge a forged token against", method, ep)}
+	}
+}
+
+// probeForgedAtMethod judges one forged token at a method the server gates.
+//
+// initialize at ep is known to be open (the caller only reaches this on
+// gateAfterInit), so the probe opens its own handshake presenting the forged
+// token - a server may bind what a session may do to the token that opened it,
+// and either way an accepted listing after that handshake is the forged token
+// being honoured - and then calls method carrying the same token.
+//
+// Returns the method response (nil on a transport failure) and its verdict.
+func probeForgedAtMethod(ctx context.Context, anon *attack.HTTPClient, ep, method, token string) (*attack.Response, accessVerdict) {
+	authHeaders := map[string]string{"Authorization": "Bearer " + token}
+	initResp, err := anon.POST(ctx, ep, authHeaders, json.RawMessage(mcpInitBody))
+	if err != nil {
+		return nil, accessUndetermined
+	}
+	if !initResp.IsAccepted() {
+		// Initialize was open for an anonymous caller moments ago; this reply
+		// differs only in the forged Authorization header, so whatever it says
+		// was said to that token.
+		return initResp, classifyAccess(initResp, nil)
+	}
+
+	session := mcpSession{
+		Endpoint:        ep,
+		SessionID:       initResp.Headers.Get("Mcp-Session-Id"),
+		ProtocolVersion: negotiatedVersion(initResp.Body),
+		RawInit:         initResp.Body,
+	}
+	_, _ = anon.POST(ctx, ep, session.header(), map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  "notifications/initialized",
+	})
+
+	resp, err := session.postShaping(ctx, anon, 10, method, map[string]interface{}{}, func(h map[string]string) {
+		h["Authorization"] = "Bearer " + token
+	})
+	return resp, classifyAccess(resp, err)
+}
+
+// judgedAtLabel names the surface a probe's verdict came from, for evidence.
+func judgedAtLabel(method string) string {
+	if method == "" {
+		return "initialize"
+	}
+	return method + " (initialize accepts anonymous callers, so the token was judged at the gated method)"
+}

--- a/internal/attack/mcp/oauth_audience.go
+++ b/internal/attack/mcp/oauth_audience.go
@@ -83,6 +83,9 @@ type probeOutcome struct {
 	status   int
 	bodySnip string
 	tokenHP  string // header.payload (signature redacted)
+	// judgedAt names the surface the verdict came from: "initialize", or the
+	// gated method an ungated-initialize server was re-probed against.
+	judgedAt string
 }
 
 // Execute runs the audience-matching probes against the target.
@@ -118,7 +121,8 @@ func (e *OAuthAudienceExecutor) Execute(ctx context.Context, target string, opts
 
 	probes := buildProbes(expected)
 
-	endpoint, outcomes, err := runProbesAgainstEndpoint(ctx, client, vars.BaseURL, probes)
+	endpoint, outcomes, err := runProbesAgainstEndpoint(ctx, client,
+		attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL, probes)
 	if err != nil {
 		return nil, err
 	}
@@ -378,18 +382,31 @@ func fetchResourceFromMetadata(ctx context.Context, client *attack.HTTPClient, m
 // strength of four requests to a path that did not exist. A stray /api path must
 // not be able to hide a real /mcp finding, which is what the old comment here
 // claimed and the code did not do.
-func runProbesAgainstEndpoint(ctx context.Context, client *attack.HTTPClient, baseURL string, probes []audienceProbe) (string, []probeOutcome, error) {
+//
+// anon is a credential-free client. It backs one control: a probe accepted at
+// initialize only says something about tokens if the server examines them
+// there, and plenty of servers leave initialize ungated and authorize the calls
+// that follow. On those, every forged token was accepted by a method that never
+// looked at it, and this rule reported blanket forged-token acceptance on the
+// strength of it. When any probe is accepted, probeInitGate establishes where
+// the gate sits; if it is after initialize, every probe is re-judged at the
+// gated method (see init_gate.go).
+func runProbesAgainstEndpoint(ctx context.Context, client *attack.HTTPClient, anon *attack.HTTPClient, baseURL string, probes []audienceProbe) (string, []probeOutcome, error) {
+	forge := func(p audienceProbe) (string, error) {
+		return forgeHS256JWT(map[string]interface{}{
+			"iss": "https://attacker.example.com",
+			"sub": "batesian-probe",
+			"aud": p.audClaim,
+			"iat": 1700000000,
+			"exp": 9999999999,
+		})
+	}
 	for _, ep := range endpointCandidates(baseURL) {
 		outcomes := make([]probeOutcome, 0, len(probes))
 		anyResponse := false
+		anyAccepted := false
 		for _, p := range probes {
-			tok, err := forgeHS256JWT(map[string]interface{}{
-				"iss": "https://attacker.example.com",
-				"sub": "batesian-probe",
-				"aud": p.audClaim,
-				"iat": 1700000000,
-				"exp": 9999999999,
-			})
+			tok, err := forge(p)
 			if err != nil {
 				return "", nil, fmt.Errorf("forging token for probe %s: %w", p.name, err)
 			}
@@ -399,26 +416,71 @@ func runProbesAgainstEndpoint(ctx context.Context, client *attack.HTTPClient, ba
 			}, json.RawMessage(mcpInitBody))
 			if err != nil {
 				outcomes = append(outcomes, probeOutcome{
-					probe:   p,
-					verdict: verdictInconclusive,
-					tokenHP: jwtHeaderPayload(tok),
+					probe:    p,
+					verdict:  verdictInconclusive,
+					tokenHP:  jwtHeaderPayload(tok),
+					judgedAt: "initialize",
 				})
 				continue
 			}
 			if !endpointAbsent(resp) {
 				anyResponse = true
 			}
+			verdict := classifyResponse(resp)
+			if verdict == verdictAcceptedVulnerable {
+				anyAccepted = true
+			}
 			outcomes = append(outcomes, probeOutcome{
 				probe:    p,
-				verdict:  classifyResponse(resp),
+				verdict:  verdict,
 				status:   resp.StatusCode,
 				bodySnip: snippetMCP(resp.Body),
 				tokenHP:  jwtHeaderPayload(tok),
+				judgedAt: "initialize",
 			})
 		}
-		if anyResponse {
-			return ep, outcomes, nil
+		if !anyResponse {
+			continue
 		}
+
+		if anyAccepted {
+			gp := probeInitGate(ctx, anon, ep)
+			switch gp.gate {
+			case gateOnInit:
+				// Initialize itself demands a credential; its verdicts stand.
+			case gateAfterInit:
+				// Initialize does not authenticate; the advertised listing
+				// does. Re-judge every probe there.
+				for i := range outcomes {
+					tok, err := forge(outcomes[i].probe)
+					if err != nil {
+						return "", nil, fmt.Errorf("forging token for probe %s: %w", outcomes[i].probe.name, err)
+					}
+					mresp, verdict := probeForgedAtMethod(ctx, anon, ep, gp.method, tok)
+					outcomes[i].tokenHP = jwtHeaderPayload(tok)
+					outcomes[i].judgedAt = judgedAtLabel(gp.method)
+					outcomes[i].verdict = verdictInconclusive
+					outcomes[i].status = 0
+					outcomes[i].bodySnip = ""
+					if mresp != nil {
+						outcomes[i].status = mresp.StatusCode
+						outcomes[i].bodySnip = snippetMCP(mresp.Body)
+					}
+					switch verdict {
+					case accessGranted:
+						outcomes[i].verdict = verdictAcceptedVulnerable
+					case accessRefused:
+						outcomes[i].verdict = verdictRejected
+					}
+				}
+			default:
+				// gateNowhere / gateUnknown: nothing here can be attributed to
+				// the token rather than to an open surface or a control that
+				// did not answer.
+				return "", nil, fmt.Errorf("%w: %s", attack.ErrInconclusive, gp.reason)
+			}
+		}
+		return ep, outcomes, nil
 	}
 	return "", nil, nil
 }
@@ -596,6 +658,9 @@ func formatEvidence(endpoint, expected string, vulnerable []probeOutcome) string
 
 func writeOutcomeLine(sb *strings.Builder, o probeOutcome) {
 	fmt.Fprintf(sb, "  - %s: HTTP %d\n", o.probe.name, o.status)
+	if o.judgedAt != "" && o.judgedAt != "initialize" {
+		fmt.Fprintf(sb, "      judged at: %s\n", o.judgedAt)
+	}
 	fmt.Fprintf(sb, "      token header.payload: %s...[signature omitted]\n", o.tokenHP)
 	fmt.Fprintf(sb, "      response snippet: %s\n", oneLine(o.bodySnip))
 }

--- a/internal/attack/mcp/oauth_audience_test.go
+++ b/internal/attack/mcp/oauth_audience_test.go
@@ -172,12 +172,13 @@ func TestOAuthAudience_VulnerableServer_ArrayBranchSkip(t *testing.T) {
 	}
 }
 
-// TestOAuthAudience_BlanketForgedAcceptance: the server accepts ANY forged token
-// regardless of audience (no signature/audience validation). The negative
-// control fires, so the rule must report blanket acceptance - NOT misattribute
-// it to a specific aud-matching bug.
+// TestOAuthAudience_BlanketForgedAcceptance: the server demands a bearer on
+// every call but accepts ANY token regardless of audience (no signature or
+// audience validation behind a presence-only gate). The negative control
+// fires, so the rule must report blanket acceptance - NOT misattribute it to a
+// specific aud-matching bug.
 func TestOAuthAudience_BlanketForgedAcceptance(t *testing.T) {
-	srv := newAudienceServer(t, func(aud interface{}) bool { return true })
+	srv := newAudienceServer(t, func(aud interface{}) bool { return aud != nil })
 	defer srv.Close()
 
 	exec := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC())
@@ -330,6 +331,12 @@ func TestOAuthAudience_Ambiguous200(t *testing.T) {
 func TestOAuthAudience_TrapAcceptedControlNonResult(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+			// The gate: initialize itself demands a bearer, so the probes'
+			// initialize verdicts stand.
+			challenge401(w)
+			return
+		}
 		aud := decodeJWTAud(t, r.Header.Get("Authorization"))
 		if s, ok := aud.(string); ok && strings.HasPrefix(s, "https://batesian-control") {
 			// negative control: 200 with no JSON-RPC result envelope
@@ -541,11 +548,11 @@ func TestOAuthAudience_ClaimDisagreesWithAdvertisedIsNotTested(t *testing.T) {
 }
 
 // A disagreement is not a reason to withhold a finding the server demonstrated.
-// This one accepts any forged token, which the control probe catches regardless
-// of which audience the traps were built from.
+// This one accepts any presented bearer token, which the control probe catches
+// regardless of which audience the traps were built from.
 func TestOAuthAudience_ClaimDisagreesButFindingStillReported(t *testing.T) {
 	srv := audienceServerAdvertising(t, "https://API.acme.com/mcp", func(aud interface{}) bool {
-		return true // accepts every forged token, audience irrelevant
+		return aud != nil // accepts every forged token, audience irrelevant
 	})
 	defer srv.Close()
 
@@ -576,5 +583,64 @@ func TestOAuthAudience_ClaimMatchesAdvertisedStaysClean(t *testing.T) {
 	}
 	if len(findings) != 0 {
 		t.Errorf("expected zero findings on a strict server, got %d", len(findings))
+	}
+}
+
+// The ungated-initialize posture, from the audience rule's side. The
+// ungatedInitServer fixture is defined in token_replay_test.go (same package).
+
+// initialize answers anyone and the gate validates tokens: no finding. The
+// rule used to report blanket forged-token acceptance here, because the
+// control probe (forged unrelated audience) was accepted by a method that
+// never looked at it.
+func TestOAuthAudience_UngatedInitValidatingGateStaysSilent(t *testing.T) {
+	srv := ungatedInitServer(t, "validate")
+	defer srv.Close()
+
+	findings, err := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC()).Execute(context.Background(), srv.URL, optsWithAudience(testExpectedAud))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings against an ungated-initialize server that validates tokens at the gate, got %d: %+v", len(findings), findings)
+	}
+}
+
+// initialize answers anyone, the gate checks bearer presence only: the blanket
+// acceptance finding still fires, judged at the gated method.
+func TestOAuthAudience_UngatedInitPresenceOnlyGateFiresAtMethod(t *testing.T) {
+	srv := ungatedInitServer(t, "presence")
+	defer srv.Close()
+
+	findings, err := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC()).Execute(context.Background(), srv.URL, optsWithAudience(testExpectedAud))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 coalesced finding, got %d: %+v", len(findings), findings)
+	}
+	if findings[0].Confidence != attack.ConfirmedExploit {
+		t.Errorf("expected ConfirmedExploit, got %q", findings[0].Confidence)
+	}
+	if !strings.Contains(findings[0].Evidence, "judged at: tools/list") {
+		t.Errorf("evidence must name the gated method the token was judged at: %s", findings[0].Evidence)
+	}
+}
+
+// No gate anywhere: the unauth rules own the surface, this rule reports not
+// tested instead of blanket forged-token acceptance.
+func TestOAuthAudience_FullyOpenServerIsNotTested(t *testing.T) {
+	srv := ungatedInitServer(t, "open")
+	defer srv.Close()
+
+	findings, err := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC()).Execute(context.Background(), srv.URL, optsWithAudience(testExpectedAud))
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings against a fully open server, got %d: %+v", len(findings), findings)
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "no credential-gated surface") {
+		t.Errorf("reason should explain the open surface: %v", err)
 	}
 }

--- a/internal/attack/mcp/token_replay.go
+++ b/internal/attack/mcp/token_replay.go
@@ -21,19 +21,29 @@ import (
 // signature-valid tokens are isolated separately by mcp-oauth-audience-002.
 //
 // Attack sequence:
+//
 //  1. Confirm the server participates in OAuth 2.1 / OIDC by probing the known
 //     discovery documents (RFC 9728 protected-resource-metadata, RFC 8414
 //     authorization-server metadata, and OIDC openid-configuration). If none is
 //     present, skip gracefully (the server does not appear to use OAuth).
+//
 //  2. Forge three JWTs using stdlib only (no third-party JWT library):
 //     - no-aud: HS256 token with no aud claim
 //     - wrong-aud: HS256 token with aud pointing to a different server
 //     - alg-none: unsigned token (alg:none) whose aud matches the target
+//
 //  3. POST each token to {target}/mcp with an MCP initialize request body.
-//  4. Emit a finding for any probe that the server ACCEPTS - HTTP 200 carrying a
-//     JSON-RPC `result` envelope. A 200 carrying a JSON-RPC `error` (a
-//     protocol-layer rejection) or any 4xx is treated as a rejection, so a
-//     server that returns 200 + {"error":...} for a bad token is not a finding.
+//
+//  4. For a probe the server ACCEPTS - HTTP 200 carrying a JSON-RPC `result`
+//     envelope - establish where tokens are actually examined before reporting
+//     (see init_gate.go): an anonymous initialize. If initialize itself gates,
+//     acceptance is a finding. If initialize is open, the probe is re-run
+//     against the advertised listing that DOES gate; only acceptance there is
+//     a finding. A server that answers both anonymously reports not tested.
+//
+//     A 200 carrying a JSON-RPC `error` (a protocol-layer rejection) or any 4xx
+//     is treated as a rejection, so a server that returns 200 + {"error":...}
+//     for a bad token is not a finding.
 type TokenReplayExecutor struct {
 	rule attack.RuleContext
 }
@@ -158,6 +168,13 @@ func (e *TokenReplayExecutor) Execute(ctx context.Context, target string, opts a
 	// examined yet the server was reported as rejecting alg:none and forged
 	// signatures. oauth_audience took this fix in #148 against the same candidate
 	// list and the same init body; this rule did not.
+	//
+	// anon carries no credential (the operator's --token included), because the
+	// controls that attribute an accepted probe ask what the server does for a
+	// caller who presents nothing.
+	anon := attack.NewUnauthHTTPClient(opts, vars)
+	gates := map[string]gateProbe{}
+	notTestedReason := ""
 	anyEndpoint := false
 	var findings []attack.Finding
 	for _, p := range probes {
@@ -176,7 +193,21 @@ func (e *TokenReplayExecutor) Execute(ctx context.Context, target string, opts a
 			// Acceptance = HTTP 200 with a JSON-RPC result envelope. A 200 that
 			// carries a JSON-RPC error is a protocol-layer rejection of the
 			// forged token and must not be reported.
-			if resp.IsAccepted() {
+			if !resp.IsAccepted() {
+				continue
+			}
+
+			// The probe was accepted at initialize. Before that says anything
+			// about tokens, establish where this server actually examines them
+			// (see init_gate.go). The gate is a property of the endpoint, so it
+			// is probed once and shared across the three probes.
+			gp, ok := gates[ep]
+			if !ok {
+				gp = probeInitGate(ctx, anon, ep)
+				gates[ep] = gp
+			}
+			switch gp.gate {
+			case gateOnInit:
 				findings = append(findings, attack.Finding{
 					RuleID:      e.rule.ID,
 					RuleName:    e.rule.Name,
@@ -185,23 +216,64 @@ func (e *TokenReplayExecutor) Execute(ctx context.Context, target string, opts a
 					Title:       fmt.Sprintf("MCP server %s", p.titleSufx),
 					Description: p.descSufx,
 					Evidence: fmt.Sprintf(
-						"probe: %s\ntoken header.payload: %s...[signature omitted]\nHTTP %d from %s\n%s",
+						"probe: %s (judged at initialize, which refuses an anonymous caller)\ntoken header.payload: %s...[signature omitted]\nHTTP %d from %s\n%s",
 						p.name, jwtHeaderPayload(p.token), resp.StatusCode, ep, snippetMCP(resp.Body),
 					),
 					Remediation: e.rule.Remediation,
 					TargetURL:   ep,
 				})
-				break // Found a responsive endpoint for this probe; no need to try others.
+			case gateAfterInit:
+				// Initialize does not authenticate; the advertised listing does.
+				// The acceptance above proves nothing, so judge the token there.
+				mresp, verdict := probeForgedAtMethod(ctx, anon, ep, gp.method, p.token)
+				if verdict == accessGranted {
+					findings = append(findings, attack.Finding{
+						RuleID:      e.rule.ID,
+						RuleName:    e.rule.Name,
+						Severity:    p.severity,
+						Confidence:  attack.ConfirmedExploit,
+						Title:       fmt.Sprintf("MCP server %s", p.titleSufx),
+						Description: p.descSufx,
+						Evidence: fmt.Sprintf(
+							"probe: %s (judged at %s, which refuses an anonymous caller while initialize accepts one)\ntoken header.payload: %s...[signature omitted]\n%s",
+							p.name, gp.method, jwtHeaderPayload(p.token), evidenceSnippet(mresp, ep),
+						),
+						Remediation: e.rule.Remediation,
+						TargetURL:   ep,
+					})
+				}
+				// A refusal at the gated method is the server validating the
+				// token; no finding. An undetermined reply suppresses the
+				// finding rather than attribute it.
+			default:
+				// gateNowhere / gateUnknown: nothing on this endpoint can be
+				// said about token validation. Record why, once.
+				if notTestedReason == "" {
+					notTestedReason = gp.reason
+				}
 			}
+			break // Found a responsive endpoint for this probe; no need to try others.
 		}
 	}
 
+	if len(findings) == 0 && notTestedReason != "" {
+		return nil, fmt.Errorf("%w: %s", attack.ErrInconclusive, notTestedReason)
+	}
 	if len(findings) == 0 && !anyEndpoint {
 		return nil, fmt.Errorf("%w: %s publishes OAuth metadata but no MCP endpoint answered at "+
 			"any candidate path, so no forged token was ever examined",
 			attack.ErrInconclusive, vars.BaseURL)
 	}
 	return findings, nil
+}
+
+// evidenceSnippet renders a method-probe response for a finding's evidence,
+// covering the nil response a transport failure leaves behind.
+func evidenceSnippet(resp *attack.Response, ep string) string {
+	if resp == nil {
+		return fmt.Sprintf("no response from %s", ep)
+	}
+	return fmt.Sprintf("HTTP %d from %s\n%s", resp.StatusCode, ep, snippetMCP(resp.Body))
 }
 
 // oauthWellKnownPaths are the discovery documents that signal a server

--- a/internal/attack/mcp/token_replay_test.go
+++ b/internal/attack/mcp/token_replay_test.go
@@ -338,3 +338,139 @@ func TestTokenReplay_CurrentVersionNotRejected(t *testing.T) {
 		t.Fatal("expected a finding (current-version initialize accepted, forged token accepted); got 0 - the offered protocolVersion may have been rejected as stale")
 	}
 }
+
+// ungatedInitServer models the posture that broke both forged-token rules:
+// initialize answers anyone, and what happens on the calls that follow is what
+// mode selects.
+//
+//   - validate: the follow-up gate accepts only the sentinel bearer - a server
+//     that validates tokens and leaves initialize open. The rules must stay
+//     silent here; before the anonymous-initialize control they fired three
+//     findings claiming absent signature validation.
+//   - presence: the gate accepts any bearer - presence-only validation. The
+//     findings must fire, judged at the gated method.
+//   - open: no gate anywhere. The unauth rules own that surface, and the token
+//     rules must report not tested rather than "accepted a forged token".
+//
+// The initialize result advertises the tools capability so the control probes
+// the real listing rather than the ping fallback. Shared with
+// oauth_audience_test.go (same package).
+func ungatedInitServer(t *testing.T, mode string) *httptest.Server {
+	t.Helper()
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		base := "http://" + srv.Listener.Addr().String()
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"issuer":         base,
+				"token_endpoint": base + "/token",
+			})
+		case "/mcp":
+			var req struct {
+				Method string `json:"method"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+
+			// initialize is ungated in every mode: it answers anyone.
+			if req.Method == "initialize" {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"jsonrpc": "2.0",
+					"id":      1,
+					"result": map[string]interface{}{
+						"protocolVersion": "2025-11-25",
+						"serverInfo":      map[string]interface{}{"name": "ungated-init", "version": "1.0"},
+						"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+					},
+				})
+				return
+			}
+
+			authz := r.Header.Get("Authorization")
+			accepted := false
+			switch mode {
+			case "open":
+				accepted = true
+			case "presence":
+				accepted = strings.HasPrefix(authz, "Bearer ")
+			case "validate":
+				accepted = authz == "Bearer good-token"
+			}
+			if accepted {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"jsonrpc": "2.0",
+					"id":      2,
+					"result":  map[string]interface{}{"tools": []interface{}{}},
+				})
+				return
+			}
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]interface{}{"error": "invalid_token"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return srv
+}
+
+// The regression the anonymous-initialize control exists for: initialize
+// answers anyone, and the token is validated at the methods that follow. The
+// rule used to fire three findings (two high, one critical) claiming absent
+// signature validation, against a server that rejects every forged token where
+// it matters.
+func TestTokenReplay_UngatedInitValidatingGateStaysSilent(t *testing.T) {
+	srv := ungatedInitServer(t, "validate")
+	defer srv.Close()
+
+	findings, err := mcpattack.NewTokenReplayExecutor(tokenReplayRC()).Execute(context.Background(), srv.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings against an ungated-initialize server that validates tokens at the gate, got %d: %+v", len(findings), findings)
+	}
+}
+
+// The same posture with a presence-only gate: any bearer is accepted at the
+// gated method. The findings must still fire - attributed to the method that
+// actually examined (and failed to validate) the token, not to initialize.
+func TestTokenReplay_UngatedInitPresenceOnlyGateFiresAtMethod(t *testing.T) {
+	srv := ungatedInitServer(t, "presence")
+	defer srv.Close()
+
+	findings, err := mcpattack.NewTokenReplayExecutor(tokenReplayRC()).Execute(context.Background(), srv.URL, testOpts())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 3 {
+		t.Fatalf("expected one finding per forged probe, got %d: %+v", len(findings), findings)
+	}
+	for _, f := range findings {
+		if !strings.Contains(f.Evidence, "judged at tools/list") {
+			t.Errorf("evidence must name the gated method the token was judged at: %s", f.Evidence)
+		}
+	}
+}
+
+// A server that answers everyone everywhere presents no credential-gated
+// surface; the unauth rules report it, and this rule reports not tested rather
+// than "accepted a forged token".
+func TestTokenReplay_FullyOpenServerIsNotTested(t *testing.T) {
+	srv := ungatedInitServer(t, "open")
+	defer srv.Close()
+
+	findings, err := mcpattack.NewTokenReplayExecutor(tokenReplayRC()).Execute(context.Background(), srv.URL, testOpts())
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings against a fully open server, got %d: %+v", len(findings), findings)
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "no credential-gated surface") {
+		t.Errorf("reason should explain the open surface: %v", err)
+	}
+}

--- a/rules/mcp/oauth-audience-002.yaml
+++ b/rules/mcp/oauth-audience-002.yaml
@@ -37,6 +37,17 @@ info:
       canaries. Catches validators that only inspect string-form `aud` and skip
       the array-shape branch entirely.
 
+    Every probe is submitted with an MCP `initialize` request, and plenty of
+    servers leave `initialize` ungated and authorize the calls that follow - a
+    probe accepted there was accepted by a method that never looked at it. When
+    any probe is accepted, an anonymous `initialize` control therefore
+    establishes where the gate sits: if `initialize` itself refuses the
+    anonymous caller, its verdicts stand; if it answers anyone, every probe is
+    re-judged at the server's first advertised listing (`ping` when nothing is
+    listable), confirmed to refuse an anonymous caller, and the evidence names
+    that method. A server that answers both anonymously is reported not tested -
+    the unauthenticated-access rules own that surface.
+
     Honest scope: because probes are forged HS256 self-signed tokens, acceptance
     indicates that **both** signature validation and audience matching are
     inadequate. Catching servers that validate signatures correctly but still

--- a/rules/mcp/token-replay-001.yaml
+++ b/rules/mcp/token-replay-001.yaml
@@ -12,7 +12,18 @@ info:
     three.
 
     Accepting any of them proves the server does not validate the token
-    signature. Without signature validation, audience binding cannot be enforced
+    signature - provided the surface the token was presented to examines tokens
+    at all. Plenty of servers leave `initialize` ungated and authorize the calls
+    that follow, so before reporting, an anonymous `initialize` control
+    establishes where the gate sits. If `initialize` itself refuses the
+    anonymous caller, acceptance there is the finding. If `initialize` answers
+    anyone, the probes are re-run against the server's first advertised listing
+    (`ping` when nothing is listable), which the control confirms refuses an
+    anonymous caller; only acceptance at that method is a finding. A server
+    that answers both anonymously authenticates nothing this rule can reach and
+    is reported not tested - the unauthenticated-access rules own that surface.
+
+    Without signature validation, audience binding cannot be enforced
     either, so a token forged for any audience, or issued for an unrelated
     service, can be replayed against this endpoint. Audience-matching bugs on
     signature-valid tokens are isolated separately by mcp-oauth-audience-002.


### PR DESCRIPTION
Both forged-token rules presented their probes to `initialize` and fired on acceptance. Plenty of servers leave `initialize` ungated and authorize the calls that follow; that is the exact posture `session-as-credential` documented for its own controls ("plenty of servers leave initialize ungated and authorize the calls that follow", `session_as_credential.go`) and built a fixture for (`open-init-session-auth`). On such a server every forged token is "accepted" by a method that never looked at it, and:

- `mcp-token-replay-001` fired up to three findings (two high, one critical) whose text asserts "the server does not verify the token signature";
- `mcp-oauth-audience-002`'s accepted control reported confirmed blanket forged-token acceptance.

Against a server that validates tokens correctly at every gated method, both were false positives. Neither rule had a fixture modeling the posture, so no test could catch it.

## The control

`init_gate.go` adds one shared control: an anonymous `initialize`, sent by a credential-free client so the operator's `--token` cannot answer for the anonymous caller.

- **initialize itself refuses the anonymous caller**: acceptance of a forged token there is a genuine finding; existing behavior stands.
- **initialize answers anyone**: the control finds a method that does gate, the server's first advertised listing (`tools/list`/`resources/list`/`prompts/list` from the initialize capabilities), falling back to `ping` when nothing is listable. No capability advertises ping, but every MCP server must answer it. It confirms that method refuses an anonymous caller, then re-judges every accepted probe there: the probe opens its own handshake presenting the forged token (a server may bind what a session may do to the token that opened it; either way an accepted listing after that handshake is the forged token being honoured) and calls the gated method carrying the same token. Evidence names the surface the verdict came from.
- **both answer anonymously**: the server presents no credential-gated surface; the rule reports not tested with that reason, because the unauth rules own an open surface and "accepted a forged token" is not the actionable claim there.

The gate is probed once per endpoint that accepted a probe (at most 3 extra requests on a full walk), and a control that returns neither result nor refusal suppresses the finding rather than attributing it, the same direction as #190.

## Fixture honesty

Three existing audience fixtures accepted anonymous callers everywhere, which under the control is a fully-open server (not tested, correctly). They intended "accepts any forged token", so they now model a presence-only gate (a bearer required, any bearer accepted), which is that vulnerability and is attributable. A fully-open server is covered by its own not-tested test instead.

## Verification

Six new tests across the two rules, one shared fixture (`ungatedInitServer`) with three postures:

- validating gate behind an open initialize: both rules silent (the false positive this fixes);
- presence-only gate behind an open initialize: findings still fire, evidence carries `judged at tools/list` / `judged at: tools/list`;
- fully open: `ErrInconclusive` naming the open surface.

`go test ./...` green, `golangci-lint` clean. YAML descriptions and `docs/rules-mcp.md` updated to state where acceptance is judged.
