### PR TITLE
rule(mcp): detect tools reachable beyond a credential's scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ CLI for adversarial testing of [A2A](https://a2a-protocol.org) and [MCP](https:/
 
 ## What ships
 
-Bundled rules: **18 A2A, 22 MCP (40 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
+Bundled rules: **18 A2A, 23 MCP (41 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
 
 - [A2A rules](docs/rules-a2a.md) (18)
 - [MCP rules](docs/rules-mcp.md) (21)
@@ -30,7 +30,7 @@ Rules are validated against third-party reference implementations, not only agai
 
 Coverage spans:
 
-- **OAuth & token validation** - OAuth 2.1 / DCR scope escalation, audience binding, token replay, version-downgrade bypass, forged-token acceptance, redirect_uri confused deputy
+- **OAuth & token validation** - OAuth 2.1 / DCR scope escalation, audience binding, token replay, version-downgrade bypass, forged-token acceptance, redirect_uri confused deputy, tool-level scope enforcement
 - **Agent-card trust (A2A)** - JWS signatures, canonicalization, cache/freshness, required-extension downgrade, host-header injection, unauthenticated extended card, declared-but-unenforced auth
 - **Request & task integrity** - task IDOR, agent-role injection, artifact tampering, SEP-2243 header/body routing, SSE resumption replay
 - **Multi-party isolation** - cross-tenant isolation, cross-principal task enumeration, session/context fixation, session id accepted as a credential, delegation chain-of-custody, cross-principal task cancellation, cross-context MCP task and result access

--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -1,6 +1,6 @@
 # MCP Attack Rules
 
-Batesian ships **22 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
+Batesian ships **23 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
 Every rule is an active probe: it sends crafted protocol traffic and judges the
 server's actual response. Rules are deliberately scoped to MCP-specific semantics
 (OAuth 2.1 authorization, DCR, audience binding, discovery-chain metadata-fetch
@@ -172,6 +172,7 @@ candidate answers does a rule report that it could not test.
 | `mcp-session-as-credential-001` | [Session ID Accepted as a Credential](#mcp-session-as-credential-001) | High | confirmed | CWE-287 / CWE-565 |
 | `mcp-log-optin-001` | [Log Notifications Without a Per-Request Opt-In](#mcp-log-optin-001) | Medium | confirmed | CWE-200 / CWE-532 |
 | `mcp-tool-param-traversal-001` | [Tool Path Traversal](#mcp-tool-param-traversal-001) | High | confirmed | CWE-22 |
+| `mcp-scope-confusion-001` | [Tool Scope Confusion](#mcp-scope-confusion-001) | High | confirmed | CWE-285 |
 
 ---
 
@@ -885,3 +886,51 @@ filesystem path (`path`, `file_path`, `filename`, `directory`, ...). A server
 whose safe tools take no such parameter reports clean: the rule does not
 dispatch unannotated tools, and the catalog records that trade-off here rather
 than hiding it behind a clean-looking result.
+
+---
+
+### mcp-scope-confusion-001
+
+**Tool Scope Confusion (Valid Token, Privileged Dispatch)** | Severity: High | CWE-285
+
+Tests whether `tools/call` enforces the scopes of the credential presented, or
+merely that a credential exists. The failure sits between two rules that
+already ship: `mcp-token-replay-001` covers tokens the server cannot have
+validated, and `mcp-oauth-dcr-001` covers registration granting privileged
+scopes. Neither says anything about a validly-signed, genuinely-issued token
+whose scope set is too small. Servers that authenticate correctly and then
+authorize nothing per-tool hand every authenticated caller every tool - OWASP
+MCP02 scope creep.
+
+**Two identities drive it**, via the same `--principal` machinery the
+cross-principal rules use: principal A holds full privilege, principal B a
+deliberately limited one. For each privileged-looking candidate tool -
+annotations declaring it non-read-only or destructive, or write/admin
+vocabulary in its name - the rule sends the SAME invalid-subject call twice:
+
+1. As principal A. The baseline must reach argument validation; a
+   `-32602`-style answer proves the dispatcher ran for a legitimate caller
+   and that the call shape is not what gets refused.
+2. As principal B. An authorization refusal here is the boundary holding,
+   which is the pass sought. Dispatching like A while an unauthenticated
+   control was refused means the server authenticates callers and then
+   ignores what their credential is scoped to do - reported **confirmed**
+   at high.
+
+**Safety.** The arguments are invalid on purpose: every required string
+parameter names an object that does not exist. A scope-ignoring server stops
+at argument validation and executes nothing; the oracle never needs a
+successful state-changing call, which is the same never-executes trick
+`mcp-tools-unauth-001` uses on its dispatch probe.
+
+**Controls.** The limited credential must succeed somewhere (`tools/list`)
+before any refusal below is read as a scope decision rather than a dead
+token. An anonymous call on the first candidate must be refused: a server
+that dispatches unauthenticated calls gates nothing by identity, which
+belongs to `mcp-tools-unauth-001`, and reporting it as a scope failure would
+count one defect twice under the wrong name.
+
+**Precondition.** Two distinct credentials are required, because crossing a
+scope boundary needs two differently-scoped ones. With fewer - or with two
+principals presenting the same credential - the rule reports **not tested**
+rather than clean, naming what was missing.

--- a/internal/attack/mcp/scope_confusion.go
+++ b/internal/attack/mcp/scope_confusion.go
@@ -1,0 +1,507 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// ScopeConfusionExecutor tests whether MCP tools/call enforces the scopes of
+// the credential it is handed, or merely that a credential exists
+// (rule mcp-scope-confusion-001).
+//
+// The failure sits between two rules that already ship. mcp-token-replay-001
+// covers tokens the server cannot have validated (signature checks absent);
+// mcp-oauth-dcr-001 covers registration granting privileged scopes. Neither
+// says anything about a validly-signed, genuinely-issued token whose scope set
+// is too small: servers that authenticate correctly and then authorize nothing
+// per-tool hand every authenticated caller every tool. That is OWASP MCP02,
+// and the spec's own Security Best Practices call for least privilege.
+//
+// Two identities drive it, via the same --principal machinery the
+// cross-principal rules use: principal A holds full privilege, principal B
+// holds a deliberately limited one. For each privileged-looking candidate tool
+// the rule sends the SAME invalid-subject call twice, once as A and once as B:
+//
+//	full principal    -> dispatches (argument validation answers)   [baseline]
+//	limited principal -> refused with an authz error                [scope held]
+//	limited principal -> dispatches like A                          [scope ignored]
+//
+// SAFETY: the arguments are invalid on purpose - a subject id that does not
+// exist - so a scope-ignoring server stops at argument validation and executes
+// nothing. The oracle never needs a successful state-changing call, only the
+// difference between "refused before validating" and "validated and not
+// found". This is the same never-executes trick mcp-tools-unauth-001 uses on
+// its dispatch probe.
+type ScopeConfusionExecutor struct {
+	rule attack.RuleContext
+}
+
+func init() {
+	attack.Register("mcp-scope-confusion", func(rc attack.RuleContext) attack.Executor { return NewScopeConfusionExecutor(rc) })
+}
+
+func NewScopeConfusionExecutor(r attack.RuleContext) *ScopeConfusionExecutor {
+	return &ScopeConfusionExecutor{rule: r}
+}
+
+// scopeCandidateCap bounds how many candidate tools one wire will drive. Each
+// costs two calls (the identical pair), so the cap keeps cost off the target's
+// tool count.
+const scopeCandidateCap = 6
+
+// scopeCallIDs space the rule's request ids apart from any other stage.
+const (
+	scopeIDListFull = 3
+	scopeIDListLim  = 4
+	scopeIDAnon     = 5
+	scopeIDFullBase = 10
+	scopeIDLimBase  = 20
+)
+
+func (e *ScopeConfusionExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
+	vars := attack.NewVars(target, opts.OOBListenerURL)
+	client := attack.NewUnauthHTTPClient(opts, vars)
+
+	// The credential check defers until the tool surface is confirmed present,
+	// the same ordering mcp-task-idor-001 uses: telling an operator to add a
+	// second principal when adding one would change nothing is worse than
+	// saying the feature is absent.
+	princA, princB, credErr := scopePrincipals(opts)
+	discovery := princA
+	if credErr != nil {
+		discovery = taskPrincipal{name: "the configured credential", token: opts.Token}
+	}
+
+	sessions, sessErr := openSessionsAs(ctx, client, vars.BaseURL, discovery)
+	if sessErr != nil {
+		return nil, sessErr // not an MCP server, and why
+	}
+
+	var findings []attack.Finding
+	capabilityKnown := false
+	var lastReason string
+
+	for _, sessA := range sessions {
+		if !sessA.ServerSupports("tools") {
+			continue // this wire has no tool surface; nothing for the rule to say
+		}
+		capabilityKnown = true
+
+		// The tool surface exists on at least one wire, so a missing or shared
+		// second identity is now the reason the rule cannot run rather than a
+		// detail about a server it does not apply to.
+		if credErr != nil {
+			return nil, credErr
+		}
+
+		fs, reason, determined := e.probeSession(ctx, client, sessA, princA, princB, vars.RandID)
+		findings = append(findings, labelEra(sessA, fs)...)
+		if determined {
+			lastReason = ""
+		} else if reason != "" {
+			lastReason = reason
+		}
+	}
+
+	if !capabilityKnown {
+		return nil, fmt.Errorf("%w: no served wire advertises the tools capability at %s",
+			attack.ErrInconclusive, vars.BaseURL)
+	}
+	if len(findings) == 0 && lastReason != "" {
+		return nil, fmt.Errorf("%w: %s", attack.ErrInconclusive, lastReason)
+	}
+	return findings, nil
+}
+
+// scopePrincipals resolves the two identities this rule needs: a full one and
+// a deliberately limited one, in that order. It mirrors taskPrincipals'
+// distinctness rules with wording about scopes rather than tasks.
+func scopePrincipals(opts attack.Options) (a, b taskPrincipal, err error) {
+	if len(opts.Principals) < 2 {
+		return a, b, fmt.Errorf("%w: telling whether tool access honours granted scopes needs two "+
+			"differently-scoped credentials, and %d principal(s) were configured; pass a full and a "+
+			"limited identity as two --principal flags (or a config with two principals)",
+			attack.ErrInconclusive, len(opts.Principals))
+	}
+	a = taskPrincipal{name: opts.Principals[0].Name, token: opts.Principals[0].Token,
+		headers: opts.Principals[0].Headers}
+	b = taskPrincipal{name: opts.Principals[1].Name, token: opts.Principals[1].Token,
+		headers: opts.Principals[1].Headers}
+	if a.token == b.token && sameHeaders(a.headers, b.headers) {
+		return a, b, fmt.Errorf("%w: principals %q and %q present the same credential, so there is "+
+			"no scope boundary between them for this rule to test",
+			attack.ErrInconclusive, a.name, b.name)
+	}
+	return a, b, nil
+}
+
+// openSessionsAs opens every wire the target serves, handshaking as the given
+// principal. openSessions itself presents no credential, which reads every
+// gated server as unreachable; the handshake here carries the principal the
+// way mcp-task-idor-001's does.
+func openSessionsAs(ctx context.Context, client *attack.HTTPClient, baseURL string, p taskPrincipal) ([]mcpSession, error) {
+	sess, err := scopeHandshake(ctx, client, baseURL, p)
+	if err != nil {
+		return nil, err
+	}
+	sess.Era = EraLegacy
+	out := []mcpSession{sess}
+
+	for _, ep := range []string{sess.Endpoint} {
+		if modern, ok := discoverModern(ctx, client, ep); ok {
+			out = append(out, modern)
+			break
+		}
+	}
+	return out, nil
+}
+
+// scopeHandshake performs an initialize as the given principal, walking the
+// candidate paths and reporting why none answered.
+func scopeHandshake(ctx context.Context, client *attack.HTTPClient, baseURL string, p taskPrincipal) (mcpSession, error) {
+	var observed initObservation
+	for _, ep := range endpointCandidates(baseURL) {
+		headers := map[string]string{}
+		if p.token != "" {
+			headers["Authorization"] = "Bearer " + p.token
+		}
+		for k, v := range p.headers {
+			headers[k] = v
+		}
+		resp, err := client.POST(ctx, ep, headers, map[string]interface{}{
+			"jsonrpc": "2.0", "id": 1, "method": "initialize",
+			"params": map[string]interface{}{
+				"protocolVersion": "2025-11-25",
+				"capabilities":    map[string]interface{}{},
+				"clientInfo":      map[string]interface{}{"name": "batesian", "version": attack.Version},
+			},
+		})
+		if err != nil {
+			continue
+		}
+		if !resp.IsSuccess() || !resp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
+			observed.observe(classifyInitFailure(ep, p.token != "", resp))
+			continue
+		}
+		session := mcpSession{
+			Endpoint:        ep,
+			SessionID:       resp.Headers.Get("Mcp-Session-Id"),
+			ProtocolVersion: negotiatedVersion(resp.Body),
+			RawInit:         resp.Body,
+		}
+		_, _ = client.POST(ctx, ep, session.header(), map[string]interface{}{
+			"jsonrpc": "2.0", "method": "notifications/initialized",
+		})
+		return session, nil
+	}
+	if observed.rank > rankNothing {
+		return mcpSession{}, handshakeRefusal{observed.reason}
+	}
+	return mcpSession{}, fmt.Errorf("no MCP server found at %s", baseURL)
+}
+
+// scopeTool is the slice of a tools/list entry this rule grades.
+type scopeTool struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Annotations *struct {
+		ReadOnlyHint    *bool `json:"readOnlyHint"`
+		DestructiveHint *bool `json:"destructiveHint"`
+	} `json:"annotations"`
+	InputSchema map[string]interface{} `json:"inputSchema"`
+}
+
+// scopeWriteVocabulary names the tool-name fragments treated as privileged
+// when annotations are absent or ambiguous. Matching is on the lowercase name
+// containing the fragment; a read-only annotated tool never qualifies through
+// the name path.
+var scopeWriteVocabulary = []string{
+	"write", "create", "delete", "remove", "update", "set_", "send", "exec",
+	"run", "invoke", "admin", "install", "deploy", "restart", "shutdown",
+	"grant", "revoke", "cancel",
+}
+
+// scopeLooksPrivileged reports whether a tool plausibly mutates state: its
+// annotations say so, or its name carries write vocabulary without a
+// read-only declaration contradicting it.
+func scopeLooksPrivileged(t scopeTool) bool {
+	if t.Annotations != nil {
+		if t.Annotations.ReadOnlyHint != nil && *t.Annotations.ReadOnlyHint {
+			return false // declared read-only wins over the name heuristic
+		}
+		if t.Annotations.DestructiveHint != nil && *t.Annotations.DestructiveHint {
+			return true
+		}
+		if t.Annotations.ReadOnlyHint != nil && !*t.Annotations.ReadOnlyHint {
+			return true // explicitly declared non-read-only
+		}
+	}
+	lower := strings.ToLower(t.Name)
+	for _, frag := range scopeWriteVocabulary {
+		if strings.Contains(lower, frag) {
+			return true
+		}
+	}
+	return false
+}
+
+// probeSession drives one wire. determined reports whether the wire produced a
+// verdict anywhere; reason carries what stopped it when it did not.
+func (e *ScopeConfusionExecutor) probeSession(ctx context.Context, client *attack.HTTPClient, sessA mcpSession,
+	princA, princB taskPrincipal, randID string) (findings []attack.Finding, stopReason string, determined bool) {
+
+	candidates, reason, ok := e.scopeCandidates(ctx, client, sessA, princA)
+	if !ok {
+		return nil, reason, false
+	}
+	if len(candidates) == 0 {
+		return nil, "", true // listed, and nothing privileged-shaped to test
+	}
+
+	// Validity control: the limited credential must succeed somewhere before a
+	// refusal below can be read as a scope decision rather than a dead token.
+	listResp, listErr := sessA.postShaping(ctx, client, scopeIDListLim, "tools/list", nil,
+		func(h map[string]string) { attachPrincipal(h, princB) })
+	if verdict, _ := classifyProbe(listResp, listErr); verdict != probeAnswered {
+		return nil, fmt.Sprintf("tools/list refused the limited principal %q (%s), so its privilege "+
+			"level was never established", princB.name, scopeVerdictName(verdict)), false
+	}
+
+	// Anonymous control on the first candidate: a server that dispatches an
+	// unauthenticated call gates nothing by identity, which is
+	// mcp-tools-unauth-001's finding rather than a scope boundary.
+	anonymousText := e.callAs(ctx, client, sessA, anonymousPrincipal, scopeIDAnon, candidates[0], randID)
+	if scopeShowsDispatch(anonymousText) {
+		return nil, "", true
+	}
+
+	for i, cand := range candidates {
+		if i >= scopeCandidateCap {
+			break
+		}
+
+		fullText := e.callAs(ctx, client, sessA, princA, scopeIDFullBase+i, cand, randID)
+		if !scopeShowsDispatch(fullText) {
+			continue // baseline did not establish dispatch; nothing to compare
+		}
+
+		limText := e.callAs(ctx, client, sessA, princB, scopeIDLimBase+i, cand, randID)
+		switch {
+		case scopeShowsDispatch(limText):
+			findings = append(findings, e.finding(sessA.Endpoint, cand, princA.name, princB.name))
+		case scopeShowsAuthRefusal(limText):
+			// The boundary held on this candidate: exactly the pass sought.
+		default:
+			// No verdict either way; this candidate says nothing about scoping.
+		}
+	}
+	return findings, "", true
+}
+
+// scopeCandidates lists the tools as the full principal and selects the
+// privileged-looking ones. ok is false when the listing produced no usable
+// answer, in which case reason says why the rule could not run on this wire.
+func (e *ScopeConfusionExecutor) scopeCandidates(ctx context.Context, client *attack.HTTPClient, sessA mcpSession, princA taskPrincipal) (cands []scopeTool, reason string, ok bool) {
+	resp, err := sessA.postShaping(ctx, client, scopeIDListFull, "tools/list", nil,
+		func(h map[string]string) { attachPrincipal(h, princA) })
+	verdict, _ := classifyProbe(resp, err)
+	if verdict != probeAnswered {
+		return nil, fmt.Sprintf("tools/list refused the full principal %q (%s), so the privileged "+
+			"surface could not be discovered", princA.name, scopeVerdictName(verdict)), false
+	}
+	var body struct {
+		Result struct {
+			Tools []scopeTool `json:"tools"`
+		} `json:"result"`
+		Error map[string]interface{} `json:"error"`
+	}
+	if json.Unmarshal(resp.Body, &body) != nil || body.Error != nil {
+		return nil, "tools/list returned no parseable listing", false
+	}
+	for _, t := range body.Result.Tools {
+		if scopeLooksPrivileged(t) {
+			cands = append(cands, t)
+		}
+	}
+	return cands, "", true
+}
+
+// attachPrincipal adds a principal's credential to headers this session's era
+// already built. Explicit attachment is what lets one transport carry two
+// identities without an ambient token deciding for them.
+func attachPrincipal(h map[string]string, p taskPrincipal) {
+	if p.token != "" {
+		h["Authorization"] = "Bearer " + p.token
+	}
+	for k, v := range p.headers {
+		h[k] = v
+	}
+}
+
+// callAs issues one tools/call with invalid subject arguments as the given
+// principal and returns the response text the oracle reads: the JSON-RPC error
+// message when the envelope carries one, otherwise the result's textual
+// content. Both shapes occur, since many servers report tool failures inside
+// result.isError rather than as protocol errors.
+//
+// The call goes through postShaping so the modern wire's mandatory mirrored
+// headers and _meta travel with it; building headers by hand here would send a
+// legacy-shaped request onto the stateless wire and read its -32020 refusals
+// as authorization decisions.
+func (e *ScopeConfusionExecutor) callAs(ctx context.Context, client *attack.HTTPClient, s mcpSession, p taskPrincipal, id int, cand scopeTool, randID string) string {
+	args := scopeInvalidArgs(cand.InputSchema, randID)
+	params := map[string]interface{}{"name": cand.Name, "arguments": args}
+	resp, err := s.postShaping(ctx, client, id, "tools/call", params,
+		func(h map[string]string) { attachPrincipal(h, p) })
+	if err != nil || !resp.IsSuccess() {
+		// An HTTP-level auth rejection still speaks: read the status line plus
+		// any challenge header into the same text the classifier reads.
+		if err == nil && (resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden) {
+			return fmt.Sprintf("http %d %s", resp.StatusCode, resp.Headers.Get("WWW-Authenticate"))
+		}
+		return ""
+	}
+	var body struct {
+		Result struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"result"`
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(resp.Body, &body) != nil {
+		return ""
+	}
+	if body.Error.Message != "" {
+		return body.Error.Message
+	}
+	var sb strings.Builder
+	for _, c := range body.Result.Content {
+		sb.WriteString(c.Text)
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+// scopeInvalidArgs builds arguments that fail validation after authorization:
+// every required string gets a subject id that cannot exist, other required
+// types get inert values. A server that ignores scopes stops right here.
+func scopeInvalidArgs(schema map[string]interface{}, randID string) map[string]interface{} {
+	args := map[string]interface{}{}
+	props, _ := schema["properties"].(map[string]interface{})
+	required := map[string]bool{}
+	req, _ := schema["required"].([]interface{})
+	for _, r := range req {
+		if s, ok := r.(string); ok {
+			required[s] = true
+		}
+	}
+	for name, raw := range props {
+		if !required[name] {
+			continue
+		}
+		spec, _ := raw.(map[string]interface{})
+		switch spec["type"] {
+		case "string":
+			args[name] = "batesian-nonexistent-" + randID
+		case "number", "integer":
+			args[name] = 1
+		case "boolean":
+			args[name] = false
+		case "array":
+			args[name] = []interface{}{}
+		case "object":
+			args[name] = map[string]interface{}{}
+		}
+	}
+	if len(args) == 0 {
+		args["batesian_probe"] = "batesian-nonexistent-" + randID
+	}
+	return args
+}
+
+var scopeAuthFlavored = regexp.MustCompile(`(?i)(insufficient[_ ]?scope|missing[_ ]?scope|invalid[_ ]?token|` +
+	`unauthorized|forbidden|access denied|not authorized|not permitted|permission denied|requires?[_ ](a )?scope|` +
+	`scope[s]? required|insufficient.?privilege|not allowed)`)
+
+// scopeShowsAuthRefusal reads a response text as an authorization refusal:
+// HTTP 401/403 with a challenge, or a message carrying authz vocabulary. A
+// validation message ("Item x not found") matches none of these.
+func scopeShowsAuthRefusal(text string) bool {
+	if strings.HasPrefix(text, "http 401") || strings.HasPrefix(text, "http 403") {
+		return true
+	}
+	return text != "" && scopeAuthFlavored.MatchString(text)
+}
+
+// scopeShowsDispatch reads a response text as evidence the dispatcher ran past
+// authorization: a protocol validation error, a not-found style tool error, or
+// any result content at all.
+func scopeShowsDispatch(text string) bool {
+	if text == "" {
+		return false
+	}
+	if strings.HasPrefix(text, "http ") {
+		return false // a status-line reading is always a refusal shape here
+	}
+	if scopeAuthFlavored.MatchString(text) {
+		return false // refused, not dispatched
+	}
+	lower := strings.ToLower(text)
+	for _, marker := range []string{
+		"unknown tool", "not found", "no such", "does not exist", "invalid param",
+		"invalid argument", "unexpected", "missing required", "validation",
+	} {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	// Any other result text means the handler ran too - but only report that as
+	// dispatch when it looks like an error outcome, since arbitrary success
+	// output would mean the tool genuinely executed. The invalid-subject probe
+	// makes real success implausible; treat non-empty as dispatched anyway and
+	// let the finding's evidence show the text.
+	return strings.TrimSpace(text) != ""
+}
+
+func scopeVerdictName(v probeVerdict) string {
+	switch v {
+	case probeRejected:
+		return "refused"
+	default:
+		return "no verdict"
+	}
+}
+
+func (e *ScopeConfusionExecutor) finding(endpoint string, cand scopeTool, fullName, limName string) attack.Finding {
+	return attack.Finding{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "high",
+		Confidence: attack.ConfirmedExploit,
+		Title:      fmt.Sprintf("MCP tools/call runs %q under a scope-limited credential", cand.Name),
+		Description: fmt.Sprintf(
+			"The identical invalid-subject tools/call for %q at %s was sent as two principals: %q "+
+				"(full) and %q (limited). Both reached argument validation, while an unauthenticated "+
+				"call was refused, so the server authenticates callers and then ignores what their "+
+				"credential is scoped to do. Every authenticated caller can reach the privileged tool "+
+				"surface regardless of granted scopes. Nothing executed during the probe: the subject "+
+				"arguments name objects that do not exist, and both calls stopped at validation.",
+			cand.Name, endpoint, fullName, limName),
+		Evidence: fmt.Sprintf(
+			"endpoint: %s\ntool: %s\nfull principal %q: dispatched (validation answered)\n"+
+				"limited principal %q: dispatched (validation answered)\n"+
+				"anonymous control: refused",
+			endpoint, cand.Name, fullName, limName),
+		Remediation: e.rule.Remediation,
+		TargetURL:   endpoint,
+	}
+}

--- a/internal/attack/mcp/scope_confusion_test.go
+++ b/internal/attack/mcp/scope_confusion_test.go
@@ -1,0 +1,307 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcp "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+func scopeRC() attack.RuleContext {
+	return attack.RuleContext{
+		ID:          "mcp-scope-confusion-001",
+		Name:        "MCP Tool Scope Confusion",
+		Severity:    "high",
+		Remediation: "Check tool scopes at dispatch, after authentication.",
+	}
+}
+
+// scopeOpts carries the two identities every scope run needs: A full, B
+// limited, in the order the rule documents.
+func scopeOpts() attack.Options {
+	return attack.Options{
+		TimeoutSeconds: 5,
+		Principals: []attack.Principal{
+			{Name: "full", Token: "tok-full-a"},
+			{Name: "limited", Token: "tok-lim-b"},
+		},
+	}
+}
+
+// scopeServer models an MCP server with a read-only listing tool and a
+// privileged delete tool.
+//
+//   - auth gates every non-initialize method on a known bearer token
+//   - enforceWriteScope additionally refuses delete_item without the write
+//     scope, before argument validation (the patched posture)
+type scopeServer struct {
+	auth              bool
+	enforceWriteScope bool
+}
+
+func (s *scopeServer) validToken(token string) bool {
+	return token == "tok-full-a" || token == "tok-lim-b"
+}
+
+func (s *scopeServer) hasWrite(token string) bool { return token == "tok-full-a" }
+
+func (s *scopeServer) tools() []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"name":        "list_items",
+			"annotations": map[string]interface{}{"readOnlyHint": true},
+			"inputSchema": map[string]interface{}{
+				"type": "object", "properties": map[string]interface{}{}, "required": []interface{}{},
+			},
+		},
+		{
+			"name":        "delete_item",
+			"annotations": map[string]interface{}{"readOnlyHint": false},
+			"inputSchema": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"item_id": map[string]interface{}{"type": "string"},
+				},
+				"required": []interface{}{"item_id"},
+			},
+		},
+	}
+}
+
+func (s *scopeServer) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string      `json:"method"`
+			ID     json.Number `json:"id"`
+			Params struct {
+				Name      string                 `json:"name"`
+				Arguments map[string]interface{} `json:"arguments"`
+			} `json:"params"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+
+		reply := func(payload map[string]interface{}, status int) {
+			if status != http.StatusOK {
+				w.WriteHeader(status)
+			}
+			_ = json.NewEncoder(w).Encode(payload)
+		}
+		rpcErr := func(code int, msg string, status int) {
+			reply(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req.ID,
+				"error": map[string]interface{}{"code": code, "message": msg},
+			}, status)
+		}
+
+		switch req.Method {
+		case "initialize":
+			w.Header().Set("Mcp-Session-Id", "sess-scope")
+			reply(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req.ID,
+				"result": map[string]interface{}{
+					"protocolVersion": "2025-06-18",
+					"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+					"serverInfo":      map[string]interface{}{"name": "scope-fixture", "version": "1"},
+				},
+			}, http.StatusOK)
+			return
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+
+		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if s.auth && !s.validToken(token) {
+			rpcErr(-32000, "unauthorized: missing or invalid bearer token", http.StatusUnauthorized)
+			return
+		}
+
+		switch req.Method {
+		case "tools/list":
+			reply(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req.ID,
+				"result": map[string]interface{}{"tools": s.tools()},
+			}, http.StatusOK)
+
+		case "tools/call":
+			switch req.Params.Name {
+			case "list_items":
+				reply(map[string]interface{}{
+					"jsonrpc": "2.0", "id": req.ID,
+					"result": map[string]interface{}{
+						"content": []map[string]interface{}{{"type": "text", "text": "0 item(s)"}},
+					},
+				}, http.StatusOK)
+			case "delete_item":
+				if s.enforceWriteScope && !s.hasWrite(token) {
+					rpcErr(-32000, "insufficient_scope: items:write required", http.StatusForbidden)
+					return
+				}
+				itemID, _ := req.Params.Arguments["item_id"].(string)
+				msg := "Item " + itemID + " not found"
+				if itemID == "" {
+					msg = "invalid params: item_id required"
+				}
+				rpcErr(-32602, msg, http.StatusOK)
+			default:
+				rpcErr(-32601, "Method not found", http.StatusOK)
+			}
+
+		default:
+			rpcErr(-32601, "Method not found", http.StatusOK)
+		}
+	}
+}
+
+func runScope(t *testing.T, ts *httptest.Server) ([]attack.Finding, error) {
+	t.Helper()
+	return mcp.NewScopeConfusionExecutor(scopeRC()).Execute(context.Background(), ts.URL, scopeOpts())
+}
+
+// TestScope_VulnerableFires: both tokens authenticate; only the full one
+// should reach delete_item. The limited one dispatches identically while the
+// anonymous control is refused, which is the confirmed failure.
+func TestScope_VulnerableFires(t *testing.T) {
+	ts := httptest.NewServer((&scopeServer{auth: true}).handler())
+	defer ts.Close()
+
+	findings, err := runScope(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 finding, got %d: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Confidence != attack.ConfirmedExploit || f.Severity != "high" {
+		t.Errorf("want high/ConfirmedExploit, got %q/%q", f.Severity, f.Confidence)
+	}
+	if !strings.Contains(f.Evidence, "limited principal") {
+		t.Errorf("evidence should name the limited principal's dispatch, got: %q", f.Evidence)
+	}
+}
+
+// TestScope_PatchedStaysSilent: the limited token is refused with
+// insufficient_scope before validation on the privileged call. The boundary
+// held; MUST stay silent.
+func TestScope_PatchedStaysSilent(t *testing.T) {
+	ts := httptest.NewServer((&scopeServer{auth: true, enforceWriteScope: true}).handler())
+	defer ts.Close()
+
+	findings, err := runScope(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings when scopes are enforced, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestScope_OpenSuppressed: no authentication anywhere. The anonymous control
+// dispatches, so identity gates nothing and the surface belongs to
+// mcp-tools-unauth-001 rather than to a scope verdict.
+func TestScope_OpenSuppressed(t *testing.T) {
+	ts := httptest.NewServer((&scopeServer{auth: false}).handler())
+	defer ts.Close()
+
+	findings, err := runScope(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings against an open server, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestScope_MissingPrincipalsNotTested: one identity cannot cross a scope
+// boundary. With no credentials configured but the tool surface reachable,
+// the rule reports not tested naming what is missing, never clean.
+func TestScope_MissingPrincipalsNotTested(t *testing.T) {
+	ts := httptest.NewServer((&scopeServer{auth: false}).handler())
+	defer ts.Close()
+
+	findings, err := mcp.NewScopeConfusionExecutor(scopeRC()).
+		Execute(context.Background(), ts.URL, attack.Options{TimeoutSeconds: 5})
+	if err == nil {
+		t.Fatalf("expected an inconclusive error with fewer than two principals")
+	}
+	if !strings.Contains(err.Error(), "principal") {
+		t.Errorf("expected the reason to name the missing principals, got: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings alongside the inconclusive result, got %d", len(findings))
+	}
+}
+
+// TestScope_LimitedRefusedNotTested: the limited token is dead, so its
+// refusals say nothing about scoping. The rule reports not tested naming it.
+func TestScope_LimitedRefusedNotTested(t *testing.T) {
+	ts := httptest.NewServer((&scopeServer{auth: true, enforceWriteScope: true}).handler())
+	defer ts.Close()
+
+	opts := scopeOpts()
+	opts.Principals[1].Token = "tok-dead"
+	findings, err := mcp.NewScopeConfusionExecutor(scopeRC()).Execute(context.Background(), ts.URL, opts)
+	if err == nil {
+		t.Fatalf("expected an inconclusive error when the limited credential is refused outright")
+	}
+	if !strings.Contains(err.Error(), "limited principal") {
+		t.Errorf("expected the reason to name the limited principal, got: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings alongside the inconclusive result, got %d", len(findings))
+	}
+}
+
+// TestScope_NoPrivilegedCandidatesClean: only read-only annotated tools are
+// listed, so nothing qualifies as privileged and the wire is clean by
+// determination rather than by silence.
+func TestScope_NoPrivilegedCandidatesClean(t *testing.T) {
+	base := (&scopeServer{auth: true}).handler()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		var probe struct {
+			Method string `json:"method"`
+		}
+		if json.Unmarshal(raw, &probe) != nil {
+			http.NotFound(w, r)
+			return
+		}
+		if probe.Method == "tools/list" {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": 1,
+				"result": map[string]interface{}{"tools": []map[string]interface{}{{
+					"name":        "list_items",
+					"annotations": map[string]interface{}{"readOnlyHint": true},
+					"inputSchema": map[string]interface{}{
+						"type": "object", "properties": map[string]interface{}{}, "required": []interface{}{},
+					},
+				}}},
+			})
+			return
+		}
+		// Hand the buffered body back before delegating: the probe above
+		// consumed the stream, and the wrapped handler routes on it too.
+		r.Body = io.NopCloser(strings.NewReader(string(raw)))
+		base.ServeHTTP(w, r)
+	}))
+	defer ts.Close()
+
+	findings, err := runScope(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings with no privileged candidates, got %d: %+v", len(findings), findings)
+	}
+}

--- a/rules/mcp/scope-confusion-001.yaml
+++ b/rules/mcp/scope-confusion-001.yaml
@@ -1,0 +1,80 @@
+id: mcp-scope-confusion-001
+info:
+  name: MCP Tool Scope Confusion (Valid Token, Privileged Dispatch)
+  author: batesian
+  severity: high
+  description: |
+    Tests whether tools/call enforces the scopes of the credential presented,
+    or merely that A credential exists. The failure sits between two rules
+    that already ship: mcp-token-replay-001 covers tokens the server cannot
+    have validated (signature checks absent), and mcp-oauth-dcr-001 covers
+    registration granting privileged scopes. Neither says anything about a
+    validly-signed, genuinely-issued token whose scope set is too small.
+    Servers that authenticate correctly and then authorize nothing per-tool
+    hand every authenticated caller every tool. That is OWASP MCP02 scope
+    creep, and the Security Best Practices call for least privilege.
+
+    Two identities drive it, via the --principal machinery the
+    cross-principal rules use: principal A holds full privilege, principal B
+    holds a deliberately limited one. For each privileged-looking candidate
+    tool (annotations declaring it non-read-only or destructive, or write/
+    admin vocabulary in its name), the rule sends the SAME invalid-subject
+    call twice:
+
+      1. As principal A. This baseline must reach argument validation - a
+         -32602-style answer proves the dispatcher ran for a legitimate
+         caller and that the call shape itself is not what gets refused.
+      2. As principal B. An authorization refusal here is the boundary
+         holding, which is the pass sought. Dispatching like A while an
+         unauthenticated control was refused means the server authenticates
+         callers and then ignores what their credential is scoped to do -
+         reported confirmed at high.
+
+    SAFETY. The arguments are invalid on purpose: every required string
+    parameter names an object that does not exist. A scope-ignoring server
+    stops at argument validation and executes nothing; the oracle never needs
+    a successful state-changing call. This is the same never-executes trick
+    mcp-tools-unauth-001 uses on its dispatch probe.
+
+    CONTROLS. The limited credential must succeed somewhere (tools/list)
+    before any refusal is read as a scope decision rather than a dead token;
+    an anonymous call on the first candidate must be refused, since a server
+    dispatching unauthenticated calls gates nothing by identity and belongs
+    to mcp-tools-unauth-001 instead.
+
+    PRECONDITION. Two distinct credentials are required, because crossing a
+    scope boundary needs two differently-scoped ones. With fewer - or with
+    two principals presenting the same credential - the rule reports not
+    tested rather than clean, naming what was missing.
+
+  references:
+    - https://modelcontextprotocol.io/docs/2026-07-28/tutorials/security/security_best_practices
+    - https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization
+    - https://owasp.org/www-project-mcp-top-10/
+    - https://cwe.mitre.org/data/definitions/285.html
+
+  tags:
+    - mcp
+    - oauth
+    - scope-enforcement
+    - least-privilege
+    - tools
+    - cwe-285
+
+attack:
+  protocol: mcp
+  type: mcp-scope-confusion
+
+remediation: |
+  1. Map every tool to the scope(s) it requires at registration time, and
+     check those scopes at dispatch - before validating arguments, but after
+     authenticating the caller.
+  2. On failure, return an OAuth-shaped insufficient_scope error (RFC 6750
+     section 3.1) so clients can distinguish "not allowed" from "not found".
+  3. Do not treat mere possession of a valid token as authorization for every
+     tool; authentication answers who the caller is, scopes answer what it
+     may do.
+  4. Keep granted scopes minimal at issuance; a server cannot enforce scopes
+     narrower than the tokens it hands out carry.
+  5. Log scope-refusals separately from validation errors so operators can
+     see probing of the boundary.

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -31,7 +31,7 @@ a run that treats it as a clean result is reporting coverage it does not have.
 
 ## Server Registry
 
-The bundled rule set is **18 A2A + 22 MCP = 40 rules**. Every rule's primary
+The bundled rule set is **18 A2A + 23 MCP = 41 rules**. Every rule's primary
 validation is an in-process `net/http/httptest` harness in its Go
 `*_test.go` (multiple server postures: vulnerable must fire / patched / open /
 benign must stay silent). The Python servers below are optional standalone
@@ -73,8 +73,9 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_session_as_credential_server.py` | 7803 | `mcp-session-as-credential-001` (needs `--token tok-a`; four postures, see below) |
 | `mcp_log_optin_server.py` | 7804 | `mcp-log-optin-001` must fire on `always`; stay silent on `on-optin`; report not tested on `never` (three postures, see below) |
 | `mcp_tool_param_traversal_server.py` | 7805 | `mcp-tool-param-traversal-001` must fire on `vulnerable`; stay silent on `patched` (two postures, see below) |
+| `mcp_scope_confusion_server.py` | 7806 | `mcp-scope-confusion-001` must fire on `vulnerable`; stay silent on `patched` and `open` (three postures, see below; needs `--token tok-a` and two principals) |
 
-**Coverage.** 39 of the 40 rules have a standalone Python fixture above, and each
+**Coverage.** 40 of the 41 rules have a standalone Python fixture above, and each
 of those was checked by actually running it rather than by reading this table. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
 (`internal/attack/mcp/token_replay_test.go`); the same is true of the per-rule
@@ -345,6 +346,30 @@ The scanner may only dispatch annotated tools, so `admin_read` staying broken an
 untouched is part of the validation: if a finding ever names it, the safety gate
 is gone. The oracle reads resolution disclosures, not file content - every probe
 names a file that does not exist, in either posture.
+
+**`mcp_scope_confusion_server.py` takes a posture argument**, defaulting to
+`vulnerable`, and needs `--token tok-a` plus two principals:
+
+```sh
+python testdata/mcp_scope_confusion_server.py vulnerable  # rule must fire
+python testdata/mcp_scope_confusion_server.py patched     # rule must stay silent
+python testdata/mcp_scope_confusion_server.py open        # rule must stay silent
+```
+
+```sh
+batesian scan --target http://127.0.0.1:7806 --token tok-a \
+  --principal name=full,token=tok-a --principal name=limited,token=tok-b -v
+```
+
+All postures authenticate every non-initialize method; `tok-a` is the full
+principal and `tok-b` the limited one. In `vulnerable` both reach everything,
+so `delete_item` dispatches for either while an anonymous call is refused -
+the confirmed failure. In `patched` the limited token draws
+`insufficient_scope` before argument validation and the boundary held. In
+`open` nothing authenticates at all, the anonymous control dispatches, and the
+rule suppresses itself because identity gates nothing here (that surface is
+`mcp-tools-unauth-001`'s). Every call names an item id that does not exist, so
+nothing is ever deleted in any posture.
 
 > Note: some multi-rule Python servers may still carry leftover routes from rules
 > that were pruned from the scanner. Only the rule IDs listed in the table above

--- a/testdata/mcp_scope_confusion_server.py
+++ b/testdata/mcp_scope_confusion_server.py
@@ -1,0 +1,157 @@
+"""
+Deliberately vulnerable MCP test server for validating:
+
+  mcp-scope-confusion-001: a server that authenticates every tools/call and
+  then ignores what the credential is scoped to do. Both bearer tokens are
+  valid; in the vulnerable posture the limited one reaches every tool the
+  full one can.
+
+Postures:
+  vulnerable (default) - any accepted bearer authorizes everything. The rule
+                         MUST fire confirmed/high on delete_item.
+  patched              - tokens carry scopes (tok-a -> items:write+read,
+                         tok-b -> items:read) and privileged tools check them
+                         first, refusing with an insufficient_scope message
+                         before argument validation. The rule MUST stay silent.
+  open                 - no authentication anywhere. The anonymous control
+                         dispatches, so scope enforcement is not the boundary
+                         this rule can speak about, and it MUST stay silent
+                         (the surface belongs to mcp-tools-unauth-001).
+
+Tokens: tok-a is the full principal, tok-b the limited one. Pass
+--token tok-a plus two --principal flags exactly as validate_secured_agent.py
+does for the cross-principal rules.
+
+Both postures serve list_items (readOnlyHint true) and delete_item (explicitly
+non-read-only). Every probe call names an item_id that does not exist, so
+nothing is ever deleted regardless of posture.
+
+Validate against it:
+  python testdata/mcp_scope_confusion_server.py              # vulnerable
+  python testdata/mcp_scope_confusion_server.py patched      # silent
+  python testdata/mcp_scope_confusion_server.py open         # silent
+
+Run: python testdata/mcp_scope_confusion_server.py [posture]
+"""
+import sys
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+import uvicorn
+
+PORT = 7806
+
+FULL_SCOPES = {"items:read", "items:write"}
+LIMITED_SCOPES = {"items:read"}
+
+TOOLS = [
+    {
+        "name": "list_items",
+        "description": "List stored items.",
+        "annotations": {"readOnlyHint": True},
+        "inputSchema": {"type": "object", "properties": {}, "required": []},
+    },
+    {
+        "name": "delete_item",
+        "description": "Delete a stored item.",
+        "annotations": {"readOnlyHint": False},
+        "inputSchema": {
+            "type": "object",
+            "properties": {"item_id": {"type": "string"}},
+            "required": ["item_id"],
+        },
+    },
+]
+
+ITEMS_STORE = {}  # empty on purpose: probes name ids that cannot exist
+
+
+def token_scopes(token: str):
+    if token == "tok-a":
+        return FULL_SCOPES
+    if token == "tok-b":
+        return LIMITED_SCOPES
+    return None
+
+
+async def jsonrpc(request: Request) -> JSONResponse:
+    body = await request.json()
+    method = body.get("method")
+    rid = body.get("id", 1)
+    auth = request.headers.get("authorization", "")
+    token = auth[len("Bearer "):] if auth.startswith("Bearer ") else ""
+
+    if method == "initialize":
+        return JSONResponse({
+            "jsonrpc": "2.0", "id": rid,
+            "result": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "scope-confusion-fixture", "version": "1.0"},
+            },
+        })
+    if method == "notifications/initialized":
+        return JSONResponse({"jsonrpc": "2.0", "id": rid, "result": {}})
+
+    posture = request.app.state.posture
+    if posture == "open":
+        scopes = FULL_SCOPES  # no gate at all: everyone reads as full
+    else:
+        scopes = token_scopes(token)
+        if scopes is None:
+            return JSONResponse(
+                {"jsonrpc": "2.0", "id": rid,
+                 "error": {"code": -32000, "message": "unauthorized: missing or invalid bearer token"}},
+                status_code=401,
+            )
+
+    if method == "tools/list":
+        return JSONResponse({"jsonrpc": "2.0", "id": rid, "result": {"tools": TOOLS}})
+    if method == "tools/call":
+        params = body.get("params", {})
+        name = params.get("name")
+        args = params.get("arguments", {}) or {}
+
+        if name == "list_items":
+            return JSONResponse({"jsonrpc": "2.0", "id": rid, "result": {
+                "content": [{"type": "text", "text": f"{len(ITEMS_STORE)} item(s)"}], "isError": False}})
+
+        if name == "delete_item":
+            item_id = args.get("item_id", "")
+            if posture == "patched" and "items:write" not in scopes:
+                # Refuse BEFORE validation, naming the missing scope the way an
+                # OAuth resource server does.
+                return JSONResponse({
+                    "jsonrpc": "2.0", "id": rid,
+                    "error": {"code": -32000,
+                              "message": f"insufficient_scope: items:write required (token has {sorted(scopes)})"},
+                }, status_code=403)
+            # VULNERABLE (and open): dispatch reached; validation runs after.
+            if not item_id:
+                return JSONResponse({
+                    "jsonrpc": "2.0", "id": rid,
+                    "error": {"code": -32602, "message": "invalid params: item_id required"},
+                })
+            if item_id not in ITEMS_STORE:
+                return JSONResponse({
+                    "jsonrpc": "2.0", "id": rid,
+                    "error": {"code": -32602, "message": f"Item {item_id} not found"},
+                })
+            ITEMS_STORE.pop(item_id, None)
+            return JSONResponse({"jsonrpc": "2.0", "id": rid, "result": {
+                "content": [{"type": "text", "text": "deleted"}], "isError": False}})
+
+    return JSONResponse({
+        "jsonrpc": "2.0", "id": rid,
+        "error": {"code": -32601, "message": "Method not found"},
+    })
+
+
+app = Starlette(routes=[Route("/", jsonrpc, methods=["POST"]), Route("/mcp", jsonrpc, methods=["POST"])])
+
+
+if __name__ == "__main__":
+    app.state.posture = sys.argv[1] if len(sys.argv) > 1 else "vulnerable"
+    print(f"[*] MCP scope-confusion fixture ({app.state.posture}) on port {PORT}", flush=True)
+    uvicorn.run(app, host="127.0.0.1", port=PORT)


### PR DESCRIPTION
A server can authenticate every caller correctly and still authorize nothing per-tool: any valid token reaches every tool whatever it is scoped to do. That failure sits between the rules already here - `mcp-token-replay-001` covers tokens that were never validated, `mcp-oauth-dcr-001` covers registration granting privileged scopes - and nothing covered a validly-signed, genuinely-issued token whose scope set was too small. OWASP calls this MCP02 scope creep; the Security Best Practices call for least privilege.

**How it drives.** Two identities via the existing `--principal` machinery: a full principal and a limited one (your pick from the design question). Each privileged-looking candidate - annotations declaring it non-read-only or destructive, or write/admin vocabulary in its name - gets the same invalid-subject call twice:

- full principal dispatches (baseline: the call shape itself passes)
- limited principal refused with an authz error => boundary held, clean
- limited principal dispatches like the full one, while an anonymous control was refused => confirmed scope confusion at high

**Safety.** The arguments name objects that do not exist, so a scope-ignoring server stops at argument validation and executes nothing. The oracle never needs a successful state-changing call - the same never-executes trick `mcp-tools-unauth-001` uses.

**Controls.** The limited credential must succeed somewhere before its refusals count as scope decisions rather than a dead token. The anonymous control must be refused, since an open server gates nothing by identity and belongs to `mcp-tools-unauth-001`. Fewer than two distinct principals reports not tested naming what is missing, never clean; a shared credential across both names reports not tested too.

Implementation notes:
- modern-wire calls go through `postShaping` so the era's mandatory mirrored headers travel with each principal's credential; hand-built headers would send legacy shapes onto the stateless wire and read its `-32020` refusals as authorization decisions
- findings from the 2026-07-28 wire carry the standard era label

Changes:
- `internal/attack/mcp/scope_confusion.go` + harness (six postures: vulnerable fires confirmed/high, patched silent, open suppressed, missing principals not-tested, dead limited token not-tested, no-candidates clean)
- `rules/mcp/scope-confusion-001.yaml` - CWE-285, remediation covering per-tool scope maps and RFC 6750 insufficient_scope errors
- `testdata/mcp_scope_confusion_server.py` (port 7806) - vulnerable/patched/open postures on tok-a/tok-b
- counts updated: 23 MCP / 41 total in `README.md`, catalog table plus detail section in `docs/rules-mcp.md`, registry row in `testdata/README.md`

Verified locally in the pinned containers: gofmt clean, vet, race suite green, lint 0 issues, fixture Python syntax checked.