### PR TITLE
fix: pin rule YAML severity to what the executors emit

### DIFF
--- a/docs/rules-a2a.md
+++ b/docs/rules-a2a.md
@@ -102,14 +102,14 @@ report them not tested against a secured agent, and say so.
 
 | Rule ID | Attack | Severity | Confidence | CWE |
 |---|---|:---:|:---:|---|
-| `a2a-extcard-unauth-001` | [Extended Agent Card Unauthenticated Disclosure](#a2a-extcard-unauth-001) | High | confirmed | CWE-862 |
+| `a2a-extcard-unauth-001` | [Extended Agent Card Unauthenticated Disclosure](#a2a-extcard-unauth-001) | High / Critical | confirmed | CWE-862 |
 | `a2a-push-ssrf-001` | [Push Notification SSRF](#a2a-push-ssrf-001) | High | confirmed | CWE-918 |
-| `a2a-task-idor-001` | [Task IDOR via Unauthenticated tasks/get](#a2a-task-idor-001) | High | confirmed | CWE-639 |
+| `a2a-task-idor-001` | [Task IDOR via Unauthenticated tasks/get](#a2a-task-idor-001) | High / Critical | confirmed | CWE-639 |
 | `a2a-session-smuggle-001` | [Agent Role Injection / Session Smuggling](#a2a-session-smuggle-001) | High | confirmed | CWE-384 |
 | `a2a-wellknown-hostinject-001` | [Agent Card Host Header Injection](#a2a-wellknown-hostinject-001) | High / Medium | indicator | CWE-601 |
 | `a2a-jws-algconf-001` | [AgentCard JWS Algorithm Confusion](#a2a-jws-algconf-001) | Critical | indicator | CWE-327 |
-| `a2a-peer-impersonation-001` | [Peer Agent Impersonation via Forged JWT](#a2a-peer-impersonation-001) | Critical | confirmed | CWE-290 |
-| `a2a-artifact-tamper-001` | [Task Artifact Tampering via Task ID Reuse](#a2a-artifact-tamper-001) | High | confirmed | CWE-284 |
+| `a2a-peer-impersonation-001` | [Peer Agent Impersonation via Forged JWT](#a2a-peer-impersonation-001) | High / Medium | confirmed | CWE-290 |
+| `a2a-artifact-tamper-001` | [Task Artifact Tampering via Task ID Reuse](#a2a-artifact-tamper-001) | Critical | confirmed | CWE-284 |
 | `a2a-multitenant-isolation-001` | [Multi-Tenant Task Isolation Breach](#a2a-multitenant-isolation-001) | High | confirmed | CWE-639 |
 | `a2a-delegation-integrity-001` | [Delegation Chain-of-Custody Break](#a2a-delegation-integrity-001) | High | confirmed | CWE-863 |
 | `a2a-context-fixation-001` | [Context ID Fixation](#a2a-context-fixation-001) | High | confirmed | CWE-384 |
@@ -127,7 +127,7 @@ report them not tested against a secured agent, and say so.
 
 ### a2a-extcard-unauth-001
 
-**Extended Agent Card Unauthenticated Disclosure** | Severity: High | CWE-862
+**Extended Agent Card Unauthenticated Disclosure** | Severity: High / Critical | CWE-862
 
 Fetches the Extended Agent Card without credentials, over both transports the spec
 allows: the JSON-RPC `agent/getAuthenticatedExtendedCard` method and the legacy
@@ -177,7 +177,7 @@ Confirmed unfixed in the reference `a2a-python` SDK as of April 2026
 
 ### a2a-task-idor-001
 
-**Task IDOR via Unauthenticated tasks/get** | Severity: High | CWE-639
+**Task IDOR via Unauthenticated tasks/get** | Severity: High / Critical | CWE-639
 
 Detects broken object-level authorization (IDOR / BOLA) on task lookup using an
 **auth-enforcement discriminator** so an open server is not mislabelled. It (1)
@@ -253,7 +253,7 @@ impact-if-true, not a demonstrated exploit).
 
 ### a2a-peer-impersonation-001
 
-**Peer Agent Impersonation via Forged JWT** | Severity: Critical | CWE-290
+**Peer Agent Impersonation via Forged JWT** | Severity: High / Medium | CWE-290
 
 Forges an HS256 JWT signed with a random key the server cannot know, claiming to
 be a trusted peer agent (`sub`, `iss`, `role`, `aud`), and submits it. The result
@@ -268,17 +268,19 @@ authentication at all and a lower-severity finding is raised instead.
 
 ### a2a-artifact-tamper-001
 
-**Task Artifact Tampering via Task ID Reuse** | Severity: High | CWE-284
+**Task Artifact Tampering via Task ID Reuse** | Severity: Critical | CWE-284
 
 Submits a task, then re-submits the same client-generated task ID with different
 content, then **reads the task back via `tasks/get`** to prove what the server
 actually stored. Acceptance requires HTTP success *and* no JSON-RPC error (a
 "task already exists" error is correctly treated as a rejection). A **confirmed**
-finding is reported only from the read-back: tampered content replacing the
-original is a critical overwrite; tampered content appended alongside the original
-is high-severity injection. If the re-submission is accepted but the original is
-preserved, no finding is raised; if accepted but the result cannot be verified, an
-**indicator** is reported.
+finding is reported only from the read-back, and only when the tampered
+content has fully replaced the original - the stored task returns the attacker's
+content alone, which is a critical-severity overwrite. Tampered content appended
+alongside the original means the original was preserved - a conformant
+continuation, and no finding. If the re-submission is accepted but the stored
+result cannot be read back, nothing was determined and the rule reports **not
+tested**.
 
 ---
 

--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -152,9 +152,9 @@ candidate answers does a rule report that it could not test.
 |---|---|:---:|:---:|---|
 | `mcp-oauth-dcr-001` | [OAuth DCR Scope Escalation](#mcp-oauth-dcr-001) | High | indicator | CWE-284 |
 | `mcp-oauth-audience-002` | [OAuth Audience Matching Bug Probes](#mcp-oauth-audience-002) | High | confirmed / indicator | CWE-863 |
-| `mcp-token-replay-001` | [OAuth Token Signature and Audience Validation Bypass](#mcp-token-replay-001) | High | confirmed | CWE-294 |
+| `mcp-token-replay-001` | [OAuth Token Signature and Audience Validation Bypass](#mcp-token-replay-001) | High / Critical | confirmed | CWE-294 |
 | `mcp-resources-unauth-001` | [Unauthenticated Resource Read](#mcp-resources-unauth-001) | High / Critical | confirmed | CWE-862 |
-| `mcp-prompt-unauth-001` | [Prompt Templates Without Authentication](#mcp-prompt-unauth-001) | Medium | confirmed | CWE-862 |
+| `mcp-prompt-unauth-001` | [Prompt Templates Without Authentication](#mcp-prompt-unauth-001) | High / Medium | confirmed | CWE-862 |
 | `mcp-tools-unauth-001` | [Tools Accessible Without Authentication](#mcp-tools-unauth-001) | High / Medium | confirmed | CWE-862 |
 | `mcp-completion-unauth-001` | [completion/complete Without Authentication](#mcp-completion-unauth-001) | High / Medium | confirmed | CWE-862 |
 | `mcp-logging-unauth-001` | [logging/setLevel Without Authentication](#mcp-logging-unauth-001) | Medium | confirmed | CWE-862 |
@@ -250,7 +250,7 @@ token and is tracked as a follow-up.
 
 ### mcp-token-replay-001
 
-**OAuth Token Signature and Audience Validation Bypass** | Severity: High | CWE-294
+**OAuth Token Signature and Audience Validation Bypass** | Severity: High / Critical | CWE-294
 
 Submits forged bearer tokens the server cannot have validated: two HS256 tokens
 signed with a random key (one with no `aud`, one with a wrong `aud`) and one
@@ -301,7 +301,7 @@ distinguishable from one that saw everything.
 
 ### mcp-prompt-unauth-001
 
-**Prompt Templates Without Authentication** | Severity: Medium | CWE-862
+**Prompt Templates Without Authentication** | Severity: High / Medium | CWE-862
 
 Sends `prompts/list` and `prompts/get` without credentials. Prompt templates can
 encode system-level instructions and internal context that were not intended to be

--- a/internal/attack/a2a/artifact_tamper_test.go
+++ b/internal/attack/a2a/artifact_tamper_test.go
@@ -285,9 +285,13 @@ func TestArtifactTamper_ImmutableTasks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	// The old assertion checked strings.Contains(f.Title, "TAMPERED"), but the
+	// rule's confirmed title spells "tampered" in lowercase, so the guard could
+	// never fire and the test passed with any confirmed finding. An immutable
+	// server must not produce one at all, which is the claim worth pinning.
 	for _, f := range findings {
-		if f.Confidence == attack.ConfirmedExploit && strings.Contains(f.Title, "TAMPERED") {
-			t.Errorf("tampered content should not appear for immutable server: %s", f.Title)
+		if f.Confidence == attack.ConfirmedExploit {
+			t.Errorf("an immutable server must not produce a confirmed finding: %s", f.Title)
 		}
 	}
 }

--- a/internal/repocheck/severity_pinning_test.go
+++ b/internal/repocheck/severity_pinning_test.go
@@ -1,0 +1,111 @@
+package repocheck
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	batesian "github.com/calbebop/batesian"
+	"github.com/calbebop/batesian/internal/rules"
+	"github.com/calbebop/batesian/internal/severity"
+)
+
+// TestSeverityLiteralsWithinDeclaredSeverity pins every severity literal an
+// executor hardcodes to at or below the severity its rule YAML declares.
+//
+// --severity filters on the YAML value while findings carry the executor's own,
+// so a literal above the YAML makes the filter silently skip a rule that can
+// emit at the filtered level: an operator running --severity critical missed
+// every critical finding from five rules that declared high (and one that
+// declared critical while emitting only high/medium, the reverse lie). Nothing
+// connected the two sides, so the drift was invisible to CI.
+//
+// Findings graded BELOW the YAML are fine and intentional: several rules
+// impact-grade downward (a resources list at high under a critical headline), so
+// the pinned direction is one-way. Severities chosen at runtime (escalations
+// from response content, rc.Severity flowing from the YAML itself) are not
+// literals and are out of this scan's reach by construction.
+//
+// The rule-to-executor mapping comes from each file's own attack.Register call,
+// not from a naming convention, so a renamed file cannot detach the check.
+func TestSeverityLiteralsWithinDeclaredSeverity(t *testing.T) {
+	loaded, _, err := rules.LoadFS(batesian.RulesFS())
+	if err != nil {
+		t.Fatalf("loading bundled rules: %v", err)
+	}
+
+	typeFile, fileLiterals := scanExecutors(t)
+
+	for _, r := range loaded {
+		src, ok := typeFile[r.Attack.Type]
+		if !ok {
+			t.Errorf("no executor registers attack type %q (rule %s); the rule can never run", r.Attack.Type, r.ID)
+			continue
+		}
+		declared := severity.Rank(r.Info.Severity)
+		for _, lit := range fileLiterals[src] {
+			if rank := severity.Rank(lit); rank > declared {
+				t.Errorf("%s declares severity %q but its executor (%s) hardcodes a %q finding; "+
+					"--severity filtering reads the YAML, so filtering at %q skips this rule entirely",
+					r.ID, r.Info.Severity, src, lit, r.Info.Severity)
+			}
+		}
+	}
+}
+
+// scanExecutors walks the two executor packages and returns, per attack type,
+// the file that registers it, and per file, the distinct severity string
+// literals assigned to a Severity/severity field.
+func scanExecutors(t *testing.T) (map[string]string, map[string][]string) {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+
+	registerRe := regexp.MustCompile(`attack\.Register\("([^"]+)"`)
+	// Both spellings the executors use: the Finding field (Severity:) and
+	// per-probe tables that feed it (severity:). A literal that is not a
+	// canonical severity (Rank 0, unknown strings included) cannot exceed any
+	// declared value, so non-severity collisions are harmless.
+	literalRe := regexp.MustCompile(`[Ss]everity:\s*"([A-Za-z]+)"`)
+
+	typeFile := map[string]string{}
+	fileLiterals := map[string][]string{}
+	for _, pkg := range []string{"a2a", "mcp"} {
+		dir := filepath.Join(repoRoot, "internal", "attack", pkg)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read %s: %v", dir, err)
+		}
+		for _, e := range entries {
+			name := e.Name()
+			if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				continue
+			}
+			path := filepath.Join(pkg, name)
+			b, err := os.ReadFile(filepath.Join(dir, name))
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			for _, m := range registerRe.FindAllSubmatch(b, -1) {
+				if prev, dup := typeFile[string(m[1])]; dup {
+					t.Errorf("attack type %q is registered in both %s and %s", m[1], prev, path)
+				}
+				typeFile[string(m[1])] = path
+			}
+			seen := map[string]bool{}
+			for _, m := range literalRe.FindAllSubmatch(b, -1) {
+				seen[string(m[1])] = true
+			}
+			for lit := range seen {
+				fileLiterals[path] = append(fileLiterals[path], lit)
+			}
+		}
+	}
+	return typeFile, fileLiterals
+}

--- a/rules/a2a/artifact-tamper-001.yaml
+++ b/rules/a2a/artifact-tamper-001.yaml
@@ -2,7 +2,7 @@ id: a2a-artifact-tamper-001
 info:
   name: A2A Task Artifact Tampering via Task ID Reuse
   author: batesian
-  severity: high
+  severity: critical
   description: |
     Tests whether an A2A server allows a client to overwrite or alter the content
     of a completed task by re-submitting a tasks/send request with the same task ID

--- a/rules/a2a/card-trust-001.yaml
+++ b/rules/a2a/card-trust-001.yaml
@@ -18,7 +18,7 @@ info:
          /.well-known/agent-card.json and the legacy /.well-known/agent.json. If
          one path serves a SIGNED card and the other serves an UNSIGNED card, an
          attacker (or MITM) can steer verification to the unsigned path to strip
-         the signature requirement - reported CONFIRMED. If both are signed but
+         the signature requirement - reported as an indicator. If both are signed but
          their routing-critical `url` differs, reported as an INDICATOR (routing
          ambiguity).
 
@@ -33,7 +33,7 @@ info:
       3. Signature freshness. When the card carries JWS signatures, each protected
          header is decoded: a signature with no `exp` never expires (a captured
          card is valid forever - INDICATOR); a signature whose `exp` is already in
-         the past is still being served (CONFIRMED stale signature).
+         the past is still being served (indicator: stale signature).
 
   references:
     - https://a2a-protocol.org/latest/specification/

--- a/rules/a2a/extcard-unauth-001.yaml
+++ b/rules/a2a/extcard-unauth-001.yaml
@@ -2,7 +2,7 @@ id: a2a-extcard-unauth-001
 info:
   name: Extended Agent Card Unauthenticated Disclosure
   author: batesian
-  severity: high
+  severity: critical
   description: |
     Tests whether the A2A Extended Agent Card endpoint is accessible without
     authentication. The extended agent card contains privileged capability listings

--- a/rules/a2a/peer-impersonation-001.yaml
+++ b/rules/a2a/peer-impersonation-001.yaml
@@ -2,7 +2,7 @@ id: a2a-peer-impersonation-001
 info:
   name: A2A Peer Agent Impersonation via Forged JWT
   author: batesian
-  severity: critical
+  severity: high
   description: |
     A2A servers are expected to validate the identity of calling agents using
     bearer tokens with cryptographic signatures. An attacker can forge a JWT

--- a/rules/a2a/task-idor-001.yaml
+++ b/rules/a2a/task-idor-001.yaml
@@ -2,7 +2,7 @@ id: a2a-task-idor-001
 info:
   name: A2A Task IDOR via Unauthenticated tasks/get
   author: batesian
-  severity: high
+  severity: critical
   description: |
     Detects broken object-level authorization (IDOR / BOLA) on A2A task lookup:
     a server that authenticates task creation but does not bind tasks/get to the

--- a/rules/a2a/wellknown-hostinject-001.yaml
+++ b/rules/a2a/wellknown-hostinject-001.yaml
@@ -12,7 +12,7 @@ info:
 
     Severity is graded by WHERE the canary lands. Reflection into an
     authority/URL field (`url`, `endpoint`, any `*.url`/`*.uri`, or any value
-    that is itself a URL) is reported as high / ConfirmedExploit - that is the
+    that is itself a URL) is reported as high severity (RiskIndicator) - that is the
     agent's advertised service location that peers and registries trust. A
     reflection that only lands in a non-URL field (e.g. `description`) is a real
     injection primitive but lower direct impact, reported as medium /

--- a/rules/mcp/completion-unauth-001.yaml
+++ b/rules/mcp/completion-unauth-001.yaml
@@ -2,7 +2,7 @@ id: mcp-completion-unauth-001
 info:
   name: MCP completion/complete Reachable Without Authentication
   author: batesian
-  severity: medium
+  severity: high
   description: |
     Tests whether an MCP server answers completion/complete requests without
     requiring authentication.

--- a/rules/mcp/prompt-unauth-001.yaml
+++ b/rules/mcp/prompt-unauth-001.yaml
@@ -2,7 +2,7 @@ id: mcp-prompt-unauth-001
 info:
   name: MCP Prompt Templates Accessible Without Authentication
   author: batesian
-  severity: medium
+  severity: high
   description: |
     Tests whether an MCP server exposes its prompt templates via prompts/list
     and prompts/get without requiring authentication.

--- a/rules/mcp/task-idor-001.yaml
+++ b/rules/mcp/task-idor-001.yaml
@@ -2,7 +2,7 @@ id: mcp-task-idor-001
 info:
   name: MCP Task Readable Across Authorization Contexts
   author: batesian
-  severity: high
+  severity: critical
   description: |
     Tests whether MCP tasks are bound to the authorization context that created
     them.

--- a/rules/mcp/token-replay-001.yaml
+++ b/rules/mcp/token-replay-001.yaml
@@ -2,7 +2,7 @@ id: mcp-token-replay-001
 info:
   name: MCP OAuth Token Signature and Audience Validation Bypass
   author: batesian
-  severity: high
+  severity: critical
   description: |
     Tests whether an MCP server accepts forged or unsigned OAuth 2.1 bearer
     tokens. The probes are JWTs the server cannot have validated: two signed with


### PR DESCRIPTION
`--severity` filters on the YAML value; findings carry the severity their executor hardcodes. Those two sides were never connected, so eight rules drifted apart in the one direction that lies to the filter: the YAML declares less than the rule can emit, and `--severity critical` silently skipped rules that emit critical findings:

```
a2a-artifact-tamper-001     high   -> emits critical
a2a-extcard-unauth-001      high   -> emits critical
a2a-task-idor-001           high   -> emits critical
mcp-token-replay-001        high   -> emits critical (alg:none)
mcp-task-idor-001           high   -> emits critical (tasks/result, tasks/list)
mcp-completion-unauth-001   medium -> emits high (get-level)   # found by the new test
mcp-prompt-unauth-001       medium -> emits high (get-level)   # found by the new test
```

The last two were not in the audit that motivated this; the new pinning test flagged them on its first run. One rule drifted in the reverse direction: `a2a-peer-impersonation-001` declared critical while emitting only high (forged accepted) and medium (no auth), so `batesian rules --severity critical` advertised a critical rule whose findings never surface above high. Its YAML is now high.

The YAML severity is now the headline: the maximum severity the rule can emit, which is what a level filter must select on. Findings graded BELOW it stay as they are; several rules impact-grade downward by design (a resources list at high under a critical headline), so the pinned relation is one-way.

Two description overclaims went with them: `a2a-card-trust-001` calls signature-stripping and a stale signature "CONFIRMED" while the code emits RiskIndicator for both (the docs table already said indicator), and `a2a-wellknown-hostinject-001` calls URL reflection "high / ConfirmedExploit" while the code emits a high-severity RiskIndicator.

## The pinning test

`internal/repocheck/severity_pinning_test.go` loads the bundled YAMLs, maps each rule's attack type to the executor file through that file's own `attack.Register` call (no naming convention to rot), and fails if any `Severity:`/`severity:` string literal in the file outranks the declared severity. It also fails if a rule's type has no registering executor. Non-vacuous by construction here: it caught the completion/prompt drift above on its first run. Runtime-chosen severities (content-based escalations, `rc.Severity` flowing from the YAML) are not literals and are outside the scan by construction.

## Also in this PR

`TestArtifactTamper_ImmutableTasks` asserted `strings.Contains(f.Title, "TAMPERED")`, but the rule's confirmed title spells "tampered" in lowercase, so the guard could never fire and the test passed with any confirmed finding. It now fails on any confirmed finding from the immutable fixture, which is the claim it existed to pin. And the `a2a-artifact-tamper-001` doc paragraph that contradicted both the code and itself (append = "high-severity injection" two sentences before "the original is preserved, no finding"; unverifiable = "indicator" where the code returns not tested) now states the actual verdicts.

Docs table rows and detail headings for the eight rules updated to the graded ranges ("High / Critical" etc.), matching the convention `mcp-resources-unauth-001` and `mcp-task-idor-001` already used. `go test ./...` green, `golangci-lint` clean.
