### PR TITLE
rule(mcp): detect Origin validators bypassed by prefix-forged values

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ CLI for adversarial testing of [A2A](https://a2a-protocol.org) and [MCP](https:/
 
 ## What ships
 
-Bundled rules: **19 A2A, 26 MCP (45 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
+Bundled rules: **19 A2A, 27 MCP (46 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
 
 - [A2A rules](docs/rules-a2a.md) (18)
 - [MCP rules](docs/rules-mcp.md) (21)
@@ -37,6 +37,7 @@ Coverage spans:
 - **Multi-party isolation** - cross-tenant isolation, cross-principal task enumeration, session/context fixation, session id accepted as a credential, delegation chain-of-custody, cross-principal task cancellation, cross-context MCP task and result access
 - **SSRF & secret leakage** - push-notification SSRF, push control-plane binding, OAuth discovery/metadata SSRF, credential leakage into responses
 - **Shadow surfaces** - unauthenticated inspector/dashboard listeners on adjacent ports, graded by whether a foreign origin can reach them
+- **Origin validation quality** - prefix-forged origins that slip past startswith()-style validators while unrelated origins are correctly refused
 - **Tool manifest integrity** - hidden-character payloads, description injection patterns, duplicate-name shadowing, and manifest drift between consecutive reads (OWASP MCP03)
 - **Component exposure** - self-reported server identity matched against a closed table of published MCP advisories
 - **Unauthenticated & cross-origin access** - exposed MCP tools, resources, prompt templates, completion suggestions, and log-level control, Streamable HTTP Origin validation (DNS rebinding)

--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -1,6 +1,6 @@
 # MCP Attack Rules
 
-Batesian ships **26 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
+Batesian ships **27 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
 Every rule is an active probe: it sends crafted protocol traffic and judges the
 server's actual response. Rules are deliberately scoped to MCP-specific semantics
 (OAuth 2.1 authorization, DCR, audience binding, discovery-chain metadata-fetch
@@ -176,6 +176,7 @@ candidate answers does a rule report that it could not test.
 | `mcp-shadow-surface-001` | [Shadow MCP Surface on an Adjacent Port](#mcp-shadow-surface-001) | High / Medium / Low | confirmed / indicator | CWE-488 |
 | `mcp-tool-poisoning-001` | [Tool Manifest Integrity (Poisoning)](#mcp-tool-poisoning-001) | High / Medium | confirmed / indicator | CWE-74 |
 | `mcp-vulnerable-version-001` | [Known-Vulnerable Component Identity](#mcp-vulnerable-version-001) | High | indicator | CWE-1104 |
+| `mcp-origin-prefix-bypass-001` | [Origin Prefix-Match Bypass](#mcp-origin-prefix-bypass-001) | High | confirmed | CWE-346 |
 
 ---
 
@@ -1058,3 +1059,45 @@ Two edge cases are pinned rather than papered over:
 
 Both wires are read where served: legacy carries identity in
 `result.serverInfo`, modern under `result._meta`, and the two need not agree.
+
+---
+
+### mcp-origin-prefix-bypass-001
+
+**Origin Prefix-Match Bypass** | Severity: High | confirmed | CWE-346
+
+Asks whether the Origin validation that exists actually means anything.
+mcp-dns-rebind-origin-001 establishes whether validation happens at all using
+a fully unrelated origin; the recurring real-world defect sits one step
+inside - validators written as string comparisons:
+
+```go
+strings.HasPrefix(origin, "https://trusted.example")
+strings.Contains(origin, "trusted.example")
+```
+
+Such validators reject that same unrelated origin and read clean under the
+sibling rule, while accepting anything whose STRING starts with (or contains)
+the trusted value:
+
+- `https://trusted.example.attacker.tld` - attacker subdomain
+- `https://trusted.example@attacker.tld` - userinfo smuggle
+
+Parsed out, both resolve to attacker infrastructure, so the browser-mediated
+exposure is identical to having no check at all. This family published
+repeatedly this quarter: CVE-2026-55532 prefix match, CVE-2026-55637 local
+rebind, GHSA-489g TOCTOU.
+
+The probe is a control pair on every served wire: the baseline handshake is
+repeated with a fully foreign Origin first, and its rejection is what proves
+a validator exists on that wire. Only then do the two crafted origins go out;
+acceptance of either against the rejecting control is **confirmed** at high,
+with evidence showing all three outcomes side by side. If the control twin is
+also accepted there is no validator to bypass - that surface belongs to
+`mcp-dns-rebind-origin-001` and is suppressed here rather than double-counted.
+
+The crafted domains are non-resolving RFC 6761 `.invalid` names, so nothing
+the probe accepts can call out to the scanner. Both crafts mirror the target's
+own scheme and host-port verbatim, because deployments allowlist what they
+themselves serve: an http server never accepts https-prefixed strings, and a
+craft that cannot fool a prefix validator measures nothing.

--- a/internal/attack/mcp/origin_prefix_bypass.go
+++ b/internal/attack/mcp/origin_prefix_bypass.go
@@ -1,0 +1,173 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// OriginPrefixBypassExecutor tests whether an MCP server's Origin validation
+// compares strings instead of parsed hosts (rule mcp-origin-prefix-bypass-001).
+//
+// mcp-dns-rebind-origin-001 asks whether any validation exists at all, using a
+// completely unrelated origin. But the recurring real-world defect sits one
+// step inside: validators implemented as string prefix or containment checks -
+//
+//	strings.HasPrefix(origin, "https://trusted.example")
+//	strings.Contains(origin, "trusted.example")
+//
+// - reject that same unrelated origin and read clean under the existing rule,
+// while accepting anything that merely STARTS WITH the trusted string:
+//
+//	https://trusted.example.attacker.tld   (attacker subdomain)
+//	https://trusted.example@attacker.tld    (userinfo smuggle)
+//
+// Both published repeatedly as CVEs in MCP platform transports this quarter
+// (CVE-2026-55532 prefix match, CVE-2026-55637 local rebind), because every
+// naive implementation reaches for HasPrefix before reaching for url.Parse.
+//
+// The probe is a control pair on each served wire:
+//
+//	baseline        handshake without Origin                  -> must succeed
+//	control twin    same request + fully foreign origin       -> must FAIL
+//	                (a failure proves a validator exists)
+//	prefix twins    same request + <host>-sharing origins     -> any ACCEPT is
+//	                the bypass, confirmed against the rejecting control
+//
+// If the control twin is also accepted there is no validator to bypass; that
+// surface belongs to mcp-dns-rebind-origin-001 and is suppressed here rather
+// than double-counted.
+type OriginPrefixBypassExecutor struct {
+	rule attack.RuleContext
+}
+
+func init() {
+	attack.Register("mcp-origin-prefix-bypass", func(rc attack.RuleContext) attack.Executor {
+		return NewOriginPrefixBypassExecutor(rc)
+	})
+}
+
+func NewOriginPrefixBypassExecutor(r attack.RuleContext) *OriginPrefixBypassExecutor {
+	return &OriginPrefixBypassExecutor{rule: r}
+}
+
+// prefixCanaryZone is the non-resolving RFC 6761 zone used to craft attacker
+// domains that share the target's hostname as a string prefix.
+const prefixCanaryZone = "prefix-rebind.batesian-invalid.invalid"
+
+// originProbe is one crafted Origin value plus what its acceptance would mean.
+type originProbe struct {
+	label  string
+	origin string
+}
+
+// prefixProbes composes the crafted origins for a target exactly as a
+// prefix-matching validator sees them: raw strings starting with the trusted
+// value. The target's own scheme and host[:port] travel verbatim inside the
+// craft, because deployments allowlist whatever they themselves serve - an
+// http server never accepts https-prefixed strings, so the mirror is what
+// makes a prefix bug observable rather than merely another rejection.
+func prefixProbes(trustedOrigin string) []originProbe {
+	return []originProbe{
+		{"attacker subdomain sharing the trusted hostname",
+			trustedOrigin + "." + prefixCanaryZone},
+		{"userinfo-smuggled attacker domain",
+			trustedOrigin + "@" + prefixCanaryZone},
+	}
+}
+
+func (e *OriginPrefixBypassExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
+	vars := attack.NewVars(target, opts.OOBListenerURL)
+	client := attack.NewHTTPClient(opts, vars)
+
+	u, err := url.Parse(vars.BaseURL)
+	if err != nil || u.Host == "" {
+		return nil, fmt.Errorf("%w: could not parse a host out of %s",
+			attack.ErrInconclusive, vars.BaseURL)
+	}
+
+	targetHostPort := u.Host // kept raw incl. port: prefix matches are literal
+	trustedOrigin := u.Scheme + "://" + targetHostPort
+
+	return runOnEachWire(ctx, client, vars.BaseURL, func(session mcpSession) ([]attack.Finding, bool) {
+
+		// Control: an unrelated origin. Accepted means no validator runs here at
+		// all, which suppresses the rule; rejected proves one does.
+		ctrlOK, ctrlResp := e.originWith(ctx, client, session, foreignOrigin)
+		if ctrlResp == nil {
+			return nil, false // no verdict from this wire
+		}
+		if ctrlOK {
+			return nil, true // no gate: dns-rebind's surface, not ours
+		}
+
+		for _, probe := range prefixProbes(trustedOrigin) {
+			ok, _ := e.originWith(ctx, client, session, probe.origin)
+			if !ok {
+				continue // this craft was rejected too: validator held on it
+			}
+			return []attack.Finding{e.finding(session, probe)}, true
+		}
+		// Every craft rejected against a live validator: the boundary held.
+		return nil, true
+	})
+}
+
+// originWith repeats this wire's baseline request carrying the given Origin.
+// The request shape mirrors dns-rebind's twin selection so both rules pair
+// their probes against the identical baseline per era.
+func (e *OriginPrefixBypassExecutor) originWith(ctx context.Context, client *attack.HTTPClient,
+	session mcpSession, origin string) (bool, *attack.Response) {
+	if session.Era == EraModern {
+		resp, err := session.postShaping(ctx, client, "batesian-originpfx", "server/discover", nil,
+			func(h map[string]string) { h["Origin"] = origin })
+		if err != nil {
+			return false, nil
+		}
+		return resp.IsAccepted(), resp
+	}
+	headers := map[string]string{"Content-Type": "application/json", "Origin": origin}
+	resp, err := client.POST(ctx, session.Endpoint, headers, legacyHandshakeBody())
+	if err != nil {
+		return false, nil
+	}
+	return resp.IsAccepted(), resp
+}
+
+func (e *OriginPrefixBypassExecutor) finding(session mcpSession, probe originProbe) attack.Finding {
+	method := probeMethod(session)
+	host := sessionHost(session.Endpoint)
+	return attack.Finding{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "high",
+		Confidence: attack.ConfirmedExploit,
+		Title:      "MCP Origin validation accepts " + method + " with a prefix-forged origin (" + method + " reached)",
+		Description: fmt.Sprintf(
+			"The %s endpoint rejected a fully foreign Origin but accepted one whose string merely "+
+				"starts with the trusted value (%q). That is a string prefix or containment check, not "+
+				"host validation: parsed out, the accepted origin resolves to attacker infrastructure "+
+				"(%s), so the DNS rebinding protection the check pretends to provide does not exist. "+
+				"A page on such a domain can drive this server from a victim's browser exactly as if "+
+				"no check were present. Parse the Origin header into a URL and compare scheme and host "+
+				"components individually.", session.Endpoint, probe.origin, host),
+		Evidence: fmt.Sprintf(
+			"endpoint: %s\nbaseline %s (no Origin): accepted\n"+
+				"control, unrelated origin %s: rejected\n"+
+				"probe (%s) %s: ACCEPTED\naccepted origin resolves to attacker infrastructure; "+
+				"shared substring only", session.Endpoint, method, foreignOrigin, probe.label, probe.origin),
+		Remediation: e.rule.Remediation,
+		TargetURL:   session.Endpoint,
+	}
+}
+
+// sessionHost extracts the host component of an endpoint for finding text.
+func sessionHost(endpoint string) string {
+	if u, err := url.Parse(endpoint); err == nil && u.Host != "" {
+		return u.Host
+	}
+	return strings.TrimPrefix(strings.TrimPrefix(endpoint, "https://"), "http://")
+}

--- a/internal/attack/mcp/origin_prefix_bypass_test.go
+++ b/internal/attack/mcp/origin_prefix_bypass_test.go
@@ -1,0 +1,236 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcp "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+func originPfxRC() attack.RuleContext {
+	return attack.RuleContext{
+		ID:          "mcp-origin-prefix-bypass-001",
+		Name:        "MCP Origin Prefix Bypass",
+		Severity:    "high",
+		Remediation: "Parse the Origin and compare scheme and host individually.",
+	}
+}
+
+// originPfxServer validates the Origin header with a chosen strategy:
+//
+//	prefix       strings.HasPrefix(origin, ownOrigin)        (vulnerable)
+//	none         no validation at all                        (suppressed)
+//	parsed-host  scheme+host equality after url.Parse        (patched)
+type originPfxStrategy string
+
+const (
+	opfxPrefix     originPfxStrategy = "prefix"
+	opfxNone       originPfxStrategy = "none"
+	opfxParsedHost originPfxStrategy = "parsed-host"
+)
+
+func originPfxHandler(strategy originPfxStrategy) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string      `json:"method"`
+			ID     json.Number `json:"id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		switch req.Method {
+		case "initialize":
+			if !originAllowed(strategy, r.Header.Get("Origin"), "http://"+r.Host) {
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req.ID,
+				"result": map[string]interface{}{
+					"protocolVersion": "2025-06-18",
+					"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+					"serverInfo":      map[string]interface{}{"name": "originpfx-fixture", "version": "1"},
+				},
+			})
+			return
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+			return
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req.ID,
+				"error": map[string]interface{}{"code": -32601, "message": "Method not found"},
+			})
+		}
+	}
+}
+
+// originAllowed implements each strategy against the server's own origin.
+func originAllowed(strategy originPfxStrategy, origin, own string) bool {
+	switch strategy {
+	case opfxPrefix:
+		// The published bug shape: literal prefix, no parse. An empty Origin
+		// (non-browser clients send none) passes; this is what makes the
+		// baseline handshake succeed for the scanner too.
+		if origin == "" {
+			return true
+		}
+		return strings.HasPrefix(origin, own)
+	case opfxNone:
+		return true
+	case opfxParsedHost:
+		if origin == "" {
+			return true
+		}
+		uo, err1 := url.Parse(origin)
+		uo2, err2 := url.Parse(own)
+		if err1 != nil || err2 != nil {
+			return false
+		}
+		// A crafted attacker subdomain shares the string but not the host.
+		return strings.EqualFold(uo.Scheme, uo2.Scheme) &&
+			strings.EqualFold(uo.Host, uo2.Host)
+	}
+	return false
+}
+
+func runOriginPfx(t *testing.T, ts *httptest.Server) ([]attack.Finding, error) {
+	t.Helper()
+	return mcp.NewOriginPrefixBypassExecutor(originPfxRC()).
+		Execute(context.Background(), ts.URL, attack.Options{TimeoutSeconds: 5})
+}
+
+// TestOriginPfx_PrefixMatchFires: control rejected, attacker-subdomain origin
+// accepted. MUST fire confirmed/high naming the craft in evidence.
+func TestOriginPfx_PrefixMatchFires(t *testing.T) {
+	ts := httptest.NewServer(originPfxHandler(opfxPrefix))
+	defer ts.Close()
+
+	findings, err := runOriginPfx(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 finding, got %d: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Severity != "high" || f.Confidence != attack.ConfirmedExploit {
+		t.Errorf("want high/ConfirmedExploit, got %q/%q", f.Severity, f.Confidence)
+	}
+	if !strings.Contains(f.Evidence, "control") || !strings.Contains(f.Evidence, "ACCEPTED") {
+		t.Errorf("evidence should show the control-rejected / probe-accepted pair, got: %q", f.Evidence)
+	}
+}
+
+// TestOriginPfx_OpenSuppressed: no validation anywhere. The control twin is
+// accepted too, so there is no validator to bypass and the surface belongs to
+// mcp-dns-rebind-origin-001.
+func TestOriginPfx_OpenSuppressed(t *testing.T) {
+	ts := httptest.NewServer(originPfxHandler(opfxNone))
+	defer ts.Close()
+
+	findings, err := runOriginPfx(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings when nothing validates Origin, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestOriginPfx_ParsedHostClean: correct scheme+host comparison rejects every
+// craft while still admitting empty-Origin baselines. MUST stay silent.
+func TestOriginPfx_ParsedHostClean(t *testing.T) {
+	ts := httptest.NewServer(originPfxHandler(opfxParsedHost))
+	defer ts.Close()
+
+	findings, err := runOriginPfx(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings under parsed-host validation, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestOriginPfx_UserinfoCraftFires: a hardened validator that special-cases
+// plain foreign origins but compares with Contains still accepts the userinfo
+// smuggle. Both crafts must be attempted before concluding clean.
+func TestOriginPfx_UserinfoCraftFires(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		var req struct {
+			Method string      `json:"method"`
+			ID     json.Number `json:"id"`
+		}
+		if json.Unmarshal(raw, &req) != nil || req.Method == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if req.Method != "initialize" {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+
+		origin := r.Header.Get("Origin")
+		host := "127.0.0.1:" + portOfServer(r.Host)
+		switch {
+		case origin == "":
+			// baseline
+		case !strings.Contains(origin, "prefix-rebind"):
+			// Fully foreign: rejected (a validator exists here).
+			w.WriteHeader(http.StatusForbidden)
+			return
+		case strings.Contains(origin, "prefix-rebind") && !strings.Contains(origin, "@"):
+			// The subdomain craft was special-cased away by an upstream fix...
+			w.WriteHeader(http.StatusForbidden)
+			return
+		default:
+			if !strings.Contains(origin, host) {
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": req.ID,
+			"result": map[string]interface{}{
+				"protocolVersion": "2025-06-18",
+				"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+				"serverInfo":      map[string]interface{}{"name": "originpfx-userinfo", "version": "1"},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	findings, err := runOriginPfx(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 finding via the userinfo craft, got %d: %+v", len(findings), findings)
+	}
+	if !strings.Contains(findings[0].Evidence, "@") {
+		t.Errorf("expected evidence to name the userinfo smuggle origin, got: %q", findings[0].Evidence)
+	}
+}
+
+func portOfServer(hostPort string) string {
+	if i := strings.LastIndex(hostPort, ":"); i >= 0 {
+		return hostPort[i+1:]
+	}
+	return hostPort
+}

--- a/rules/mcp/origin-prefix-bypass-001.yaml
+++ b/rules/mcp/origin-prefix-bypass-001.yaml
@@ -1,0 +1,71 @@
+id: mcp-origin-prefix-bypass-001
+info:
+  name: MCP Origin Validation Bypassed by Prefix-Forged Origin
+  author: batesian
+  severity: high
+  description: |
+    Tests whether the server's Origin validation compares strings instead of
+    parsed hosts. mcp-dns-rebind-origin-001 asks whether any validation exists;
+    this rule asks whether the validation that does exist means anything.
+
+    The recurring defect is a validator written as a string check:
+
+      strings.HasPrefix(origin, "https://trusted.example")
+      strings.Contains(origin, "trusted.example")
+
+    Such validators reject a fully foreign origin - so a plain DNS-rebinding
+    probe reads them as clean - while accepting any origin whose STRING starts
+    with (or contains) the trusted value:
+
+      https://trusted.example.attacker.tld     attacker subdomain
+      https://trusted.example@attacker.tld     userinfo smuggle
+
+    Parsed out, both resolve to attacker infrastructure. The browser-mediated
+    exposure is identical to having no check at all, which is why this family
+    keeps publishing: CVE-2026-55532 (prefix match), CVE-2026-55637 (local
+    rebind), and the mcp-atlassian GHSA-489g TOCTOU bypass all live in this
+    gap between what is compared and what a URL parse would say.
+
+    CONTROL PAIR. On every served wire the baseline handshake is repeated with
+    three Origin values:
+
+      1. control twin - fully unrelated origin. MUST be rejected; that failure
+         proves a validator exists on this wire.
+      2-3. prefix twins - the two crafted forms above sharing the target's
+           host string.
+
+    Acceptance of either twin against a rejecting control is CONFIRMED at
+    high. If the control is also accepted there is no validator to bypass:
+    that surface belongs to mcp-dns-rebind-origin-001 and is suppressed here.
+    Every craft rejected is the pass being sought.
+
+    The crafted domains are non-resolving RFC 6761 .invalid names, so nothing
+    the probe accepts can actually call out to the scanner.
+
+  references:
+    - https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-55532
+    - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin
+    - https://cwe.mitre.org/data/definitions/346.html
+
+  tags:
+    - mcp
+    - origin-validation
+    - dns-rebinding
+    - request-forgery
+    - cwe-346
+
+attack:
+  protocol: mcp
+  type: mcp-origin-prefix-bypass
+
+remediation: |
+  1. Parse the Origin header into a URL and compare scheme and host components
+     individually against an allowlist of exact origins. Never compare raw
+     strings with HasPrefix, Contains, or suffix tricks.
+  2. Reject (403) any Origin that fails to parse, has credentials in it, or
+     resolves to a host other than an allowlisted one byte-for-byte.
+  3. Re-run the two crafted origins above in your own test suite; a validator
+     that passes both along with the unrelated-foreign case is doing real work.
+  4. Keep the check in middleware shared by every wire the server serves -
+     prefix validators often guard one handler only.

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -31,7 +31,7 @@ a run that treats it as a clean result is reporting coverage it does not have.
 
 ## Server Registry
 
-The bundled rule set is **19 A2A + 26 MCP = 45 rules**. Every rule's primary
+The bundled rule set is **19 A2A + 27 MCP = 46 rules**. Every rule's primary
 validation is an in-process `net/http/httptest` harness in its Go
 `*_test.go` (multiple server postures: vulnerable must fire / patched / open /
 benign must stay silent). The Python servers below are optional standalone
@@ -77,9 +77,10 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_shadow_surface_server.py` | 7807 + 6277 | `mcp-shadow-surface-001` must fire on `shadow-open`; fire medium on `shadow-hardened`; stay silent on `none` (three postures, see below) |
 | `mcp_tool_poisoning_server.py` | 7808 | `mcp-tool-poisoning-001`: checks 1-3 fire on `poisoned`, check 4 fires on `drifting`, all silent on `clean` (three postures, see below) |
 | `mcp_vulnerable_version_server.py` | 7809 | `mcp-vulnerable-version-001` must fire on `vulnerable`; stay silent on `patched` and `unknown` (three postures, see below) |
+| `mcp_origin_prefix_bypass_server.py` | 7811 | `mcp-origin-prefix-bypass-001` must fire on `prefix`; stay silent on `hardened` and `open` (three postures, see below) |
 | `a2a_push_callback_auth_server.py` | 7810 | `a2a-push-callback-auth-001` must fire on `unsigned`; stay silent on `signed`; report not tested on `nocallback` (three postures, see below) |
 
-**Coverage.** 43 of the 45 rules have a standalone Python fixture above, and each
+**Coverage.** 44 of the 46 rules have a standalone Python fixture above, and each
 of those was checked by actually running it rather than by reading this table. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
 (`internal/attack/mcp/token_replay_test.go`); the same is true of the per-rule
@@ -500,6 +501,23 @@ header and must stay silent. `nocallback` never dials out at all; the rule
 reports not tested because its oracle never ran, which is different from a
 clean claim about callbacks nobody sent.
 
+
+**`mcp_origin_prefix_bypass_server.py` takes a posture argument**, defaulting to
+`prefix`:
+
+```sh
+python testdata/mcp_origin_prefix_bypass_server.py prefix    # high finding
+python testdata/mcp_origin_prefix_bypass_server.py hardened  # silent
+python testdata/mcp_origin_prefix_bypass_server.py open      # silent
+batesian scan --target http://127.0.0.1:7811 --rule-ids mcp-origin-prefix-bypass-001 -v
+```
+
+The `prefix` posture validates with `startswith()` against its own origin -
+it rejects a fully foreign origin, which is exactly why the sibling DNS-
+rebinding rule reads this server clean and why this rule exists. `hardened`
+parses scheme and host individually and rejects every craft. `open` accepts
+the control twin too; there is no validator to bypass, so the rule suppresses
+itself rather than double-counting the other rule's finding.
 
 ---
 

--- a/testdata/mcp_origin_prefix_bypass_server.py
+++ b/testdata/mcp_origin_prefix_bypass_server.py
@@ -1,0 +1,91 @@
+"""
+Deliberately vulnerable MCP test server for validating:
+
+  mcp-origin-prefix-bypass-001: an Origin validator implemented as a string
+  prefix match. It rejects a fully foreign origin - so a plain DNS-rebinding
+  probe reads it as clean - while accepting any origin whose string starts
+  with its own, which is exactly what the rule's crafted twins exploit.
+
+Postures:
+  prefix (default) - HasPrefix(origin, own-origin) validation. The subdomain
+                     craft MUST fire confirmed/high.
+  hardened         - parsed scheme+host equality. Every craft MUST be
+                     rejected; the rule MUST stay silent.
+  open             - no validation at all. The control twin is accepted too,
+                     so the rule suppresses itself: that surface belongs to
+                     mcp-dns-rebind-origin-001.
+
+Only initialize and notifications are served; this rule is about header
+handling, not tool surface.
+
+Validate against it:
+  python testdata/mcp_origin_prefix_bypass_server.py prefix    # fires
+  python testdata/mcp_origin_prefix_bypass_server.py hardened  # silent
+  python testdata/mcp_origin_prefix_bypass_server.py open      # silent
+
+Run: python testdata/mcp_origin_prefix_bypass_server.py [posture]
+Scan: batesian scan --target http://127.0.0.1:7811 --rule-ids mcp-origin-prefix-bypass-001 -v
+"""
+import sys
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+import uvicorn
+
+PORT = 7811
+
+
+async def jsonrpc(request: Request) -> JSONResponse:
+    body = await request.json()
+    method = body.get("method")
+    rid = body.get("id", 1)
+
+    if method == "initialize":
+        origin = request.headers.get("origin", "")
+        if not request.app.state.origin_allowed(origin):
+            return JSONResponse(status_code=403, content={"error": "forbidden origin"})
+        return JSONResponse({
+            "jsonrpc": "2.0", "id": rid,
+            "result": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "originpfx-fixture", "version": "1.0"},
+            },
+        })
+    if method == "notifications/initialized":
+        return JSONResponse({"jsonrpc": "2.0", "id": rid, "result": {}})
+
+    return JSONResponse({"jsonrpc": "2.0", "id": rid,
+                         "error": {"code": -32601, "message": "Method not found"}})
+
+
+def make_allowed(posture):
+    def allowed(origin: str) -> bool:
+        if posture == "open" or origin == "":
+            return True
+        # The server's own wire origin as a caller would see it in scripts.
+        own = f"http://127.0.0.1:{PORT}"
+        if posture == "prefix":
+            # VULNERABLE: literal string comparison.
+            return origin.startswith(own)
+        # hardened: parse and compare components individually.
+        from urllib.parse import urlsplit
+        parts = urlsplit(origin)
+        mine = urlsplit(own)
+        return parts.scheme == mine.scheme and parts.netloc.lower() == mine.netloc.lower()
+    return allowed
+
+
+app = Starlette(routes=[Route("/", jsonrpc, methods=["POST"]), Route("/mcp", jsonrpc, methods=["POST"])])
+app.state.posture = "prefix"
+app.state.origin_allowed = make_allowed("prefix")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        app.state.posture = sys.argv[1]
+    app.state.origin_allowed = make_allowed(app.state.posture)
+    print(f"[*] MCP origin-prefix-bypass fixture ({app.state.posture}) on port {PORT}", flush=True)
+    uvicorn.run(app, host="127.0.0.1", port=PORT)


### PR DESCRIPTION
mcp-dns-rebind-origin-001 asks whether any Origin validation exists, using a fully unrelated origin. But the recurring defect sits one step inside: validators written as strings.HasPrefix / strings.Contains against the trusted origin reject that unrelated value and read clean under the existing rule, while accepting anything that merely starts with it:

- https://trusted.example.attacker.tld (attacker subdomain)
- https://trusted.example@attacker.tld (userinfo smuggle)

Parsed out, both resolve to attacker infrastructure; the browser-mediated exposure is identical to no check at all. CVE-2026-55532 and CVE-2026-55637 are this exact shape, published within weeks of each other this quarter.

The probe is a control pair on every served wire: baseline handshake repeated with a fully foreign Origin first - its rejection proves a validator exists; then two crafted origins whose acceptance against that rejecting control is confirmed/high. If the control is accepted too there is no validator to bypass: suppressed here so mcp-dns-rebind-origin-001 owns it without double-counting.

Craft details worth noting:
- crafts mirror the target's own scheme and host-port verbatim; a scheme-blind craft just earns another rejection from any validator, http or https alike, and measures nothing
- canary domains are RFC 6761 .invalid names, so nothing accepted can call out to the scanner

Changes:
- internal/attack/mcp/origin_prefix_bypass.go plus harness (four postures: prefix-match fires high/confirmed with three-outcome evidence, open suppressed, parsed-host clean, userinfo craft fires where subdomain was special-cased)
- rules/mcp/origin-prefix-bypass-001.yaml, CWE-346, remediation centred on parse-then-compare
- testdata/mcp_origin_prefix_bypass_server.py (port 7811): prefix/hardened/open
- counts updated to 27 MCP / 46 total across README.md, catalog table plus detail section, registry

Verified locally in the pinned containers: gofmt clean, vet, full race suite green, lint 0 issues.
