### PR TITLE
rule(mcp): flag servers identifying as known-vulnerable components

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ CLI for adversarial testing of [A2A](https://a2a-protocol.org) and [MCP](https:/
 
 ## What ships
 
-Bundled rules: **18 A2A, 25 MCP (43 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
+Bundled rules: **18 A2A, 26 MCP (44 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
 
 - [A2A rules](docs/rules-a2a.md) (18)
 - [MCP rules](docs/rules-mcp.md) (21)
@@ -37,6 +37,7 @@ Coverage spans:
 - **SSRF & secret leakage** - push-notification SSRF, push control-plane binding, OAuth discovery/metadata SSRF, credential leakage into responses
 - **Shadow surfaces** - unauthenticated inspector/dashboard listeners on adjacent ports, graded by whether a foreign origin can reach them
 - **Tool manifest integrity** - hidden-character payloads, description injection patterns, duplicate-name shadowing, and manifest drift between consecutive reads (OWASP MCP03)
+- **Component exposure** - self-reported server identity matched against a closed table of published MCP advisories
 - **Unauthenticated & cross-origin access** - exposed MCP tools, resources, prompt templates, completion suggestions, and log-level control, Streamable HTTP Origin validation (DNS rebinding)
 - **Tool argument integrity** - path traversal in read-only MCP tool arguments (sandbox escape via resolution evidence, zero content read)
 

--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -1,6 +1,6 @@
 # MCP Attack Rules
 
-Batesian ships **25 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
+Batesian ships **26 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
 Every rule is an active probe: it sends crafted protocol traffic and judges the
 server's actual response. Rules are deliberately scoped to MCP-specific semantics
 (OAuth 2.1 authorization, DCR, audience binding, discovery-chain metadata-fetch
@@ -175,6 +175,7 @@ candidate answers does a rule report that it could not test.
 | `mcp-scope-confusion-001` | [Tool Scope Confusion](#mcp-scope-confusion-001) | High | confirmed | CWE-285 |
 | `mcp-shadow-surface-001` | [Shadow MCP Surface on an Adjacent Port](#mcp-shadow-surface-001) | High / Medium / Low | confirmed / indicator | CWE-488 |
 | `mcp-tool-poisoning-001` | [Tool Manifest Integrity (Poisoning)](#mcp-tool-poisoning-001) | High / Medium | confirmed / indicator | CWE-74 |
+| `mcp-vulnerable-version-001` | [Known-Vulnerable Component Identity](#mcp-vulnerable-version-001) | High | indicator | CWE-1104 |
 
 ---
 
@@ -1013,3 +1014,43 @@ them reads only the listing - no tool is ever invoked:
 
 Both protocol wires are driven where a server serves them, since a manifest
 need not agree with itself across eras either.
+
+---
+
+### mcp-vulnerable-version-001
+
+**Known-Vulnerable Component Identity** | Severity: High | indicator | CWE-1104
+
+Reads the identity a target publishes in its handshake - `serverInfo` on the
+legacy initialize result, the same block under `result._meta` on the 2026-07-
+28 discover result - and matches it against documented advisories for MCP
+components with published vulnerabilities. Every Tier-1 SDK and most product
+servers state who they are, which is exactly what an attacker needs to pick
+the right exploit; it is also what a scanner can check.
+
+The advisory table is deliberately short, and closed: only products whose
+patched version is published and unambiguous carry an entry, each with its
+citations in both the YAML and the finding evidence.
+
+- **mcp-server-git** <2025.12.18 - argument injection and path escape chain (CVE-2025-68143/44/45)
+- **mcp-remote** <0.1.16 - OAuth flow command injection (CVE-2025-6514)
+- **mcp-atlassian** <0.17.0 - attachment path traversal to RCE (CVE-2026-27825/26)
+- **inspector** <0.14.1 - unauthenticated RCE via DNS rebinding (CVE-2025-49596)
+- **serena** <1.5.2 - dashboard memory poisoning to RCE via DNS rebinding (CVE-2026-49471)
+- **mcpjam** <=1.4.2 - exposed control endpoint RCE (CVE-2026-23744)
+
+Every finding is an **indicator**. The version is self-reported and trivially
+spoofable, and matching a range does not prove the vulnerable code path is
+reachable from this surface; each finding names its advisories so the operator
+verifies against the actual patch.
+
+Two edge cases are pinned rather than papered over:
+
+- A name that matches a table entry but reports an unparseable version is a
+  **low indicator** - neither clean nor vulnerable can be claimed from what
+  the server publishes.
+- An identity matching nothing reports clean, because the table is reviewed
+  and closed rather than a heuristic net.
+
+Both wires are read where served: legacy carries identity in
+`result.serverInfo`, modern under `result._meta`, and the two need not agree.

--- a/internal/attack/mcp/vulnerable_version.go
+++ b/internal/attack/mcp/vulnerable_version.go
@@ -1,0 +1,291 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// VulnerableVersionExecutor reads the server identity a target publishes and
+// matches it against documented advisories for MCP components with known
+// vulnerabilities (rule mcp-vulnerable-version-001).
+//
+// Every Tier-1 SDK and most product servers state who they are in the
+// handshake: result.serverInfo{name,version} on the legacy wire, the same
+// block under result._meta on 2026-07-28's server/discover. That is exactly
+// what an attacker needs to pick the right exploit, so it is also what a
+// scanner should check: a self-declared version inside a known-vulnerable
+// range is a lead no operator should have to find by hand.
+//
+// Everything here is an indicator. The version string is self-reported -
+// trivially spoofed, sometimes wrong in real deployments - and matching a
+// range is not proof that the vulnerable code path is reachable. Each finding
+// names the advisory so an operator can verify against the actual patch.
+//
+// The advisory table is deliberately short: only products whose patched
+// version is published and unambiguous get an entry. A table nobody maintains
+// rots into false confidence; additions follow the same review bar as rules.
+type VulnerableVersionExecutor struct {
+	rule attack.RuleContext
+}
+
+func init() {
+	attack.Register("mcp-vulnerable-version", func(rc attack.RuleContext) attack.Executor { return NewVulnerableVersionExecutor(rc) })
+}
+
+func NewVulnerableVersionExecutor(r attack.RuleContext) *VulnerableVersionExecutor {
+	return &VulnerableVersionExecutor{rule: r}
+}
+
+// vvAdvisory maps a component identity to a published vulnerability.
+type vvAdvisory struct {
+	// key matches case-insensitively as a substring of serverInfo.name.
+	key string
+	// affected is "<X.Y.Z", "<=X.Y.Z" or "=X.Y.Z".
+	affected string
+	// severity for this finding (never above the rule YAML declares).
+	severity string
+	title    string
+	refs     string
+}
+
+// vvTable entries carry their own citations; keep them in step with upstream
+// advisories when bumping.
+var vvTable = []vvAdvisory{
+	{
+		key: "mcp-server-git", affected: "<2025.12.18", severity: "high",
+		title: "mcp-server-git argument injection and path escape chain",
+		refs:  "CVE-2025-68143, CVE-2025-68144, CVE-2025-68145",
+	},
+	{
+		key: "mcp-remote", affected: "<0.1.16", severity: "high",
+		title: "mcp-remote OAuth flow command injection",
+		refs:  "CVE-2025-6514",
+	},
+	{
+		key: "mcp-atlassian", affected: "<0.17.0", severity: "high",
+		title: "mcp-atlassian attachment path traversal to RCE",
+		refs:  "CVE-2026-27825, CVE-2026-27826",
+	},
+	{
+		key: "inspector", affected: "<0.14.1", severity: "high",
+		title: "MCP Inspector unauthenticated RCE via DNS rebinding",
+		refs:  "CVE-2025-49596",
+	},
+	{
+		key: "serena", affected: "<1.5.2", severity: "high",
+		title: "Serena dashboard memory poisoning to RCE via DNS rebinding",
+		refs:  "CVE-2026-49471",
+	},
+	{
+		key: "mcpjam", affected: "<=1.4.2", severity: "high",
+		title: "MCPJam inspector exposed control endpoint RCE",
+		refs:  "CVE-2026-23744",
+	},
+}
+
+func (e *VulnerableVersionExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
+	vars := attack.NewVars(target, opts.OOBListenerURL)
+	client := attack.NewUnauthHTTPClient(opts, vars)
+
+	return runOnEachWire(ctx, client, vars.BaseURL, func(session mcpSession) ([]attack.Finding, bool) {
+		name, version, ok := vvExtractServerInfo(session.RawInit)
+		if !ok {
+			return nil, false // identity unreadable: nothing assessed on this wire
+		}
+		return e.matchAdvisories(session.Endpoint, name, version), true
+	})
+}
+
+// vvExtractServerInfo pulls {name, version} from wherever the wire puts it:
+// legacy initialize results carry result.serverInfo; the modern discover
+// result carries the same block under result._meta. Both paths are tried on
+// any body, since the shapes are unambiguous.
+func vvExtractServerInfo(raw []byte) (name, version string, ok bool) {
+	var legacy struct {
+		Result struct {
+			ServerInfo struct {
+				Name    string `json:"name"`
+				Version string `json:"version"`
+			} `json:"serverInfo"`
+		} `json:"result"`
+	}
+	if json.Unmarshal(raw, &legacy) == nil && legacy.Result.ServerInfo.Name != "" {
+		return legacy.Result.ServerInfo.Name, legacy.Result.ServerInfo.Version, true
+	}
+	var modern struct {
+		Result struct {
+			Meta map[string]struct {
+				Name    string `json:"name"`
+				Version string `json:"version"`
+			} `json:"_meta"`
+		} `json:"result"`
+	}
+	if json.Unmarshal(raw, &modern) == nil {
+		if si, present := modern.Result.Meta[metaServerInfoKey]; present && si.Name != "" {
+			return si.Name, si.Version, true
+		}
+	}
+	return "", "", false
+}
+
+// metaServerInfoKey is the _meta key carrying server identity on the modern
+// wire.
+const metaServerInfoKey = "io.modelcontextprotocol/serverInfo"
+
+// matchAdvisories compares one identity against the table. Findings are per
+// advisory; a product matching several entries yields several findings, which
+// is the honest shape when the ranges differ.
+func (e *VulnerableVersionExecutor) matchAdvisories(endpoint, name, version string) []attack.Finding {
+	lower := strings.ToLower(name)
+	parsed := vvParseVersion(version)
+
+	var findings []attack.Finding
+	for _, adv := range vvTable {
+		if !strings.Contains(lower, adv.key) {
+			continue
+		}
+		op, bound, ok := vvParseRange(adv.affected)
+		if !ok || parsed == nil {
+			findings = append(findings, e.unverifiableFinding(endpoint, name, version, adv))
+			continue
+		}
+		cmp := vvCompare(parsed, bound)
+		inRange := false
+		switch op {
+		case "<":
+			inRange = cmp < 0
+		case "<=":
+			inRange = cmp <= 0
+		case "=":
+			inRange = cmp == 0
+		}
+		if !inRange {
+			continue
+		}
+		findings = append(findings, e.finding(endpoint, name, version, adv))
+	}
+	return findings
+}
+
+func (e *VulnerableVersionExecutor) finding(endpoint, name, version string, adv vvAdvisory) attack.Finding {
+	return attack.Finding{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   adv.severity,
+		Confidence: attack.RiskIndicator,
+		Title:      fmt.Sprintf("MCP server identifies as %q %s (%s)", name, version, adv.title),
+		Description: fmt.Sprintf(
+			"The handshake at %s identifies this server as %q running version %s, which falls inside "+
+				"the affected range %s for %s (%s). The version is self-reported and spoofable, and the "+
+				"match does not prove the vulnerable code path is reachable from this surface - verify "+
+				"against the advisory before acting.",
+			endpoint, name, version, adv.affected, adv.key, adv.refs),
+		Evidence: fmt.Sprintf("endpoint: %s\nserverInfo.name: %s\nserverInfo.version: %s\nmatched: %s %s\nadvisories: %s",
+			endpoint, name, version, adv.key, adv.affected, adv.refs),
+		Remediation: e.rule.Remediation,
+		TargetURL:   endpoint,
+	}
+}
+
+// unverifiableFinding covers the awkward middle: the name says this is a
+// product with a published advisory but the version string cannot be parsed,
+// so neither clean nor vulnerable can be claimed.
+func (e *VulnerableVersionExecutor) unverifiableFinding(endpoint, name, version string, adv vvAdvisory) attack.Finding {
+	return attack.Finding{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "low",
+		Confidence: attack.RiskIndicator,
+		Title:      fmt.Sprintf("MCP server identifies as %q but its version is unverifiable", name),
+		Description: fmt.Sprintf(
+			"The handshake at %s identifies this server as %q reporting version %q, which is not a "+
+				"parseable version for range comparison against %s (%s). Whether this deployment is "+
+				"affected could not be determined from what the server publishes.",
+			endpoint, name, version, adv.key, adv.refs),
+		Evidence: fmt.Sprintf("endpoint: %s\nserverInfo.name: %s\nserverInfo.version: %s\nrelated advisories: %s",
+			endpoint, name, version, adv.refs),
+		Remediation: e.rule.Remediation,
+		TargetURL:   endpoint,
+	}
+}
+
+// vvParseVersion extracts the leading dotted-numeric core of a version
+// string: "v0.14.1-beta2" -> [0,14,1], "2025.12.18" -> [2025,12,18]. nil when
+// no numeric core exists.
+func vvParseVersion(s string) []int {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = strings.TrimPrefix(s, "v")
+	end := 0
+	for end < len(s) {
+		c := s[end]
+		if (c >= '0' && c <= '9') || c == '.' {
+			end++
+			continue
+		}
+		break
+	}
+	core := s[:end]
+	if core == "" || strings.HasPrefix(core, ".") || strings.HasSuffix(core, ".") || strings.Contains(core, "..") {
+		return nil
+	}
+	parts := strings.Split(core, ".")
+	out := make([]int, 0, len(parts))
+	for _, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return nil
+		}
+		out = append(out, n)
+	}
+	return out
+}
+
+// vvParseRange splits an operator like "<" into op and bound segments.
+func vvParseRange(r string) (op string, bound []int, ok bool) {
+	switch {
+	case strings.HasPrefix(r, "<="):
+		op = "<="
+	case strings.HasPrefix(r, "<"):
+		op = "<"
+	case strings.HasPrefix(r, ">="):
+		op = ">="
+	case strings.HasPrefix(r, ">"):
+		op = ">"
+	case strings.HasPrefix(r, "="):
+		op = "="
+	default:
+		return "", nil, false
+	}
+	bound = vvParseVersion(r[len(op):])
+	return op, bound, bound != nil
+}
+
+// vvCompare compares two dotted-numeric versions segment by segment; missing
+// segments read as zero, so 1.0 == 1.0.0.
+func vvCompare(a, b []int) int {
+	n := len(a)
+	if len(b) > n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		av, bv := 0, 0
+		if i < len(a) {
+			av = a[i]
+		}
+		if i < len(b) {
+			bv = b[i]
+		}
+		if av != bv {
+			if av < bv {
+				return -1
+			}
+			return 1
+		}
+	}
+	return 0
+}

--- a/internal/attack/mcp/vulnerable_version_test.go
+++ b/internal/attack/mcp/vulnerable_version_test.go
@@ -1,0 +1,195 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcp "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+func vvRC() attack.RuleContext {
+	return attack.RuleContext{
+		ID:          "mcp-vulnerable-version-001",
+		Name:        "MCP Known-Vulnerable Component",
+		Severity:    "high",
+		Remediation: "Upgrade the component past the patched version.",
+	}
+}
+
+// vvServer serves an initialize whose serverInfo carries the given name and
+// version, verbatim.
+func vvServer(name, version string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string      `json:"method"`
+			ID     json.Number `json:"id"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.Method != "initialize" {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": req.ID,
+			"result": map[string]interface{}{
+				"protocolVersion": "2025-06-18",
+				"capabilities":    map[string]interface{}{},
+				"serverInfo":      map[string]interface{}{"name": name, "version": version},
+			},
+		})
+	}))
+}
+
+func runVV(t *testing.T, ts *httptest.Server) ([]attack.Finding, error) {
+	t.Helper()
+	return mcp.NewVulnerableVersionExecutor(vvRC()).Execute(
+		context.Background(), ts.URL, attack.Options{TimeoutSeconds: 5})
+}
+
+// TestVV_VulnerableGitFires: the reference git server one patch behind. MUST
+// fire a high indicator naming the advisory set.
+func TestVV_VulnerableGitFires(t *testing.T) {
+	ts := vvServer("mcp-server-git", "2025.12.17")
+	defer ts.Close()
+
+	findings, err := runVV(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 finding, got %d: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Severity != "high" || f.Confidence != attack.RiskIndicator {
+		t.Errorf("want high/RiskIndicator, got %q/%q", f.Severity, f.Confidence)
+	}
+	if !strings.Contains(f.Evidence, "CVE-2025-68143") {
+		t.Errorf("evidence should cite the advisories, got: %q", f.Evidence)
+	}
+}
+
+// TestVV_PatchedSilent: same product at the patched version. MUST stay
+// silent.
+func TestVV_PatchedSilent(t *testing.T) {
+	ts := vvServer("mcp-server-git", "2025.12.18")
+	defer ts.Close()
+
+	findings, err := runVV(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings at the patched version, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestVV_UnknownProductSilent: an unrelated identity matches nothing in the
+// closed table.
+func TestVV_UnknownProductSilent(t *testing.T) {
+	ts := vvServer("my-custom-mcp-server", "1.0.0")
+	defer ts.Close()
+
+	findings, err := runVV(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings for an unknown product, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestVV_UnparseableVersionLow: name matches a table entry but the version is
+// not parseable, so neither clean nor vulnerable can be claimed - low
+// indicator instead of silence.
+func TestVV_UnparseableVersionLow(t *testing.T) {
+	ts := vvServer("mcp-remote", "not-a-version")
+	defer ts.Close()
+
+	findings, err := runVV(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 finding, got %d: %+v", len(findings), findings)
+	}
+	if findings[0].Severity != "low" || findings[0].Confidence != attack.RiskIndicator {
+		t.Errorf("want low/RiskIndicator for unverifiable version, got %q/%q",
+			findings[0].Severity, findings[0].Confidence)
+	}
+}
+
+// TestVV_Boundaries: the range edges behave - equal-to-bound is not affected
+// under "<", but is under "<=".
+func TestVV_Boundaries(t *testing.T) {
+	cases := []struct {
+		label   string
+		product string
+		version string
+		want    int
+	}{
+		{"inspector at bound excluded", "mcp-inspector-proxy", "0.14.1", 0},
+		{"inspector just below fires", "mcp-inspector-proxy", "0.14.0", 1},
+		{"mcpjam inclusive bound fires", "mcpjam-inspector", "1.4.2", 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			ts := vvServer(tc.product, tc.version)
+			defer ts.Close()
+
+			findings, err := runVV(t, ts)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(findings) != tc.want {
+				t.Fatalf("version %q: want %d findings, got %d: %+v",
+					tc.version, tc.want, len(findings), findings)
+			}
+		})
+	}
+}
+
+// TestVV_ModernWireMeta: on the modern wire the identity travels under
+// result._meta rather than result.serverInfo; the extractor reads both.
+func TestVV_ModernWireMeta(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string      `json:"method"`
+			ID     json.Number `json:"id"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.Method == "initialize" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": req.ID,
+			"result": map[string]interface{}{
+				// A modern discover result must advertise the revision to be
+				// taken as a modern wire at all.
+				"supportedVersions": []string{"2026-07-28"},
+				"_meta": map[string]interface{}{
+					"io.modelcontextprotocol/serverInfo": map[string]interface{}{
+						"name": "serena", "version": "1.5.1",
+					},
+				},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	findings, err := runVV(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 finding from _meta identity, got %d: %+v", len(findings), findings)
+	}
+	if !strings.Contains(findings[0].Evidence, "CVE-2026-49471") {
+		t.Errorf("evidence should cite the Serena advisory, got: %q", findings[0].Evidence)
+	}
+}

--- a/rules/mcp/vulnerable-version-001.yaml
+++ b/rules/mcp/vulnerable-version-001.yaml
@@ -1,0 +1,60 @@
+id: mcp-vulnerable-version-001
+info:
+  name: MCP Server Identifies as a Known-Vulnerable Component
+  author: batesian
+  severity: high
+  description: |
+    Reads the identity a target publishes in its handshake - serverInfo on the
+    legacy initialize result, the same block under result._meta on the 2026-
+    07-28 discover result - and matches it against documented advisories for
+    MCP components with published vulnerabilities. Every Tier-1 SDK and most
+    product servers state who they are, which is exactly what an attacker
+    needs to pick the right exploit; it is also what a scanner can check.
+
+    The advisory table is deliberately short: only products whose patched
+    version is published and unambiguous carry an entry, each with citations.
+    Current entries:
+
+      - mcp-server-git <2025.12.18 (CVE-2025-68143/44/45)
+      - mcp-remote <0.1.16          (CVE-2025-6514)
+      - mcp-atlassian <0.17.0       (CVE-2026-27825/26)
+      - inspector <0.14.1           (CVE-2025-49596)
+      - serena <1.5.2               (CVE-2026-49471)
+      - mcpjam <=1.4.2              (CVE-2026-23744)
+
+    Every finding is an INDICATOR. The version is self-reported and trivially
+    spoofed, and matching a range does not prove the vulnerable code path is
+    reachable from this surface. Each finding names its advisories so the
+    operator verifies against the actual patch.
+
+    A name that matches a table entry but reports an unparseable version is a
+    low indicator: neither clean nor vulnerable can be claimed from what the
+    server publishes. A server whose identity matches nothing reports clean -
+    the table is closed and reviewed, not a heuristic net.
+
+  references:
+    - https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-49596
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-49471
+    - https://cwe.mitre.org/data/definitions/1104.html
+
+  tags:
+    - mcp
+    - versioning
+    - known-vulnerabilities
+    - supply-chain
+    - cwe-1104
+
+attack:
+  protocol: mcp
+  type: mcp-vulnerable-version
+
+remediation: |
+  1. Upgrade the identified component past the patched versions named in the
+     matched advisories, then re-scan to confirm the disclosure changed.
+  2. If the reported version is wrong or stale, fix the build metadata: an
+     accurate serverInfo is operationally useful and reduces attacker
+     reconnaissance asymmetry when it matches reality rather than guessing.
+  3. Keep MCP components on a supported, patched release line; subscribe to
+     the component's advisory feed so upgrades are driven by publication,
+     not discovery.

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -31,7 +31,7 @@ a run that treats it as a clean result is reporting coverage it does not have.
 
 ## Server Registry
 
-The bundled rule set is **18 A2A + 25 MCP = 43 rules**. Every rule's primary
+The bundled rule set is **18 A2A + 26 MCP = 44 rules**. Every rule's primary
 validation is an in-process `net/http/httptest` harness in its Go
 `*_test.go` (multiple server postures: vulnerable must fire / patched / open /
 benign must stay silent). The Python servers below are optional standalone
@@ -76,8 +76,9 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_scope_confusion_server.py` | 7806 | `mcp-scope-confusion-001` must fire on `vulnerable`; stay silent on `patched` and `open` (three postures, see below; needs `--token tok-a` and two principals) |
 | `mcp_shadow_surface_server.py` | 7807 + 6277 | `mcp-shadow-surface-001` must fire on `shadow-open`; fire medium on `shadow-hardened`; stay silent on `none` (three postures, see below) |
 | `mcp_tool_poisoning_server.py` | 7808 | `mcp-tool-poisoning-001`: checks 1-3 fire on `poisoned`, check 4 fires on `drifting`, all silent on `clean` (three postures, see below) |
+| `mcp_vulnerable_version_server.py` | 7809 | `mcp-vulnerable-version-001` must fire on `vulnerable`; stay silent on `patched` and `unknown` (three postures, see below) |
 
-**Coverage.** 41 of the 43 rules have a standalone Python fixture above, and each
+**Coverage.** 42 of the 44 rules have a standalone Python fixture above, and each
 of those was checked by actually running it rather than by reading this table. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
 (`internal/attack/mcp/token_replay_test.go`); the same is true of the per-rule
@@ -463,10 +464,26 @@ consecutive reads, so only the drift check may fire; its evidence names what
 was added or changed. `clean` is factual, unique and stable. Nothing beyond
 `tools/list` is served anywhere, so validation never executes a tool.
 
+**`mcp_vulnerable_version_server.py` takes a posture argument**, defaulting to
+`vulnerable`:
+
+```sh
+python testdata/mcp_vulnerable_version_server.py vulnerable  # high indicator
+python testdata/mcp_vulnerable_version_server.py patched     # silent
+python testdata/mcp_vulnerable_version_server.py unknown     # silent
+batesian scan --target http://127.0.0.1:7809 --rule-ids mcp-vulnerable-version-001 -v
+```
+
+The three postures differ only in what `serverInfo` reports: one patch below
+the mcp-server-git fix, exactly at it, and an unrelated product identity. The
+patched posture pins the range boundary - the fix version itself must not
+fire - and `unknown` pins that the advisory table is closed rather than
+heuristic. Only `initialize` is served; this rule reads identity and nothing
+else.
+
 ---
 
 ## Port allocation
-
 
 When adding a new test server, pick the next free port, document it in the
 Server Registry table above before merging. Prefer the `77xx` band for servers

--- a/testdata/mcp_vulnerable_version_server.py
+++ b/testdata/mcp_vulnerable_version_server.py
@@ -1,0 +1,74 @@
+"""
+Deliberately vulnerable MCP test server for validating:
+
+  mcp-vulnerable-version-001: a handshake whose serverInfo names a component
+  with published advisories, reporting a version inside the affected range.
+
+Postures:
+  vulnerable (default) - identifies as mcp-server-git 2025.12.17, one patch
+                         before the fixed release. The rule MUST fire a high
+                         indicator citing CVE-2025-68143.
+  patched              - same product at 2025.12.18. The rule MUST stay
+                         silent: the range is exclusive of the fix.
+  unknown              - an unrelated custom identity. Nothing in the table
+                         matches; the rule MUST stay silent.
+
+The server serves nothing beyond initialize - this rule reads identity only,
+so there is no other surface to exercise.
+
+Validate against it:
+  python testdata/mcp_vulnerable_version_server.py vulnerable  # fires
+  python testdata/mcp_vulnerable_version_server.py patched     # silent
+  python testdata/mcp_vulnerable_version_server.py unknown     # silent
+
+Run: python testdata/mcp_vulnerable_version_server.py [posture]
+Scan: batesian scan --target http://127.0.0.1:7809 --rule-ids mcp-vulnerable-version-001 -v
+"""
+import sys
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+import uvicorn
+
+PORT = 7809
+
+SERVER_INFO = {
+    "vulnerable": {"name": "mcp-server-git", "version": "2025.12.17"},
+    "patched": {"name": "mcp-server-git", "version": "2025.12.18"},
+    "unknown": {"name": "acme-custom-mcp", "version": "1.0.0"},
+}
+
+
+async def jsonrpc(request: Request) -> JSONResponse:
+    body = await request.json()
+    method = body.get("method")
+    rid = body.get("id", 1)
+
+    if method == "initialize":
+        info = SERVER_INFO[request.app.state.posture]
+        return JSONResponse({
+            "jsonrpc": "2.0", "id": rid,
+            "result": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "serverInfo": info,
+            },
+        })
+    if method == "notifications/initialized":
+        return JSONResponse({"jsonrpc": "2.0", "id": rid, "result": {}})
+
+    return JSONResponse({"jsonrpc": "2.0", "id": rid,
+                         "error": {"code": -32601, "message": "Method not found"}})
+
+
+app = Starlette(routes=[Route("/", jsonrpc, methods=["POST"]), Route("/mcp", jsonrpc, methods=["POST"])])
+app.state.posture = "vulnerable"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        app.state.posture = sys.argv[1]
+    print(f"[*] MCP vulnerable-version fixture ({app.state.posture}) on port {PORT}", flush=True)
+    uvicorn.run(app, host="127.0.0.1", port=PORT)


### PR DESCRIPTION
Every Tier-1 SDK and most product servers state who they are in the handshake: serverInfo on the legacy initialize result, the same block under result._meta on the 2026-07-28 discover result. That is exactly what an attacker needs to pick the right exploit, so it is also what a scanner can check: a self-declared version inside a published advisory range is a lead no operator should have to find by hand.

This closes the supply-chain gap from the threat review (OX Security Apr 2026 class): the rule ships a deliberately short, closed advisory table where every entry has a published patched version and citations carried into both the YAML and each finding's evidence.

- mcp-server-git <2025.12.18 - CVE-2025-68143/44/45
- mcp-remote <0.1.16 - CVE-2025-6514
- mcp-atlassian <0.17.0 - CVE-2026-27825/26
- inspector <0.14.1 - CVE-2025-49596
- serena <1.5.2 - CVE-2026-49471
- mcpjam <=1.4.2 - CVE-2026-23744

Everything is an indicator: the version is self-reported, trivially spoofable, and range membership does not prove reachability. Two edge cases are pinned rather than papered over:

- name matches an entry but version unparseable => low indicator; neither clean nor vulnerable can be claimed
- identity matches nothing => clean, because the table is reviewed rather than heuristic

Both wires are read where served, and the two need not agree.

Changes:
- internal/attack/mcp/vulnerable_version.go plus harness: vulnerable/patched/unknown/unparseable postures, range-boundary subtests (< vs <=), modern-wire _meta extraction
- rules/mcp/vulnerable-version-001.yaml, CWE-1104, remediation covering upgrade verification and build-metadata accuracy
- testdata/mcp_vulnerable_version_server.py (port 7809): vulnerable/patched/unknown
- counts updated to 26 MCP / 44 total across README.md, catalog table plus detail section, registry

Verified locally in the pinned containers: gofmt clean, vet, full race suite green, lint 0 issues, fixture Python syntax checked.
