### PR TITLE
ci: re-lint the whole tree daily with the issue cache disabled

### DIFF
--- a/.github/workflows/lint-sweep.yml
+++ b/.github/workflows/lint-sweep.yml
@@ -1,0 +1,47 @@
+name: Lint sweep
+
+# golangci-lint caches analysis results per file, and the CI lint job restores
+# that cache between runs. A file whose content has not changed keeps its cached
+# verdict, which means a latent finding in a file nobody has edited stays
+# invisible until the next PR that touches it - where it surfaces as a red job
+# mixed into unrelated work (#222: an unparam finding on a test helper that had
+# been there since the helper was written, exposed only because that PR edited
+# the file).
+#
+# This job re-analyzes the whole tree with the cache disabled on a schedule, so
+# those findings surface here instead. A scheduled failure notifies on its own
+# and blocks nothing.
+
+on:
+  schedule:
+    # Daily, 05:43 UTC. An odd minute keeps this off the top-of-hour spike
+    # every scheduled workflow lands on.
+    - cron: '43 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint (cache disabled)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: golangci-lint (fresh analysis)
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version: v2.11.4
+          skip-cache: true


### PR DESCRIPTION
golangci-lint caches analysis results per file, and the CI lint job restores that cache between runs. A file whose content has not changed keeps its cached verdict, so a latent finding in a file nobody has edited stays invisible until the next PR that touches it, where it lands as a red job mixed into unrelated work.

That is how #222 shipped: the `unparam` finding on `unsignedCard` had been there since the helper was written, and surfaced only because #222 edited the same file. The sweep makes those findings surface on a schedule instead of by accident.

Changes:
- `.github/workflows/lint-sweep.yml` - new nightly job (05:43 UTC plus manual dispatch) running golangci-lint v2.11.4 with `skip-cache: true`, forcing full-tree analysis every run. Scheduled only: a failure notifies through the normal Actions channel and blocks nothing, matching the era-watch and validation conventions.

Validation:
- YAML parses clean (validated all six workflow files in a container).
- Same action pins as `ci.yml`; no new third-party actions introduced.