### PR TITLE
fix(cli): canonical severity in JSON findings; unknown bucket in summary

### DIFF
--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -18,6 +18,7 @@ import (
 	"github.com/calbebop/batesian/internal/httpx"
 	"github.com/calbebop/batesian/internal/report"
 	"github.com/calbebop/batesian/internal/rules"
+	"github.com/calbebop/batesian/internal/severity"
 	"github.com/spf13/cobra"
 )
 
@@ -689,9 +690,14 @@ func buildScanJSON(target string, results []engine.RunResult) map[string]interfa
 				})
 			}
 			findings = append(findings, jsonFinding{
-				RuleID:      f.RuleID,
-				RuleName:    f.RuleName,
-				Severity:    f.Severity,
+				RuleID:   f.RuleID,
+				RuleName: f.RuleName,
+				// Canonical, matching the summary buckets and SARIF output:
+				// a finding carrying "Critical" used to serialize as
+				// "Critical" while being counted under "critical" in the
+				// same document. Unknown severities fall back to the raw
+				// string rather than collapsing to empty.
+				Severity:    severity.CanonicalOrRaw(f.Severity),
 				Confidence:  confidence,
 				Title:       f.Title,
 				Description: f.Description,
@@ -720,13 +726,32 @@ func buildScanJSON(target string, results []engine.RunResult) map[string]interfa
 		"findings": findings,
 		"skipped":  skipped,
 		"errors":   ruleErrors,
-		"summary": map[string]int{
-			"total":    engine.TotalFindings(results),
-			"critical": len(engine.FindingsBySeverity(results)["critical"]),
-			"high":     len(engine.FindingsBySeverity(results)["high"]),
-			"medium":   len(engine.FindingsBySeverity(results)["medium"]),
-			"low":      len(engine.FindingsBySeverity(results)["low"]),
-			"info":     len(engine.FindingsBySeverity(results)["info"]),
-		},
+		"summary":  buildSummary(results),
 	}
+}
+
+// buildSummary counts findings into the canonical severity buckets. An
+// "unknown" bucket accounts for findings whose severity is not one of the
+// known values, so the buckets always sum to total - executors set severity
+// as a plain string, and a value nothing validates used to be counted in
+// total while vanishing from every bucket.
+func buildSummary(results []engine.RunResult) map[string]int {
+	total := engine.TotalFindings(results)
+	bySev := engine.FindingsBySeverity(results)
+	summary := map[string]int{
+		"total":    total,
+		"critical": len(bySev["critical"]),
+		"high":     len(bySev["high"]),
+		"medium":   len(bySev["medium"]),
+		"low":      len(bySev["low"]),
+		"info":     len(bySev["info"]),
+	}
+	known := 0
+	for _, k := range []string{"critical", "high", "medium", "low", "info"} {
+		known += summary[k]
+	}
+	if unknown := total - known; unknown > 0 {
+		summary["unknown"] = unknown
+	}
+	return summary
 }

--- a/internal/cli/scan_summary_test.go
+++ b/internal/cli/scan_summary_test.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/calbebop/batesian/internal/attack"
+	"github.com/calbebop/batesian/internal/engine"
+	"github.com/calbebop/batesian/internal/severity"
+)
+
+// TestCanonicalOrRaw pins the fallback: known severities fold to canonical
+// spelling; anything else comes back verbatim rather than as an empty string
+// (an output site collapsing "Critical" to "" would erase the severity).
+func TestCanonicalOrRaw(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"critical", "critical"},
+		{"Critical", "critical"},
+		{"  HIGH  ", "high"},
+		{"sev1", "sev1"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := severity.CanonicalOrRaw(tc.in); got != tc.want {
+			t.Errorf("CanonicalOrRaw(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func findingWithSeverity(sev string) attack.Finding {
+	return attack.Finding{
+		RuleID:   "test-rule-001",
+		Severity: sev,
+		Title:    "t",
+	}
+}
+
+// TestBuildSummary_SumsToTotalWithUnknown pins the property the unknown
+// bucket exists for: executors set severity as a plain string, so a value
+// nothing validates used to be counted in total while vanishing from every
+// bucket. The buckets must always sum to total.
+func TestBuildSummary_SumsToTotalWithUnknown(t *testing.T) {
+	results := []engine.RunResult{
+		{Findings: []attack.Finding{
+			findingWithSeverity("critical"),
+			findingWithSeverity("high"),
+			findingWithSeverity("High"), // folds with the one above
+			findingWithSeverity("info"),
+			findingWithSeverity("sev1"), // unknown
+		}},
+		{Findings: []attack.Finding{
+			findingWithSeverity("low"),
+		}},
+	}
+
+	summary := buildSummary(results)
+	if summary["total"] != 6 {
+		t.Fatalf("total = %d, want 6", summary["total"])
+	}
+	if summary["critical"] != 1 || summary["high"] != 2 || summary["info"] != 1 || summary["low"] != 1 {
+		t.Fatalf("canonical buckets wrong: %+v", summary)
+	}
+	if summary["unknown"] != 1 {
+		t.Fatalf("unknown bucket = %d, want 1 (the sev1 finding)", summary["unknown"])
+	}
+
+	sum := 0
+	for _, k := range []string{"critical", "high", "medium", "low", "info", "unknown"} {
+		sum += summary[k]
+	}
+	if sum != summary["total"] {
+		t.Fatalf("buckets sum to %d, want total %d: %+v", sum, summary["total"], summary)
+	}
+}
+
+// TestBuildSummary_AllKnownOmitsUnknown: the unknown key is absent when every
+// finding has a known severity, so consumers never see a zero-count noise
+// bucket.
+func TestBuildSummary_AllKnownOmitsUnknown(t *testing.T) {
+	results := []engine.RunResult{
+		{Findings: []attack.Finding{findingWithSeverity("high")}},
+	}
+	summary := buildSummary(results)
+	if _, present := summary["unknown"]; present {
+		t.Fatalf("unknown bucket must be omitted when empty: %+v", summary)
+	}
+}
+
+// TestBuildSummaryMarshal_JSONStable: the summary must serialize without
+// map-order surprises, since scripts diff scan outputs.
+func TestBuildSummaryMarshal_JSONStable(t *testing.T) {
+	summary := buildSummary([]engine.RunResult{
+		{Findings: []attack.Finding{findingWithSeverity("high")}},
+	})
+	b, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var keys []string
+	if err := json.Unmarshal(b, &keys); err == nil {
+		t.Fatalf("expected object, got array: %s", b)
+	}
+	var doc map[string]int
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if doc["high"] != 1 || doc["total"] != 1 {
+		t.Fatalf("round-trip mismatch: %s", b)
+	}
+}

--- a/internal/severity/severity.go
+++ b/internal/severity/severity.go
@@ -49,6 +49,16 @@ func Canonical(s string) string {
 // Valid reports whether s names a severity, ignoring case and surrounding space.
 func Valid(s string) bool { return Canonical(s) != "" }
 
+// CanonicalOrRaw returns Canonical(s), or s verbatim when it names no known
+// severity - for output sites that must not collapse an unrecognized value
+// to the empty string.
+func CanonicalOrRaw(s string) string {
+	if c := Canonical(s); c != "" {
+		return c
+	}
+	return s
+}
+
 // Rank orders severities for comparison, higher being worse. An unrecognized
 // value ranks below every legal one rather than tying with "info", so a typo can
 // never win a coalescing contest against a real severity.


### PR DESCRIPTION
Two views of one finding disagreed on severity spelling inside the same JSON document: the findings array serialized the executor's raw string ("Critical") while the summary buckets folded to canonical ("critical"), and SARIF canonicalized on its own. Three outputs, two spellings, one scan.

The findings array now emits severity.CanonicalOrRaw - canonical spelling for known severities, verbatim otherwise. The "otherwise" matters: collapsing an unrecognized value through Canonical would have produced an empty severity field, erasing information rather than normalizing it.

Second fix in the same document: the summary buckets could sum to less than total. A severity that validates to nothing was counted in total and then vanished from every bucket - invisible in critical/high/medium/low/info while still inflating the headline count. buildSummary (extracted from the inline map) now adds an "unknown" key when that residue is non-zero, keeping the buckets-sum-to-total invariant; the key is omitted when empty so consumers never see zero-count noise. FindingsBySeverity already folded by canonical, which is why "High" and "high" were counted together while the finding said "High" - the row-level fix makes the list side match the bucket side instead of the reverse.

Changes:
- internal/severity/severity.go - CanonicalOrRaw, documented as the output-site fallback
- internal/cli/scan.go - canonical severity in jsonFinding; buildSummary extracted with unknown-bucket logic
- internal/cli/scan_summary_test.go - four tests: CanonicalOrRaw fallback table, buckets-sum-to-total with an unknown severity mixed in (including "High" folding), unknown-key omission when empty, JSON round-trip shape

Verified locally in the pinned containers: gofmt clean, vet, full race suite green, lint 0 issues.
