### PR TITLE
perf(mcp): share endpoint discovery across rules within a scan

### DIFF
--- a/internal/attack/discovery.go
+++ b/internal/attack/discovery.go
@@ -1,0 +1,87 @@
+package attack
+
+import (
+	"sync"
+)
+
+// DiscoveryCache remembers, for the lifetime of one scan, which candidate
+// path answered as MCP on each target base URL and whether a modern-era
+// wire was seen there. Without it every MCP rule re-walks the same
+// candidate list and re-issues the same discovery handshakes, so a scan
+// over N rules floods a target with N-fold duplicated traffic - log noise,
+// rate-limit bait, and avoidable latency.
+//
+// The engine allocates one cache per scan and hands it to executors through
+// Options.Discovery. A nil cache is legal everywhere in this API: helpers
+// treat it as always-miss, which restores the pre-cache behaviour for
+// direct executor use in tests.
+//
+// Only positive resolutions are trusted across rules. Discovering that
+// nothing answered is not remembered: a refusal observed by one rule under
+// its own credentials must not silence the next rule's chance to see one,
+// and probe-honesty depends on those refusals being re-observed live.
+type DiscoveryCache struct {
+	mu     sync.Mutex
+	legacy map[string]string // baseURL -> endpoint that completed a handshake
+	modern map[string]bool   // endpoint -> a modern wire answers there
+}
+
+// NewDiscoveryCache returns an empty scan-scoped cache.
+func NewDiscoveryCache() *DiscoveryCache {
+	return &DiscoveryCache{
+		legacy: map[string]string{},
+		modern: map[string]bool{},
+	}
+}
+
+// LegacyEndpoint returns the endpoint known to complete a handshake for
+// baseURL, if any earlier rule recorded one.
+func (c *DiscoveryCache) LegacyEndpoint(baseURL string) (string, bool) {
+	if c == nil {
+		return "", false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ep, ok := c.legacy[baseURL]
+	return ep, ok
+}
+
+// RememberLegacy records the endpoint that completed a handshake for baseURL.
+func (c *DiscoveryCache) RememberLegacy(baseURL, endpoint string) {
+	if c == nil || endpoint == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.legacy == nil {
+		c.legacy = map[string]string{}
+	}
+	c.legacy[baseURL] = endpoint
+}
+
+// ModernPresent reports whether a earlier lookup established that the
+// endpoint serves the modern wire. known is false when nobody has looked.
+func (c *DiscoveryCache) ModernPresent(endpoint string) (present, known bool) {
+	if c == nil {
+		return false, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	present, known = c.modern[endpoint]
+	return present, known
+}
+
+// RememberModernPresent records the outcome of a modern-wire detection at
+// endpoint, positive or negative, so later rules repeat neither the request
+// nor the misreading of its absence.
+func (c *DiscoveryCache) RememberModernPresent(endpoint string, present bool) {
+	if c == nil || endpoint == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.modern == nil {
+		c.modern = map[string]bool{}
+	}
+	c.modern[endpoint] = present
+}

--- a/internal/attack/discovery_test.go
+++ b/internal/attack/discovery_test.go
@@ -1,0 +1,48 @@
+package attack
+
+import "testing"
+
+func TestDiscoveryCacheRoundTrip(t *testing.T) {
+	c := NewDiscoveryCache()
+
+	if _, ok := c.LegacyEndpoint("http://x"); ok {
+		t.Fatal("expected miss on empty cache")
+	}
+	c.RememberLegacy("http://x", "http://x/mcp")
+	ep, ok := c.LegacyEndpoint("http://x")
+	if !ok || ep != "http://x/mcp" {
+		t.Fatalf("want remembered endpoint, got %q ok=%v", ep, ok)
+	}
+	// Overwrite: a later successful walk may relocate the handler.
+	c.RememberLegacy("http://x", "http://x/api")
+	if ep, _ = c.LegacyEndpoint("http://x"); ep != "http://x/api" {
+		t.Fatalf("want updated endpoint, got %q", ep)
+	}
+}
+
+func TestDiscoveryCacheModernNegativesCached(t *testing.T) {
+	c := NewDiscoveryCache()
+	if _, known := c.ModernPresent("http://x/mcp"); known {
+		t.Fatal("expected unknown on empty cache")
+	}
+	c.RememberModernPresent("http://x/mcp", false)
+	present, known := c.ModernPresent("http://x/mcp")
+	if !known || present {
+		t.Fatalf("want cached negative (present=false, known=true), got %v/%v", present, known)
+	}
+}
+
+// TestDiscoveryCacheNilSafe pins the contract that a nil cache behaves as an
+// always-miss store: executors built outside the engine pass no cache and
+// must keep working unchanged.
+func TestDiscoveryCacheNilSafe(t *testing.T) {
+	var c *DiscoveryCache
+	if _, ok := c.LegacyEndpoint("http://x"); ok {
+		t.Fatal("nil LegacyEndpoint must miss")
+	}
+	c.RememberLegacy("http://x", "http://x/mcp") // must not panic
+	if _, known := c.ModernPresent("http://x"); known {
+		t.Fatal("nil ModernPresent must be unknown")
+	}
+	c.RememberModernPresent("http://x", true) // must not panic
+}

--- a/internal/attack/executor.go
+++ b/internal/attack/executor.go
@@ -81,6 +81,12 @@ type Options struct {
 	// Recorder collects the requests captured during a dry run. It must be non-nil
 	// when DryRun is set; the engine stamps the active rule onto it per rule.
 	Recorder *Recorder
+
+	// Discovery, when non-nil, lets MCP rules share endpoint-resolution
+	// results within one scan instead of each re-walking the same candidate
+	// paths. The engine allocates it per scan; nil keeps every rule walking
+	// independently (the behaviour direct executor use in tests expects).
+	Discovery *DiscoveryCache
 }
 
 // Principal is an authenticated identity a chained rule can act as. Multi-tenant

--- a/internal/attack/http.go
+++ b/internal/attack/http.go
@@ -38,8 +38,10 @@ var Version = "dev"
 // HTTPClient is a thin wrapper around net/http.Client with helpers for attack requests.
 type HTTPClient struct {
 	inner *http.Client
-	vars  Vars
-	token string // bearer token injected into requests to targetHost when set
+	// discovery is the scan-scoped endpoint cache; nil disables reuse.
+	discovery *DiscoveryCache
+	vars      Vars
+	token     string // bearer token injected into requests to targetHost when set
 	// targetHost is the host:port of the scan target. The auto-injected token is
 	// withheld from any other host; see tokenAllowedFor.
 	targetHost string
@@ -118,6 +120,7 @@ func NewHTTPClient(opts Options, vars Vars) *HTTPClient {
 		timeout = 10 * time.Second
 	}
 	return &HTTPClient{
+		discovery: opts.Discovery,
 		inner: &http.Client{
 			Timeout:   timeout,
 			Transport: Transport(opts),
@@ -399,4 +402,13 @@ func marshalBody(body interface{}, vars Vars) ([]byte, error) {
 	// Expand template vars in the JSON string before re-encoding.
 	expanded := vars.Expand(string(raw))
 	return []byte(expanded), nil
+}
+
+// Discovery returns the scan-scoped discovery cache this client carries, or
+// nil when the engine did not provide one.
+func (c *HTTPClient) Discovery() *DiscoveryCache {
+	if c == nil {
+		return nil
+	}
+	return c.discovery
 }

--- a/internal/attack/mcp/resources_unauth.go
+++ b/internal/attack/mcp/resources_unauth.go
@@ -274,7 +274,15 @@ func (e *ResourcesUnauthExecutor) readResource(ctx context.Context, client *atta
 // Servers implementing MCP 2025-03-26 require the session ID on all follow-up
 // requests; omitting it causes 4xx errors that silently suppress findings.
 func initializeMCP(ctx context.Context, client *attack.HTTPClient, baseURL string) (mcpSession, error) {
+	// A sibling rule may already have resolved which path completes a
+	// handshake. Try it first and skip the remaining candidates; if that one
+	// endpoint stops answering mid-scan (restart, flake), fall through to the
+	// full walk rather than trusting a stale resolution.
 	endpoints := endpointCandidates(baseURL)
+	cachedEp, hadCached := client.Discovery().LegacyEndpoint(baseURL)
+	if hadCached {
+		endpoints = append([]string{cachedEp}, endpoints...)
+	}
 	// Why the walk failed, so a rule that could not run can say what happened
 	// instead of sending the operator to check their network. Classified from the
 	// responses this loop already has, so it costs no extra requests.
@@ -285,6 +293,11 @@ func initializeMCP(ctx context.Context, client *attack.HTTPClient, baseURL strin
 			continue // transport failure: nothing answered, so nothing to explain
 		}
 		if !initResp.IsSuccess() || !initResp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
+			if hadCached && ep == cachedEp {
+				// The remembered endpoint has gone stale: forget it and let
+				// this walk continue over every candidate as before.
+				client.Discovery().RememberLegacy(baseURL, "")
+			}
 			observed.observe(classifyInitFailure(ep, client.PresentsCredential(ep), initResp))
 			continue
 		}
@@ -295,6 +308,10 @@ func initializeMCP(ctx context.Context, client *attack.HTTPClient, baseURL strin
 			ProtocolVersion: negotiatedVersion(initResp.Body),
 			RawInit:         initResp.Body,
 		}
+
+		// First successful resolution wins for the whole scan: later rules
+		// start here instead of re-walking every candidate.
+		client.Discovery().RememberLegacy(baseURL, ep)
 
 		// notifications/initialized - fire and forget
 		_, _ = client.POST(ctx, ep, session.header(), map[string]interface{}{

--- a/internal/attack/mcp/session.go
+++ b/internal/attack/mcp/session.go
@@ -190,3 +190,20 @@ func negotiatedVersion(initBody []byte) string {
 	}
 	return latestStable
 }
+
+// OpenSessionForTest resolves sessions for a caller-supplied Options, so the
+// harness can share one discovery cache across repeated resolutions exactly
+// the way the engine does across rules.
+func OpenSessionForTest(baseURL string, opts attack.Options) ([]string, error) {
+	vars := attack.NewVars(baseURL, opts.OOBListenerURL)
+	client := attack.NewUnauthHTTPClient(opts, vars)
+	sessions, err := openSessions(context.Background(), client, baseURL)
+	if err != nil {
+		return nil, err
+	}
+	eps := make([]string, 0, len(sessions))
+	for _, s := range sessions {
+		eps = append(eps, s.Endpoint)
+	}
+	return eps, nil
+}

--- a/internal/attack/mcp/session_cache_test.go
+++ b/internal/attack/mcp/session_cache_test.go
@@ -1,0 +1,70 @@
+package mcp_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	mcp "github.com/calbebop/batesian/internal/attack/mcp"
+)
+
+// TestDiscoveryCacheSkipsWalk pins the property the cache exists for: the
+// first session resolution may probe several candidate paths - here /mcp
+// answers 404 and / carries the handler - but a second resolution over the
+// same Options goes straight to the endpoint the first one found, instead of
+// repeating the miss.
+func TestDiscoveryCacheSkipsWalk(t *testing.T) {
+	var misses atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string      `json:"method"`
+			ID     json.Number `json:"id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Method != "initialize" {
+			// notifications, discover probes and other traffic are not the
+			// metric this test watches.
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		if r.URL.Path == "/mcp" {
+			misses.Add(1)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Mcp-Session-Id", "sess-cache")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": req.ID,
+			"result": map[string]interface{}{
+				"protocolVersion": "2025-06-18",
+				"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+				"serverInfo":      map[string]interface{}{"name": "cache-fixture", "version": "1"},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	opts := attack.Options{TimeoutSeconds: 5, Discovery: attack.NewDiscoveryCache()}
+
+	eps1, err := mcp.OpenSessionForTest(ts.URL, opts)
+	if err != nil {
+		t.Fatalf("first resolution: %v", err)
+	}
+	first := misses.Load()
+	if first != 1 {
+		t.Fatalf("first walk should have missed exactly once at /mcp, got %d", first)
+	}
+
+	eps2, err := mcp.OpenSessionForTest(ts.URL, opts)
+	if err != nil {
+		t.Fatalf("second resolution: %v", err)
+	}
+	if eps2[0] != eps1[0] {
+		t.Errorf("second resolution should land on the same endpoint, got %q vs %q", eps2[0], eps1[0])
+	}
+	if after := misses.Load(); after != first {
+		t.Errorf("cached walk must not repeat the dead-candidate probe: misses %d -> %d", first, after)
+	}
+}

--- a/internal/attack/mcp/wire.go
+++ b/internal/attack/mcp/wire.go
@@ -169,12 +169,18 @@ func openSessions(ctx context.Context, client *attack.HTTPClient, baseURL string
 // era it serves, so answering it proves nothing on its own; see
 // modernWireAdvertised for what treating the answer as proof cost.
 func discoverModern(ctx context.Context, client *attack.HTTPClient, ep string) (mcpSession, bool) {
-	probe := mcpSession{Endpoint: ep, Era: EraModern}
-	resp, err := probe.post(ctx, client, "batesian-discover", "server/discover", nil)
-	if err != nil || !resp.IsAccepted() {
+	// A sibling rule may already have asked this endpoint. Negative results
+	// are cached too: the detection is one request per rule otherwise, and a
+	// mid-scan flake freezing an absence for later rules costs them only the
+	// legacy path they would walk anyway.
+	if present, known := client.Discovery().ModernPresent(ep); known && !present {
 		return mcpSession{}, false
 	}
-	if !modernWireAdvertised(resp.Body) {
+	probe := mcpSession{Endpoint: ep, Era: EraModern}
+	resp, err := probe.post(ctx, client, "batesian-discover", "server/discover", nil)
+	found := err == nil && resp.IsAccepted() && modernWireAdvertised(resp.Body)
+	client.Discovery().RememberModernPresent(ep, found)
+	if !found {
 		return mcpSession{}, false
 	}
 	return mcpSession{

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -32,8 +32,14 @@ type Engine struct {
 	opts attackpkg.Options
 }
 
-// New creates an Engine with the given execution options.
+// New creates an Engine with the given execution options. The engine owns
+// one discovery cache per scan and injects it into the options it hands to
+// executors, so endpoint resolution happens once per target rather than once
+// per rule.
 func New(opts attackpkg.Options) *Engine {
+	if opts.Discovery == nil {
+		opts.Discovery = attackpkg.NewDiscoveryCache()
+	}
 	return &Engine{opts: opts}
 }
 


### PR DESCRIPTION
Every MCP rule resolved its own endpoint. The candidate walk re-issued the same initialize to the same dead paths once per rule, so a full scan of 47 rules sent a target dozens of duplicated discovery handshakes: log noise on the target, rate-limit bait, and avoidable latency that grows linearly with the rule set.

The engine now allocates one discovery cache per scan and injects it into executors through Options.Discovery; MCP helpers reach it through their HTTP client, so no executor signature changed anywhere.

Semantics:

- Positive legacy resolutions are shared. Whichever candidate path completes a handshake first becomes the starting point of every later walk.
- A mid-scan staleness fallback: if the remembered endpoint stops answering, the cache forgets it and the walk continues over every candidate as before - a restarted server cannot wedge eleven rules onto a dead path.
- Modern-wire detection outcomes are cached both ways per endpoint, so rules repeat neither the server/discover probe nor a misreading of its absence.
- Negative legacy results are deliberately NOT shared. One rule's refusal must not silence another rule's chance to observe a refusal live - probe-honesty semantics (not-tested vs clean) depend on those being re-observed, and nil-cache behaviour is pinned by test as always-miss so standalone executor use in harnesses is unchanged.

Changes:
- internal/attack/discovery.go (+test) - scan-scoped cache, nil-receiver-safe
- internal/attack/executor.go, http.go - Options.Discovery carried to clients
- internal/engine/engine.go - allocate per scan
- internal/attack/mcp/session.go, wire.go, resources_unauth.go - consult/populate
- new session_cache_test.go pinning the skip-walk property

Verified locally in the pinned containers: gofmt/vet/race suite green, lint 0 issues, and the complete nightly MCP validation suite passes end-to-end through the cached engine path (11/11 suites) - the behavioral regression net for exactly this kind of change.
