### PR TITLE
fix: report not tested where four rules claimed clean on unexercised surfaces

### DIFF
--- a/docs/rules-a2a.md
+++ b/docs/rules-a2a.md
@@ -468,11 +468,15 @@ failures:
   B. A **confirmed** finding is raised only when B's cancel succeeds and a
   read-back as owner A shows the task is now `canceled`.
 
-A server that rejects the wrong-principal cancel, or that cannot cancel the task
-(already terminal), produces no finding. The rule creates and cancels its own
-throwaway task; it never cancels a pre-existing one. Against a server that
+A server that rejects the wrong-principal cancel produces no finding: the
+boundary was tested and held. Two outcomes are not clean results: an anonymous
+cancel answered with an application error (task hidden from anonymous callers,
+task already terminal) never established whether the cancel handler demands a
+credential, so the rule reports **not tested**; and a server implementing no
+cancel method on either wire is not applicable. The rule creates and cancels its
+own throwaway task; it never cancels a pre-existing one. Against a server that
 completes tasks almost immediately, the probe task may be terminal before it can
-be canceled, in which case the rule reports nothing.
+be canceled, in which case the rule reports not tested.
 
 ---
 

--- a/internal/attack/a2a/context_fixation.go
+++ b/internal/attack/a2a/context_fixation.go
@@ -105,8 +105,16 @@ func (e *ContextFixationExecutor) ExecuteChained(ctx context.Context, target str
 	}
 
 	// Step 4: as A, read the context back. Confirmed only if A can see B's marker.
-	if !e.taskHistoryContains(ctx, clientA, endpoint, a.Headers, taskA, marker, vars.RandID) {
-		return nil, nil
+	// A read that never happened is not evidence of isolation: a marker "not
+	// found" in a history that was never fetched says nothing about the merge.
+	// a2a-artifact-tamper-001 reports the identical unreadable-read-back as not
+	// tested; this step used to return clean.
+	read, contains, readObs := e.taskHistoryContains(ctx, clientA, endpoint, a.Headers, taskA, marker, vars.RandID)
+	if !read {
+		return nil, readObs.err()
+	}
+	if !contains {
+		return nil, nil // the history was read; the victim's marker was not merged into A's view
 	}
 
 	return []attack.Finding{e.finding(endpoint, a, b, fixedCtx, taskA, taskB)}, nil
@@ -168,7 +176,13 @@ func (e *ContextFixationExecutor) sendUnderContext(ctx context.Context, c *attac
 // taskHistoryContains reads a task via GetTask (v1.0) / tasks/get (v0.3) and
 // reports whether the returned history contains the given marker - i.e. the
 // shared context exposed another principal's message.
-func (e *ContextFixationExecutor) taskHistoryContains(ctx context.Context, c *attack.HTTPClient, endpoint string, extraHeaders map[string]string, taskID, marker, randID string) bool {
+//
+// read is false when neither shape yielded a usable task result; obs then
+// explains why (and contains is meaningless). Callers must not read a false
+// contains as "marker absent" without checking read first.
+func (e *ContextFixationExecutor) taskHistoryContains(ctx context.Context, c *attack.HTTPClient, endpoint string,
+	extraHeaders map[string]string, taskID, marker, randID string) (read, contains bool, obs setupObservation) {
+	what := "reading the task history back"
 	v1Headers := map[string]string{"A2A-Version": "1.0"}
 	for k, v := range extraHeaders {
 		v1Headers[k] = v
@@ -179,18 +193,21 @@ func (e *ContextFixationExecutor) taskHistoryContains(ctx context.Context, c *at
 		"method":  "GetTask",
 		"params":  map[string]interface{}{"id": taskID, "historyLength": 50},
 	})
-	if err != nil || !resp.IsAccepted() {
-		resp, err = c.POST(ctx, endpoint, extraHeaders, map[string]interface{}{
-			"jsonrpc": "2.0",
-			"id":      "batesian-ctxfix-get-" + randID,
-			"method":  "tasks/get",
-			"params":  map[string]interface{}{"id": taskID, "historyLength": 50},
-		})
+	if err == nil && resp.IsAccepted() {
+		return true, resp.ContainsAny(marker), setupObservation{}
 	}
-	if err != nil || !resp.IsAccepted() {
-		return false
+	obs.observe(classifyTaskSetup(what, endpoint, c.PresentsCredential(endpoint), resp))
+	resp, err = c.POST(ctx, endpoint, extraHeaders, map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      "batesian-ctxfix-get-" + randID,
+		"method":  "tasks/get",
+		"params":  map[string]interface{}{"id": taskID, "historyLength": 50},
+	})
+	if err == nil && resp.IsAccepted() {
+		return true, resp.ContainsAny(marker), setupObservation{}
 	}
-	return resp.ContainsAny(marker)
+	obs.observe(classifyTaskSetup(what, endpoint, c.PresentsCredential(endpoint), resp))
+	return false, false, obs
 }
 
 // finding builds the confirmed context-fixation cross-principal disclosure.

--- a/internal/attack/a2a/context_fixation_test.go
+++ b/internal/attack/a2a/context_fixation_test.go
@@ -25,6 +25,8 @@ type ctxMsg struct {
 //     requested task's own messages (no cross-principal merge)
 //   - "server-minted": ignores the client contextId and mints its own
 //   - "open":         no authentication at all
+//   - "read-fails":   like vulnerable, but GetTask answers HTTP 500, so whether
+//     the context merged cannot be observed
 func contextServer(mode string) *httptest.Server {
 	var mu sync.Mutex
 	ctxMsgs := map[string][]ctxMsg{} // contextId -> messages
@@ -72,6 +74,12 @@ func contextServer(mode string) *httptest.Server {
 			mu.Unlock()
 			taskResult(w, id, taskID, ctxID)
 		case "GetTask", "tasks/get":
+			if mode == "read-fails" {
+				// The read-back breaks at the gateway: sends work, but nothing
+				// about the merge can be observed.
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
 			if mode != "open" && tenant == "" {
 				rpcErr(w, id, -32600, "authentication required")
 				return
@@ -178,6 +186,26 @@ func TestContextFixation_ServerMinted(t *testing.T) {
 	}
 	if len(findings) != 0 {
 		t.Errorf("expected zero findings when the server mints its own contextId, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestContextFixation_UnreadableReadBackIsNotTested: the discriminator passed,
+// both principals posted under the fixed context, and then the attacker's
+// read-back failed. A "marker not found" in a history that was never fetched is
+// not evidence of isolation; this used to return clean, while
+// a2a-artifact-tamper-001 reports the identical unreadable read-back as not
+// tested.
+func TestContextFixation_UnreadableReadBackIsNotTested(t *testing.T) {
+	ts := contextServer("read-fails")
+	defer ts.Close()
+
+	findings, err := a2a.NewContextFixationExecutor(testRuleCtx()).
+		Execute(context.Background(), ts.URL, mtOpts(tenantPrincipals()...))
+	if len(findings) != 0 {
+		t.Fatalf("expected zero findings, got %d: %+v", len(findings), findings)
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive for an unreadable read-back, got %v", err)
 	}
 }
 

--- a/internal/attack/a2a/session_smuggle.go
+++ b/internal/attack/a2a/session_smuggle.go
@@ -109,7 +109,17 @@ func (e *SessionSmuggleExecutor) Execute(ctx context.Context, target string, opt
 		// means the message never reached the role handling, so a clean result would
 		// claim this agent does not preserve a forged role without ever having offered
 		// it one.
-		if !resp.IsAccepted() || !looksLikeTask(resp.Body) {
+		//
+		// Only a rejection takes this branch. An ACCEPTED reply that does not look
+		// like a task used to be funneled through the same observation, where
+		// errIfAuthRefused read it as a pass - but A2A lets an agent answer a send
+		// with a Message instead of a Task, and the rule's own documentation says
+		// that shape reports not tested. evaluateAcceptance already says so for a
+		// task reply with no extractable id; the gate only mattered for rejections,
+		// and on the accepted side it also suppressed real findings from task
+		// bodies whose state spelled none of the needles (e.g. a completed task
+		// keyed by bare "id").
+		if !resp.IsAccepted() {
 			obs.observe(classifyTaskSetup("sending a message claiming the agent role", ep,
 				client.PresentsCredential(ep), resp))
 			continue
@@ -281,23 +291,6 @@ func isAgentRole(v interface{}) bool {
 	default:
 		return false
 	}
-}
-
-// looksLikeTask returns true if the body resembles an A2A task response.
-//
-// Task states appear in two spellings. v0.3 used lowercase strings ("working"),
-// while v1.0 carries the proto enum ("TASK_STATE_WORKING"), and A2A v1.0.1
-// standardized the specification's own examples on the enum form. Both are
-// matched, because this gates whether a finding is reported at all: a server
-// whose task body carried only the enum state would otherwise be read as not a
-// task, and the rule would stay silent against a target it should flag.
-func looksLikeTask(body []byte) bool {
-	s := string(body)
-	return containsAnyStr(s,
-		`"contextId"`, `"taskId"`, `"kind":"task"`,
-		`"working"`, `"submitted"`,
-		"TASK_STATE_WORKING", "TASK_STATE_SUBMITTED",
-	)
 }
 
 // extractTaskContext extracts the taskId and contextId from a JSON-RPC task result.

--- a/internal/attack/a2a/session_smuggle_test.go
+++ b/internal/attack/a2a/session_smuggle_test.go
@@ -256,9 +256,7 @@ func TestSessionSmuggle_AcceptedWithNoTaskIsNotTested(t *testing.T) {
 		body := readBody(r)
 		id := body["id"]
 		w.Header().Set("Content-Type", "application/json")
-		// A Message result: legal, and it carries no task identifiers. The state string
-		// keeps looksLikeTask satisfied, so this exercises the no-task path rather than
-		// being filtered out before it.
+		// A Message result: legal, and it carries no task identifiers.
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"jsonrpc": "2.0", "id": id,
 			"result": map[string]interface{}{
@@ -272,6 +270,43 @@ func TestSessionSmuggle_AcceptedWithNoTaskIsNotTested(t *testing.T) {
 	findings, err := a2a.NewSessionSmuggleExecutor(testRuleCtx()).Execute(context.Background(), ts.URL, testOpts())
 	if len(findings) != 0 {
 		t.Fatalf("no task means no stored turn to report, got %d: %+v", len(findings), findings)
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "no task id") {
+		t.Errorf("reason should name the missing task; got: %v", err)
+	}
+}
+
+// A Message reply carrying none of the task-identifier markers at all. The
+// accepted-side looksLikeTask gate used to read this shape as "not a task" and
+// funnel it through the refusal observations, which errIfAuthRefused turned
+// into a clean result - while the rule's own contract (and the test above)
+// says a reply with no task reports not tested. The gate could also suppress
+// real findings from task bodies whose state spelled none of its needles.
+func TestSessionSmuggle_MessageReplyWithNoTaskMarkersIsNotTested(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		body := readBody(r)
+		id := body["id"]
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": id,
+			"result": map[string]interface{}{
+				"messageId": "srv-1", "role": "ROLE_AGENT",
+				"parts": []interface{}{map[string]string{"text": "done"}},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	findings, err := a2a.NewSessionSmuggleExecutor(testRuleCtx()).Execute(context.Background(), ts.URL, testOpts())
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d: %+v", len(findings), findings)
 	}
 	if !errors.Is(err, attack.ErrInconclusive) {
 		t.Fatalf("expected ErrInconclusive, got %v", err)

--- a/internal/attack/a2a/task_cancel_idor.go
+++ b/internal/attack/a2a/task_cancel_idor.go
@@ -51,6 +51,7 @@ const (
 	cancelOther        cancelOutcome = iota // application error: not found / not cancelable / unknown method
 	cancelAuthRejected                      // rejected at the auth layer (HTTP 401/403 or an auth error)
 	cancelCanceled                          // accepted: the task is now canceled
+	cancelAbsent                            // every answered shape said method-not-found: no cancel surface exists
 )
 
 func (e *TaskCancelIDORExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
@@ -89,10 +90,22 @@ func (e *TaskCancelIDORExecutor) Execute(ctx context.Context, target string, opt
 		return []attack.Finding{e.unauthFinding(endpoint, taskID)}, nil
 	case cancelAuthRejected:
 		// Auth is enforced; a successful cancel by a non-owner is now a true IDOR.
-	default:
-		// The task is not cancelable (already terminal) or the server hid it, so the
-		// cancel surface cannot be exercised cleanly. No finding.
+	case cancelAbsent:
+		// The agent implements no cancel method on either wire. Nothing to test,
+		// and nothing wrong - the same verdict classifyTaskSetup gives a surface
+		// the agent does not offer.
 		return nil, nil
+	default:
+		// The anonymous cancel drew an application error (task hidden from
+		// anonymous callers, task already terminal, ...) rather than an
+		// authorization rejection, so whether the cancel handler demands a
+		// credential was never established and the cross-principal step cannot
+		// be judged. This used to return clean, claiming the ownership boundary
+		// on cancellation was tested when it was not.
+		return nil, fmt.Errorf("%w: the unauthenticated cancel of task %s at %s was answered with an "+
+			"application error rather than an authorization rejection, so the ownership boundary on "+
+			"cancellation could not be tested",
+			attack.ErrInconclusive, taskID, endpoint)
 	}
 
 	// Step 3: cancel A's task as the WRONG principal B.
@@ -179,6 +192,8 @@ func (e *TaskCancelIDORExecutor) cancelTask(ctx context.Context, c *attack.HTTPC
 		{"CancelTask", v1Headers},
 		{"tasks/cancel", extraHeaders},
 	}
+	answered := false // at least one shape got a reply
+	appErr := false   // some shape answered with an application error
 	for _, s := range shapes {
 		resp, err := c.POST(ctx, endpoint, s.headers, map[string]interface{}{
 			"jsonrpc": "2.0",
@@ -189,14 +204,24 @@ func (e *TaskCancelIDORExecutor) cancelTask(ctx context.Context, c *attack.HTTPC
 		if err != nil {
 			continue
 		}
+		answered = true
 		if isA2AAuthRejection(resp) {
 			return cancelAuthRejected
 		}
 		if resp.IsAccepted() && bodyShowsCanceled(resp.Body) {
 			return cancelCanceled
 		}
-		// Otherwise an application error (not cancelable / not found / unknown
-		// method): try the next shape.
+		// Otherwise an application error (not cancelable / not found): try the
+		// next shape. Method-not-found on every shape that answered means the
+		// agent offers no cancel surface at all, which the caller treats as
+		// absent rather than refused.
+		if code, hasErr := jsonRPCErrorCode(resp.Body); !hasErr ||
+			(code != jsonRPCMethodNotFound && code != a2aUnsupportedOperation) {
+			appErr = true
+		}
+	}
+	if answered && !appErr {
+		return cancelAbsent
 	}
 	return cancelOther
 }

--- a/internal/attack/a2a/task_cancel_idor_test.go
+++ b/internal/attack/a2a/task_cancel_idor_test.go
@@ -74,6 +74,11 @@ func cancelServer(mode string) *httptest.Server {
 				"status": map[string]interface{}{"state": "submitted"}})
 
 		case "CancelTask", "tasks/cancel":
+			if mode == "no-cancel-surface" {
+				// Neither wire implements cancellation.
+				rpcErr(-32601, "method not found")
+				return
+			}
 			if mode == "not-cancelable" {
 				rpcErr(-32002, "Task is not in a cancelable state")
 				return
@@ -177,13 +182,39 @@ func TestTaskCancelIDOR_Secure(t *testing.T) {
 	}
 }
 
-// TestTaskCancelIDOR_NotCancelable: task cannot be canceled => no finding.
+// TestTaskCancelIDOR_NotCancelable: the task cannot be canceled, so the
+// anonymous discriminator drew an application error instead of an auth
+// rejection. Whether the cancel handler demands a credential was never
+// established, so the rule reports not tested rather than clean - a server can
+// hide or terminal-state a task for anonymous callers while still letting any
+// authenticated principal cancel, which is the boundary this rule exists to
+// test.
 func TestTaskCancelIDOR_NotCancelable(t *testing.T) {
 	srv := cancelServer("not-cancelable")
 	defer srv.Close()
 
+	findings, err := runTaskCancel(t, srv)
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings, got %d: %+v", len(findings), findings)
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "ownership boundary on cancellation could not be tested") {
+		t.Errorf("reason should name the untested boundary: %v", err)
+	}
+}
+
+// TestTaskCancelIDOR_NoCancelSurface: both cancel shapes answer method-not-
+// found, so the agent offers no cancellation at all. That is genuinely not
+// applicable - the same verdict classifyTaskSetup gives an absent feature - and
+// must stay clean rather than not tested.
+func TestTaskCancelIDOR_NoCancelSurface(t *testing.T) {
+	srv := cancelServer("no-cancel-surface")
+	defer srv.Close()
+
 	if findings, err := runTaskCancel(t, srv); err != nil || len(findings) != 0 {
-		t.Errorf("expected 0 findings / nil err when the task is not cancelable, got %d findings, err=%v", len(findings), err)
+		t.Errorf("expected 0 findings / nil err when no cancel surface exists, got %d findings, err=%v", len(findings), err)
 	}
 }
 

--- a/internal/attack/a2a/taskstate_test.go
+++ b/internal/attack/a2a/taskstate_test.go
@@ -8,63 +8,6 @@ import "testing"
 // helpers that recognize a task by its state must accept both, or a rule gated
 // on them stays silent against a compliant server.
 
-func TestLooksLikeTask_AcceptsBothStateSpellings(t *testing.T) {
-	tests := []struct {
-		name string
-		body string
-		want bool
-	}{
-		{
-			name: "v0.3 lowercase state only",
-			body: `{"result":{"status":{"state":"working"}}}`,
-			want: true,
-		},
-		{
-			name: "v1.0 enum state only",
-			body: `{"result":{"status":{"state":"TASK_STATE_WORKING"}}}`,
-			want: true,
-		},
-		{
-			name: "v1.0 enum submitted only",
-			body: `{"result":{"status":{"state":"TASK_STATE_SUBMITTED"}}}`,
-			want: true,
-		},
-		{
-			name: "id fields with no state at all",
-			body: `{"result":{"contextId":"c-1"}}`,
-			want: true,
-		},
-		{
-			name: "task kind marker",
-			body: `{"result":{"kind":"task"}}`,
-			want: true,
-		},
-		{
-			name: "not a task",
-			body: `{"result":{"messageId":"m-1","parts":[]}}`,
-			want: false,
-		},
-		{
-			name: "error envelope",
-			body: `{"error":{"code":-32001,"message":"Task not found"}}`,
-			want: false,
-		},
-		{
-			name: "empty",
-			body: ``,
-			want: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := looksLikeTask([]byte(tt.body)); got != tt.want {
-				t.Errorf("looksLikeTask(%s) = %v, want %v", tt.body, got, tt.want)
-			}
-		})
-	}
-}
-
 // bodyShowsCanceled already accepted both spellings when a2a-task-cancel-idor-001
 // was written. This pins that, so a later simplification cannot quietly drop the
 // enum form and leave the rule unable to confirm a cancellation.

--- a/internal/attack/mcp/task_idor.go
+++ b/internal/attack/mcp/task_idor.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -287,6 +288,19 @@ func (e *TaskIDORExecutor) Execute(ctx context.Context, target string, opts atta
 				enforcedOn: "task creation and reads",
 				anonProbe:  "anonymous task creation: refused",
 			}
+		}
+	} else {
+		// The anonymous initialize itself returned no verdict. A refusal that
+		// was actually answered is exactly what the default anonProbe above
+		// records. An endpoint where nothing answered is not: the evidence line
+		// "anonymous initialize: refused" used to stand anyway, stamping an
+		// unobserved refusal into every finding this rule emitted - the same
+		// defect the branches inside this control were fixed for.
+		var refusal handshakeRefusal
+		if !errors.As(anonErr, &refusal) {
+			return nil, fmt.Errorf("%w: the anonymous initialize control at %s returned no verdict "+
+				"(%v), so whether this server authenticates anything could not be established",
+				attack.ErrInconclusive, sessA.Endpoint, anonErr)
 		}
 	}
 

--- a/internal/attack/mcp/task_idor_test.go
+++ b/internal/attack/mcp/task_idor_test.go
@@ -32,6 +32,8 @@ import (
 //   - "unsafe-tool":   the only task-capable tool carries no safety annotations,
 //     so the rule refuses to invoke it => skip.
 //   - "not-mcp":       everything 404s => silent.
+//   - "anon-init-hidden": initialize without a bearer 404s (the endpoint is
+//     hidden from anonymous callers) while credentialed initialize works.
 func taskIDORServer(mode string) *httptest.Server {
 	var mu sync.Mutex
 	sessions := 0
@@ -63,6 +65,14 @@ func taskIDORServer(mode string) *httptest.Server {
 
 		switch method {
 		case "initialize":
+			if mode == "anon-init-hidden" && !authed {
+				// The auth middleware hides the endpoint from anonymous callers
+				// rather than answering 401: an unanswered control, not an
+				// observed refusal (classifyInitFailure treats 404 as a routing
+				// miss, correctly).
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
 			mu.Lock()
 			sessions++
 			newSID := fmt.Sprintf("sess-%d", sessions)
@@ -200,6 +210,37 @@ func runTaskIDOR(t *testing.T, srv *httptest.Server) []attack.Finding {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	return findings
+}
+
+// TestTaskIDOR_HiddenAnonInitializeIsNotTested: the anonymous initialize
+// control was never answered - this server hides the endpoint from anonymous
+// callers (404) instead of refusing it (401), and classifyInitFailure is right
+// that a routing miss is not a refused handshake. The rule used to keep the
+// default evidence line "anonymous initialize: refused" and proceed anyway,
+// stamping a refusal it never observed into any finding it emitted; a server
+// that hides from anonymous callers may still scope tasks per authorization
+// context either way, so the rule reports not tested.
+func TestTaskIDOR_HiddenAnonInitializeIsNotTested(t *testing.T) {
+	srv := taskIDORServer("anon-init-hidden")
+	defer srv.Close()
+
+	exec := mcpattack.NewTaskIDORExecutor(attack.RuleContext{ID: "mcp-task-idor-001"})
+	findings, err := exec.Execute(context.Background(), srv.URL, attack.Options{
+		TimeoutSeconds: 5,
+		Principals: []attack.Principal{
+			{Name: "tenant-a", Token: "tok-a"},
+			{Name: "tenant-b", Token: "tok-b"},
+		},
+	})
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings when the anonymous control went unanswered, got %d: %+v", len(findings), findings)
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Fatalf("expected ErrInconclusive, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "returned no verdict") {
+		t.Errorf("reason should name the unanswered control: %v", err)
+	}
 }
 
 // TestTaskIDOR_CrossContext: B reads A's task and its result => both findings.

--- a/rules/a2a/task-cancel-idor-001.yaml
+++ b/rules/a2a/task-cancel-idor-001.yaml
@@ -26,8 +26,13 @@ info:
          principal B. A CONFIRMED finding is raised only when B's cancel succeeds
          and a read-back as owner A shows the task is now canceled.
 
-    A server that rejects the wrong-principal cancel, or that cannot cancel the
-    task (already terminal), produces no finding.
+    A server that rejects the wrong-principal cancel produces no finding: the
+    boundary was tested and held. Two outcomes are NOT clean results: an
+    anonymous cancel answered with an application error (task hidden from
+    anonymous callers, task already terminal) never established whether the
+    cancel handler demands a credential, so the rule reports not tested; and a
+    server that implements no cancel method on either wire is not applicable and
+    also reports nothing.
 
     SAFETY: the rule creates and cancels its OWN throwaway task; it never cancels
     a pre-existing task, and is standalone (it does not consume tasks other rules
@@ -35,7 +40,7 @@ info:
 
     Note: against a server that completes tasks almost immediately the probe task
     may reach a terminal state before it can be canceled, in which case the rule
-    cannot demonstrate the issue and reports nothing.
+    cannot demonstrate the issue and reports not tested.
 
   references:
     - https://a2a-protocol.org/latest/specification/


### PR DESCRIPTION
The setup machinery (`setup.go`, `twoPrincipals`, the observation ranks) exists so a rule never reports *clean* about a surface it never exercised, but four branches still funneled unexercised outcomes into clean results, one per rule:

- `a2a-context-fixation-001`: step 4's read-back collapsed "could not read" and "read, marker absent" into one `false`, and the caller returned clean for both. `a2a-artifact-tamper-001` reports the identical unreadable read-back as not tested; a marker "not found" in a history that was never fetched is not evidence of isolation. `taskHistoryContains` now returns a tri-state (read, contains, observation) and step 4 routes a failed read through `obs.err()`.

- `a2a-session-smuggle-001`: the accepted-side `looksLikeTask` gate read a legal Message-only reply as "not a task", pushed it through the refusal observations, and `errIfAuthRefused` turned that into a clean result, while the rule's own contract (and `evaluateAcceptance`'s no-task-id path) says a reply with no task reports not tested. The gate is gone; only rejections take the observation branch. It could also suppress real findings from task bodies whose state spelled none of its needles (e.g. a completed task keyed by bare `id`), which `extractTaskContext` handles correctly. Its unit test went with it; the dual-spelling guarantee it was written for is pinned by the `bodyShowsCanceled`/`extractTaskContext` tests beside it.

- `a2a-task-cancel-idor-001`: the anonymous-cancel discriminator's `default:` branch returned clean for any application error (task hidden from anonymous callers, already terminal), so the cross-principal step never ran but the ownership boundary read as tested, which is exactly what `setup.go` was written to prevent. That outcome is now not tested, naming the untested boundary. Method-not-found on both cancel shapes is split out (`cancelAbsent`) and stays clean: a server that implements no cancel method is genuinely not applicable, the same verdict `classifyTaskSetup` gives an absent feature. The secured posture is unaffected: the canary answers anonymous cancels with 401 before dispatch, which is `cancelAuthRejected`.

- `mcp-task-idor-001`: when the anonymous-initialize control itself errored, the default evidence line `anonymous initialize: refused` stood anyway, so every finding asserted an authorization boundary the rule had not observed, the very defect the branches inside that control were fixed for (ba098e8). An answered refusal (`handshakeRefusal`) keeps the line, which is then true; an unanswered walk (`no MCP server found`, e.g. a server that 404-hides from anonymous callers instead of answering 401) now reports not tested, consistent with `classifyInitFailure`'s own rule that a routing miss is not a refused handshake.

A fifth candidate from the review, `a2a-extension-downgrade-001`, was re-checked and is already honest: its rejected-control path records an observation and ends in `observed.err()`.

## Verification

New tests, one per branch: `TestContextFixation_UnreadableReadBackIsNotTested` (read-fails fixture mode, HTTP 500 on GetTask), `TestSessionSmuggle_MessageReplyWithNoTaskMarkersIsNotTested` (needle-free Message reply), `TestTaskCancelIDOR_NoCancelSurface` (both shapes -32601 stays clean) plus the repointed `TestTaskCancelIDOR_NotCancelable` (now asserts ErrInconclusive naming the boundary), and `TestTaskIDOR_HiddenAnonInitializeIsNotTested` (anonymous initialize 404s, credentialed works). `go test ./...` green, `golangci-lint` clean. YAML and `docs/rules-a2a.md` updated where they described the old clean outcomes.
