### PR TITLE
build: run CI's checks in containers via make docker-check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,6 +197,14 @@ go test ./...
 
 Both must pass with zero failures before committing.
 
+No local Go toolchain? `make docker-check` runs build, vet, race tests and
+golangci-lint inside the same pinned containers CI uses (`golang:1.25.13`,
+`golangci-lint v2.11.4`), so the verdict matches before you push:
+
+```sh
+make docker-check
+```
+
 ### Step 5: Linter
 
 ```sh

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,23 @@
-.PHONY: all build test lint vet fmt clean install run help
+.PHONY: all build test lint vet fmt clean install run docker-check help
 
 BINARY := batesian
 PKG := github.com/calbebop/batesian
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Container images for docker-check, matching what CI pins in ci.yml and
+# go.mod. Keep the two in step when bumping either side.
+GO_IMAGE := golang:1.25.13
+LINT_IMAGE := golangci/golangci-lint:v2.11.4
+
+# Named volumes cache modules and compiled packages between runs; without them
+# every invocation redownloads the module graph from scratch.
+GO_CACHE_VOLS := -v batesian-gomod:/go/pkg/mod -v batesian-gocache:/root/.cache/go-build
+
+# Repo root as seen by the container. On Docker Desktop the Windows path is
+# mounted read-write so coverage.out lands back on the host.
+MOUNT := -v "$(CURDIR):/app" -w /app
 
 LDFLAGS := -s -w \
 	-X main.version=$(VERSION) \
@@ -38,13 +51,31 @@ install:
 run: build
 	./bin/$(BINARY) $(ARGS)
 
+# docker-check runs the same gates CI runs (build, vet, race tests, lint) in
+# the pinned containers, so a contributor without a local Go toolchain gets
+# pre-push verification that matches the CI verdict. First run downloads
+# images and modules; later runs are warm.
+docker-check: docker-build-vet docker-test docker-lint
+
+docker-build-vet:
+	docker run --rm $(MOUNT) $(GO_CACHE_VOLS) $(GO_IMAGE) \
+		sh -c "go build ./... && go vet ./..."
+
+docker-test:
+	docker run --rm $(MOUNT) $(GO_CACHE_VOLS) $(GO_IMAGE) \
+		go test -race -coverprofile=coverage.out ./...
+
+docker-lint:
+	docker run --rm $(MOUNT) $(LINT_IMAGE) golangci-lint run
+
 help:
 	@echo "Available targets:"
-	@echo "  build    - Build the batesian binary"
-	@echo "  test     - Run tests with race detector and coverage"
-	@echo "  lint     - Run golangci-lint"
-	@echo "  vet      - Run go vet"
-	@echo "  fmt      - Format Go code"
-	@echo "  clean    - Remove build artifacts"
-	@echo "  install  - go install batesian to GOPATH/bin"
-	@echo "  run      - Build and run (use ARGS=... to pass flags)"
+	@echo "  build         - Build the batesian binary"
+	@echo "  test          - Run tests with race detector and coverage"
+	@echo "  lint          - Run golangci-lint"
+	@echo "  vet           - Run go vet"
+	@echo "  fmt           - Format Go code"
+	@echo "  clean         - Remove build artifacts"
+	@echo "  install       - go install batesian to GOPATH/bin"
+	@echo "  run           - Build and run (use ARGS=... to pass flags)"
+	@echo "  docker-check  - build+vet+test+lint in the pinned containers (no local Go needed)"


### PR DESCRIPTION
Two recent PRs shipped gofmt and unparam findings that a pre-push lint run would have caught. A contributor without a local Go toolchain had no way to reproduce the CI verdict before pushing, so the round trip went through CI at a few minutes per attempt.

`make docker-check` runs build, vet, race tests and golangci-lint inside the same pinned images CI uses:

- `golang:1.25.13` (the `go.mod` toolchain) for build/vet/test
- `golangci/golangci-lint:v2.11.4` (pinned in `ci.yml`) for lint

Named volumes (`batesian-gomod`, `batesian-gocache`) keep the module graph and compiled packages warm between runs. The repo mounts read-write so `coverage.out` lands on the host like the native targets do.

Changes:
- `Makefile` - add `docker-check`, `docker-build-vet`, `docker-test`, `docker-lint`; image refs defined once beside the existing variables with a note to keep them in step with CI
- `CONTRIBUTING.md` - mention `make docker-check` under Step 4 as the no-toolchain path

Verified against this tree: build OK, vet OK, all 16 packages pass `go test -race`, lint reports 0 issues.