### PR TITLE
rule(mcp): split mcp-atlassian advisory, TOCTOU fix landed at 0.22.0

### DIFF
--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -1040,6 +1040,7 @@ citations in both the YAML and the finding evidence.
 - **mcp-server-git** <2025.12.18 - argument injection and path escape chain (CVE-2025-68143/44/45)
 - **mcp-remote** <0.1.16 - OAuth flow command injection (CVE-2025-6514)
 - **mcp-atlassian** <0.17.0 - attachment path traversal to RCE (CVE-2026-27825/26)
+- **mcp-atlassian** <0.22.0 - SSRF DNS-rebinding TOCTOU bypass of the 27826 fix (GHSA-489g-7rxv-6c8q; a 0.16.x deployment matches this entry and the one above, which is accurate rather than duplicate: two distinct advisories, two distinct fixes)
 - **inspector** <0.14.1 - unauthenticated RCE via DNS rebinding (CVE-2025-49596)
 - **serena** <1.5.2 - dashboard memory poisoning to RCE via DNS rebinding (CVE-2026-49471)
 - **mcpjam** <=1.4.2 - exposed control endpoint RCE (CVE-2026-23744)

--- a/internal/attack/mcp/vulnerable_version.go
+++ b/internal/attack/mcp/vulnerable_version.go
@@ -72,6 +72,11 @@ var vvTable = []vvAdvisory{
 		refs:  "CVE-2026-27825, CVE-2026-27826",
 	},
 	{
+		key: "mcp-atlassian", affected: "<0.22.0", severity: "medium",
+		title: "mcp-atlassian SSRF DNS-rebinding TOCTOU bypass of the 27826 fix",
+		refs:  "GHSA-489g-7rxv-6c8q",
+	},
+	{
 		key: "inspector", affected: "<0.14.1", severity: "high",
 		title: "MCP Inspector unauthenticated RCE via DNS rebinding",
 		refs:  "CVE-2025-49596",

--- a/internal/attack/mcp/vulnerable_version_test.go
+++ b/internal/attack/mcp/vulnerable_version_test.go
@@ -153,6 +153,40 @@ func TestVV_Boundaries(t *testing.T) {
 	}
 }
 
+// TestVV_AtlassianTOCTOU: the 27826 fix shipped in 0.17.0 but its bypass
+// (GHSA-489g) was only patched in 0.22.0, so the table carries a second,
+// wider entry. A deployment between the two bounds fires once - the TOCTOU
+// advisory alone; one below both bounds fires twice; at 0.22.0 silent.
+func TestVV_AtlassianTOCTOU(t *testing.T) {
+	cases := []struct {
+		version string
+		want    int
+	}{
+		{"0.16.9", 2}, // traversal + TOCTOU
+		{"0.17.5", 1}, // TOCTOU only: the earlier fix is present...
+		{"0.21.9", 1}, // ...but so is the gap it left
+		{"0.22.0", 0}, // patched
+	}
+	for _, tc := range cases {
+		t.Run("v"+tc.version, func(t *testing.T) {
+			ts := vvServer("mcp-atlassian", tc.version)
+			defer ts.Close()
+
+			findings, err := runVV(t, ts)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(findings) != tc.want {
+				t.Fatalf("version %q: want %d findings, got %d: %+v",
+					tc.version, tc.want, len(findings), findings)
+			}
+			if tc.want >= 1 && !strings.Contains(findings[len(findings)-1].Evidence, "GHSA-489g") {
+				t.Errorf("newest finding should cite the TOCTOU advisory, got: %q", findings[len(findings)-1].Evidence)
+			}
+		})
+	}
+}
+
 // TestVV_ModernWireMeta: on the modern wire the identity travels under
 // result._meta rather than result.serverInfo; the extractor reads both.
 func TestVV_ModernWireMeta(t *testing.T) {

--- a/rules/mcp/vulnerable-version-001.yaml
+++ b/rules/mcp/vulnerable-version-001.yaml
@@ -18,6 +18,7 @@ info:
       - mcp-server-git <2025.12.18 (CVE-2025-68143/44/45)
       - mcp-remote <0.1.16          (CVE-2025-6514)
       - mcp-atlassian <0.17.0       (CVE-2026-27825/26)
+      - mcp-atlassian <0.22.0       (GHSA-489g TOCTOU bypass)
       - inspector <0.14.1           (CVE-2025-49596)
       - serena <1.5.2               (CVE-2026-49471)
       - mcpjam <=1.4.2              (CVE-2026-23744)


### PR DESCRIPTION
The watch item from the threat review is verified upstream and closed: GHSA-489g-7rxv-6c8q (the DNS-rebinding TOCTOU bypass of CVE-2026-27826's own middleware fix) is affected below 0.22.0 and patched at 0.22.0. The existing table entry stopped at 0.17.0, so deployments on 0.17.x through 0.21.x carried a structurally verified SSRF bypass while mcp-vulnerable-version-001 reported them clean.

The entry is a second mcp-atlassian row rather than a widened bound: two distinct advisories with different fixed versions. A deployment reporting 0.16.x now matches both (traversal RCE plus TOCTOU bypass), which is accurate rather than duplicate; 0.17.x to 0.21.x matches only the new one; 0.22.0 and above stays clean.

Severity for the new entry is medium, tracking the advisory's Moderate rating (CVSS 6.5) rather than inheriting the rule's high - the rating reflects the rebinding-race precondition the advisory itself flags in its honest-scope note.

Changes:
- internal/attack/mcp/vulnerable_version.go - second advisory entry
- internal/attack/mcp/vulnerable_version_test.go - four-version matrix pinning both bounds and the double-match shape
- rules/mcp/vulnerable-version-001.yaml and docs/rules-mcp.md - table listings

Verified locally in the pinned containers: gofmt clean, vet, full race suite green, lint 0 issues.
