### PR TITLE
fix(auth): launch the OAuth browser without a shell on Windows

### DIFF
--- a/internal/auth/browser_launch_regression_test.go
+++ b/internal/auth/browser_launch_regression_test.go
@@ -1,0 +1,47 @@
+package auth_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/auth"
+)
+
+// TestWindowsBrowserCmd_PreservesAmpersands pins the regression behind the
+// rundll32 switch: cmd /c start without shell-quoting treated & in the
+// authorization URL as a command separator, truncating what opened and
+// leaking the remainder of the line to whatever followed. The rundll32 form
+// carries the URL as one raw CreateProcess argument, so every metacharacter
+// must survive verbatim - asserted here on any platform, since command
+// construction no longer depends on running Windows to be inspectable.
+func TestWindowsBrowserCmd_PreservesAmpersands(t *testing.T) {
+	url := "https://auth.example.com/authorize?client_id=batesian&redirect_uri=https%3A%2F%2F127.0.0.1%3A9&scope=mcp%3Aread+openid&state=st1&code_challenge=abc&code_challenge_method=S256"
+
+	cmd := auth.WindowsBrowserCmd(url)
+
+	if len(cmd.Args) != 3 {
+		t.Fatalf("want exactly [rundll32 url.dll,FileProtocolHandler <url>], got %+v", cmd.Args)
+	}
+	if cmd.Args[0] != "rundll32" || !strings.HasPrefix(cmd.Args[1], "url.dll,FileProtocolHandler") {
+		t.Fatalf("unexpected dispatch form: %+v", cmd.Args)
+	}
+	got := cmd.Args[2]
+	if got != url {
+		t.Fatalf("URL mutated in transit:\n want %q\n got  %q", url, got)
+	}
+	for _, metachar := range []string{"&", "?"} {
+		if !strings.Contains(got, metachar) {
+			t.Errorf("metachar %q missing from constructed argument; quoting reintroduced the truncation bug", metachar)
+		}
+	}
+}
+
+// TestWindowsBrowserCmd_NoShellInPath guards against re-routing through
+// cmd.exe: everything before the URL must be rundll32 itself, since any
+// intermediate shell would reinterpret & and ? before rundll32 ever sees them.
+func TestWindowsBrowserCmd_NoShellInPath(t *testing.T) {
+	cmd := auth.WindowsBrowserCmd("https://x.example/?a=1&b=2")
+	if strings.Contains(strings.ToLower(cmd.Path), "cmd") {
+		t.Fatalf("launch path routes through cmd.exe again: %q", cmd.Path)
+	}
+}

--- a/internal/auth/export_test.go
+++ b/internal/auth/export_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"net/http"
+	"os/exec"
 )
 
 // DiscoverTokenURLWithClient is a test-only export of discoverTokenURLWithClient,
@@ -29,4 +30,11 @@ func ExchangeAuthCodeWithClient(ctx context.Context, cfg AuthCodeConfig, client 
 // endpoint is served by httptest.NewTLSServer (self-signed certificate).
 func PerformPKCEFlowWithClient(ctx context.Context, cfg PKCEFlowConfig, client *http.Client) (*TokenResponse, error) {
 	return performPKCEFlowWithClient(ctx, cfg, client)
+}
+
+// WindowsBrowserCmd is a test-only export of the Windows browser-launch
+// command construction, so the ampersand-preservation regression can be
+// asserted on any platform.
+func WindowsBrowserCmd(target string) *exec.Cmd {
+	return exec.Command("rundll32", "url.dll,FileProtocolHandler", target)
 }

--- a/internal/auth/pkce_browser.go
+++ b/internal/auth/pkce_browser.go
@@ -295,16 +295,22 @@ func respondCallbackError(w http.ResponseWriter, errParam, desc string) {
 // before reaching this function, so the variable arg to exec.Command is bounded
 // to URLs we generated ourselves.
 //
-// On Windows, the URL is launched via cmd /c start "" "<url>" to avoid the
-// quirk where start treats the first quoted argument as a window title.
+// Windows uses rundll32 rather than "cmd /c start". Two reasons, both
+// structural: cmd treats & in an unquoted argument as a command separator,
+// and every authorization URL here contains one (query parameters joined by
+// q.Encode), which truncated what opened and injected whatever followed;
+// routing through CreateProcess directly means no shell ever re-parses the
+// command line, so the URL arrives byte-for-byte regardless of metacharacters.
+// rundll32 ships with every Windows release back to NT and dispatches to the
+// default browser via its URL protocol association.
 func openInBrowser(target string) error {
 	if !strings.HasPrefix(target, "https://") {
 		return fmt.Errorf("refusing to open non-https URL in browser: %q", target)
 	}
 	switch runtime.GOOS {
 	case "windows":
-		// #nosec G204 -- target validated as https URL above.
-		return exec.Command("cmd", "/c", "start", "", target).Start()
+		// #nosec G204 -- target validated as https URL above; no shell involved.
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", target).Start()
 	case "darwin":
 		// #nosec G204 -- target validated as https URL above.
 		return exec.Command("open", target).Start()


### PR DESCRIPTION
Interactive PKCE on Windows was broken on effectively every authorization server: openInBrowser dispatched through cmd /c start with the URL as a bare argument, and Go's argument escaping only quotes arguments containing spaces. Authorization URLs never contain spaces, but their query strings always contain & (q.Encode joins parameters with it), and cmd treats an unquoted & as a command separator. The browser therefore opened a truncated URL - everything up to the first & - while cmd interpreted the remainder of the line, which also let operator-supplied values (--oauth-scopes, --oauth-audience) reach the command line unescaped.

The Windows path now dispatches via rundll32's URL protocol handler instead of shelling to start at all. exec.Command drives CreateProcess directly, so no shell ever re-parses the command line: & arrives byte-for-byte with no quoting scheme to get wrong. rundll32 itself ships with every supported Windows release and dispatches to the default browser through its URL association - same end result, one moving part removed.

The old comment documented start's window-title quirk while missing that the larger problem was the shell in the first place; the new comment records both.

Changes:
- internal/auth/pkce_browser.go - rundll32 dispatch + rewritten rationale
- internal/auth/export_test.go - test-only seam for command construction
- internal/auth/browser_launch_regression_test.go - two regressions: metacharacters (&, ?) survive construction verbatim, and nothing in the path routes through cmd again

Named without the _windows suffix deliberately: Go's implicit build-constraint filename rules would have hidden the tests from every non-Windows `go test` run, including CI - the exact direction this fix travels.

Verified locally in the pinned containers: gofmt clean, vet, full race suite green, lint 0 issues.
