### PR TITLE
fix(cli): surface enumeration failures in probe instead of silence

### DIFF
--- a/internal/cli/probe.go
+++ b/internal/cli/probe.go
@@ -285,6 +285,11 @@ func probeMCP(target, token string, timeoutSecs int, skipTLS bool, proxy string,
 					Description: t.Description,
 				})
 			}
+		} else {
+			// Silence here reads as "no tools", which is the one conclusion a
+			// failed listing can never support - and probe's whole deliverable
+			// is the surface map.
+			printer.Warn(fmt.Sprintf("tools/list failed: %v (tool surface not enumerated)", err))
 		}
 	}
 
@@ -303,6 +308,8 @@ func probeMCP(target, token string, timeoutSecs int, skipTLS bool, proxy string,
 				RuleID:   "mcp-resources-unauth-001",
 				Message:  fmt.Sprintf("%d resource(s) listed without authentication. Run scan to read content.", len(resources)),
 			})
+		} else if err != nil {
+			printer.Warn(fmt.Sprintf("resources/list failed: %v (resource surface not enumerated)", err))
 		}
 	}
 
@@ -324,6 +331,8 @@ func probeMCP(target, token string, timeoutSecs int, skipTLS bool, proxy string,
 					HasRequired: hasReq,
 				})
 			}
+		} else {
+			printer.Warn(fmt.Sprintf("prompts/list failed: %v (prompt surface not enumerated)", err))
 		}
 	}
 


### PR DESCRIPTION
probe's three listing blocks (tools/resources/prompts) ran inside `if err == nil` with no else branch. A transient network failure, a gateway that 502s only the listing methods, or a truncated response body all rendered identically to "server has none": probe printed no tools, no resources, and suppressed the `mcp-resources-unauth-001` flag - the one conclusion a failed listing can never support, on the command whose whole deliverable is the surface map.

Each block now has an else that warns on the status stream (`printer.Warn`, stderr under JSON output so machine-readable stdout stays clean), naming which surface could not be enumerated and carrying the underlying error.

Verification note, stated plainly: live-fire against a deliberately breaking fixture was attempted two ways (gateway-502 posture; a synthetic handshake-plus-broken-listings server). The first fails at handshake before enumeration ever runs, and the second's mock did not satisfy the protocol client's acceptance contract - rather than ship unverified claims about warning output, verification here is compile + vet + full race suite + lint, with the diff itself being three guarded warns. The broken-listing scenario remains a good candidate for a protocol-client seam later.

Changes: internal/cli/probe.go (+9).
