### PR TITLE
fix(oob,cli): listener lifecycle safety and interrupt propagation

### DIFF
--- a/cmd/batesian/main.go
+++ b/cmd/batesian/main.go
@@ -1,8 +1,12 @@
+// Batesian is an adversarial red-team CLI for AI agent protocols.
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/calbebop/batesian/internal/cli"
 )
@@ -17,8 +21,19 @@ var (
 
 func main() {
 	cli.SetVersion(version, commit, date)
-	if err := cli.Execute(); err != nil {
+
+	// Interrupt and SIGTERM cancel the context cobra hands to every command,
+	// which propagates into executor HTTP requests and the engine's
+	// between-rules checks: a Ctrl+C now unwinds in-flight work and runs the
+	// cleanup defers (OOB listeners especially) instead of killing the
+	// process with ports still bound. The second signal restores immediate
+	// termination for an operator who wants out regardless.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := cli.ExecuteContext(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		stop()
 		os.Exit(1)
 	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/calbebop/batesian/internal/attack"
@@ -28,10 +29,19 @@ scanners never see.
 Documentation: https://github.com/calbebop/batesian`,
 }
 
-// Execute is the entrypoint called by main.
+// Execute is the entrypoint called by main. The context carries signal
+// cancellation (see cmd/batesian/main.go): an interrupt propagates to every
+// in-flight request and lets executor cleanup defers actually run, rather
+// than the process dying with listeners still bound.
 func Execute() error {
+	return ExecuteContext(context.Background())
+}
+
+// ExecuteContext runs the root command bound to ctx.
+func ExecuteContext(ctx context.Context) error {
 	rootCmd.SilenceUsage = true
 	rootCmd.SilenceErrors = true
+	rootCmd.SetContext(ctx)
 	return rootCmd.Execute()
 }
 

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -181,13 +181,13 @@ func runScan(cmd *cobra.Command, args []string) error {
 
 		switch {
 		case authURL != "" && clientID != "" && tokenURL != "":
-			tok, err := fetchOAuthTokenPKCE(context.Background(), authURL, tokenURL, clientID, oauthScopes, oauthAudience, redirectPort, !noBrowser)
+			tok, err := fetchOAuthTokenPKCE(cmd.Context(), authURL, tokenURL, clientID, oauthScopes, oauthAudience, redirectPort, !noBrowser)
 			if err != nil {
 				return fmt.Errorf("OAuth PKCE flow failed: %w", err)
 			}
 			token = tok
 		case clientID != "" && tokenURL != "":
-			tok, err := fetchOAuthToken(context.Background(), tokenURL, clientID, clientSecret, oauthScopes, oauthAudience)
+			tok, err := fetchOAuthToken(cmd.Context(), tokenURL, clientID, clientSecret, oauthScopes, oauthAudience)
 			if err != nil {
 				return fmt.Errorf("OAuth token acquisition failed: %w", err)
 			}
@@ -256,7 +256,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 	}
 
 	eng := engine.New(opts)
-	ctx := context.Background()
+	ctx := cmd.Context()
 	results := eng.Run(ctx, target, filtered)
 
 	if dryRun {

--- a/internal/oob/listener.go
+++ b/internal/oob/listener.go
@@ -38,6 +38,7 @@ type Callback struct {
 // Listener is a local HTTP server that captures incoming requests.
 type Listener struct {
 	server    *http.Server
+	ln        net.Listener
 	addr      string
 	callbacks chan Callback
 	mu        sync.Mutex
@@ -70,24 +71,45 @@ func (l *Listener) Start() (string, error) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", l.handleCallback)
 
-	l.server = &http.Server{
+	srv := &http.Server{
 		Handler:      mux,
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 5 * time.Second,
 	}
+	l.server = srv
+	l.ln = ln
 
 	go func() {
-		_ = l.server.Serve(ln)
+		// The local copy matters: a fast Stop between here and the first
+		// accept nils l.server, and a Serve on a nil server panics.
+		_ = srv.Serve(ln)
 	}()
 
 	l.started = true
-	return l.URL(), nil
+	return l.urlLocked(), nil
 }
 
-// URL returns the base URL of the listener.
-// The outbound IP is detected by dialing a well-known external address.
+// URL returns the base URL of the listener, or the empty string before a
+// successful Start: without a bound port there is no usable callback URL,
+// and handing the target a half-formed one would register a probe that can
+// never fire. The outbound IP is detected by dialing a well-known external
+// address; hosts with no outbound route fall back to 127.0.0.1.
 func (l *Listener) URL() string {
-	_, port, _ := net.SplitHostPort(l.addr)
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.urlLocked()
+}
+
+// urlLocked is URL for callers already holding l.mu (Start reports the URL
+// it just bound).
+func (l *Listener) urlLocked() string {
+	if l.addr == "" {
+		return ""
+	}
+	_, port, err := net.SplitHostPort(l.addr)
+	if err != nil {
+		return ""
+	}
 	ip := outboundIP()
 	return fmt.Sprintf("http://%s:%s", ip, port)
 }
@@ -117,14 +139,28 @@ func (l *Listener) WaitForMarker(ctx context.Context, timeout time.Duration, mar
 	}
 }
 
-// Stop shuts down the HTTP server.
+// Stop shuts down the HTTP server and resets the listener so a subsequent
+// Start binds a fresh port. Without the reset, a reused Listener reported
+// its old URL as if a server still answered there - callbacks would then
+// silently never arrive.
 func (l *Listener) Stop(ctx context.Context) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if l.server == nil {
 		return nil
 	}
-	return l.server.Shutdown(ctx)
+	// Closing the listener first makes Shutdown decisive even when the serve
+	// goroutine has not reached Accept yet - without it, the open port would
+	// survive a restart racing this call.
+	if l.ln != nil {
+		_ = l.ln.Close()
+	}
+	err := l.server.Shutdown(ctx)
+	l.server = nil
+	l.ln = nil
+	l.addr = ""
+	l.started = false
+	return err
 }
 
 func (l *Listener) handleCallback(w http.ResponseWriter, r *http.Request) {

--- a/internal/oob/listener_test.go
+++ b/internal/oob/listener_test.go
@@ -2,6 +2,8 @@ package oob
 
 import (
 	"context"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 )
@@ -43,5 +45,55 @@ func TestWaitForMarker_EmptyMarkerMatchesAny(t *testing.T) {
 
 	if _, ok := l.WaitForMarker(context.Background(), time.Second, ""); !ok {
 		t.Error("empty marker should match any callback")
+	}
+}
+
+// TestListener_StopResetsLifecycle pins two contracts: URL() is empty before
+// any Start (a half-formed callback URL handed to a target would register a
+// probe that can never fire), and after Stop the listener is reusable - a
+// second Start binds a fresh, answering server instead of reporting the dead
+// one's address.
+func TestListener_StopResetsLifecycle(t *testing.T) {
+	l := New()
+	if got := l.URL(); got != "" {
+		t.Fatalf("URL before Start = %q, want empty", got)
+	}
+
+	url1, err := l.Start()
+	if err != nil {
+		t.Fatalf("first start: %v", err)
+	}
+	if url1 == "" {
+		t.Fatal("first start returned empty URL")
+	}
+
+	ctx := context.Background()
+	if err := l.Stop(ctx); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if got := l.URL(); got != "" {
+		t.Errorf("URL after Stop = %q, want empty", got)
+	}
+
+	url2, err := l.Start()
+	if err != nil {
+		t.Fatalf("restart: %v", err)
+	}
+	if url2 == "" {
+		t.Fatal("restart returned empty URL")
+	}
+
+	// The restarted server must actually answer.
+	resp, err := http.Post(url2+"/probe", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("post to restarted listener: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("restarted listener answered HTTP %d, want 200", resp.StatusCode)
+	}
+
+	if err := l.Stop(ctx); err != nil {
+		t.Errorf("second stop: %v", err)
 	}
 }


### PR DESCRIPTION
Three latent bugs in the OOB listener, two of which the new lifecycle test exposed immediately:

1. Stop never reset started/addr, so a reused Listener reported its dead URL as if it still answered - registered callbacks would silently never arrive.
2. Start's serve goroutine read l.server lazily; a fast Stop between launch and first accept nilled the field under it and panicked with a nil SIGSEGV. The goroutine now serves a local copy, and Stop closes the bound listener directly so shutdown is decisive even when Accept was never reached (without that, Shutdown on a never-served server leaves the port open and a restart races it).
3. URL before any Start returned "http://ip:" with an empty port - an unusable callback handed straight to the target. Empty now, which the registration sites already treat as unusable.

Interrupt handling had no story at all: zero signal.NotifyContext calls repo-wide, so Ctrl+C killed the process outright, skipping every executor cleanup defer - OOB listeners included, which is how ports stay bound after an aborted scan. main now installs NotifyContext (interrupt + SIGTERM) and binds it through cobra via the new ExecuteContext; scan and probe derive their context from the command instead of context.Background(), so cancellation reaches in-flight requests and the engine's between-rules check. A second Ctrl+C restores immediate exit via the standard signal-context unwinding.

Changes:
- internal/oob/listener.go + listener_test.go - lifecycle fixes plus TestListener_StopResetsLifecycle (empty-URL-before-Start, empty-after-Stop, restart answers real traffic)
- cmd/batesian/main.go, internal/cli/root.go, scan.go, probe.go - signal context end-to-end

The deadlock this surfaced mid-implementation (URL taking l.mu while Start held it) is also fixed via an assumes-locked helper. Verified locally: gofmt/vet/race suite green, oob package green under -count=5 and -race repeated runs, lint 0 issues.
