### PR TITLE
rule(mcp): measure task-handle entropy on the tasks-extension wire

### DIFF
--- a/.github/scripts/validate_mcp_fixtures.py
+++ b/.github/scripts/validate_mcp_fixtures.py
@@ -385,6 +385,30 @@ def vulnerable_version():
     return ok_all
 
 
+def task_entropy():
+    """weak mints counter handles (sequential + thin alphabet, the extension's
+    bearer-token MUST broken); clean mints uuid-shaped handles and must be
+    fully silent."""
+    ok_all = True
+    rid = "mcp-task-id-entropy-001"
+
+    p, l = start("mcp_task_entropy_server.py", 7812, "weak")
+    try:
+        fired, _, _ = scan(7812)
+    finally:
+        stop(p, l)
+    ok_all &= check("task-entropy weak (fires)", rid in fired, f"fired {sorted(fired)}")
+
+    p, l = start("mcp_task_entropy_server.py", 7812, "clean")
+    try:
+        fired, _, _ = scan(7812)
+    finally:
+        stop(p, l)
+    ok_all &= check("task-entropy clean (silent)", rid not in fired,
+                    f"fired {sorted(fired)}")
+    return ok_all
+
+
 def main():
     suites = [
         ("transient", transient()),
@@ -396,6 +420,7 @@ def main():
         ("shadow-surface", shadow_surface()),
         ("tool-poisoning", tool_poisoning()),
         ("vulnerable-version", vulnerable_version()),
+        ("task-entropy", task_entropy()),
     ]
     print()
     for name, ok in suites:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ CLI for adversarial testing of [A2A](https://a2a-protocol.org) and [MCP](https:/
 
 ## What ships
 
-Bundled rules: **19 A2A, 27 MCP (46 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
+Bundled rules: **19 A2A, 28 MCP (47 total)**. The set is deliberately narrow - every rule targets MCP/A2A-specific semantics, not generic web hygiene that `nuclei`/ZAP already cover. Each rule maps to CWE references and remediation text in the catalogs:
 
 - [A2A rules](docs/rules-a2a.md) (18)
 - [MCP rules](docs/rules-mcp.md) (21)

--- a/docs/rules-mcp.md
+++ b/docs/rules-mcp.md
@@ -1,6 +1,6 @@
 # MCP Attack Rules
 
-Batesian ships **27 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
+Batesian ships **28 rules** targeting the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
 Every rule is an active probe: it sends crafted protocol traffic and judges the
 server's actual response. Rules are deliberately scoped to MCP-specific semantics
 (OAuth 2.1 authorization, DCR, audience binding, discovery-chain metadata-fetch
@@ -177,6 +177,7 @@ candidate answers does a rule report that it could not test.
 | `mcp-tool-poisoning-001` | [Tool Manifest Integrity (Poisoning)](#mcp-tool-poisoning-001) | High / Medium | confirmed / indicator | CWE-74 |
 | `mcp-vulnerable-version-001` | [Known-Vulnerable Component Identity](#mcp-vulnerable-version-001) | High | indicator | CWE-1104 |
 | `mcp-origin-prefix-bypass-001` | [Origin Prefix-Match Bypass](#mcp-origin-prefix-bypass-001) | High | confirmed | CWE-346 |
+| `mcp-task-id-entropy-001` | [Task Handle Entropy (Extension Wire)](#mcp-task-id-entropy-001) | High / Medium | confirmed | CWE-330 |
 
 ---
 
@@ -1102,3 +1103,45 @@ the probe accepts can call out to the scanner. Both crafts mirror the target's
 own scheme and host-port verbatim, because deployments allowlist what they
 themselves serve: an http server never accepts https-prefixed strings, and a
 craft that cannot fool a prefix validator measures nothing.
+
+---
+
+### mcp-task-id-entropy-001
+
+**Task Handle Entropy (Extension Wire)** | Severity: High / Medium | confirmed | CWE-330
+
+Collects task handles the server mints for task-augmented calls and measures
+them against the tasks extension's own unguessability requirement. The
+2026-07-28 revision moved tasks out of core into
+`io.modelcontextprotocol/tasks` and deliberately dropped context binding: its
+Security Considerations permit a server to treat task ids as bearer tokens
+for stored state, PROVIDED they carry enough entropy:
+
+> "Servers MUST generate them with sufficient entropy that a third party
+> cannot enumerate or guess them."
+
+That MUST is what this rule measures, and it is why the cross-context reads
+`mcp-task-idor-001` performs on the core wire would be wrong here - a
+conformant extension-era server answering a guessed handle is doing what the
+spec allows. What is never permitted is an id a third party can guess.
+
+Two measurable failures from five samples, both confirmed:
+
+1. **Sequential handles** (high). All-numeric ids minted with a constant
+   stride, whatever it is. The next handle is demonstrated in the evidence,
+   not estimated.
+2. **Sub-threshold alphabet entropy** (medium). Bits counted as longest-
+   handle-length times log2 of every distinct character seen. The estimate is
+   deliberately generous to the server - hidden randomness beyond what the
+   samples reveal only raises real entropy - so falling under the 64-bit bar
+   violates a bearer-token MUST before prediction is even attempted.
+
+The two checks are independent and both may fire on one manifest; sequential
+counter handles are also thin-alphabet by construction.
+
+Safety mirrors `mcp-task-idor-001`: only annotated read-only or explicitly
+non-destructive tools declaring taskSupport optional/required are invoked,
+with inert arguments. A server without such a tool reports clean rather than
+dispatching anything unannotated. Refusals before enough samples report not
+tested naming the refusal - fewer than two handles cannot distinguish any
+pattern from coincidence.

--- a/internal/attack/mcp/task_id_entropy.go
+++ b/internal/attack/mcp/task_id_entropy.go
@@ -1,0 +1,348 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/calbebop/batesian/internal/attack"
+)
+
+// TaskIDEntropyExecutor collects task handles the server mints for task-
+// augmented calls and judges whether they meet the tasks extension's own
+// unguessability requirement (rule mcp-task-id-entropy-001).
+//
+// The 2026-07-28 revision moved tasks out of core into
+// io.modelcontextprotocol/tasks and deliberately DROPPED context binding:
+// its Security Considerations permit a server to treat task ids as bearer
+// tokens for stored state, provided they carry enough entropy:
+//
+//	"Servers MUST generate them with sufficient entropy that a third party
+//	 cannot enumerate or guess them."
+//
+// That MUST is what this rule measures, and it is why the cross-context
+// reads mcp-task-idor-001 performs on the core wire would be wrong here: a
+// conformant extension-era server answering a guessed handle is doing what
+// the spec allows. What is never permitted is an id a third party can guess.
+//
+// Two measurable failures, both from N samples (spec has no "minimum
+// samples"; five distinguish the classes below while keeping cost bounded):
+//
+//   - Sequential or uniformly stepped numeric handles -> CONFIRMED high.
+//     The next id is demonstrated, not estimated.
+//   - Sub-threshold alphabet entropy -> CONFIRMED medium. Bits are counted
+//     as length * log2(distinct characters) over the observed set, which is
+//     an upper bound on real entropy per id; falling under 64 bits violates
+//     a bearer-token MUST even before prediction. Exotic-but-fine formats
+//     (UUID hex at ~122 bits, nanoid at ~120) clear it comfortably.
+//
+// SAFETY mirrors mcp-task-idor-001 exactly: only tools whose annotations
+// declare readOnlyHint true or destructiveHint false and that declare
+// taskSupport optional/required are invoked; their arguments are inert.
+type TaskIDEntropyExecutor struct {
+	rule attack.RuleContext
+}
+
+func init() {
+	attack.Register("mcp-task-id-entropy", func(rc attack.RuleContext) attack.Executor {
+		return NewTaskIDEntropyExecutor(rc)
+	})
+}
+
+func NewTaskIDEntropyExecutor(r attack.RuleContext) *TaskIDEntropyExecutor {
+	return &TaskIDEntropyExecutor{rule: r}
+}
+
+const (
+	entropySampleTarget = 5
+	entropyCallBase     = 30
+)
+
+func (e *TaskIDEntropyExecutor) Execute(ctx context.Context, target string, opts attack.Options) ([]attack.Finding, error) {
+	vars := attack.NewVars(target, opts.OOBListenerURL)
+	client := attack.NewUnauthHTTPClient(opts, vars)
+
+	sessions, sessErr := openSessions(ctx, client, vars.BaseURL)
+	if sessErr != nil {
+		return nil, sessErr
+	}
+
+	var findings []attack.Finding
+	capabilityKnown := false
+	lastReason := ""
+
+	for _, session := range sessions {
+		if !session.ServerSupports("tools") {
+			continue // no tool surface on this wire: nothing mints handles here
+		}
+		capabilityKnown = true
+
+		fs, reason, determined := e.probeSession(ctx, client, session)
+		findings = append(findings, labelEra(session, fs)...)
+		if determined {
+			lastReason = ""
+		} else if reason != "" && lastReason == "" {
+			lastReason = reason
+		}
+	}
+
+	if !capabilityKnown {
+		return nil, fmt.Errorf("%w: no served wire advertises the tools capability at %s",
+			attack.ErrInconclusive, vars.BaseURL)
+	}
+	if len(findings) == 0 && lastReason != "" {
+		return nil, fmt.Errorf("%w: %s", attack.ErrInconclusive, lastReason)
+	}
+	return findings, nil
+}
+
+func (e *TaskIDEntropyExecutor) probeSession(ctx context.Context, client *attack.HTTPClient, session mcpSession) (findings []attack.Finding, stopReason string, determined bool) {
+	safeTool, ok := teFindSafeTool(ctx, client, session)
+	if !ok {
+		// Consistent with mcp-task-idor-001: nothing declared safe to invoke,
+		// so no handle could exist without breaking that gate first.
+		return nil, "", true
+	}
+
+	var ids []string
+	for i := 0; i < entropySampleTarget; i++ {
+		resp, err := session.post(ctx, client, entropyCallBase+i, "tools/call", map[string]interface{}{
+			"name":      safeTool.name,
+			"arguments": synthesizeArgs(safeTool.schema, "batesian-"+fmt.Sprint(i)),
+			"task":      map[string]interface{}{"ttl": 60000},
+		})
+		if verdict, _ := classifyProbe(resp, err); verdict != probeAnswered {
+			if len(ids) == 0 {
+				return nil, fmt.Sprintf("task-augmented tools/call against %q was %s on this wire, so "+
+					"no handle could be minted", safeTool.name, scopeVerdictName(verdict)), false
+			}
+			break // mid-collection refusal: judge what was collected
+		}
+		var body struct {
+			Result struct {
+				Task struct {
+					TaskID string `json:"taskId"`
+				} `json:"task"`
+			} `json:"result"`
+			Error map[string]interface{} `json:"error"`
+		}
+		if json.Unmarshal(resp.Body, &body) != nil || body.Error != nil || body.Result.Task.TaskID == "" {
+			if len(ids) == 0 {
+				return nil, fmt.Sprintf("tools/call against %q answered but carried no task handle, so "+
+					"the handles-per-call premise was never established", safeTool.name), false
+			}
+			break
+		}
+		ids = append(ids, body.Result.Task.TaskID)
+	}
+	if len(ids) < 2 {
+		return nil, fmt.Sprintf("only %d task handle(s) were minted by %q on this wire, so no pattern "+
+			"could be distinguished from coincidence", len(ids), safeTool.name), false
+	}
+	return e.teGradeHandles(session.Endpoint, safeTool.name, ids), "", true
+}
+
+// teSafeTool is the invoke-capable candidate the rule settles on.
+type teSafeTool struct {
+	name   string
+	schema map[string]interface{}
+}
+
+// teFindSafeTool picks the first annotated read-only/non-destructive tool
+// whose execution.taskSupport marks it task-augmentable.
+func teFindSafeTool(ctx context.Context, client *attack.HTTPClient, s mcpSession) (teSafeTool, bool) {
+	resp, err := s.post(ctx, client, 20, "tools/list", nil)
+	if verdict, _ := classifyProbe(resp, err); verdict != probeAnswered {
+		return teSafeTool{}, false
+	}
+	var body struct {
+		Result struct {
+			Tools []struct {
+				Name        string                 `json:"name"`
+				InputSchema map[string]interface{} `json:"inputSchema"`
+				Execution   struct {
+					TaskSupport string `json:"taskSupport"`
+				} `json:"execution"`
+				Annotations *struct {
+					ReadOnlyHint    *bool `json:"readOnlyHint"`
+					DestructiveHint *bool `json:"destructiveHint"`
+				} `json:"annotations"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if json.Unmarshal(resp.Body, &body) != nil {
+		return teSafeTool{}, false
+	}
+	for _, t := range body.Result.Tools {
+		if t.Execution.TaskSupport != "optional" && t.Execution.TaskSupport != "required" {
+			continue
+		}
+		if t.Annotations == nil {
+			continue
+		}
+		readOnly := t.Annotations.ReadOnlyHint != nil && *t.Annotations.ReadOnlyHint
+		nonDestructive := t.Annotations.DestructiveHint != nil && !*t.Annotations.DestructiveHint
+		if !readOnly && !nonDestructive {
+			continue
+		}
+		return teSafeTool{name: t.Name, schema: t.InputSchema}, true
+	}
+	return teSafeTool{}, false
+}
+
+var teNumericOnly = regexp.MustCompile(`^[0-9]+$`)
+
+// entropyThresholdBits is where "a third party cannot guess" becomes
+// measurable: at or above 64 bits, brute enumeration is out of reach of any
+// realistic window; below it, offline guessing is a spreadsheet exercise.
+const entropyThresholdBits = 64
+
+// teGradeHandles runs the two analyses and returns every failure found. The
+// checks are independent: a timestamp-stamped id with a short random tail
+// clears the sequence check but fails the alphabet bar, and both readings
+// belong in one report rather than short-circuiting each other.
+func (e *TaskIDEntropyExecutor) teGradeHandles(endpoint, tool string, ids []string) []attack.Finding {
+	var findings []attack.Finding
+
+	allNumeric := true
+	for _, id := range ids {
+		if !teNumericOnly.MatchString(id) {
+			allNumeric = false
+			break
+		}
+	}
+	if allNumeric {
+		if step, ok := teConstantStep(ids); ok {
+			findings = append(findings, e.sequenceFinding(endpoint, tool, ids, step))
+		}
+	}
+
+	bits, alphabet, maxLen := teAlphabetBits(ids)
+	if bits < entropyThresholdBits {
+		findings = append(findings, e.entropyFinding(endpoint, tool, ids, bits, alphabet, maxLen))
+	}
+	return findings
+}
+
+// teConstantStep reports whether every consecutive delta between mints is
+// identical and non-zero - the signature of a counter, whatever its stride.
+func teConstantStep(ids []string) (int64, bool) {
+	values := make([]int64, 0, len(ids))
+	for _, id := range ids {
+		v, err := strconv.ParseInt(id, 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		values = append(values, v)
+	}
+	step := values[1] - values[0]
+	if step == 0 {
+		return 0, false // repeated ids are a different defect
+	}
+	for i := 2; i < len(values); i++ {
+		if values[i]-values[i-1] != step {
+			return 0, false
+		}
+	}
+	return step, true
+}
+
+// teAlphabetBits upper-bounds per-id entropy as length * log2(alphabet),
+// using the longest observed id and every distinct character seen anywhere.
+// This is deliberately generous to the server: a server that adds hidden
+// randomness beyond what any sample shows only makes real entropy higher.
+func teAlphabetBits(ids []string) (bits float64, alphabet string, maxLen int) {
+	set := map[rune]bool{}
+	maxLen = 0
+	for _, id := range ids {
+		if len(id) > maxLen {
+			maxLen = len(id)
+		}
+		for _, r := range id {
+			set[r] = true
+		}
+	}
+	runes := make([]rune, 0, len(set))
+	for r := range set {
+		runes = append(runes, r)
+	}
+	sort.Slice(runes, func(i, j int) bool { return runes[i] < runes[j] })
+	alphabet = string(runes)
+	n := float64(len(set))
+	if n <= 1 || maxLen == 0 {
+		return 0, alphabet, maxLen
+	}
+	return float64(maxLen) * math.Log2(n), alphabet, maxLen
+}
+
+func (e *TaskIDEntropyExecutor) sequenceFinding(endpoint, tool string, ids []string, step int64) attack.Finding {
+	predicted := teNext(ids[len(ids)-1], step)
+	return attack.Finding{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "high",
+		Confidence: attack.ConfirmedExploit,
+		Title:      fmt.Sprintf("MCP task handles minted by %q are sequential integers", tool),
+		Description: fmt.Sprintf(
+			"%d handles requested back to back from %q at %s came back as integers with a constant "+
+				"stride (%s). Every subsequent handle is predictable before it is issued. The tasks "+
+				"extension permits servers to treat these ids as bearer tokens for stored state, which "+
+				"makes a predictable handle an authentication bypass of that scheme: anyone who sees one "+
+				"id can read, poll or cancel another caller's work.",
+			len(ids), tool, endpoint, teJoinSteps(ids)),
+		Evidence: fmt.Sprintf("endpoint: %s\ntool: %s\nhandles: %s\nconstant stride: %d\npredicted next handle: %s",
+			endpoint, tool, strings.Join(ids, ", "), step, predicted),
+		Remediation: e.rule.Remediation,
+		TargetURL:   endpoint,
+	}
+}
+
+func (e *TaskIDEntropyExecutor) entropyFinding(endpoint, tool string, ids []string, bits float64, alphabet string, maxLen int) attack.Finding {
+	return attack.Finding{
+		RuleID:     e.rule.ID,
+		RuleName:   e.rule.Name,
+		Severity:   "medium",
+		Confidence: attack.ConfirmedExploit,
+		Title: fmt.Sprintf("MCP task handles carry ~%.0f bits of alphabet entropy (below the %d-bit bar)",
+			bits, entropyThresholdBits),
+		Description: fmt.Sprintf(
+			"%d handles minted by %q at %s use only %d distinct characters over %d positions, giving "+
+				"~%.0f bits of search space per handle. The tasks extension lets servers treat these ids "+
+				"as bearer tokens for stored state and requires generation with sufficient entropy that a "+
+				"third party cannot guess them; this estimate counts only characters the samples reveal, so "+
+				"it is generous to the server - and it still falls under the bar. IDs readable once out of a "+
+				"log or trace should not also be enumerable offline.",
+			len(ids), tool, endpoint, len(alphabet), maxLen, bits),
+		Evidence: fmt.Sprintf("endpoint: %s\ntool: %s\nhandles: %s\ndistinct characters: %q\n"+
+			"longest handle: %d positions\nestimated entropy: %.1f bits (threshold %d)",
+			endpoint, tool, strings.Join(ids, ", "), alphabet, maxLen, bits, entropyThresholdBits),
+		Remediation: e.rule.Remediation,
+		TargetURL:   endpoint,
+	}
+}
+
+func teNext(last string, step int64) string {
+	v, err := strconv.ParseInt(last, 10, 64)
+	if err != nil {
+		return "?"
+	}
+	return strconv.FormatInt(v+step, 10)
+}
+
+func teJoinSteps(ids []string) string {
+	var sb strings.Builder
+	for i, id := range ids {
+		if i > 0 {
+			a, _ := strconv.ParseInt(ids[i-1], 10, 64)
+			b, _ := strconv.ParseInt(id, 10, 64)
+			fmt.Fprintf(&sb, " (%+d) ", b-a)
+		}
+		sb.WriteString(id)
+	}
+	return sb.String()
+}

--- a/internal/attack/mcp/task_id_entropy_test.go
+++ b/internal/attack/mcp/task_id_entropy_test.go
@@ -1,0 +1,301 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcp "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+func entropyRC() attack.RuleContext {
+	return attack.RuleContext{
+		ID:          "mcp-task-id-entropy-001",
+		Name:        "MCP Task Handle Entropy",
+		Severity:    "high",
+		Remediation: "Generate handles from a CSPRNG; never serialize counters.",
+	}
+}
+
+type entropyStyle string
+
+const (
+	styleSequential entropyStyle = "sequential"
+	styleLowAlpha   entropyStyle = "low-alpha"
+	styleUUID       entropyStyle = "uuid"
+)
+
+// entropyServer advertises one task-capable read-only tool and mints handles
+// in the configured style on every task-augmented tools/call.
+type entropyServer struct {
+	style entropyStyle
+}
+
+func (s *entropyServer) nextHandle(callIdx int) string {
+	switch s.style {
+	case styleSequential:
+		return fmt.Sprintf("%d", 100001+callIdx*7)
+	case styleLowAlpha:
+		// Letter-anchored so the handle is never all digits (the sequence
+		// check must stay out of this posture), and thin: 8 positions over
+		// a narrow alphabet lands far under the bit bar.
+		return fmt.Sprintf("k%07x", callIdx+0x1000)
+	default:
+		// uuid-shaped: 32 hex chars, dashes in the canonical spots.
+		h := fmt.Sprintf("%032x", callIdx+0xdeadbeefcafe)
+		return h[0:8] + "-" + h[8:12] + "-" + h[12:16] + "-" + h[16:20] + "-" + h[20:32]
+	}
+}
+
+func (s *entropyServer) handler() http.HandlerFunc {
+	callCount := 0
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string      `json:"method"`
+			ID     json.Number `json:"id"`
+			Params struct {
+				Task map[string]interface{} `json:"task"`
+			} `json:"params"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		switch req.Method {
+		case "initialize":
+			w.Header().Set("Mcp-Session-Id", "sess-te")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req.ID,
+				"result": map[string]interface{}{
+					"protocolVersion": "2025-06-18",
+					"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+					"serverInfo":      map[string]interface{}{"name": "entropy-fixture", "version": "1"},
+				},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req.ID,
+				"result": map[string]interface{}{"tools": []map[string]interface{}{{
+					"name":        "wait_a_moment",
+					"annotations": map[string]interface{}{"readOnlyHint": true},
+					"execution":   map[string]interface{}{"taskSupport": "optional"},
+					"inputSchema": map[string]interface{}{
+						"type":       "object",
+						"properties": map[string]interface{}{},
+						"required":   []interface{}{},
+					},
+				}}},
+			})
+		case "tools/call":
+			if req.Params.Task == nil {
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"jsonrpc": "2.0", "id": req.ID,
+					"error": map[string]interface{}{"code": -32602, "message": "task augmentation required"},
+				})
+				return
+			}
+			handle := s.nextHandle(callCount)
+			callCount++
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req.ID,
+				"result": map[string]interface{}{
+					"task":    map[string]interface{}{"taskId": handle, "status": "working"},
+					"isError": false,
+				},
+			})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req.ID,
+				"error": map[string]interface{}{"code": -32601, "message": "Method not found"},
+			})
+		}
+	}
+}
+
+func runEntropy(t *testing.T, ts *httptest.Server) ([]attack.Finding, error) {
+	t.Helper()
+	return mcp.NewTaskIDEntropyExecutor(entropyRC()).
+		Execute(context.Background(), ts.URL, attack.Options{TimeoutSeconds: 5})
+}
+
+// TestEntropy_SequentialFiresHigh: counter-minted handles with a constant
+// stride. The next id is demonstrated; the high sequential finding MUST fire.
+// The thin numeric alphabet will additionally trip the entropy check - both
+// readings are true and independent, so exact-count assertions would only
+// couple two detectors that are meant to be judged separately.
+func TestEntropy_SequentialFiresHigh(t *testing.T) {
+	ts := httptest.NewServer((&entropyServer{style: styleSequential}).handler())
+	defer ts.Close()
+
+	findings, err := runEntropy(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var seq *attack.Finding
+	for i := range findings {
+		if strings.Contains(findings[i].Title, "sequential integers") {
+			seq = &findings[i]
+		}
+	}
+	if seq == nil {
+		t.Fatalf("expected a sequential-handles finding among %d: %+v", len(findings), findings)
+	}
+	if seq.Severity != "high" || seq.Confidence != attack.ConfirmedExploit {
+		t.Errorf("want high/ConfirmedExploit for sequential handles, got %q/%q", seq.Severity, seq.Confidence)
+	}
+	if !strings.Contains(seq.Evidence, "predicted next handle") {
+		t.Errorf("evidence should include the prediction, got: %q", seq.Evidence)
+	}
+}
+
+// TestEntropy_LowAlphabetFiresMedium: short ids over a thin hex alphabet land
+// far under the bar without being sequential. MUST fire confirmed/medium.
+func TestEntropy_LowAlphabetFiresMedium(t *testing.T) {
+	ts := httptest.NewServer((&entropyServer{style: styleLowAlpha}).handler())
+	defer ts.Close()
+
+	findings, err := runEntropy(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 finding, got %d: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Severity != "medium" || f.Confidence != attack.ConfirmedExploit {
+		t.Errorf("want medium/ConfirmedExploit for low alphabet entropy, got %q/%q", f.Severity, f.Confidence)
+	}
+	if !strings.Contains(f.Evidence, "bits") {
+		t.Errorf("evidence should report the bit estimate, got: %q", f.Evidence)
+	}
+}
+
+// TestEntropy_UUIDCleanSilent: full-width hex ids clear the bar and carry no
+// constant stride. MUST stay silent.
+func TestEntropy_UUIDCleanSilent(t *testing.T) {
+	ts := httptest.NewServer((&entropyServer{style: styleUUID}).handler())
+	defer ts.Close()
+
+	findings, err := runEntropy(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings against uuid-style handles, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestEntropy_NoSafeToolSilent: the only tool carries no annotations and no
+// taskSupport declaration, so the safety gate refuses to mint anything.
+func TestEntropy_NoSafeToolSilent(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string      `json:"method"`
+			ID     json.Number `json:"id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		switch req.Method {
+		case "initialize":
+			w.Header().Set("Mcp-Session-Id", "sess-te2")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req.ID,
+				"result": map[string]interface{}{
+					"protocolVersion": "2025-06-18",
+					"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+					"serverInfo":      map[string]interface{}{"name": "bare", "version": "1"},
+				},
+			})
+		case "tools/list":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req.ID,
+				"result": map[string]interface{}{"tools": []map[string]interface{}{{
+					"name":        "counter_tool",
+					"inputSchema": map[string]interface{}{"type": "object", "properties": map[string]interface{}{}, "required": []interface{}{}},
+				}}},
+			})
+		default:
+			w.WriteHeader(http.StatusAccepted)
+		}
+	}))
+	defer ts.Close()
+
+	findings, err := runEntropy(t, ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings when no safe tool exists, got %d: %+v", len(findings), findings)
+	}
+}
+
+// TestEntropy_RefusalNotTested: every handle mint is refused after the gate
+// passes, so the sample premise collapses into not-tested rather than clean.
+func TestEntropy_RefusalNotTested(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string      `json:"method"`
+			ID     json.Number `json:"id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		switch req.Method {
+		case "initialize":
+			w.Header().Set("Mcp-Session-Id", "sess-te3")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req.ID,
+				"result": map[string]interface{}{
+					"protocolVersion": "2025-06-18",
+					"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+					"serverInfo":      map[string]interface{}{"name": "refusing", "version": "1"},
+				},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req.ID,
+				"result": map[string]interface{}{"tools": []map[string]interface{}{{
+					"name":        "wait_a_moment",
+					"annotations": map[string]interface{}{"readOnlyHint": true},
+					"execution":   map[string]interface{}{"taskSupport": "optional"},
+					"inputSchema": map[string]interface{}{
+						"type":       "object",
+						"properties": map[string]interface{}{},
+						"required":   []interface{}{},
+					},
+				}}},
+			})
+		case "tools/call":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req.ID,
+				"error": map[string]interface{}{"code": -32000, "message": "task queue disabled"},
+			})
+		default:
+			w.WriteHeader(http.StatusAccepted)
+		}
+	}))
+	defer ts.Close()
+
+	findings, err := runEntropy(t, ts)
+	if err == nil {
+		t.Fatalf("expected an inconclusive error when no handle could be minted")
+	}
+	if !strings.Contains(err.Error(), "handle") {
+		t.Errorf("expected the reason to name the missing handles, got: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings alongside the inconclusive result, got %d", len(findings))
+	}
+}

--- a/rules/mcp/task-id-entropy-001.yaml
+++ b/rules/mcp/task-id-entropy-001.yaml
@@ -1,0 +1,66 @@
+id: mcp-task-id-entropy-001
+info:
+  name: MCP Task Handle Entropy (Guessable Handles on the Tasks Extension Wire)
+  author: batesian
+  severity: high
+  description: |
+    Collects task handles the server mints for task-augmented calls and
+    measures them against the tasks extension's own unguessability
+    requirement. The 2026-07-28 revision moved tasks out of core into
+    io.modelcontextprotocol/tasks and deliberately DROPPED context binding:
+    its Security Considerations permit a server to treat task ids as bearer
+    tokens for stored state, PROVIDED they carry enough entropy:
+
+      "Servers MUST generate them with sufficient entropy that a third party
+       cannot enumerate or guess them."
+
+    That MUST is what this rule measures, and it is why the cross-context
+    reads mcp-task-idor-001 performs on the core wire would be wrong here - a
+    conformant extension-era server answering a guessed handle is doing what
+    the spec allows. What is never permitted is an id a third party can guess.
+
+    Two measurable failures from five samples:
+
+      1. Sequential handles (CONFIRMED, high). All-numeric ids minted with a
+         constant stride, whatever it is. The next handle is demonstrated,
+         not estimated; evidence shows the stride and the predicted value.
+      2. Sub-threshold alphabet entropy (CONFIRMED, medium). Bits counted as
+         longest-handle-length times log2 of every distinct character seen -
+         deliberately generous to the server, since hidden randomness beyond
+         what samples reveal only makes real entropy higher. Under 64 bits a
+         bearer-token MUST is violated before prediction is even attempted.
+
+    SAFETY mirrors mcp-task-idor-001: only annotated read-only or explicitly
+    non-destructive tools declaring taskSupport optional/required are invoked,
+    with inert arguments. A server without such a tool reports clean rather
+    than dispatching anything unannotated.
+
+    Refusals before enough samples are collected report NOT TESTED naming the
+    refusal - two or more samples are required to distinguish any pattern from
+    coincidence.
+
+  references:
+    - https://github.com/modelcontextprotocol/ext-tasks
+    - https://modelcontextprotocol.io/specification/2026-07-28/changelog
+    - https://cwe.mitre.org/data/definitions/330.html
+
+  tags:
+    - mcp
+    - tasks
+    - entropy
+    - bearer-token
+    - cwe-330
+
+attack:
+  protocol: mcp
+  type: mcp-task-id-entropy
+
+remediation: |
+  1. Generate task handles from a cryptographically secure random source with
+     at least 128 bits of output; never serialize counters, timestamps alone,
+     or fixed-width sequences a caller can correlate.
+  2. Treat handles exactly as the extension frames them - bearer tokens for
+     stored state - and give them the same generation discipline as session
+     credentials.
+  3. If a counter must exist internally, keep it behind an opaque random
+     mapping so externally visible ids carry no stride information.

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -31,7 +31,7 @@ a run that treats it as a clean result is reporting coverage it does not have.
 
 ## Server Registry
 
-The bundled rule set is **19 A2A + 27 MCP = 46 rules**. Every rule's primary
+The bundled rule set is **19 A2A + 28 MCP = 47 rules**. Every rule's primary
 validation is an in-process `net/http/httptest` harness in its Go
 `*_test.go` (multiple server postures: vulnerable must fire / patched / open /
 benign must stay silent). The Python servers below are optional standalone
@@ -78,9 +78,10 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_tool_poisoning_server.py` | 7808 | `mcp-tool-poisoning-001`: checks 1-3 fire on `poisoned`, check 4 fires on `drifting`, all silent on `clean` (three postures, see below) |
 | `mcp_vulnerable_version_server.py` | 7809 | `mcp-vulnerable-version-001` must fire on `vulnerable`; stay silent on `patched` and `unknown` (three postures, see below) |
 | `mcp_origin_prefix_bypass_server.py` | 7811 | `mcp-origin-prefix-bypass-001` must fire on `prefix`; stay silent on `hardened` and `open` (three postures, see below) |
+| `mcp_task_entropy_server.py` | 7812 | `mcp-task-id-entropy-001` must fire on `weak`; stay silent on `clean` (two postures, see below) |
 | `a2a_push_callback_auth_server.py` | 7810 | `a2a-push-callback-auth-001` must fire on `unsigned`; stay silent on `signed`; report not tested on `nocallback` (three postures, see below) |
 
-**Coverage.** 44 of the 46 rules have a standalone Python fixture above, and each
+**Coverage.** 45 of the 47 rules have a standalone Python fixture above, and each
 of those was checked by actually running it rather than by reading this table. The
 remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
 (`internal/attack/mcp/token_replay_test.go`); the same is true of the per-rule
@@ -518,6 +519,21 @@ rebinding rule reads this server clean and why this rule exists. `hardened`
 parses scheme and host individually and rejects every craft. `open` accepts
 the control twin too; there is no validator to bypass, so the rule suppresses
 itself rather than double-counting the other rule's finding.
+
+**`mcp_task_entropy_server.py` takes a posture argument**, defaulting to
+`weak`:
+
+```sh
+python testdata/mcp_task_entropy_server.py weak   # high sequential finding
+python testdata/mcp_task_entropy_server.py clean  # silent
+batesian scan --target http://127.0.0.1:7812 --rule-ids mcp-task-id-entropy-001 -v
+```
+
+The `weak` posture mints handles from a plain counter with a visible stride -
+the exact shape the extension's unguessability MUST forbids, since ids double
+as bearer tokens for stored state there. `clean` mints uuid-shaped handles.
+The only tool served is annotated read-only and never acts on its arguments,
+so validation mints handles and executes nothing.
 
 ---
 

--- a/testdata/mcp_task_entropy_server.py
+++ b/testdata/mcp_task_entropy_server.py
@@ -1,0 +1,90 @@
+"""
+Deliberately vulnerable MCP test server for validating:
+
+  mcp-task-id-entropy-001: task handles minted with a counter instead of a
+  random source. The tasks extension lets servers treat handles as bearer
+  tokens for stored state, provided they are unguessable - this fixture
+  breaks that MUST on purpose.
+
+Postures:
+  weak (default) - handles are sequential integers ("100007", "100014", ...).
+                   The rule MUST fire the high sequential finding.
+  clean          - handles are uuid-shaped hex. The rule MUST stay silent.
+
+Only initialize and a read-only annotated wait tool that returns one handle
+per task-augmented call are served. The arguments it receives are never used;
+nothing executes.
+
+Validate against it:
+  python testdata/mcp_task_entropy_server.py weak    # high finding
+  python testdata/mcp_task_entropy_server.py clean   # silent
+
+Run: python testdata/mcp_task_entropy_server.py [posture]
+Scan: batesian scan --target http://127.0.0.1:7812 --rule-ids mcp-task-id-entropy-001 -v
+"""
+import sys
+import uuid
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+import uvicorn
+
+PORT = 7812
+
+COUNTER = {"n": 100007}
+
+
+async def jsonrpc(request: Request) -> JSONResponse:
+    body = await request.json()
+    method = body.get("method")
+    rid = body.get("id", 1)
+
+    if method == "initialize":
+        return JSONResponse({
+            "jsonrpc": "2.0", "id": rid,
+            "result": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "entropy-fixture", "version": "1.0"},
+            },
+        })
+    if method == "notifications/initialized":
+        return JSONResponse({"jsonrpc": "2.0", "id": rid, "result": {}})
+    if method == "tools/list":
+        return JSONResponse({"jsonrpc": "2.0", "id": rid, "result": {"tools": [{
+            "name": "wait_a_moment",
+            "description": "Waits briefly; safe to run.",
+            "annotations": {"readOnlyHint": True},
+            "execution": {"taskSupport": "optional"},
+            "inputSchema": {"type": "object", "properties": {}, "required": []},
+        }]}})
+    if method == "tools/call":
+        if request.app.state.posture == "weak":
+            COUNTER["n"] += 7
+            handle = str(COUNTER["n"])
+        else:
+            handle = str(uuid.uuid4())
+        return JSONResponse({
+            "jsonrpc": "2.0", "id": rid,
+            "result": {
+                "task": {"taskId": handle,
+                         "status": {"state": "TASK_STATE_WORKING"}},
+                "isError": False,
+            },
+        })
+
+    return JSONResponse({"jsonrpc": "2.0", "id": rid,
+                         "error": {"code": -32601, "message": "Method not found"}})
+
+
+app = Starlette(routes=[Route("/", jsonrpc, methods=["POST"]), Route("/mcp", jsonrpc, methods=["POST"])])
+app.state.posture = "weak"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        app.state.posture = sys.argv[1]
+    print(f"[*] MCP task-entropy fixture ({app.state.posture}) on port {PORT}", flush=True)
+    uvicorn.run(app, host="127.0.0.1", port=PORT)


### PR DESCRIPTION
The 2026-07-28 revision moved tasks out of core into the io.modelcontextprotocol/tasks extension and deliberately dropped context binding: its Security Considerations permit servers to treat task ids as bearer tokens for stored state, provided they carry enough entropy that a third party cannot guess them. That MUST is measurable and nothing measured it - the cross-context reads mcp-task-idor-001 performs on the core wire would accuse a conformant extension-era server, which is why task_idor's own comments flagged entropy as the correct, separate oracle.

mcp-task-id-entropy-001 collects five handles from an annotated read-only, taskSupport-declaring tool (safety mirrors mcp-task-idor-001; inert arguments) and runs two independent checks:

- sequential all-numeric ids with a constant stride => confirmed/high. The evidence shows every handle, the stride, and the predicted next value.
- alphabet entropy below 64 bits (length x log2 of distinct characters observed) => confirmed/medium. The estimate is deliberately generous to the server - hidden randomness only raises real entropy - so falling under the bar violates the bearer-token MUST on its own.

Both may fire together; counter handles are also thin-alphabet by construction, so exact-count assertions would couple two detectors meant to be judged separately.

Not-tested paths: no annotated task-capable tool reports clean per the shared safety-gate convention; refusals before enough samples report not-tested naming the refusal - fewer than two handles cannot distinguish any pattern from coincidence.

Changes:
- internal/attack/mcp/task_id_entropy.go plus harness: sequential/high, low-alphabet/medium, uuid clean, no-safe-tool silent, refusal not-tested
- rules/mcp/task-id-entropy-001.yaml, CWE-330, remediation centred on CSPRNG generation and opaque random mapping over counters
- testdata/mcp_task_entropy_server.py (port 7812): weak/clean postures
- nightly gate: new task-entropy suite in validate_mcp_fixtures.py
- counts updated to 28 MCP / 47 total across README.md, catalog table plus detail section, registry

Verified locally in the pinned containers: gofmt clean, vet, full race suite green, lint 0 issues, and the complete nightly MCP validation suite passes end-to-end (10/10 suites) against a freshly built binary.
