### PR TITLE
ci: gate the six new rules against their live fixtures

### DIFF
--- a/.github/scripts/validate_mcp_fixtures.py
+++ b/.github/scripts/validate_mcp_fixtures.py
@@ -19,6 +19,28 @@ is a difference the gate catches:
   mcp_large_body_server           large finding set == small finding set. A body
                                   read limit that truncates silently made the large
                                   server hide every unauth finding (S8).
+  mcp_tool_param_traversal_*      vulnerable fires; patched silent. Patched pins
+                                  the containment discriminator (generic refusal,
+                                  no resolution echo), so silence means the
+                                  boundary held rather than that the oracle was
+                                  blind (#226).
+  mcp_scope_confusion_server      vulnerable fires (limited token dispatches like
+                                  full while anonymous is refused); patched and
+                                  open stay silent - enforced scopes are a pass,
+                                  an open server belongs to tools-unauth (#227).
+  mcp_shadow_surface_server       shadow-open high, shadow-hardened medium, none
+                                  silent: severity tracks whether a foreign origin
+                                  can reach the surface, and a closed port is an
+                                  answer, not could-not-tell (#228).
+  mcp_tool_poisoning_server       poisoned fires checks 1-3 on one STABLE manifest;
+                                  drifting alternates two benign manifests so only
+                                  the drift check fires; clean silent. The split
+                                  keeps drift from firing where content was the
+                                  defect, and vice versa (#229).
+  mcp_vulnerable_version_*        one patch below the fix fires citing advisories;
+                                  exactly at the fix is silent (exclusive bound);
+                                  unknown identity matches nothing because the
+                                  table is closed, not heuristic (#230).
 
 Run by .github/workflows/validation.yml.
 """
@@ -230,12 +252,150 @@ def large_body():
                  large == small, f"large {sorted(large)}; small {sorted(small)}")
 
 
+def traversal():
+    """vulnerable fires confirmed/high; patched stays silent.
+
+    The patched posture pins the discriminator rather than a vacuous pass: it
+    refuses outside-root paths generically without echoing any resolution, so
+    silence there means containment held, not that the oracle was blind."""
+    ok_all = True
+    rid = "mcp-tool-param-traversal-001"
+    p, l = start("mcp_tool_param_traversal_server.py", 7805, "vulnerable")
+    try:
+        fired, _, _ = scan(7805)
+    finally:
+        stop(p, l)
+    ok_all &= check("traversal vulnerable (fires)", rid in fired,
+                    f"fired {sorted(fired)}")
+
+    p, l = start("mcp_tool_param_traversal_server.py", 7805, "patched")
+    try:
+        fired, _, _ = scan(7805)
+    finally:
+        stop(p, l)
+    ok_all &= check("traversal patched (silent)", rid not in fired,
+                    f"fired {sorted(fired)}")
+    return ok_all
+
+
+def scope_confusion():
+    """Both tokens authenticate; only the full one should reach delete_item.
+
+    vulnerable ignores scopes entirely (limited dispatches like full) while an
+    anonymous call is refused - the confirmed failure. patched refuses the
+    limited token with insufficient_scope before validation. open authenticates
+    nothing at all, which suppresses the rule because identity gates nothing
+    (that surface belongs to mcp-tools-unauth-001)."""
+    ok_all = True
+    rid = "mcp-scope-confusion-001"
+    principals = ["--token", "tok-a",
+                  "--principal", "name=full,token=tok-a",
+                  "--principal", "name=limited,token=tok-b"]
+    for posture, expect_fire in [("vulnerable", True), ("patched", False), ("open", False)]:
+        p, l = start("mcp_scope_confusion_server.py", 7806, posture)
+        try:
+            fired, skipped, _ = scan(7806, *principals)
+        finally:
+            stop(p, l)
+        fires = rid in fired
+        ok_all &= check(f"scope-confusion {posture}", fires == expect_fire,
+                        f"{rid} {'fired' if fires else 'silent'}; skipped {rid in skipped}")
+    return ok_all
+
+
+def shadow_surface():
+    """shadow-open is the full chain (unauthenticated plus foreign Origin
+    accepted, high); shadow-hardened refuses the Origin twin (medium); none
+    binds no second listener at all, and a closed port is an answer, so
+    silence there is checked-and-absent."""
+    ok_all = True
+    rid = "mcp-shadow-surface-001"
+
+    def severity_for(doc):
+        for f in doc.get("findings", []):
+            if f.get("rule_id") == rid:
+                return f.get("severity")
+        return None
+
+    for posture, expect_sev in [("shadow-open", "high"), ("shadow-hardened", "medium"), ("none", None)]:
+        p, l = start("mcp_shadow_surface_server.py", 7807, posture)
+        try:
+            fired, _, doc = scan(7807)
+        finally:
+            stop(p, l)
+        sev = severity_for(doc)
+        if expect_sev is None:
+            ok_all &= check("shadow none (silent)", rid not in fired,
+                            f"fired {sorted(fired)}")
+        else:
+            ok_all &= check(f"shadow {posture} ({expect_sev})",
+                            rid in fired and sev == expect_sev,
+                            f"severity {sev}; fired {sorted(fired)}")
+    return ok_all
+
+
+def tool_poisoning():
+    """poisoned carries hidden characters, injection phrasing and a duplicate
+    name pair in ONE stable manifest (checks 1-3 fire, drift must not);
+    drifting alternates two benign manifests so ONLY the drift check fires;
+    clean is factual, unique and stable."""
+    ok_all = True
+    rid = "mcp-tool-poisoning-001"
+    p, l = start("mcp_tool_poisoning_server.py", 7808, "poisoned")
+    try:
+        fired, _, _ = scan(7808)
+    finally:
+        stop(p, l)
+    ok_all &= check("poisoning poisoned (fires)", rid in fired,
+                    f"fired {sorted(fired)}")
+
+    p, l = start("mcp_tool_poisoning_server.py", 7808, "drifting")
+    try:
+        fired, _, _ = scan(7808)
+    finally:
+        stop(p, l)
+    ok_all &= check("poisoning drifting (drift check fires)", rid in fired,
+                    f"fired {sorted(fired)}")
+
+    p, l = start("mcp_tool_poisoning_server.py", 7808, "clean")
+    try:
+        fired, _, _ = scan(7808)
+    finally:
+        stop(p, l)
+    ok_all &= check("poisoning clean (silent)", rid not in fired,
+                    f"fired {sorted(fired)}")
+    return ok_all
+
+
+def vulnerable_version():
+    """One patch below the fix fires citing the advisory; exactly at the fix is
+    silent (exclusive bound); an unrelated identity matches nothing because the
+    table is closed rather than heuristic."""
+    ok_all = True
+    rid = "mcp-vulnerable-version-001"
+    for posture, expect_fire in [("vulnerable", True), ("patched", False), ("unknown", False)]:
+        p, l = start("mcp_vulnerable_version_server.py", 7809, posture)
+        try:
+            fired, _, _ = scan(7809)
+        finally:
+            stop(p, l)
+        fires = rid in fired
+        ok_all &= check(f"vulnerable-version {posture}", fires == expect_fire,
+                        f"{rid} {'fired' if fires else 'silent'}")
+    return ok_all
+
+
 def main():
     suites = [
         ("transient", transient()),
         ("session-as-credential", session_as_credential()),
         ("log-optin", log_optin()),
         ("large-body", large_body()),
+        ("traversal", traversal()),
+        ("scope-confusion", scope_confusion()),
+        ("shadow-surface", shadow_surface()),
+        ("tool-poisoning", tool_poisoning()),
+        ("vulnerable-version", vulnerable_version()),
     ]
     print()
     for name, ok in suites:

--- a/.github/scripts/validate_push_callback_auth.py
+++ b/.github/scripts/validate_push_callback_auth.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""CI validation harness for the A2A push-callback-auth fixture.
+
+Companion to validate_secured_agent.py. a2a-push-callback-auth-001 grades what
+an agent's outgoing push notification carried, which needs a live OOB listener:
+batesian starts its own during the scan, so the harness only has to start the
+fixture and read the verdict.
+
+  unsigned    -> the agent accepted the integrity token at registration and
+                 dropped it on the outbound call: the rule MUST fire.
+                 Receivers get nothing to authenticate, so completions can be
+                 forged (#231).
+  signed      -> the callback presents the configured token in the documented
+                 header: the boundary held, the rule MUST stay silent.
+  nocallback  -> registration accepted but no outbound call ever made: the
+                 oracle never ran, so the rule MUST report NOT TESTED (skipped),
+                 never clean - silence there is could-not-tell, not secure.
+
+Only the v1.0 two-step wire is served, so --rule-ids isolates the rule under
+test from unrelated A2A discovery noise.
+
+Run by .github/workflows/validation.yml.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+
+BINARY = os.environ.get("BATESIAN_BIN", "./batesian")
+FIXTURE = os.environ.get("BATESIAN_FIXTURE", "testdata/a2a_push_callback_auth_server.py")
+PORT = 7810
+RULE = "a2a-push-callback-auth-001"
+
+SCAN_ARGS = [
+    "scan",
+    "--target", f"http://127.0.0.1:{PORT}",
+    "--rule-ids", RULE,
+    "--output", "json",
+    "--timeout", "20",
+]
+
+
+def _read(log):
+    log.flush()
+    log.seek(0)
+    return log.read()
+
+
+def _ready(deadline_s=40):
+    """Poll POST / until uvicorn answers. Any HTTP status counts as up."""
+    url = f"http://127.0.0.1:{PORT}"
+    body = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize",
+                       "params": {"protocolVersion": "2025-11-25", "capabilities": {},
+                                  "clientInfo": {"name": "ci", "version": "1"}}}).encode()
+    deadline = time.time() + deadline_s
+    while time.time() < deadline:
+        try:
+            req = urllib.request.Request(url, data=body,
+                                         headers={"Content-Type": "application/json"})
+            urllib.request.urlopen(req, timeout=2)
+            return
+        except urllib.error.HTTPError:
+            return
+        except (urllib.error.URLError, OSError):
+            time.sleep(0.25)
+    raise RuntimeError(f"fixture on {url} not ready within {deadline_s}s")
+
+
+def start_fixture(posture):
+    log = tempfile.NamedTemporaryFile("w+", suffix="-cbauth-fixture.log", delete=False,
+                                      encoding="utf-8")
+    proc = subprocess.Popen(
+        [sys.executable, FIXTURE, posture],
+        stdout=log, stderr=subprocess.STDOUT, text=True,
+    )
+    try:
+        _ready()
+    except Exception:
+        stop_fixture(proc, log)
+        raise
+    return proc, log
+
+
+def stop_fixture(proc, log=None):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+    if log is not None:
+        try:
+            log.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def scan():
+    out = subprocess.run([BINARY, *SCAN_ARGS], capture_output=True, text=True, timeout=180)
+    if out.returncode != 0:
+        raise RuntimeError(f"batesian scan exited {out.returncode}:\nstdout:\n{out.stdout}\nstderr:\n{out.stderr}")
+    doc = json.loads(out.stdout)
+    fired = {f["rule_id"] for f in doc.get("findings", [])}
+    skipped = {s["rule_id"] for s in doc.get("skipped", [])}
+    return fired, skipped
+
+
+def check(name, ok, detail):
+    print(f"[{'PASS' if ok else 'FAIL'}] {name}: {detail}")
+    return ok
+
+
+def main():
+    ok_all = True
+
+    for posture, expect in [("unsigned", "fire"), ("signed", "silent")]:
+        proc, log = start_fixture(posture)
+        try:
+            fired, skipped = scan()
+        finally:
+            stop_fixture(proc, log)
+        # "Ran and found nothing" must be distinguishable from "never ran": a
+        # skip here means the fixture was not exercised, which would make the
+        # signed pass vacuous.
+        ran = RULE in fired or RULE not in skipped
+        fires = RULE in fired
+        ok_all &= check(f"{posture} (must {expect})", ran and fires == (expect == "fire"),
+                        f"{RULE} {'fired' if fires else ('skipped' if not ran else 'silent')}")
+
+    proc, log = start_fixture("nocallback")
+    try:
+        fired, skipped = scan()
+    finally:
+        stop_fixture(proc, log)
+    not_tested = RULE in skipped
+    ok_all &= check("nocallback (not tested, never clean)",
+                    not_tested and RULE not in fired,
+                    f"fired {RULE in fired}; skipped {RULE in skipped}")
+
+    print()
+    print(f"[{'PASS' if ok_all else 'FAIL'}] push-callback-auth")
+    return 0 if ok_all else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -60,6 +60,39 @@ jobs:
         env:
           BATESIAN_BIN: ./batesian
 
+  a2a-push-callback-auth:
+    name: A2A push callback-auth gate (unsigned/signed/nocallback)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install fixture dependencies
+        # The fixture dials the registered webhook itself, so it needs httpx.
+        run: pip install starlette uvicorn httpx
+
+      - name: Build batesian
+        run: go build -o batesian ./cmd/batesian
+
+      - name: Run the push callback-auth validation
+        run: python .github/scripts/validate_push_callback_auth.py
+        env:
+          BATESIAN_BIN: ./batesian
+
   mcp-property-fixtures:
     name: MCP property gates (probe-honesty, log opt-in, body size, session)
     runs-on: ubuntu-latest

--- a/testdata/a2a_push_callback_auth_server.py
+++ b/testdata/a2a_push_callback_auth_server.py
@@ -28,6 +28,7 @@ Validate against it (batesian starts its local OOB listener automatically):
 Run: python testdata/a2a_push_callback_auth_server.py [posture]
 Scan: batesian scan --target http://127.0.0.1:7810 --rule-ids a2a-push-callback-auth-001 -v
 """
+import sys
 import threading
 import time
 


### PR DESCRIPTION
The rules shipped since the validation gates went to PRs (#226 through #231) carried Go harnesses and manual fixtures, but none were wired into the nightly validation - the exact coverage the repo's own history says catches what harnesses cannot (the secured-agent gate caught a false positive in #222 on its first PR run).

Five MCP suites join validate_mcp_fixtures.py, each pinning the property that makes its fixture worth having rather than just "the rule runs":

- traversal: vulnerable fires; patched pins the containment discriminator (generic refusal with no resolution echo), so silence means the boundary held
- scope-confusion: vulnerable fires; patched and open stay silent for opposite reasons (enforced scopes vs no identity gate at all)
- shadow-surface: severity tracks foreign-Origin reachability (high vs medium); the none posture pins that a closed port reads as checked-and-absent
- tool-poisoning: poisoned and drifting both fire but through different checks (content defects vs manifest instability); clean is fully silent
- vulnerable-version: one patch below the fix fires citing advisories; at-the-fix is silent (exclusive bound); unknown identity matches nothing because the table is closed

The A2A push-callback-auth gate gets its own script and workflow job: unsigned must fire, signed must stay silent with the rule confirmed as having run rather than skipped (a skip would make the signed pass vacuous), and nocallback must read as not-tested rather than clean.

Also fixes a missing sys import in the callback-auth fixture that only the live run surfaced.

Verified locally in containers against a freshly built binary: all 9 MCP suites pass (25 posture checks), push-callback-auth passes 3/3.
