### PR TITLE
docs: measure the discovery cache instead of describing it

### DIFF
--- a/docs/validation-results.md
+++ b/docs/validation-results.md
@@ -240,3 +240,30 @@ batesian scan --target http://127.0.0.1:7797 --rule-ids mcp-logging-unauth-001 -
 Reference servers are third-party software; their behavior changes between
 versions. The version scanned is recorded above so a differing result can be
 attributed to the target rather than to Batesian.
+
+---
+
+## Scan cost against rule growth (measured)
+
+Rule count tripled since launch while every MCP rule still resolves its own
+endpoint. The discovery cache (#239) lets later rules skip earlier rules'
+walk results; this measures what that saves in practice, so the claim is a
+number rather than an adjective.
+
+Setup: `mcp_transient_failure_server.py` (`ok` posture) as the counting
+target - uvicorn access logging enabled, three full 47-rule scans per binary
+after one discarded warm-up, binaries built from the commits immediately
+before and after the cache landed.
+
+| Binary | Requests / 3 scans | Avg scan wall |
+|---|---|---|
+| pre-cache | 600 | 328 ms |
+| cached | 561 | 272 ms |
+
+Read honestly: on this target the handler sits at the FIRST candidate path,
+so the legacy walk never paid for its misses and the cache's saving is the
+per-rule modern-wire probe plus repeated handshakes at the resolved path -
+about 6% of requests and 17% of wall clock. Targets whose handler answers on
+a later candidate (the common misconfiguration shape) shift more of their
+traffic into missed probes, which is precisely the part caching removes; the
+saving grows with how deep the service hides.


### PR DESCRIPTION
The cache PR (#239) asserted duplicated-handshake waste without numbers; this adds the measurement so the claim is a figure rather than an adjective.

Setup: the same 47-rule scan run against an instrumented mcp_transient_failure_server target, three timed scans per binary after one discarded warm-up, binaries built from commits immediately before and after #239 landed, uvicorn access-log lines diffed around each phase as the request counter.

Result:

| Binary | Requests / 3 scans | Avg scan wall |
|---|---|---|
| pre-cache | 600 | 328 ms |
| cached | 561 | 272 ms |

Read honestly: this target answers at the first candidate path, so the legacy walk never paid for its misses and what the cache removes is the per-rule modern-wire probe plus repeated handshakes at the resolved path - about 6 percent of requests and 17 percent of wall clock. Targets whose handler answers on a later candidate shift more traffic into missed probes, which is precisely the part caching eliminates, so deeper-mounted handlers benefit more than these figures show.

Single-file change to docs/validation-results.md appending a dated measured subsection.
