### PR TITLE
rule(mcp): detect shadow MCP surfaces on adjacent ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ CLI for adversarial testing of [A2A](https://a2a-protocol.org) and [MCP](https:/
 
 ## What ships
 
-Bundled rules: **18 A2A, 23 MCP (41 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
+Bundled rules: **18 A2A, 24 MCP (42 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
 
 - [A2A rules](docs/rules-a2a.md) (18)
 - [MCP rules](docs/rules-mcp.md) (21)
@@ -35,6 +35,7 @@ Coverage spans:
 - **Request & task integrity** - task IDOR, agent-role injection, artifact tampering, SEP-2243 header/body routing, SSE resumption replay
 - **Multi-party isolation** - cross-tenant isolation, cross-principal task enumeration, session/context fixation, session id accepted as a credential, delegation chain-of-custody, cross-principal task cancellation, cross-context MCP task and result access
 - **SSRF & secret leakage** - push-notification SSRF, push control-plane binding, OAuth discovery/metadata SSRF, credential leakage into responses
+- **Shadow surfaces** - unauthenticated inspector/dashboard listeners on adjacent ports, graded by whether a foreign origin can reach them
 - **Unauthenticated & cross-origin access** - exposed MCP tools, resources, prompt templates, completion suggestions, and log-level control, Streamable HTTP Origin validation (DNS rebinding)
 - **Tool argument integrity** - path traversal in read-only MCP tool arguments (sandbox escape via resolution evidence, zero content read)
 

--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -1,6 +1,6 @@
 # MCP Attack Rules
 
-Batesian ships **23 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
+Batesian ships **24 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
 Every rule is an active probe: it sends crafted protocol traffic and judges the
 server's actual response. Rules are deliberately scoped to MCP-specific semantics
 (OAuth 2.1 authorization, DCR, audience binding, discovery-chain metadata-fetch
@@ -173,6 +173,7 @@ candidate answers does a rule report that it could not test.
 | `mcp-log-optin-001` | [Log Notifications Without a Per-Request Opt-In](#mcp-log-optin-001) | Medium | confirmed | CWE-200 / CWE-532 |
 | `mcp-tool-param-traversal-001` | [Tool Path Traversal](#mcp-tool-param-traversal-001) | High | confirmed | CWE-22 |
 | `mcp-scope-confusion-001` | [Tool Scope Confusion](#mcp-scope-confusion-001) | High | confirmed | CWE-285 |
+| `mcp-shadow-surface-001` | [Shadow MCP Surface on an Adjacent Port](#mcp-shadow-surface-001) | High / Medium / Low | confirmed / indicator | CWE-488 |
 
 ---
 
@@ -934,3 +935,43 @@ count one defect twice under the wrong name.
 scope boundary needs two differently-scoped ones. With fewer - or with two
 principals presenting the same credential - the rule reports **not tested**
 rather than clean, naming what was missing.
+
+---
+
+### mcp-shadow-surface-001
+
+**Shadow MCP Surface on an Adjacent Port (Inspector/Dashboard Class)** | Severity: High / Medium / Low | confirmed / indicator | CWE-488
+
+Looks for MCP surfaces the target host serves on ports adjacent to the one the
+scan was aimed at. Developer dashboards and inspector proxies bind to loopback
+or every interface with no authentication, on ports nobody associates with the
+production service, and operators rarely know these listeners exist - so
+scanning only the named URL misses them entirely.
+
+The port list is deliberately short and documented rather than a sweep; each
+entry is a default binding of a product with a published unauthenticated-RCE
+advisory:
+
+- **6277** - MCP Inspector proxy server default (CVE-2025-49596)
+- **24282** - Serena dashboard/API default (CVE-2026-49471)
+- **3000** - the conventional dev-server port
+
+Probing a closed port costs one refused connection and is an answer, not a
+failure: silence from this rule means each documented port was checked and none
+spoke MCP.
+
+Three outcomes, all from read-only probes:
+
+1. An `initialize` answered without credentials is an open shadow surface.
+   The exact same request repeated with a foreign Origin separates severities:
+   both accepted is the full browser-reachable chain behind CVE-2025-49596
+   (**high**, confirmed); the foreign Origin refused leaves an unauthenticated
+   surface reachable from the machine and network path (**medium**, confirmed).
+2. A page fingerprinting as "MCP Inspector" or "Serena" whose protocol
+   endpoint does not answer the probed paths is a **low indicator** naming the
+   exposed product page.
+3. Anything else - closed port, unrelated service - produces nothing.
+
+Nothing is ever invoked through a discovered surface; the initialize that
+proves the finding creates no state the listener was not already prepared to
+track for its own clients.

--- a/internal/attack/mcp/shadow_export_test.go
+++ b/internal/attack/mcp/shadow_export_test.go
@@ -1,0 +1,15 @@
+package mcp
+
+// Test seams over the shadow-surface port list. The harness needs to aim the
+// executor at ephemeral listeners instead of the documented product ports;
+// production callers never touch these.
+
+// ShadowPorts returns a copy of the candidate port list.
+func ShadowPorts() []int {
+	return append([]int(nil), shadowPorts...)
+}
+
+// SetShadowPorts replaces the candidate port list.
+func SetShadowPorts(ports []int) {
+	shadowPorts = append([]int(nil), ports...)
+}

--- a/internal/attack/mcp/shadow_surface.go
+++ b/internal/attack/mcp/shadow_surface.go
@@ -1,0 +1,206 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// ShadowSurfaceExecutor looks for MCP surfaces the target host serves on
+// ports adjacent to the one it was given (rule mcp-shadow-surface-001).
+//
+// The class: developer dashboards and inspector proxies bind to loopback or
+// every interface with no authentication, on ports nobody associates with the
+// production service. An MCP server answering there is reachable by anything
+// on the machine and, when Origin validation is also absent, by any web page
+// in a browser via DNS rebinding - which is exactly the chain behind
+// CVE-2025-49596 (MCP Inspector), CVE-2026-49471 (Serena) and
+// CVE-2026-23744 (MCPJam). Operators rarely know these listeners exist, so
+// scanning only the URL they named misses them entirely.
+//
+// The port list is deliberately short and documented rather than a sweep:
+// each entry is a default binding of a product with a published unauth-RCE
+// advisory against it. Probing closed ports costs one refused connection.
+//
+//   - 6277  - MCP Inspector's proxy server default
+//   - 24282 - Serena's dashboard/API default
+//   - 3000  - the conventional dev-server port
+//
+// Oracles, all read-only:
+//
+//   - an initialize answered without credentials is an open shadow surface;
+//     repeating that exact request with a foreign Origin distinguishes the
+//     full browser-reachable chain (both accepted, high) from an open surface
+//     behind Origin validation (medium)
+//   - a dashboard fingerprint ("MCP Inspector", "Serena") without a drivable
+//     protocol endpoint is a low indicator naming the exposed product page
+type ShadowSurfaceExecutor struct {
+	rule attack.RuleContext
+}
+
+func init() {
+	attack.Register("mcp-shadow-surface", func(rc attack.RuleContext) attack.Executor { return NewShadowSurfaceExecutor(rc) })
+}
+
+func NewShadowSurfaceExecutor(r attack.RuleContext) *ShadowSurfaceExecutor {
+	return &ShadowSurfaceExecutor{rule: r}
+}
+
+// shadowPorts are the candidate ports probed on the target's host. Package
+// level so the harness can point it at ephemeral listeners; callers must not
+// mutate it outside tests.
+var shadowPorts = []int{6277, 24282, 3000}
+
+// shadowFingerprints are substrings treated as naming a known-vulnerable
+// dashboard product when its protocol endpoint cannot be driven directly.
+var shadowFingerprints = []string{"MCP Inspector", "Serena"}
+
+// shadowPaths are the candidate paths per port. Two, not four: the walk here
+// asks whether this listener speaks MCP at all, and a listener that answers
+// neither spelling is reported as closed to the protocol.
+var shadowPaths = []string{"/mcp", "/"}
+
+func (e *ShadowSurfaceExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
+	vars := attack.NewVars(target, opts.OOBListenerURL)
+	client := attack.NewUnauthHTTPClient(opts, vars)
+
+	u, err := url.Parse(vars.BaseURL)
+	if err != nil || u.Hostname() == "" {
+		return nil, fmt.Errorf("%w: could not parse a host out of %s",
+			attack.ErrInconclusive, vars.BaseURL)
+	}
+	scheme := "http"
+	if u.Scheme == "https" {
+		scheme = "https"
+	}
+	targetPort := u.Port()
+
+	var findings []attack.Finding
+	for _, port := range shadowPorts {
+		if strconv.Itoa(port) == targetPort {
+			continue // the surface the operator already aimed at; other rules own it
+		}
+		if f := e.probePort(ctx, client, scheme, u.Hostname(), port); f != nil {
+			findings = append(findings, *f)
+		}
+	}
+	return findings, nil
+}
+
+// probePort characterises one listener. A nil return covers everything from
+// "connection refused" to "an unrelated service answered": none of those is a
+// shadow MCP surface, and a refused connection is itself an answer - silence
+// here means checked-and-absent, never could-not-tell.
+func (e *ShadowSurfaceExecutor) probePort(ctx context.Context, client *attack.HTTPClient, scheme, host string, port int) *attack.Finding {
+	base := scheme + "://" + host + ":" + strconv.Itoa(port)
+
+	marker := e.fingerprint(ctx, client, base)
+
+	mcpPath := ""
+	for _, path := range shadowPaths {
+		resp, err := client.POST(ctx, base+path, nil, legacyHandshakeBody())
+		if err != nil || !resp.IsSuccess() || !resp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
+			continue
+		}
+		mcpPath = path
+		break
+	}
+
+	if mcpPath == "" {
+		if marker == "" {
+			return nil
+		}
+		// A known dashboard is served but its protocol endpoint did not answer
+		// the probes. Exposed product page, undriven protocol: low indicator.
+		return &attack.Finding{
+			RuleID:     e.rule.ID,
+			RuleName:   e.rule.Name,
+			Severity:   "low",
+			Confidence: attack.RiskIndicator,
+			Title:      fmt.Sprintf("Known MCP dashboard served without credentials on %s:%d (%s)", host, port, marker),
+			Description: fmt.Sprintf(
+				"GET %s/ returned a page identifying as %q, but no MCP endpoint answered on the "+
+					"probed paths. The dashboard for this product is exposed to your scan position; "+
+					"whether its control endpoints are reachable depends on paths and methods this "+
+					"rule does not drive. Inspector-class dashboards have shipped with unauthenticated "+
+					"RCE when exposed like this (CVE-2025-49596), so confirm what else the process serves.",
+				base, marker),
+			Evidence:    fmt.Sprintf("GET %s/ -> HTTP 200, body names %q\nno MCP handshake on %s", base, marker, strings.Join(shadowPaths, ", ")),
+			Remediation: e.rule.Remediation,
+			TargetURL:   base + "/",
+		}
+	}
+
+	endpoint := base + mcpPath
+
+	// Foreign-Origin twin of the request that just succeeded: identical bytes,
+	// one header different. Accepting it is the browser-reachability half of
+	// the rebinding chain.
+	rebindResp, rebindErr := client.POST(ctx, endpoint, map[string]string{"Origin": foreignOrigin}, legacyHandshakeBody())
+	originOpen := rebindErr == nil && rebindResp.IsSuccess() &&
+		rebindResp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`)
+
+	sev, title := "medium", fmt.Sprintf("MCP surface answers without authentication on %s:%d%s", host, port, mcpPath)
+	if originOpen {
+		sev = "high"
+		title = fmt.Sprintf("Unauthenticated MCP surface accepts foreign Origins on %s:%d%s (DNS-rebinding chain)", host, port, mcpPath)
+	}
+	return &attack.Finding{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   sev,
+		Confidence: attack.ConfirmedExploit,
+		Title:      title,
+		Description: fmt.Sprintf(
+			"The host behind %s also answers an MCP initialize at %s with no credentials. This "+
+				"listener sits on a non-standard port, away from the service the operator named, which "+
+				"is where inspector and dashboard processes end up after setup.", scheme+"://"+host, endpoint) +
+			func() string {
+				if originOpen {
+					return " The same handshake was accepted carrying a foreign Origin, so a page on " +
+						"another origin can reach this surface from a victim's browser - the full " +
+						"precondition pair behind CVE-2025-49596. Anything the process can do, the " +
+						"page can drive."
+				}
+				return " A foreign-Origin twin of the same handshake was refused, so direct cross-origin " +
+					"reaching is mitigated here; the surface is still unauthenticated for anything on " +
+					"the machine or network path."
+			}(),
+		Evidence: func() string {
+			lines := fmt.Sprintf("endpoint: %s\ninitialize without credentials: accepted\nforeign Origin twin (%s): ",
+				endpoint, foreignOrigin)
+			if originOpen {
+				lines += "accepted"
+			} else {
+				lines += "refused"
+			}
+			if marker != "" {
+				lines += "\npage fingerprint: " + marker
+			}
+			return lines
+		}(),
+		Remediation: e.rule.Remediation,
+		TargetURL:   endpoint,
+	}
+}
+
+// fingerprint GETs the listener root and returns the first known product name
+// its body admits, or empty. It is a hint used for evidence and the low
+// finding, never load-bearing on its own.
+func (e *ShadowSurfaceExecutor) fingerprint(ctx context.Context, client *attack.HTTPClient, base string) string {
+	resp, err := client.GET(ctx, base+"/", nil)
+	if err != nil || !resp.IsSuccess() {
+		return ""
+	}
+	body := strings.ToLower(string(resp.Body))
+	for _, fp := range shadowFingerprints {
+		if strings.Contains(body, strings.ToLower(fp)) {
+			return fp
+		}
+	}
+	return ""
+}

--- a/internal/attack/mcp/shadow_surface_test.go
+++ b/internal/attack/mcp/shadow_surface_test.go
@@ -1,0 +1,184 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcp "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+func shadowRC() attack.RuleContext {
+	return attack.RuleContext{
+		ID:          "mcp-shadow-surface-001",
+		Name:        "Shadow MCP Surface",
+		Severity:    "high",
+		Remediation: "Bind inspector processes to loopback behind authentication.",
+	}
+}
+
+// withShadowPorts points the executor at the given ports for one test,
+// restoring the documented list afterwards.
+func withShadowPorts(t *testing.T, ports ...int) {
+	t.Helper()
+	old := mcp.ShadowPorts()
+	mcp.SetShadowPorts(ports)
+	t.Cleanup(func() { mcp.SetShadowPorts(old) })
+}
+
+// shadowMCPHandler models an inspector-style listener: an HTML page naming
+// the product, and an MCP initialize that answers on any POST path. The
+// foreignOriginRefused flag makes the Origin twin fail, as a hardened
+// deployment would.
+func shadowMCPHandler(foreignOriginRefused bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte("<html><title>MCP Inspector</title><body>proxy ready</body></html>"))
+		case foreignOriginRefused && r.Header.Get("Origin") != "":
+			http.Error(w, "forbidden origin", http.StatusForbidden)
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": 1,
+				"result": map[string]interface{}{
+					"protocolVersion": "2025-06-18",
+					"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+					"serverInfo":      map[string]interface{}{"name": "inspector-proxy", "version": "1"},
+				},
+			})
+		}
+	}
+}
+
+func runShadow(t *testing.T, target string) ([]attack.Finding, error) {
+	t.Helper()
+	return mcp.NewShadowSurfaceExecutor(shadowRC()).Execute(context.Background(), target, attack.Options{TimeoutSeconds: 5})
+}
+
+// TestShadow_OpenWithOpenOriginFires: an unauthenticated MCP surface on an
+// adjacent port that also accepts a foreign-Origin handshake is the full
+// browser-reachable chain. MUST fire confirmed/high.
+func TestShadow_OpenWithOpenOriginFires(t *testing.T) {
+	main := httptest.NewServer(http.NotFoundHandler())
+	defer main.Close()
+	shadow := httptest.NewServer(shadowMCPHandler(false))
+	defer shadow.Close()
+
+	withShadowPorts(t, portOf(shadow.URL))
+	findings, err := runShadow(t, main.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 finding, got %d: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Severity != "high" || f.Confidence != attack.ConfirmedExploit {
+		t.Errorf("want high/ConfirmedExploit, got %q/%q", f.Severity, f.Confidence)
+	}
+}
+
+// TestShadow_HardenedOriginMedium: the surface is open but refuses the
+// foreign-Origin twin. Rebinding is mitigated; the unauthenticated surface
+// remains and reports medium.
+func TestShadow_HardenedOriginMedium(t *testing.T) {
+	main := httptest.NewServer(http.NotFoundHandler())
+	defer main.Close()
+	shadow := httptest.NewServer(shadowMCPHandler(true))
+	defer shadow.Close()
+
+	withShadowPorts(t, portOf(shadow.URL))
+	findings, err := runShadow(t, main.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 finding, got %d: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Severity != "medium" || f.Confidence != attack.ConfirmedExploit {
+		t.Errorf("want medium/ConfirmedExploit, got %q/%q", f.Severity, f.Confidence)
+	}
+}
+
+// TestShadow_FingerprintOnlyLow: the page names a known product but no MCP
+// endpoint answers. Low indicator, not silence - the dashboard is exposed
+// even though its protocol could not be driven from here.
+func TestShadow_FingerprintOnlyLow(t *testing.T) {
+	main := httptest.NewServer(http.NotFoundHandler())
+	defer main.Close()
+	shadow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Dashboard page on every path, protocol never answers: exactly the
+		// "exposed product page, undriven control plane" posture.
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html><title>Serena Dashboard</title></html>"))
+	}))
+	defer shadow.Close()
+
+	withShadowPorts(t, portOf(shadow.URL))
+	findings, err := runShadow(t, main.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 finding, got %d: %+v", len(findings), findings)
+	}
+	if findings[0].Severity != "low" || findings[0].Confidence != attack.RiskIndicator {
+		t.Errorf("want low/RiskIndicator, got %q/%q", findings[0].Severity, findings[0].Confidence)
+	}
+}
+
+// TestShadow_NothingListeningClean: every probed port answers closed or with
+// an unrelated service. Checked-and-absent is a genuine clean result here -
+// each probe received an answer, so nothing went untested.
+func TestShadow_NothingListeningClean(t *testing.T) {
+	main := httptest.NewServer(http.NotFoundHandler())
+	defer main.Close()
+	unrelated := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("<html>totally normal site</html>"))
+	}))
+	defer unrelated.Close()
+
+	withShadowPorts(t, portOf(unrelated.URL))
+	findings, err := runShadow(t, main.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings with no shadow surfaces, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestShadow_TargetPortSkipped: the port named in the target URL belongs to
+// whatever rule owns that surface directly. The executor must not re-report
+// it as a shadow discovery.
+func TestShadow_TargetPortSkipped(t *testing.T) {
+	main := httptest.NewServer(shadowMCPHandler(false))
+	defer main.Close()
+
+	withShadowPorts(t, portOf(main.URL))
+	findings, err := runShadow(t, main.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings: the target's own port must be skipped, got %d: %+v", len(findings), findings)
+	}
+}
+
+func portOf(serverURL string) int {
+	for i := len(serverURL) - 1; i >= 0; i-- {
+		if serverURL[i] == ':' {
+			out := 0
+			for _, c := range serverURL[i+1:] {
+				out = out*10 + int(c-'0')
+			}
+			return out
+		}
+	}
+	panic("no port in " + serverURL)
+}

--- a/rules/mcp/shadow-surface-001.yaml
+++ b/rules/mcp/shadow-surface-001.yaml
@@ -1,0 +1,64 @@
+id: mcp-shadow-surface-001
+info:
+  name: Shadow MCP Surface on an Adjacent Port (Inspector/Dashboard Class)
+  author: batesian
+  severity: high
+  description: |
+    Looks for MCP surfaces the target host serves on ports adjacent to the one
+    the scan was aimed at. Developer dashboards and inspector proxies bind to
+    loopback or every interface with no authentication, on ports nobody
+    associates with the production service. Operators rarely know these
+    listeners exist, so scanning only the named URL misses them entirely.
+
+    The port list is deliberately short and documented - each entry is a
+    default binding of a product with a published unauthenticated-RCE advisory:
+
+      1. 6277  - MCP Inspector proxy server default (CVE-2025-49596)
+      2. 24282 - Serena dashboard/API default (CVE-2026-49471)
+      3. 3000  - the conventional dev-server port
+
+    ORACLES. An initialize answered without credentials is an open shadow
+    surface. Repeating that exact request with a foreign Origin separates two
+    severities: both accepted means a page on another origin can drive the
+    process from a victim's browser, which is the full precondition pair of
+    CVE-2025-49596 (high, confirmed); the foreign Origin refused leaves an
+    unauthenticated surface reachable from the machine and network path
+    (medium, confirmed). A page fingerprinting as a known dashboard without a
+    drivable protocol endpoint is a low indicator naming the product.
+
+    Every probe is read-only: an initialize creates no session state beyond
+    what the listener already tracks for its own clients, and nothing is ever
+    invoked through a discovered surface.
+
+    A closed port is an answer, not a failure: silence from this rule means
+    each documented port was checked and none spoke MCP.
+
+  references:
+    - https://modelcontextprotocol.io/docs/2026-07-28/tutorials/security/security_best_practices
+    - https://github.com/advisories/GHSA-7xvr-hh38-w3qf
+    - https://owasp.org/www-project-mcp-top-10/
+    - https://cwe.mitre.org/data/definitions/488.html
+
+  tags:
+    - mcp
+    - shadow-surface
+    - inspector
+    - dns-rebinding
+    - cwe-488
+
+attack:
+  protocol: mcp
+  type: mcp-shadow-surface
+
+remediation: |
+  1. Inventory listening processes on hosts that run MCP tooling
+     (`ss -tlnp` / `Get-NetTCPListener`); treat any inspector or dashboard
+     bound beyond strict loopback as an incident to close.
+  2. Do not run inspector or dashboard processes on production hosts. If one
+     is required, bind it to 127.0.0.1 explicitly and put it behind an
+     authenticated reverse proxy.
+  3. Validate the Origin header on every connection the listener accepts,
+     including non-initialize paths; reject foreign origins with 403 before
+     any protocol handling.
+  4. Require authentication on MCP surfaces even when they are "local only" -
+     the spec's own guidance is that local never stays local in practice.

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -31,7 +31,7 @@ a run that treats it as a clean result is reporting coverage it does not have.
 
 ## Server Registry
 
-The bundled rule set is **18 A2A + 23 MCP = 41 rules**. Every rule's primary
+The bundled rule set is **18 A2A + 24 MCP = 42 rules**. Every rule's primary
 validation is an in-process `net/http/httptest` harness in its Go
 `*_test.go` (multiple server postures: vulnerable must fire / patched / open /
 benign must stay silent). The Python servers below are optional standalone
@@ -74,8 +74,9 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_log_optin_server.py` | 7804 | `mcp-log-optin-001` must fire on `always`; stay silent on `on-optin`; report not tested on `never` (three postures, see below) |
 | `mcp_tool_param_traversal_server.py` | 7805 | `mcp-tool-param-traversal-001` must fire on `vulnerable`; stay silent on `patched` (two postures, see below) |
 | `mcp_scope_confusion_server.py` | 7806 | `mcp-scope-confusion-001` must fire on `vulnerable`; stay silent on `patched` and `open` (three postures, see below; needs `--token tok-a` and two principals) |
+| `mcp_shadow_surface_server.py` | 7807 + 6277 | `mcp-shadow-surface-001` must fire on `shadow-open`; fire medium on `shadow-hardened`; stay silent on `none` (three postures, see below) |
 
-**Coverage.** 40 of the 41 rules have a standalone Python fixture above, and each
+**Coverage.** 40 of the 42 rules have a standalone Python fixture above, and each
 of those was checked by actually running it rather than by reading this table. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
 (`internal/attack/mcp/token_replay_test.go`); the same is true of the per-rule
@@ -370,6 +371,24 @@ the confirmed failure. In `patched` the limited token draws
 rule suppresses itself because identity gates nothing here (that surface is
 `mcp-tools-unauth-001`'s). Every call names an item id that does not exist, so
 nothing is ever deleted in any posture.
+
+**`mcp_shadow_surface_server.py` binds two ports** and takes a posture argument,
+defaulting to `shadow-open`:
+
+```sh
+python testdata/mcp_shadow_surface_server.py shadow-open       # high finding
+python testdata/mcp_shadow_surface_server.py shadow-hardened   # medium finding
+python testdata/mcp_shadow_surface_server.py none              # silent
+batesian scan --target http://127.0.0.1:7807 --rule-ids mcp-shadow-surface-001 -v
+```
+
+Port 7807 is the named target and serves nothing but 404s. Port 6277 is the
+shadow listener - an inspector-style page plus an unauthenticated initialize -
+which exists to prove the rule finds surfaces the operator never aimed at. In
+`shadow-hardened` the listener refuses any request carrying a foreign Origin,
+so only the medium severity may appear. In `none` the second listener simply
+is not started; a closed port is an answer, and the rule reporting clean there
+is checked-and-absent rather than could-not-tell.
 
 > Note: some multi-rule Python servers may still carry leftover routes from rules
 > that were pruned from the scanner. Only the rule IDs listed in the table above

--- a/testdata/mcp_shadow_surface_server.py
+++ b/testdata/mcp_shadow_surface_server.py
@@ -1,0 +1,111 @@
+"""
+Deliberately vulnerable MCP test server for validating:
+
+  mcp-shadow-surface-001: an MCP surface the operator did not aim at. This
+  fixture binds TWO listeners:
+
+    port 7807 - the "named target". Serves nothing but 404s, so the scan has
+                no protocol surface where it was pointed.
+    port 6277 - the shadow listener, an inspector-style proxy that answers an
+                unauthenticated initialize and (in the default posture)
+                accepts a foreign Origin as well.
+
+Postures:
+  shadow-open (default) - 6277 answers initialize without credentials AND
+                          accepts the foreign-Origin twin.
+                          The rule MUST fire confirmed/high.
+  shadow-hardened       - 6277 still answers anonymously, but refuses any
+                          request carrying a foreign Origin with 403.
+                          The rule MUST fire confirmed/medium.
+  none                  - no shadow listener at all; only 7807 runs.
+                          The rule MUST stay silent.
+
+The shadow page fingerprints as "MCP Inspector" so the evidence names the
+product class. Nothing beyond initialize is ever served: no tool executes,
+no session state matters.
+
+Validate against it:
+  python testdata/mcp_shadow_surface_server.py                   # shadow-open
+  python testdata/mcp_shadow_surface_server.py shadow-hardened   # medium
+  python testdata/mcp_shadow_surface_server.py none              # silent
+
+Run: python testdata/mcp_shadow_surface_server.py [posture]
+Scan: batesian scan --target http://127.0.0.1:7807 --rule-ids mcp-shadow-surface-001 -v
+"""
+import json
+import sys
+import threading
+
+import uvicorn
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, JSONResponse
+from starlette.routing import Route
+
+MAIN_PORT = 7807
+SHADOW_PORT = 6277
+
+FOREIGN_ORIGIN = "dns-rebind.batesian.invalid"
+
+
+async def main_404(request: Request) -> JSONResponse:
+    return JSONResponse({"error": "not found"}, status_code=404)
+
+
+def handshake_result(rid):
+    return {
+        "jsonrpc": "2.0", "id": rid,
+        "result": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "inspector-proxy", "version": "1.0"},
+        },
+    }
+
+
+async def shadow_endpoint(request: Request) -> JSONResponse:
+    if request.app.state.posture == "shadow-hardened":
+        origin = request.headers.get("origin", "")
+        if origin and FOREIGN_ORIGIN in origin:
+            return JSONResponse(
+                {"jsonrpc": "2.0", "id": 1,
+                 "error": {"code": -32000, "message": "forbidden origin"}},
+                status_code=403,
+            )
+    try:
+        rid = (await request.json()).get("id", 1)
+    except Exception:
+        rid = 1
+    return JSONResponse(handshake_result(rid))
+
+
+async def shadow_page(request: Request) -> HTMLResponse:
+    # Fingerprint on purpose: the evidence should name the product class.
+    return HTMLResponse("<html><head><title>MCP Inspector</title></head>"
+                        "<body>proxy ready</body></html>")
+
+
+shadow_app = Starlette(routes=[
+    Route("/{path:path}", shadow_endpoint, methods=["POST"]),
+    Route("/", shadow_page, methods=["GET"]),
+])
+main_app = Starlette(routes=[Route("/{path:path}", main_404, methods=["GET", "POST"])])
+
+
+def serve(app, port):
+    uvicorn.run(app, host="127.0.0.1", port=port, log_level="warning")
+
+
+if __name__ == "__main__":
+    posture = sys.argv[1] if len(sys.argv) > 1 else "shadow-open"
+    print(f"[*] shadow-surface fixture ({posture}): named target on {MAIN_PORT}, "
+          f"shadow listener on {SHADOW_PORT}", flush=True)
+
+    if posture == "none":
+        print("[*] shadow listener intentionally not started", flush=True)
+    else:
+        shadow_app.state.posture = posture
+        t = threading.Thread(target=serve, args=(shadow_app, SHADOW_PORT), daemon=True)
+        t.start()
+
+    serve(main_app, MAIN_PORT)


### PR DESCRIPTION
Inspector and dashboard processes bind to loopback or every interface with no authentication, on ports nobody associates with the production service. Operators rarely know these listeners exist, so scanning only the named URL misses them entirely. An unauthenticated MCP surface that also accepts a foreign Origin is the full precondition pair behind CVE-2025-49596 (MCP Inspector): reachable from any page in a victim's browser via DNS rebinding. Same class as CVE-2026-49471 (Serena) and CVE-2026-23744 (MCPJam).

Scope discipline: the port list is three entries, each documented with the advisory that justifies it.

- 6277: MCP Inspector default
- 24282: Serena dashboard/API
- 3000: conventional dev port

A refused connection costs one packet and is itself an answer, so silence from this rule means checked-and-absent rather than could-not-tell; there is no not-tested ambiguity anywhere in it.

Outcomes, all read-only; nothing is invoked through a discovered surface:

- unauthenticated initialize answered AND foreign-Origin twin accepted => high / confirmed, the full browser-reachable chain
- initialize open but twin refused => medium / confirmed, unauthenticated surface, rebinding mitigated
- page fingerprints as "MCP Inspector" or "Serena" but no protocol endpoint answers => low / indicator, exposed product page
- anything else => nothing

The target's own port is skipped: if the operator already aimed at that surface, the rules that own it report on it directly.

Changes:

- internal/attack/mcp/shadow_surface.go plus harness, five postures including target-port skip and unrelated-service clean
- rules/mcp/shadow-surface-001.yaml, CWE-488, remediation covering listener inventory, loopback binding, Origin checks
- testdata/mcp_shadow_surface_server.py binds two listeners (7807 named target serving only 404s, 6277 shadow) with shadow-open / shadow-hardened / none postures
- counts updated to 24 MCP / 42 total across README.md, catalog, registry

Verified locally in the pinned containers: gofmt clean, vet, full race suite green, lint 0 issues.
