### PR TITLE
rule(a2a): flag push notifications sent without the integrity token

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ CLI for adversarial testing of [A2A](https://a2a-protocol.org) and [MCP](https:/
 
 ## What ships
 
-Bundled rules: **18 A2A, 26 MCP (44 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
+Bundled rules: **19 A2A, 26 MCP (45 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
 
 - [A2A rules](docs/rules-a2a.md) (18)
 - [MCP rules](docs/rules-mcp.md) (21)
@@ -32,6 +32,7 @@ Coverage spans:
 
 - **OAuth & token validation** - OAuth 2.1 / DCR scope escalation, audience binding, token replay, version-downgrade bypass, forged-token acceptance, redirect_uri confused deputy, tool-level scope enforcement
 - **Agent-card trust (A2A)** - JWS signatures, canonicalization, cache/freshness, required-extension downgrade, host-header injection, unauthenticated extended card, declared-but-unenforced auth
+- **Push notification authenticity** - callbacks that drop the configured integrity token, so receivers cannot distinguish genuine events from forgeries
 - **Request & task integrity** - task IDOR, agent-role injection, artifact tampering, SEP-2243 header/body routing, SSE resumption replay
 - **Multi-party isolation** - cross-tenant isolation, cross-principal task enumeration, session/context fixation, session id accepted as a credential, delegation chain-of-custody, cross-principal task cancellation, cross-context MCP task and result access
 - **SSRF & secret leakage** - push-notification SSRF, push control-plane binding, OAuth discovery/metadata SSRF, credential leakage into responses

--- a/docs/rules-a2a.md
+++ b/docs/rules-a2a.md
@@ -1,6 +1,6 @@
 # A2A Attack Rules
 
-Batesian ships **18 rules** targeting the [Agent-to-Agent (A2A) protocol](https://a2a-protocol.org/).
+Batesian ships **19 rules** targeting the [Agent-to-Agent (A2A) protocol](https://a2a-protocol.org/).
 Every rule is an active probe: it sends crafted protocol traffic and judges the
 server's actual response. Rules are deliberately scoped to A2A-specific semantics
 (agent cards, JWS card signatures, tasks/contexts, push notifications, peer
@@ -77,10 +77,10 @@ evidence. A card rule with no card has nothing to say either way.
 
 ### Rules that need a task first
 
-Nine rules cannot say anything until they have created a task: `a2a-task-idor-001`,
+Ten rules cannot say anything until they have created a task: `a2a-task-idor-001`,
 `a2a-push-ssrf-001`, `a2a-session-smuggle-001`, `a2a-context-fixation-001`,
 `a2a-delegation-integrity-001`, `a2a-multitenant-isolation-001`,
-`a2a-push-binding-001`, `a2a-task-cancel-idor-001` and `a2a-task-enumeration-001`.
+`a2a-push-binding-001`, `a2a-task-cancel-idor-001`, `a2a-task-enumeration-001` and `a2a-push-callback-auth-001`.
 Against an agent that enforces authorization, whether they can depends on the
 credential the scan was given, so a failure to create one is reported as **not
 tested**, naming the refusal and whether the request carried a credential at all. A
@@ -120,6 +120,7 @@ report them not tested against a secured agent, and say so.
 | `a2a-task-cancel-idor-001` | [Cross-Principal Task Cancellation](#a2a-task-cancel-idor-001) | High | confirmed | CWE-639 / CWE-862 |
 | `a2a-task-enumeration-001` | [ListTasks Enumerates Another Principal's Tasks](#a2a-task-enumeration-001) | High | confirmed | CWE-639 / CWE-200 |
 | `a2a-card-security-unenforced-001` | [Agent Card Declares Unenforced Authentication](#a2a-card-security-unenforced-001) | High | confirmed | CWE-287 / CWE-306 |
+| `a2a-push-callback-auth-001` | [Push Notification Without Integrity Token](#a2a-push-callback-auth-001) | High | confirmed | CWE-345 |
 
 ---
 
@@ -559,3 +560,39 @@ v0.3 REST binding's list path is covered anonymously by `a2a-task-idor-001`; the
 authenticated case on that binding is not probed, because its prefix belongs to the
 deployment and guessing it is how earlier rules came to post at paths that never
 existed.
+
+---
+
+### a2a-push-callback-auth-001
+
+**Push Notification Without Integrity Token** | Severity: High | confirmed | CWE-345
+
+Tests whether an A2A agent's outgoing push notifications carry anything a
+receiver can use to verify where they came from. The push flow hands the
+agent a webhook URL plus, optionally, a secret token the agent is expected to
+present when it calls (typically as `X-A2A-Notification-Token`). A receiver
+that knows the token can tell genuine completion events from forged ones. An
+agent that accepts the token at registration and then never presents it
+produces notifications with no verifiable provenance: anyone who learns or
+guesses the webhook URL can forge task completions, failures, or injected
+results, indistinguishable from genuine agent output - the notification-side
+enabler of task hijacking.
+
+The registration mechanics are shared with `a2a-push-ssrf-001` across all
+three transport bindings; two things differ. The URL marker routing the
+callback and the integrity token are deliberately different values here,
+because in the SSRF rule they coincide and "the callback arrived" is the same
+string as "the callback was authenticated". And the oracle grades what the
+callback carried rather than that it happened:
+
+1. Callback presents the secret - header or body -> the transport is
+   verifiable, no finding. A held boundary is exactly the pass sought.
+2. Callback arrives WITHOUT it (**confirmed**, high): the agent ignored
+   integrity material it accepted at registration.
+3. No callback within the window -> **not tested**: accepting a config is
+   normal A2A behaviour and says nothing about what callbacks carry.
+4. With an external `--oob-url`, an info indicator names the token so the
+   operator can verify against their own collector.
+
+Like every task-first rule, creation depends on the credential the scan was
+given; a refused creation is not tested naming the refusal.

--- a/internal/attack/a2a/push_callback_auth.go
+++ b/internal/attack/a2a/push_callback_auth.go
@@ -1,0 +1,274 @@
+package a2a
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/calbebop/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/oob"
+)
+
+// PushCallbackAuthExecutor tests whether an A2A agent's outgoing push
+// notifications carry anything a receiver can use to verify where they came
+// from (rule a2a-push-callback-auth-001).
+//
+// The push flow hands the agent a webhook plus, optionally, a secret token
+// the agent is supposed to present when it calls. A receiver that knows the
+// token can tell genuine completion events from forged ones; without it,
+// anyone who learns the webhook URL can spoof task completions, failures or
+// injected results - the notification-side half of the task-hijack class.
+//
+// The probe registers a callback toward the Batesian listener carrying a
+// unique secret, waits for the agent's outbound call, and reads what
+// arrived:
+//
+//   - callback carries the secret (X-A2A-Notification-Token, another header,
+//     or the body) -> the transport is verifiable, no finding
+//   - callback arrives WITHOUT the secret -> confirmed: the agent ignored the
+//     integrity material it accepted at registration, so its notifications
+//     are indistinguishable from forgeries
+//   - no callback within the window -> the oracle never ran; reported as not
+//     tested rather than clean
+//
+// Registration mechanics are shared with a2a-push-ssrf-001; the marker in the
+// URL path and the integrity token are deliberately different values here,
+// because conflating them made "the callback arrived" and "the callback was
+// authenticated" the same observation.
+type PushCallbackAuthExecutor struct {
+	rule attack.RuleContext
+}
+
+func init() {
+	attack.Register("a2a-push-callback-auth", func(rc attack.RuleContext) attack.Executor { return NewPushCallbackAuthExecutor(rc) })
+}
+
+func NewPushCallbackAuthExecutor(r attack.RuleContext) *PushCallbackAuthExecutor {
+	return &PushCallbackAuthExecutor{rule: r}
+}
+
+func (e *PushCallbackAuthExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
+	vars := attack.NewVars(target, opts.OOBListenerURL)
+
+	listenerURL := opts.OOBListenerURL
+	var listener *oob.Listener
+	if listenerURL == "" {
+		if opts.DryRun {
+			listenerURL = attack.DryRunOOBPlaceholderURL
+		} else {
+			listener = oob.New()
+			var err error
+			listenerURL, err = listener.Start()
+			if err != nil {
+				return nil, fmt.Errorf("push-callback-auth: starting OOB listener: %w", err)
+			}
+			defer func() {
+				stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				defer cancel()
+				_ = listener.Stop(stopCtx)
+			}()
+		}
+		vars = attack.NewVars(target, listenerURL)
+	}
+
+	client := attack.NewHTTPClient(opts, vars)
+	endpoint, endpointOK := resolveA2AEndpoint(ctx, attack.NewUnauthHTTPClient(opts, vars), vars.BaseURL)
+	reached := false
+
+	// Marker and token are separate on purpose: the marker routes the callback
+	// to this run, the token is what the agent is expected to present back.
+	callbackURL := listenerURL + "/batesian-oob-" + vars.RandID
+	token := "batesian-token-" + vars.RandID
+	a2aHeaders := map[string]string{"A2A-Version": "1.0"}
+
+	var obs setupObservation
+	credentialed := client.PresentsCredential(endpoint)
+	taskAccepted := false
+	acceptedBinding := ""
+
+	// Attempt 1: v1.0 two-step - SendMessage, then CreateTaskPushNotificationConfig
+	// whose params ARE a TaskPushNotificationConfig (flat url + token).
+	sendResp, err := client.POST(ctx, endpoint, a2aHeaders, map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      "batesian-sm-" + vars.RandID,
+		"method":  "SendMessage",
+		"params": map[string]interface{}{
+			"message": map[string]interface{}{
+				"role":      1,
+				"parts":     []interface{}{map[string]string{"text": "ping"}},
+				"messageId": "batesian-" + vars.RandID,
+			},
+		},
+	})
+	if err == nil && sendResp.StatusCode != 404 {
+		reached = true
+	}
+	if err != nil || !sendResp.IsAccepted() {
+		obs.observe(classifyTaskSetup("creating a task to attach a push config to", endpoint, credentialed, sendResp))
+	}
+	if err == nil && sendResp.IsAccepted() {
+		if taskID, _ := extractTaskContext(sendResp.Body); taskID != "" {
+			pushResp, pushErr := client.POST(ctx, endpoint, a2aHeaders, map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      "batesian-push-" + vars.RandID,
+				"method":  "CreateTaskPushNotificationConfig",
+				"params": map[string]interface{}{
+					"taskId": taskID,
+					"url":    callbackURL,
+					"token":  token,
+				},
+			})
+			if pushErr == nil && pushResp.IsAccepted() {
+				taskAccepted = true
+				acceptedBinding = "JSONRPC/v1.0-CreateTaskPushNotificationConfig"
+			}
+		}
+	}
+
+	// Attempt 2: v0.3 wire - inline configuration on message/send, plus the
+	// explicit set call for servers that ignore the inline form.
+	if !taskAccepted {
+		sendResp2, err2 := client.POST(ctx, endpoint, map[string]string{}, buildV03SendRequest(callbackURL, token, vars.RandID))
+		if err2 == nil && sendResp2.StatusCode != 404 {
+			reached = true
+		}
+		if err2 != nil || !sendResp2.IsAccepted() {
+			obs.observe(classifyTaskSetup("creating a task on the v0.3 wire", endpoint, credentialed, sendResp2))
+		}
+		if err2 == nil && sendResp2.IsAccepted() {
+			if taskID, _ := extractTaskContext(sendResp2.Body); taskID != "" {
+				taskAccepted = true
+				acceptedBinding = "JSONRPC/v0.3-message-send"
+				setResp, setErr := client.POST(ctx, endpoint, map[string]string{}, map[string]interface{}{
+					"jsonrpc": "2.0",
+					"id":      "batesian-set-" + vars.RandID,
+					"method":  "tasks/pushNotificationConfig/set",
+					"params": map[string]interface{}{
+						"taskId": taskID,
+						"pushNotificationConfig": map[string]string{
+							"url":   callbackURL,
+							"token": token,
+						},
+					},
+				})
+				if setErr == nil && setResp.IsAccepted() {
+					acceptedBinding = "JSONRPC/v0.3-pushNotificationConfig-set"
+				}
+			}
+		}
+	}
+
+	// Attempt 3: HTTP+JSON binding, driven only where the card advertises one.
+	if restBase := resolveHTTPJSONBase(ctx, client, vars.BaseURL); !taskAccepted && restBase != "" {
+		sendResp3, err3 := client.POST(ctx, restBase+"/message:send", map[string]string{"A2A-Version": "1.0"},
+			buildRESTSendRequest(vars.RandID))
+		if err3 == nil && sendResp3.StatusCode != 404 {
+			reached = true
+		}
+		if err3 == nil && sendResp3.IsSuccess() && sendResp3.IsJSON() && !isJSONRPCError(sendResp3.Body) {
+			if taskID := restTaskID(sendResp3.Body); taskID != "" {
+				cfgResp, cfgErr := client.POST(ctx, restBase+"/tasks/"+taskID+"/pushNotificationConfigs",
+					map[string]string{"A2A-Version": "1.0"},
+					map[string]interface{}{"url": callbackURL, "token": token})
+				if cfgErr == nil && cfgResp.IsSuccess() && cfgResp.IsJSON() && !isJSONRPCError(cfgResp.Body) {
+					taskAccepted = true
+					acceptedBinding = "HTTP+JSON/pushNotificationConfigs"
+				}
+			}
+		}
+	}
+
+	if !taskAccepted {
+		if !reached {
+			return nil, attack.ErrInconclusive
+		}
+		if err := notTestableGiven(ctx, client, vars.BaseURL, endpointOK); err != nil {
+			return nil, err
+		}
+		return nil, obs.err()
+	}
+
+	// The registration was accepted. What the rule has to say depends entirely
+	// on what the callback carried - or on whether one can be observed at all.
+	if listener == nil {
+		if opts.DryRun {
+			// A dry run sends nothing and observes nothing; the recorded plan
+			// already shows the callback request.
+			return nil, nil
+		}
+		return []attack.Finding{{
+			RuleID:     e.rule.ID,
+			RuleName:   e.rule.Name,
+			Severity:   "info",
+			Confidence: attack.RiskIndicator,
+			Title:      "A2A push config accepted with integrity token; manual verification required",
+			Description: fmt.Sprintf(
+				"The agent accepted a push config whose callback (%s) carries a unique integrity "+
+					"token via %s. Check your OOB collector for the inbound call and confirm it presents "+
+					"the token %q (typically as X-A2A-Notification-Token, sometimes in the body). A call "+
+					"without it means notifications cannot be authenticated by receivers and forged "+
+					"completions are indistinguishable from real ones.",
+				callbackURL, acceptedBinding, token),
+			Evidence:    fmt.Sprintf("registration binding: %s\ncallback url: %s\nexpected token: %s", acceptedBinding, callbackURL, token),
+			Remediation: e.rule.Remediation,
+			TargetURL:   target,
+		}}, nil
+	}
+
+	cb, received := listener.WaitForMarker(ctx, 10*time.Second, "/batesian-oob-"+vars.RandID)
+	if !received {
+		return nil, fmt.Errorf("%w: the push config was accepted via %s but no callback reached the "+
+			"listener within 10s, so the transport's provenance material could not be observed",
+			attack.ErrInconclusive, acceptedBinding)
+	}
+
+	authz := callbackHeader(cb, "Authorization")
+	tokenEchoed := containsToken(cb, token)
+	if tokenEchoed {
+		// The receiver side can authenticate the call: the boundary held, and a
+		// held boundary is exactly the pass sought. Silent.
+		return nil, nil
+	}
+
+	evidence := fmt.Sprintf(
+		"registration binding: %s\nconfigured token: %s\ncallback received: %s %s\n"+
+			"token echoed: no\nAuthorization header present: %s\nbody snippet: %.200s",
+		acceptedBinding, token, cb.Method, cb.URL, yesNo(authz != ""), string(cb.Body))
+
+	return []attack.Finding{{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "high",
+		Confidence: attack.ConfirmedExploit,
+		Title:      "A2A push notification sent without the configured integrity token",
+		Description: fmt.Sprintf(
+			"The agent at %s accepted a push config carrying a unique integrity token, then called the "+
+				"webhook WITHOUT presenting it (binding: %s). Receivers have nothing to verify, so any "+
+				"party who learns or guesses the webhook URL can forge task completions, failures or "+
+				"injected results and they will be indistinguishable from genuine agent output. This is "+
+				"the notification-side enabler of task hijacking.",
+			target, acceptedBinding),
+		Evidence:    evidence,
+		Remediation: e.rule.Remediation,
+		TargetURL:   target,
+	}}, nil
+}
+
+// callbackHeader reads a single header value case-insensitively off a
+// captured callback.
+func callbackHeader(cb *oob.Callback, name string) string {
+	for k, vals := range cb.Headers {
+		if strings.EqualFold(k, name) && len(vals) > 0 {
+			return vals[0]
+		}
+	}
+	return ""
+}
+
+func yesNo(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}

--- a/internal/attack/a2a/push_callback_auth_test.go
+++ b/internal/attack/a2a/push_callback_auth_test.go
@@ -1,0 +1,212 @@
+package a2a_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/calbebop/batesian/internal/attack"
+	a2a "github.com/calbebop/batesian/internal/attack/a2a"
+)
+
+func cbAuthRC() attack.RuleContext {
+	return attack.RuleContext{
+		ID:          "a2a-push-callback-auth-001",
+		Name:        "A2A Push Callback Authentication",
+		Severity:    "high",
+		Remediation: "Present the configured token on every push callback.",
+	}
+}
+
+// cbAuthServer models a v1.0 agent that registers the caller's push config
+// verbatim and then calls the webhook once. signed decides whether the
+// outbound call carries X-A2A-Notification-Token; callOut decides whether it
+// calls at all.
+type cbAuthServer struct {
+	signed  bool
+	callOut bool
+}
+
+func (s *cbAuthServer) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string `json:"method"`
+			ID     string `json:"id"`
+			Params struct {
+				TaskID string `json:"taskId"`
+				URL    string `json:"url"`
+				Token  string `json:"token"`
+			} `json:"params"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+
+		switch req.Method {
+		case "SendMessage":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req.ID,
+				"result": map[string]interface{}{
+					"id":        "task-cbauth-1",
+					"contextId": "ctx-cbauth",
+					"status":    map[string]interface{}{"state": "TASK_STATE_WORKING"},
+				},
+			})
+		case "CreateTaskPushNotificationConfig":
+			url, token := req.Params.URL, req.Params.Token
+			if s.callOut {
+				go func() {
+					time.Sleep(150 * time.Millisecond)
+					body := map[string]interface{}{
+						"kind": "status-update", "taskId": req.Params.TaskID,
+						"status": map[string]string{"state": "TASK_STATE_COMPLETED"},
+					}
+					b, _ := json.Marshal(body)
+					req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(string(b)))
+					if err != nil {
+						return
+					}
+					req.Header.Set("Content-Type", "application/json")
+					if s.signed {
+						req.Header.Set("X-A2A-Notification-Token", token)
+					}
+					client := &http.Client{Timeout: 5 * time.Second}
+					resp, err := client.Do(req)
+					if err == nil {
+						_ = resp.Body.Close()
+					}
+				}()
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req.ID,
+				"result": map[string]interface{}{
+					"taskId": req.Params.TaskID, "url": url, "token": token,
+				},
+			})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req.ID,
+				"error": map[string]interface{}{"code": -32601, "message": "Method not found"},
+			})
+		}
+	}
+}
+
+func runCbAuth(t *testing.T, target string, oobURL string) ([]attack.Finding, error) {
+	t.Helper()
+	opts := attack.Options{TimeoutSeconds: 10}
+	if oobURL != "" {
+		opts.OOBListenerURL = oobURL
+	}
+	return a2a.NewPushCallbackAuthExecutor(cbAuthRC()).Execute(context.Background(), target, opts)
+}
+
+// TestCbAuth_UnsignedCallbackFires: the agent accepted the token at
+// registration and dropped it on the way out. Receivers get nothing to
+// verify; MUST fire confirmed/high.
+func TestCbAuth_UnsignedCallbackFires(t *testing.T) {
+	target := httptest.NewServer((&cbAuthServer{signed: false, callOut: true}).handler())
+	defer target.Close()
+
+	findings, err := runCbAuth(t, target.URL, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 finding, got %d: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Severity != "high" || f.Confidence != attack.ConfirmedExploit {
+		t.Errorf("want high/ConfirmedExploit, got %q/%q", f.Severity, f.Confidence)
+	}
+	if !strings.Contains(f.Evidence, "token echoed: no") {
+		t.Errorf("evidence should record the missing echo, got: %q", f.Evidence)
+	}
+}
+
+// TestCbAuth_SignedCallbackSilent: the callback presents the configured token,
+// so receivers can authenticate it. The boundary held; MUST stay silent.
+func TestCbAuth_SignedCallbackSilent(t *testing.T) {
+	target := httptest.NewServer((&cbAuthServer{signed: true, callOut: true}).handler())
+	defer target.Close()
+
+	findings, err := runCbAuth(t, target.URL, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings when the token is echoed, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestCbAuth_NoCallbackNotTested: registration accepted, webhook never hit.
+// The oracle never ran, so the rule reports not tested rather than clean.
+func TestCbAuth_NoCallbackNotTested(t *testing.T) {
+	target := httptest.NewServer((&cbAuthServer{callOut: false}).handler())
+	defer target.Close()
+
+	findings, err := runCbAuth(t, target.URL, "")
+	if err == nil {
+		t.Fatalf("expected an inconclusive error when no callback arrived")
+	}
+	if !strings.Contains(err.Error(), "provenance") {
+		t.Errorf("expected the reason to name provenance, got: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings alongside the inconclusive result, got %d", len(findings))
+	}
+}
+
+// TestCbAuth_ExternalOOBInfoIndicator: with an external collector the scanner
+// cannot see the callback itself; an info indicator names the token to check
+// for instead.
+func TestCbAuth_ExternalOOBInfoIndicator(t *testing.T) {
+	target := httptest.NewServer((&cbAuthServer{signed: false, callOut: true}).handler())
+	defer target.Close()
+
+	findings, err := runCbAuth(t, target.URL, "http://127.0.0.1:9/oob")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 finding, got %d: %+v", len(findings), findings)
+	}
+	if findings[0].Severity != "info" || findings[0].Confidence != attack.RiskIndicator {
+		t.Errorf("want info/RiskIndicator for external OOB, got %q/%q",
+			findings[0].Severity, findings[0].Confidence)
+	}
+}
+
+// TestCbAuth_AnonymousRefusedNotTested: a secured agent refuses the task
+// creation from an anonymous scan. Not tested, naming the refusal - never a
+// clean claim about callbacks nobody agreed to send.
+func TestCbAuth_AnonymousRefusedNotTested(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string      `json:"method"`
+			ID     json.Number `json:"id"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.Method == "SendMessage" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req.ID,
+				"error": map[string]interface{}{"code": -32000, "message": "unauthorized"},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer ts.Close()
+
+	findings, err := a2a.NewPushCallbackAuthExecutor(cbAuthRC()).
+		Execute(context.Background(), ts.URL, attack.Options{TimeoutSeconds: 5})
+	if err == nil {
+		t.Fatalf("expected an inconclusive error against a secured anonymous scan")
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings alongside the inconclusive result, got %d", len(findings))
+	}
+}

--- a/rules/a2a/push-callback-auth-001.yaml
+++ b/rules/a2a/push-callback-auth-001.yaml
@@ -1,0 +1,72 @@
+id: a2a-push-callback-auth-001
+info:
+  name: A2A Push Notification Sent Without Configured Integrity Token
+  author: batesian
+  severity: high
+  description: |
+    Tests whether an A2A agent's outgoing push notifications carry anything a
+    receiver can use to verify where they came from.
+
+    The push flow hands the agent a webhook URL plus, optionally, a secret
+    token the agent is expected to present when it calls (typically as
+    X-A2A-Notification-Token). A receiver that knows the token can tell
+    genuine completion events from forged ones. An agent that accepts the
+    token at registration and then never presents it produces notifications
+    with no verifiable provenance: anyone who learns or guesses the webhook
+    URL can forge task completions, failures, or injected results and they
+    are indistinguishable from genuine agent output. That is the
+    notification-side enabler of task hijacking.
+
+    MECHANICS. The probe registers a callback toward the Batesian listener
+    carrying a unique secret - across all three transport bindings the
+    push-notification surface has (v1.0 CreateTaskPushNotificationConfig,
+    v0.3 message/send inline plus tasks/pushNotificationConfig/set, and the
+    card-advertised HTTP+JSON binding) - waits for the agent's outbound call,
+    and reads what arrived:
+
+      1. Callback carries the secret in any header or in the body -> the
+         transport is verifiable. No finding; a held boundary is the pass.
+      2. Callback arrives WITHOUT the secret -> CONFIRMED at high. The agent
+         ignored integrity material it accepted at registration, so its
+         notifications cannot be authenticated by receivers.
+      3. No callback within the window -> the oracle never ran; reported as
+         NOT TESTED rather than clean, since accepting a config is normal and
+         says nothing about what callbacks carry.
+      4. With an external --oob-url collector, an INFO indicator names the
+         token to look for so the operator can verify manually.
+
+    The marker routing the callback and the integrity token are deliberately
+    different values: conflating them made "the callback arrived" and "the
+    callback was authenticated" one observation instead of two.
+
+    PRECONDITION. A task must be creatable, which on an authorization-
+    enforcing agent depends on the supplied credential; a refused creation is
+    reported as not tested naming the refusal, per the shared task-first
+    convention.
+
+  references:
+    - https://a2a-protocol.org/latest/specification/
+    - https://owasp.org/www-project-mcp-top-10/
+    - https://cwe.mitre.org/data/definitions/345.html
+
+  tags:
+    - a2a
+    - push-notifications
+    - webhooks
+    - authenticity
+    - cwe-345
+
+attack:
+  protocol: a2a
+  type: a2a-push-callback-auth
+
+remediation: |
+  1. When a push config declares a token, present it on every callback -
+     conventionally as the X-A2A-Notification-Token header - exactly as
+     configured; do not drop or transform it.
+  2. Refuse push configs whose authentication material is absent rather than
+     silently downgrading to unauthenticated callbacks.
+  3. Sign notification payloads where the transport allows it, so receivers
+     verify origin and integrity rather than relying on URL secrecy.
+  4. Document the verification requirement for client implementers; a token
+     the receiver does not know to check protects nobody.

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -31,7 +31,7 @@ a run that treats it as a clean result is reporting coverage it does not have.
 
 ## Server Registry
 
-The bundled rule set is **18 A2A + 26 MCP = 44 rules**. Every rule's primary
+The bundled rule set is **19 A2A + 26 MCP = 45 rules**. Every rule's primary
 validation is an in-process `net/http/httptest` harness in its Go
 `*_test.go` (multiple server postures: vulnerable must fire / patched / open /
 benign must stay silent). The Python servers below are optional standalone
@@ -77,8 +77,9 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_shadow_surface_server.py` | 7807 + 6277 | `mcp-shadow-surface-001` must fire on `shadow-open`; fire medium on `shadow-hardened`; stay silent on `none` (three postures, see below) |
 | `mcp_tool_poisoning_server.py` | 7808 | `mcp-tool-poisoning-001`: checks 1-3 fire on `poisoned`, check 4 fires on `drifting`, all silent on `clean` (three postures, see below) |
 | `mcp_vulnerable_version_server.py` | 7809 | `mcp-vulnerable-version-001` must fire on `vulnerable`; stay silent on `patched` and `unknown` (three postures, see below) |
+| `a2a_push_callback_auth_server.py` | 7810 | `a2a-push-callback-auth-001` must fire on `unsigned`; stay silent on `signed`; report not tested on `nocallback` (three postures, see below) |
 
-**Coverage.** 42 of the 44 rules have a standalone Python fixture above, and each
+**Coverage.** 43 of the 45 rules have a standalone Python fixture above, and each
 of those was checked by actually running it rather than by reading this table. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
 (`internal/attack/mcp/token_replay_test.go`); the same is true of the per-rule
@@ -480,6 +481,25 @@ patched posture pins the range boundary - the fix version itself must not
 fire - and `unknown` pins that the advisory table is closed rather than
 heuristic. Only `initialize` is served; this rule reads identity and nothing
 else.
+
+**`a2a_push_callback_auth_server.py` takes a posture argument**, defaulting to
+`unsigned`. batesian starts its local OOB listener for this one, so no extra
+flags are needed:
+
+```sh
+python testdata/a2a_push_callback_auth_server.py unsigned    # high finding
+python testdata/a2a_push_callback_auth_server.py signed      # silent
+python testdata/a2a_push_callback_auth_server.py nocallback  # NOT TESTED
+batesian scan --target http://127.0.0.1:7810 --rule-ids a2a-push-callback-auth-001 -v
+```
+
+All three postures register the caller's config verbatim on the v1.0 wire.
+`unsigned` drops the token on the outbound call, so the notification carries
+nothing a receiver could authenticate. `signed` presents it in the documented
+header and must stay silent. `nocallback` never dials out at all; the rule
+reports not tested because its oracle never ran, which is different from a
+clean claim about callbacks nobody sent.
+
 
 ---
 

--- a/testdata/a2a_push_callback_auth_server.py
+++ b/testdata/a2a_push_callback_auth_server.py
@@ -1,0 +1,95 @@
+"""
+Deliberately vulnerable A2A test server for validating:
+
+  a2a-push-callback-auth-001: an agent that accepts the caller's integrity
+  token at push-config registration and then drops it on the way out, so its
+  notifications carry nothing receivers can authenticate.
+
+Postures:
+  unsigned (default) - the outbound callback POSTs the status JSON with NO
+                       X-A2A-Notification-Token header and no token in the
+                       body. The rule MUST fire confirmed/high.
+  signed             - the callback presents the configured token in the
+                       documented header. The rule MUST stay silent: the
+                       transport is verifiable.
+  nocallback         - registration accepted, no outbound call ever made.
+                       The rule MUST report NOT TESTED.
+
+Only the v1.0 two-step wire is served (SendMessage +
+CreateTaskPushNotificationConfig). Nothing beyond a status update is ever
+sent to the registered URL, and only URLs the scan itself supplied receive
+traffic.
+
+Validate against it (batesian starts its local OOB listener automatically):
+  python testdata/a2a_push_callback_auth_server.py unsigned    # fires
+  python testdata/a2a_push_callback_auth_server.py signed      # silent
+  python testdata/a2a_push_callback_auth_server.py nocallback  # not tested
+
+Run: python testdata/a2a_push_callback_auth_server.py [posture]
+Scan: batesian scan --target http://127.0.0.1:7810 --rule-ids a2a-push-callback-auth-001 -v
+"""
+import threading
+import time
+
+import httpx
+import uvicorn
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+PORT = 7810
+
+
+async def jsonrpc(request: Request) -> JSONResponse:
+    body = await request.json()
+    method = body.get("method")
+    rid = body.get("id", "1")
+
+    if method == "SendMessage":
+        return JSONResponse({
+            "jsonrpc": "2.0", "id": rid,
+            "result": {
+                "id": "task-cbauth-live",
+                "contextId": "ctx-cbauth-live",
+                "status": {"state": "TASK_STATE_WORKING"},
+            },
+        })
+
+    if method == "CreateTaskPushNotificationConfig":
+        url = body.get("params", {}).get("url", "")
+        token = body.get("params", {}).get("token", "")
+        posture = request.app.state.posture
+        if posture != "nocallback" and url:
+            def fire():
+                time.sleep(0.5)
+                headers = {}
+                if posture == "signed":
+                    headers["X-A2A-Notification-Token"] = token
+                try:
+                    httpx.post(url, json={
+                        "kind": "status-update",
+                        "taskId": "task-cbauth-live",
+                        "status": {"state": "TASK_STATE_COMPLETED"},
+                    }, headers=headers, timeout=5)
+                except Exception:
+                    pass
+            threading.Thread(target=fire, daemon=True).start()
+        return JSONResponse({
+            "jsonrpc": "2.0", "id": rid,
+            "result": {"taskId": "task-cbauth-live", "url": url, "token": token},
+        })
+
+    return JSONResponse({"jsonrpc": "2.0", "id": rid,
+                         "error": {"code": -32601, "message": "Method not found"}})
+
+
+app = Starlette(routes=[Route("/", jsonrpc, methods=["POST"]), Route("/a2a/jsonrpc", jsonrpc, methods=["POST"])])
+app.state.posture = "unsigned"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        app.state.posture = sys.argv[1]
+    print(f"[*] A2A push callback-auth fixture ({app.state.posture}) on port {PORT}", flush=True)
+    uvicorn.run(app, host="127.0.0.1", port=PORT)


### PR DESCRIPTION
The push flow hands the agent a webhook plus, optionally, a secret token the agent presents when it calls. A receiver that knows the token can tell genuine completion events from forgeries; an agent that accepts the token at registration and drops it on the way out produces notifications with no verifiable provenance - anyone who learns the webhook URL can forge completions and injected results indistinguishable from genuine output. That is the notification-side enabler of task hijacking (AgentsID gap 3, CSA MAESTRO), and no existing rule graded it: push-ssrf only checks that a callback happens; push-binding grades who may attach configs to whose task.

Registration mechanics are shared with a2a-push-ssrf-001 across its three transport bindings (v1.0 CreateTaskPushNotificationConfig, v0.3 inline + set, HTTP+JSON where the card advertises it). Two things differ deliberately:

- the URL marker routing the callback and the integrity token are separate values here; in the SSRF rule they coincide, which made "a callback arrived" and "it was authenticated" one observation instead of two
- the oracle grades what the callback carried: token present in any header or body => boundary held, silent; callback without it => confirmed/high; no callback within the window => not tested, never clean; external --oob-url => info indicator naming the token to check for

Task-first precondition follows the shared convention: refused creation is not tested naming the refusal.

Changes:
- internal/attack/a2a/push_callback_auth.go plus harness (five postures: unsigned fires confirmed/high, signed silent, nocallback not-tested, external-OOB info, anonymous-refused not-tested)
- rules/a2a/push-callback-auth-001.yaml, CWE-345, remediation covering faithful token presentation, refusing unauthenticated configs, payload signing
- testdata/a2a_push_callback_auth_server.py (port 7810): unsigned/signed/nocallback
- counts updated to 19 A2A / 45 total across README.md, catalog (table row, detail section, task-first list now ten), registry

Verified locally in the pinned containers: gofmt clean, vet, full race suite green, lint 0 issues.
