### PR TITLE
rule(mcp): drive canonicalization-bypass payloads in the traversal rule

### DIFF
--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -873,9 +873,13 @@ than in the transport or authorization layer the other rules here cover.
 
 **Oracle.** Servers that resolve the joined path before opening it usually say
 where they looked when it is not there; a Node ENOENT names the resolved
-absolute path. Three requests go to each candidate parameter: a no-traversal
-baseline naming only the canary, an absolute path carrying a dot-dot chain, and
-a backslash variant for Windows-style joins. The finding fires only when a
+absolute path. Seven requests go to each candidate parameter: a no-traversal baseline naming
+only the canary, then six payloads - literal absolute dot-dot, backslash,
+URL-encoded dot-dot (validate-before-decode bugs), double-encoded dot-dot
+(two decode passes), mixed separators, and drive-lettered joins. The encoding
+variants exist because canonicalization is where the real-world bypasses live:
+CVE-2026-53766 escaped symlink-aware validation through exactly the gap between
+what is checked and what the filesystem resolves. The finding fires only when a
 traversal probe discloses a **resolved** absolute lookup in a directory outside
 the baseline's own tree - the server's own resolution proves the escape with
 zero bytes read. An echo of the caller's input with its dot-dot segments intact

--- a/internal/attack/mcp/tool_param_traversal.go
+++ b/internal/attack/mcp/tool_param_traversal.go
@@ -254,7 +254,41 @@ func (e *ToolParamTraversalExecutor) callTool(ctx context.Context, client *attac
 	return sb.String()
 }
 
-// probeTool drives baseline plus two traversals against one tool's path
+// traversalPayload is one attack-shaped argument for the path parameter.
+type traversalPayload struct {
+	label string
+	value string
+}
+
+// deepFwd / winPrefix climb twelve levels, far past any plausible root depth,
+// so the surviving segments cannot be mistaken for legitimate structure.
+const traversalDepth = 12
+
+// traversalPayloads enumerates the encodings a validating server may treat
+// differently from the literal forms. Beyond the plain variants:
+//
+//   - URL-encoded dot-dot catches servers that validate before decoding
+//     (the single most common canonicalization gap; CVE-2026-53766 class)
+//   - double-encoded catches two decode passes (proxy then handler)
+//   - mixed separators catch normalizers that treat / and \ asymmetrically
+//   - drive-lettered exercises Windows-rooted joins on POSIX frontends
+func traversalPayloads(canary string) []traversalPayload {
+	fwd := strings.Repeat("../", traversalDepth)
+	bwd := strings.Repeat("..\\", traversalDepth)
+	enc := strings.Repeat("%2e%2e%2f", traversalDepth)
+	dbl := strings.Repeat("%252e%252e%252f", traversalDepth)
+	mixed := strings.Repeat("../\\", traversalDepth)
+	return []traversalPayload{
+		{"absolute forward-slash traversal", "/" + fwd + canary},
+		{"backslash traversal", bwd + canary},
+		{"URL-encoded dotdot", enc + canary},
+		{"double-encoded dotdot", dbl + canary},
+		{"mixed separator traversal", mixed + canary},
+		{"drive-lettered traversal", "C:\\" + bwd + canary},
+	}
+}
+
+// probeTool drives the baseline plus every payload against one tool's path
 // parameter and grades what came back. A nil return means the tool validated
 // its paths, refused them without disclosing resolutions, or could not be
 // characterised; none of those is a finding.
@@ -264,16 +298,12 @@ func (e *ToolParamTraversalExecutor) probeTool(ctx context.Context, client *atta
 	baselineText := e.callTool(ctx, client, session, 10, cand.tool, cand.param, canary, cand.others)
 	baselinePath := leakedPath(baselineText, canary)
 
-	deepPrefix := strings.Repeat("../", 12)
-	winPrefix := strings.Repeat("..\\", 12)
-	traversalText := e.callTool(ctx, client, session, 11, cand.tool, cand.param, "/"+deepPrefix+canary, cand.others)
-	backslashText := e.callTool(ctx, client, session, 12, cand.tool, cand.param, winPrefix+canary, cand.others)
+	nextID := 11
+	for _, probe := range traversalPayloads(canary) {
+		text := e.callTool(ctx, client, session, nextID, cand.tool, cand.param, probe.value, cand.others)
+		nextID++
 
-	for _, probe := range []struct{ label, text string }{
-		{"absolute + forward-slash traversal", traversalText},
-		{"backslash traversal", backslashText},
-	} {
-		path := leakedPath(probe.text, canary)
+		path := leakedPath(text, canary)
 		if !resolvedAbsolute(path) {
 			// Either nothing was disclosed, or the server merely echoed the
 			// caller's input back with its dot-dot segments intact. An echo is

--- a/internal/attack/mcp/tool_param_traversal_test.go
+++ b/internal/attack/mcp/tool_param_traversal_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -285,5 +286,42 @@ func TestTraversal_ContainedClimbStaysSilent(t *testing.T) {
 	}
 	if len(findings) != 0 {
 		t.Errorf("expected zero findings when the sandbox contains the climb, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestTraversal_EncodedOnlyFires: a server that rejects literal traversal
+// up front but decodes the input before joining escapes only through the
+// percent-encoded payloads. The pre-expansion probe set read this server
+// clean; the expansion exists to catch exactly it.
+func TestTraversal_EncodedOnlyFires(t *testing.T) {
+	srv := &traversalServer{
+		caps:  map[string]interface{}{"tools": map[string]interface{}{}},
+		tools: []map[string]interface{}{readOnlySchemaTool("read_note")},
+		call: func(name string, args map[string]interface{}) (string, bool, string) {
+			p, _ := args["path"].(string)
+			if !strings.Contains(p, "%") && strings.Contains(p, "..") {
+				// Literal dot-dot is rejected before anything else happens.
+				return "rejected: path contains traversal segments", true, ""
+			}
+			decoded, err := url.PathUnescape(p)
+			if err == nil {
+				p = decoded
+			}
+			resolved := joinLikeNaive(p)
+			return strings.ReplaceAll(leakTemplate, "<PATH>", resolved), true, ""
+		},
+	}
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	findings, err := runTraversal(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 finding, got %d: %+v", len(findings), findings)
+	}
+	if !strings.Contains(findings[0].Evidence, "URL-encoded") {
+		t.Errorf("expected the URL-encoded payload to be the one that escaped, got: %q", findings[0].Evidence)
 	}
 }

--- a/rules/mcp/tool-param-traversal-001.yaml
+++ b/rules/mcp/tool-param-traversal-001.yaml
@@ -23,7 +23,7 @@ info:
 
     ORACLE. Many servers resolve the joined path before opening it, and say
     where they looked when it is not there (a Node ENOENT names the resolved
-    absolute path). The rule sends three requests per candidate parameter: a
+    absolute path). The rule sends the baseline plus six traversal payloads per candidate parameter - literal absolute dot-dot, backslash, URL-encoded dot-dot, double-encoded dot-dot, mixed separators, and drive-lettered. Encoded forms catch servers that validate before decoding; the canonicalization-bypass class behind CVE-2026-53766 (symlink and encoding aliasing) escapes precisely there. The baseline is a
     no-traversal baseline naming only the canary, an absolute path carrying a
     dot-dot chain, and a backslash variant for Windows-style joins. The finding
     fires only when a traversal probe discloses a RESOLVED absolute lookup in a


### PR DESCRIPTION
The traversal rule probed literal dot-dot in both separator styles and read validate-only-after-decode bugs as clean: the server rejects the literal probe, nothing else is tried, and the rule reports the surface sound. That is precisely the gap CVE-2026-53766 (chrome-devtools-mcp) escaped through - what the code checks differs from what the filesystem resolves. SiYuan's incomplete blocklist (CVE-2026-60083) and mcp-atlassian's attachment handling sit in the same family.

Six payloads now go to each candidate parameter, baseline plus:

- literal absolute forward-slash dot-dot (unchanged)
- backslash traversal (unchanged)
- URL-encoded dot-dot: catches servers that validate before decoding
- double-encoded dot-dot: catches proxy-plus-handler decode pairs
- mixed separators: catches normalizers treating / and \\ asymmetrically
- drive-lettered form: exercises Windows-rooted joins

The oracle is unchanged - a resolved absolute lookup outside the no-traversal baseline's directory tree, with echo-only responses ignored and no-baseline declining to report. So encoded echoes still cannot false-positive, a sandboxed clamp still stays silent across every new payload (the contained-climb posture passes against all six), and cost per candidate rises from three calls to seven.

The harness adds the posture this expansion exists for: a server that rejects literal traversal up front but decodes before joining. Pre-expansion probes read that server clean; now exactly one finding fires and its evidence names the URL-encoded payload as the one that escaped.

Changes:
- internal/attack/mcp/tool_param_traversal.go - payload table replaces the fixed pair
- internal/attack/mcp/tool_param_traversal_test.go - new encoded-only posture; existing six postures unchanged and green
- rules/mcp/tool-param-traversal-001.yaml and docs/rules-mcp.md - probe-set wording

Verified locally in the pinned containers: gofmt clean, vet, full race suite green, lint 0 issues.
