### PR TITLE
fix(report): helpUri, partialFingerprints, and dead target parameter in SARIF

### DIFF
--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -273,7 +273,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 
 	switch format {
 	case report.FormatSARIF:
-		return report.WriteSARIF(os.Stdout, target, results, attackpkg.Version)
+		return report.WriteSARIF(os.Stdout, results, attackpkg.Version)
 	case report.FormatJSON:
 		// The machine-readable payload always goes to stdout; status/banner
 		// output (above) goes to stderr so `batesian scan --output json | jq`

--- a/internal/report/sarif.go
+++ b/internal/report/sarif.go
@@ -1,10 +1,13 @@
 package report
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 
 	attackpkg "github.com/calbebop/batesian/internal/attack"
 	"github.com/calbebop/batesian/internal/engine"
@@ -59,12 +62,19 @@ type sarifRuleProperties struct {
 	Severity string   `json:"security-severity,omitempty"` // CVSS-like 0.0-10.0 string
 }
 
+// sarifResult carries partialFingerprints so GitHub code-scanning correlates
+// one logical finding to one alert across scans: without it, identity is
+// ruleId + artifact URI, and a discovered endpoint that moves (the candidate
+// walk appending or dropping a path) re-opens the same vulnerability as a new
+// alert. The fingerprint hashes rule ID plus the finding title - both stable
+// while the endpoint string is not.
 type sarifResult struct {
-	RuleID     string            `json:"ruleId"`
-	Level      string            `json:"level"` // error, warning, note, none
-	Message    sarifMessage      `json:"message"`
-	Locations  []sarifLocation   `json:"locations"`
-	Properties map[string]string `json:"properties,omitempty"`
+	RuleID              string            `json:"ruleId"`
+	Level               string            `json:"level"` // error, warning, note, none
+	Message             sarifMessage      `json:"message"`
+	Locations           []sarifLocation   `json:"locations"`
+	PartialFingerprints map[string]string `json:"partialFingerprints,omitempty"`
+	Properties          map[string]string `json:"properties,omitempty"`
 }
 
 type sarifMessage struct {
@@ -86,7 +96,7 @@ type sarifArtifactLocation struct {
 }
 
 // WriteSARIF encodes the scan results as SARIF v2.1.0 JSON to w.
-func WriteSARIF(w io.Writer, target string, results []engine.RunResult, toolVersion string) error {
+func WriteSARIF(w io.Writer, results []engine.RunResult, toolVersion string) error {
 	doc := buildSARIF(results, toolVersion)
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
@@ -115,6 +125,7 @@ func buildSARIF(results []engine.RunResult, toolVersion string) sarifLog {
 				Name:             r.Rule.Info.Name,
 				ShortDescription: sarifMessage{Text: r.Rule.Info.Name},
 				FullDescription:  sarifMessage{Text: truncateRunes(r.Rule.Info.Description, 500)},
+				HelpURI:          firstHTTPReference(r.Rule.Info.References),
 				Properties: sarifRuleProperties{
 					Tags:     tags,
 					Severity: severityScore(r.Rule.Info.Severity),
@@ -193,8 +204,34 @@ func findingToSARIF(f attackpkg.Finding) sarifResult {
 				},
 			},
 		},
+		PartialFingerprints: map[string]string{
+			"primaryLocationLineHash": fingerprint(f),
+		},
 		Properties: props,
 	}
+}
+
+// fingerprint derives the stable per-finding identity used for
+// partialFingerprints: SHA-256 over rule ID and finding title, hex-encoded.
+// Both fields survive endpoint-string drift, which is exactly the churn that
+// used to re-open one vulnerability as a fresh alert.
+func fingerprint(f attackpkg.Finding) string {
+	sum := sha256.Sum256([]byte(f.RuleID + "\x00" + f.Title))
+	return hex.EncodeToString(sum[:])
+}
+
+// firstHTTPReference picks the first http(s) reference from a rule's
+// reference list for helpUri. Rules cite specs and advisories there; GitHub
+// code-scanning renders the field as the alert's help link. A rule with no
+// http reference (or none at all) yields an empty helpUri, which the
+// omitempty tag drops.
+func firstHTTPReference(refs []string) string {
+	for _, r := range refs {
+		if strings.HasPrefix(r, "https://") || strings.HasPrefix(r, "http://") {
+			return r
+		}
+	}
+	return ""
 }
 
 // severityLevel maps Batesian severity strings to SARIF level values.

--- a/internal/report/sarif_test.go
+++ b/internal/report/sarif_test.go
@@ -53,7 +53,7 @@ type sarifDoc struct {
 // %SRCROOT% uriBaseId, violating the spec.
 func TestWriteSARIF_AbsoluteURIHasNoUriBaseId(t *testing.T) {
 	var buf bytes.Buffer
-	if err := report.WriteSARIF(&buf, "https://agent.example.com", sarifFixture(), "test"); err != nil {
+	if err := report.WriteSARIF(&buf, sarifFixture(), "test"); err != nil {
 		t.Fatalf("WriteSARIF: %v", err)
 	}
 
@@ -93,7 +93,7 @@ func TestWriteSARIF_CleanScanEmptiesResultsArray(t *testing.T) {
 	clean := []engine.RunResult{{Rule: r}} // ran, found nothing
 
 	var buf bytes.Buffer
-	if err := report.WriteSARIF(&buf, "https://agent.example.com", clean, "test"); err != nil {
+	if err := report.WriteSARIF(&buf, clean, "test"); err != nil {
 		t.Fatalf("WriteSARIF: %v", err)
 	}
 
@@ -111,5 +111,94 @@ func TestWriteSARIF_CleanScanEmptiesResultsArray(t *testing.T) {
 	if len(doc.Runs) != 1 || doc.Runs[0].Results == nil || len(doc.Runs[0].Results) != 0 {
 		t.Fatalf("expected one run with a non-nil empty results array; runs=%d results=%v",
 			len(doc.Runs), doc.Runs[0].Results)
+	}
+}
+
+// TestSARIF_HelpURIFromReferences pins that a rule's first http(s) reference
+// becomes the driver rule's helpUri - the field GitHub code-scanning renders
+// as the alert's help link. HelpURI existed as a struct field but was never
+// assigned, so every alert shipped with no help link despite every rule
+// citing specs and advisories.
+func TestSARIF_HelpURIFromReferences(t *testing.T) {
+	r := &rules.Rule{}
+	r.ID = "mcp-helpuri-001"
+	r.Info.Name = "Help URI Rule"
+	r.Info.Severity = "high"
+	r.Info.References = []string{
+		"some-non-url-citation",
+		"https://modelcontextprotocol.io/specification",
+		"https://second.example/ignored",
+	}
+	results := []engine.RunResult{{Rule: r}}
+
+	var buf bytes.Buffer
+	if err := report.WriteSARIF(&buf, results, "test"); err != nil {
+		t.Fatalf("WriteSARIF: %v", err)
+	}
+
+	var doc struct {
+		Runs []struct {
+			Tool struct {
+				Driver struct {
+					Rules []struct {
+						ID      string `json:"id"`
+						HelpURI string `json:"helpUri"`
+					} `json:"rules"`
+				} `json:"driver"`
+			} `json:"tool"`
+		} `json:"runs"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(doc.Runs) != 1 || len(doc.Runs[0].Tool.Driver.Rules) != 1 {
+		t.Fatalf("expected one driver rule, got: %+v", doc)
+	}
+	rule := doc.Runs[0].Tool.Driver.Rules[0]
+	if rule.HelpURI != "https://modelcontextprotocol.io/specification" {
+		t.Fatalf("helpUri = %q, want the first http(s) reference", rule.HelpURI)
+	}
+}
+
+// TestSARIF_PartialFingerprintStableAcrossTargetDrift pins the alert-
+// correlation property: two findings with identical rule ID and title but
+// different target URLs must produce the SAME fingerprint, since the whole
+// point is that one logical vulnerability keeps one alert when its endpoint
+// string moves. It also pins the negative - different titles hash differently.
+func TestSARIF_PartialFingerprintStableAcrossTargetDrift(t *testing.T) {
+	fp := func(ruleID, title, target string) string {
+		results := []engine.RunResult{{
+			Rule: &rules.Rule{ID: ruleID},
+			Findings: []attack.Finding{{
+				RuleID:    ruleID,
+				Severity:  "high",
+				Title:     title,
+				TargetURL: target,
+			}},
+		}}
+		var buf bytes.Buffer
+		if err := report.WriteSARIF(&buf, results, "test"); err != nil {
+			t.Fatalf("WriteSARIF: %v", err)
+		}
+		var doc struct {
+			Runs []struct {
+				Results []struct {
+					PartialFingerprints map[string]string `json:"partialFingerprints"`
+				} `json:"results"`
+			} `json:"runs"`
+		}
+		if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		return doc.Runs[0].Results[0].PartialFingerprints["primaryLocationLineHash"]
+	}
+
+	a := fp("mcp-x-001", "Same vulnerability", "https://host.example/mcp")
+	b := fp("mcp-x-001", "Same vulnerability", "https://host.example/mcp/deep/path")
+	if a == "" || a != b {
+		t.Fatalf("endpoint drift must keep one fingerprint: %q vs %q", a, b)
+	}
+	if c := fp("mcp-x-001", "Different finding", "https://host.example/mcp"); c == a {
+		t.Fatalf("different titles must hash differently, got %q for both", a)
 	}
 }


### PR DESCRIPTION
Three long-standing SARIF gaps, one user-visible on every GitHub code-scanning alert:

- **HelpURI** existed as a struct field but was never assigned - every alert shipped with no help link despite every rule citing specs and advisories. The first http(s) entry from the rule's reference list now populates it; a rule citing none omits the field via omitempty.
- **partialFingerprints** were absent, so GitHub correlated alerts on ruleId plus artifact URI alone. The candidate walk moves that URI between scans as paths resolve differently, and one logical vulnerability re-opened as a fresh alert each time. Fingerprints now hash rule ID plus finding title - both stable while the endpoint string is not - keyed as primaryLocationLineHash per the GitHub convention.
- **WriteSARIF** accepted a target parameter it never read, misleading callers into thinking scan context influenced the output. Removed; both call sites updated.

Two new tests pin the behavior: helpUri must be the first http(s) reference (a non-URL citation in the list must be skipped), and fingerprints must be identical across target drift while differing across finding titles.

Changes:
- internal/report/sarif.go - HelpURI population, PartialFingerprints + fingerprint helper, firstHTTPReference helper, dead parameter removed
- internal/report/sarif_test.go - two new tests; both existing WriteSARIF call sites updated
- internal/cli/scan.go - call site

Verified locally in the pinned containers: gofmt clean, vet, full race suite green, lint 0 issues.
