### PR TITLE
fix(report): emit an empty SARIF results array on a clean scan

### DIFF
--- a/internal/report/sarif.go
+++ b/internal/report/sarif.go
@@ -99,7 +99,12 @@ func WriteSARIF(w io.Writer, target string, results []engine.RunResult, toolVers
 func buildSARIF(results []engine.RunResult, toolVersion string) sarifLog {
 	// De-duplicate rules from the results.
 	ruleMap := make(map[string]sarifRule)
-	var sarifResults []sarifResult
+	// A clean scan is the most common outcome, and a nil slice here marshals as
+	// "results": null. SARIF 2.1.0 types runs[].results as an array - null is
+	// not a legal value - so schema-validating consumers (GitHub code-scanning
+	// upload, VS Code SARIF viewer) can reject exactly the scans that found
+	// nothing. rules below builds with make for the same reason.
+	sarifResults := make([]sarifResult, 0, len(results))
 
 	for _, r := range results {
 		if r.Rule != nil {

--- a/internal/report/sarif_test.go
+++ b/internal/report/sarif_test.go
@@ -78,3 +78,38 @@ func TestWriteSARIF_AbsoluteURIHasNoUriBaseId(t *testing.T) {
 		t.Errorf("artifactLocation must not contain uriBaseId for an absolute URI, got: %v", al)
 	}
 }
+
+// TestWriteSARIF_CleanScanEmptiesResultsArray verifies a zero-finding scan
+// writes "results": [] rather than "results": null. SARIF 2.1.0 types
+// runs[].results as an array - null is not a legal value - so a nil Go slice
+// here produced a document that schema-validating consumers (GitHub
+// code-scanning upload, VS Code SARIF viewer) reject, precisely when the
+// target was clean. A clean scan is the most common scan outcome.
+func TestWriteSARIF_CleanScanEmptiesResultsArray(t *testing.T) {
+	r := &rules.Rule{}
+	r.ID = "mcp-test-001"
+	r.Info.Name = "Test Rule"
+	r.Info.Severity = "high"
+	clean := []engine.RunResult{{Rule: r}} // ran, found nothing
+
+	var buf bytes.Buffer
+	if err := report.WriteSARIF(&buf, "https://agent.example.com", clean, "test"); err != nil {
+		t.Fatalf("WriteSARIF: %v", err)
+	}
+
+	if strings.Contains(buf.String(), "\"results\": null") {
+		t.Fatalf("clean scan must emit an empty results array, not null:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "\"results\": []") {
+		t.Fatalf("clean scan must emit \"results\": []:\n%s", buf.String())
+	}
+
+	var doc sarifDoc
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("SARIF is not valid JSON: %v", err)
+	}
+	if len(doc.Runs) != 1 || doc.Runs[0].Results == nil || len(doc.Runs[0].Results) != 0 {
+		t.Fatalf("expected one run with a non-nil empty results array; runs=%d results=%v",
+			len(doc.Runs), doc.Runs[0].Results)
+	}
+}


### PR DESCRIPTION
A zero-finding scan marshalled `runs[].results` from a nil Go slice, producing `"results": null`. SARIF 2.1.0 types that property as an array and null is not a legal value, so schema-validating consumers (the GitHub code-scanning upload behind this repo's documented CI path, the VS Code SARIF viewer) can reject the document. A clean scan is the most common scan outcome, so the documented upload path is at its most fragile exactly when the target is clean. Reproduced during the audit against a secured local fixture: the clean-scan document carried `"results": null`.

`rules` in the same builder was already constructed with `make` and marshals as `[]`; only `results` had the asymmetry, and `sarif_test.go` covered just the one-finding shape, so the empty case was untested.

## The change

One line: `sarifResults` is built with `make([]sarifResult, 0, len(results))`, with a comment recording why the empty-vs-nil distinction matters here.

## Verification

`TestWriteSARIF_CleanScanEmptiesResultsArray` writes a ran-but-found-nothing result set and asserts both the raw text (`"results": []` present, `"results": null` absent) and the unmarshaled document (one run, non-nil empty results; `null` unmarshals to a nil slice, so the check is non-vacuous). Full `go test ./...` green.
