### PR TITLE
testdata: cover mcp-token-replay-001, the last fixture gap

### DIFF
--- a/.github/scripts/validate_mcp_fixtures.py
+++ b/.github/scripts/validate_mcp_fixtures.py
@@ -409,6 +409,31 @@ def task_entropy():
     return ok_all
 
 
+def token_replay():
+    """vulnerable refuses an anonymous initialize (so the forged-probe family
+    is judged right at the gate) yet accepts any well-formed bearer: three
+    findings MUST fire. patched verifies the presented credential exactly,
+    so every forged probe is rejected and the rule stays silent."""
+    ok_all = True
+    rid = "mcp-token-replay-001"
+
+    p, l = start("mcp_token_replay_server.py", 7813, "vulnerable")
+    try:
+        fired, _, _ = scan(7813)
+    finally:
+        stop(p, l)
+    ok_all &= check("token-replay vulnerable (fires)", rid in fired, f"fired {sorted(fired)}")
+
+    p, l = start("mcp_token_replay_server.py", 7813, "patched")
+    try:
+        fired, _, _ = scan(7813)
+    finally:
+        stop(p, l)
+    ok_all &= check("token-replay patched (silent)", rid not in fired,
+                    f"fired {sorted(fired)}")
+    return ok_all
+
+
 def main():
     suites = [
         ("transient", transient()),
@@ -421,6 +446,7 @@ def main():
         ("tool-poisoning", tool_poisoning()),
         ("vulnerable-version", vulnerable_version()),
         ("task-entropy", task_entropy()),
+        ("token-replay", token_replay()),
     ]
     print()
     for name, ok in suites:

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -79,14 +79,15 @@ fixtures for live-validation / manual smoke testing.
 | `mcp_vulnerable_version_server.py` | 7809 | `mcp-vulnerable-version-001` must fire on `vulnerable`; stay silent on `patched` and `unknown` (three postures, see below) |
 | `mcp_origin_prefix_bypass_server.py` | 7811 | `mcp-origin-prefix-bypass-001` must fire on `prefix`; stay silent on `hardened` and `open` (three postures, see below) |
 | `mcp_task_entropy_server.py` | 7812 | `mcp-task-id-entropy-001` must fire on `weak`; stay silent on `clean` (two postures, see below) |
+| `mcp_token_replay_server.py` | 7813 | `mcp-token-replay-001` must fire on `vulnerable`; stay silent on `patched` (two postures, see below) |
 | `a2a_push_callback_auth_server.py` | 7810 | `a2a-push-callback-auth-001` must fire on `unsigned`; stay silent on `signed`; report not tested on `nocallback` (three postures, see below) |
 
-**Coverage.** 45 of the 47 rules have a standalone Python fixture above, and each
-of those was checked by actually running it rather than by reading this table. The
-remaining rule, `mcp-token-replay-001`, is validated only by its Go harness
-(`internal/attack/mcp/token_replay_test.go`); the same is true of the per-rule
-edge-case harnesses for every other rule. `mockserver.go` is a Go helper used by
-unit tests via `net/http/httptest`; it is not a standalone server.
+**Coverage.** All 47 rules have a standalone Python fixture above, and each
+of those was checked by actually running it rather than by reading this table.
+The last holdout, `mcp-token-replay-001`, gained `mcp_token_replay_server.py`
+(port 7813) alongside the nightly suite that drives it. The same is true of
+the per-rule edge-case harnesses for every other rule. `mockserver.go` is a Go
+helper used by unit tests via `net/http/httptest`; it is not a standalone server.
 
 A registry row is a claim, and claims rot. Three things make a fixture look broken
 when it is not, so check them before concluding a rule has regressed:
@@ -534,6 +535,25 @@ the exact shape the extension's unguessability MUST forbids, since ids double
 as bearer tokens for stored state there. `clean` mints uuid-shaped handles.
 The only tool served is annotated read-only and never acts on its arguments,
 so validation mints handles and executes nothing.
+
+**`mcp_token_replay_server.py` takes a posture argument**, defaulting to
+`vulnerable`:
+
+```sh
+python testdata/mcp_token_replay_server.py vulnerable  # 3 findings (high x2, critical)
+python testdata/mcp_token_replay_server.py patched     # silent
+batesian scan --target http://127.0.0.1:7813 --rule-ids mcp-token-replay-001 -v
+```
+
+Both postures publish RFC 9728 metadata and refuse an unauthenticated
+initialize, which is what lets the rule judge its forged probes at the gate.
+In `vulnerable`, ANY well-formed bearer is accepted, so the no-aud and
+wrong-aud forgeries land high and the alg:none forgery lands critical. In
+`patched`, tokens are checked against the single credential this fixture
+issued - an exact presentation match that a random-keyed signature fails for
+the same reason real signature verification fails it - so every forged probe
+is rejected and the rule stays silent. The fixture implements no tool surface:
+the probe is purely about token handling.
 
 ---
 

--- a/testdata/mcp_token_replay_server.py
+++ b/testdata/mcp_token_replay_server.py
@@ -1,0 +1,120 @@
+"""
+Deliberately vulnerable MCP test server for validating:
+
+  mcp-token-replay-001: an OAuth-participating resource server whose gate
+  accepts anything bearing a well-formed bearer - including tokens signed
+  with a secret it cannot know, and unsigned alg:none tokens.
+
+Postures:
+  vulnerable (default) - publishes RFC 9728 protected-resource metadata,
+                         refuses an UNauthenticated initialize, but accepts
+                         any request carrying any bearer token whatsoever.
+                         The forged-probe family MUST fire (three findings:
+                         two high for wrong/missing aud, one critical for
+                         alg:none); judging lands at initialize because the
+                         anonymous control is refused there.
+  patched              - same metadata, same refusal of anonymous calls, but
+                         tokens are verified against the one credential this
+                         fixture issued (tok-valid): an exact-match check, so
+                         random-keyed signatures fail it identically to how
+                         a signature-invalid JWT fails real validation. All
+                         forged probes MUST be rejected; the rule stays
+                         silent.
+
+Verification-model note: the patched posture implements exact presentation
+checking rather than RS256/JWKS validation, which keeps the fixture inside
+the project's dependency set (starlette/uvicorn only). A random-key HMAC
+signature fails an exact-match check for the same reason it fails signature
+verification - the server cannot reproduce it - so the regression signal
+(bad token rejected, good behavior silent) is preserved.
+
+Only initialize is implemented; no tool surface exists, keeping the probe
+purely about token handling.
+
+Validate against it:
+  python testdata/mcp_token_replay_server.py vulnerable  # 3 findings fire
+  python testdata/mcp_token_replay_server.py patched     # silent
+
+Run: python testdata/mcp_token_replay_server.py [posture]
+Scan: batesian scan --target http://127.0.0.1:7813 --rule-ids mcp-token-replay-001 -v
+"""
+import sys
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+import uvicorn
+
+PORT = 7813
+
+VALID_TOKENS = {"tok-valid"}
+
+
+async def protected_resource_metadata(request: Request) -> JSONResponse:
+    return JSONResponse({
+        "resource": f"http://127.0.0.1:{PORT}",
+        "authorization_servers": [f"http://127.0.0.1:{PORT}"],
+        "scopes_supported": ["mcp:read"],
+        "bearer_methods_supported": ["header"],
+    })
+
+
+async def jsonrpc(request: Request) -> JSONResponse:
+    body = await request.json()
+    method = body.get("method")
+    rid = body.get("id", 1)
+
+    if method != "initialize":
+        return JSONResponse({"jsonrpc": "2.0", "id": rid,
+                             "error": {"code": -32601, "message": "Method not found"}})
+
+    auth = request.headers.get("authorization", "")
+    token = auth[len("Bearer "):] if auth.startswith("Bearer ") else ""
+
+    if request.app.state.posture == "patched":
+        # Exact presentation check: only the credential this fixture issued
+        # passes. Random-keyed signatures and alg:none fail here exactly as
+        # they fail cryptographic verification.
+        if token not in VALID_TOKENS:
+            return JSONResponse(
+                {"jsonrpc": "2.0", "id": rid,
+                 "error": {"code": -32001, "message": "invalid_token: signature or issuer rejected"}},
+                status_code=401)
+
+    elif not token:
+        # VULNERABLE posture refuses only ABSENT credentials, so the rule's
+        # anonymous control reads "initialize gates" and judges its forged
+        # probes right here - yet any well-formed bearer sails through.
+        return JSONResponse(
+            {"jsonrpc": "2.0", "id": rid,
+             "error": {"code": -32001, "message": "unauthorized: bearer token required"}},
+            status_code=401)
+
+    return JSONResponse({
+        "jsonrpc": "2.0", "id": rid,
+        "result": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "serverInfo": {"name": "token-replay-fixture", "version": "1.0"},
+        },
+    })
+
+
+routes = [
+    Route("/", jsonrpc, methods=["POST"]),
+    Route("/mcp", jsonrpc, methods=["POST"]),
+    Route("/api", jsonrpc, methods=["POST"]),
+    Route("/rpc", jsonrpc, methods=["POST"]),
+    Route("/.well-known/oauth-protected-resource", protected_resource_metadata, methods=["GET"]),
+]
+
+app = Starlette(routes=routes)
+app.state.posture = "vulnerable"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        app.state.posture = sys.argv[1]
+    print(f"[*] MCP token-replay fixture ({app.state.posture}) on port {PORT}", flush=True)
+    uvicorn.run(app, host="127.0.0.1", port=PORT)


### PR DESCRIPTION
The registry carried a standing exception since the first coverage audit: mcp-token-replay-001 validated only through its Go harness while every other rule had a standalone Python fixture. The coverage line read "45 of the 47" and named the holdout. This closes it - the registry now claims full 47-of-47.

The fixture (port 7813) models the exact split the rule's gate depends on:

- vulnerable: publishes RFC 9728 metadata, refuses an unauthenticated initialize, yet accepts ANY well-formed bearer. Anonymous refusal is what makes the rule judge its forged probes at the gate rather than defer them; with acceptance at the gate, the no-aud and wrong-aud forgeries land high and alg:none lands critical - three findings.
- patched: same metadata and anonymous refusal, but tokens are verified against the single credential this fixture issued. An exact presentation check is honest here: a random-keyed HMAC signature fails it for the same reason real signature verification fails it - the server cannot reproduce it - so every forged probe is rejected and the rule stays silent.

The verification-model note is written into the fixture docstring: RS256/JWKS simulation would require a crypto dependency outside the project's test-server set, and the regression signal (forged rejected / clean silent) survives the substitution.

Wired as the eleventh suite in validate_mcp_fixtures.py; both postures verified locally in containers against a freshly built binary alongside all ten existing suites (full pass).
