### PR TITLE
ci(validation): run validation gates on pull requests

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -7,17 +7,14 @@ name: Validation
 # was found only by hand. This job runs the binary against the one fixture that
 # ENFORCES authorization (a2a_secured_agent.py), which is the false-positive
 # coverage no no-auth fixture can provide.
-#
-# It starts nightly and on dispatch only: a gate that flakes on a CI environment
-# quirk blocks development while it is diagnosed, so it earns a PR trigger only
-# once it is green on a schedule. Add `pull_request:` to the triggers below when
-# that is true.
 
 on:
   schedule:
     # Daily, 06:17 UTC. An odd minute keeps this off the top-of-hour spike every
     # scheduled workflow lands on.
     - cron: '17 6 * * *'
+  pull_request:
+    branches: [main, dev]
   workflow_dispatch:
 
 permissions:
@@ -120,8 +117,7 @@ jobs:
       - name: Install FastMCP
         # Unpinned on purpose, the era-watch way: a FastMCP release that changes
         # the server's defaults is exactly the kind of drift this job exists to
-        # surface. The job is nightly/dispatch only, so a drift failure notifies
-        # rather than blocks.
+        # surface.
         run: pip install "fastmcp>=3"
 
       - name: Build batesian


### PR DESCRIPTION
The validation workflow has been green for ten consecutive nightly runs (2026-08-16 through 2026-08-25). The header comment in `validation.yml` explicitly marked this as the promotion criterion: `Add pull_request: to the triggers below when that is true.`

This PR promotes the four validation gates from schedule/dispatch-only to also run on pull requests against `main`/`dev`:

- `a2a-secured-agent` - A2A false-positive gate (secured agent)
- `mcp-property-fixtures` - probe-honesty, log opt-in, body size, session-as-credential
- `fastmcp-target` - third-party FastMCP false-positive plus true-positive
- `oauth-dcr-fixture` - OAuth DCR cleanup plus report-leftovers

Every shipped A2A false negative so far (\#175, \#176, \#177) was found only by hand against the secured-agent fixture. With this gate on PRs the same coverage that caught them nightly will block the PR that reintroduces them.

Changes:
- `.github/workflows/validation.yml` - add `pull_request: branches: [main, dev]` trigger, drop the now-stale promotion comment. `fastmcp>=3` stays unpinned. FastMCP drift will now block the PR that introduces it, which is the point of a gate.

Validation:
- Last 10 nightly runs all succeeded (51 to 72s each, \#32820089978 through \#31932707051).
- Workflow YAML is syntactically valid and matches the shape used in `ci.yml`.
- No functional change to job steps, only triggers.