### PR TITLE
ci: timeout-minutes on every job, govulncheck bump, ldflags in gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
   build:
     name: Build & Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -60,6 +61,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -79,6 +81,7 @@ jobs:
   vuln:
     name: Vulnerability Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -89,11 +92,12 @@ jobs:
           cache: true
 
       - name: govulncheck
-        run: go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./...
 
   release:
     name: Release (goreleaser)
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     # Tag PUSH only. workflow_dispatch accepts any ref, including a tag, so a
     # ref test alone would let a manual run re-publish an existing release.
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
@@ -117,7 +121,8 @@ jobs:
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
       # cosign performs keyless signing of the checksums file using the
-      # workflow's OIDC token. Output: checksums.txt.sig + checksums.txt.pem.
+      # workflow's OIDC token. Output: checksums.txt.sigstore.json (cosign v3
+      # bundles; see .goreleaser.yaml signs block for exactly what ships).
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,6 +31,7 @@ jobs:
   analyze:
     name: Analyze Go
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       # Needed to upload results to the code-scanning dashboard.
       security-events: write

--- a/.github/workflows/lint-sweep.yml
+++ b/.github/workflows/lint-sweep.yml
@@ -30,6 +30,7 @@ jobs:
   lint:
     name: Lint (cache disabled)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/mcp-era-watch.yml
+++ b/.github/workflows/mcp-era-watch.yml
@@ -33,6 +33,7 @@ jobs:
   detect:
     name: Detect the era of a real modern server
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -18,6 +18,10 @@ on:
   schedule:
     # Weekly, Monday 05:30 UTC.
     - cron: '30 5 * * 1'
+  # Manual trigger, matching every other scheduled workflow in this repo: a
+  # direct API call that works when event delivery is degraded (the
+  # 2026-08-06 Actions incident is the precedent documented in ci.yml).
+  workflow_dispatch:
 
 permissions: read-all
 
@@ -25,6 +29,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       # Needed to upload the results to the code-scanning dashboard.
       security-events: write

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -30,12 +30,16 @@ jobs:
   a2a-secured-agent:
     name: A2A false-positive gate (secured agent)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # Tags and history feed git describe in the ldflags below, so these
+          # gates exercise the same version string a released binary carries.
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -53,7 +57,9 @@ jobs:
         run: pip install starlette uvicorn
 
       - name: Build batesian
-        run: go build -o batesian ./cmd/batesian
+        # Match the Makefile's ldflags so the gates validate the real binary
+        # identity (User-Agent included), not a bare 'dev' build.
+        run: go build -ldflags "-s -w -X main.version=$(git describe --tags --always --dirty) -X main.commit=$(git rev-parse --short HEAD)" -o batesian ./cmd/batesian
 
       - name: Run the secured-agent validation
         run: python .github/scripts/validate_secured_agent.py
@@ -63,12 +69,16 @@ jobs:
   a2a-push-callback-auth:
     name: A2A push callback-auth gate (unsigned/signed/nocallback)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # Tags and history feed git describe in the ldflags below, so these
+          # gates exercise the same version string a released binary carries.
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -86,7 +96,9 @@ jobs:
         run: pip install starlette uvicorn httpx
 
       - name: Build batesian
-        run: go build -o batesian ./cmd/batesian
+        # Match the Makefile's ldflags so the gates validate the real binary
+        # identity (User-Agent included), not a bare 'dev' build.
+        run: go build -ldflags "-s -w -X main.version=$(git describe --tags --always --dirty) -X main.commit=$(git rev-parse --short HEAD)" -o batesian ./cmd/batesian
 
       - name: Run the push callback-auth validation
         run: python .github/scripts/validate_push_callback_auth.py
@@ -96,12 +108,16 @@ jobs:
   mcp-property-fixtures:
     name: MCP property gates (probe-honesty, log opt-in, body size, session)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # Tags and history feed git describe in the ldflags below, so these
+          # gates exercise the same version string a released binary carries.
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -119,7 +135,9 @@ jobs:
         run: pip install starlette uvicorn
 
       - name: Build batesian
-        run: go build -o batesian ./cmd/batesian
+        # Match the Makefile's ldflags so the gates validate the real binary
+        # identity (User-Agent included), not a bare 'dev' build.
+        run: go build -ldflags "-s -w -X main.version=$(git describe --tags --always --dirty) -X main.commit=$(git rev-parse --short HEAD)" -o batesian ./cmd/batesian
 
       - name: Run the MCP property-fixture validations
         run: python .github/scripts/validate_mcp_fixtures.py
@@ -129,12 +147,16 @@ jobs:
   fastmcp-target:
     name: MCP false-positive + true-positive gate (FastMCP, third-party)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # Tags and history feed git describe in the ldflags below, so these
+          # gates exercise the same version string a released binary carries.
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -154,7 +176,9 @@ jobs:
         run: pip install "fastmcp>=3"
 
       - name: Build batesian
-        run: go build -o batesian ./cmd/batesian
+        # Match the Makefile's ldflags so the gates validate the real binary
+        # identity (User-Agent included), not a bare 'dev' build.
+        run: go build -ldflags "-s -w -X main.version=$(git describe --tags --always --dirty) -X main.commit=$(git rev-parse --short HEAD)" -o batesian ./cmd/batesian
 
       - name: Run the FastMCP validation
         run: python .github/scripts/validate_fastmcp.py
@@ -164,12 +188,16 @@ jobs:
   oauth-dcr-fixture:
     name: MCP OAuth DCR cleanup + report-leftovers gate
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # Tags and history feed git describe in the ldflags below, so these
+          # gates exercise the same version string a released binary carries.
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -186,7 +214,9 @@ jobs:
         run: pip install starlette uvicorn
 
       - name: Build batesian
-        run: go build -o batesian ./cmd/batesian
+        # Match the Makefile's ldflags so the gates validate the real binary
+        # identity (User-Agent included), not a bare 'dev' build.
+        run: go build -ldflags "-s -w -X main.version=$(git describe --tags --always --dirty) -X main.commit=$(git rev-parse --short HEAD)" -o batesian ./cmd/batesian
 
       - name: Run the OAuth DCR validation
         run: python .github/scripts/validate_oauth_dcr.py


### PR DESCRIPTION
Five CI hygiene items from the review, all workflow-file only:

- **timeout-minutes** was absent from all 13 jobs across the six workflows, so a wedged live-fixture job (validation dials real Python servers) or a hung npx install burned the full 6-hour runner ceiling per incident. Every job now carries a timeout tuned to its shape: 45 minutes for the release and CodeQL analysis, 15-20 for everything else.
- **govulncheck** was pinned at v1.1.4, a 2024-era release, while every surrounding action tracks a current major with digest pins. Bumped to v1.7.0 (latest at time of writing, verified via `go list -m -versions golang.org/x/vuln`).
- **cosign comment** claimed `checksums.txt.sig + .pem` output that the cosign v3 bundle migration replaced with a single `.sigstore.json` a year ago; it now points at the goreleaser signs block as authoritative instead of restating a stale inventory.
- **scorecard** gains workflow_dispatch, matching the rerun story every other scheduled workflow documents (the 2026-08-06 Actions incident precedent in ci.yml).
- **validation gates built a bare `dev` binary**, exercising a User-Agent and version string different from what ships. The five gate jobs now build with the Makefile's ldflags via `git describe --tags --always --dirty` (fetch-depth: 0 for tag access), so they validate the released identity.

All six workflow YAMLs parse clean (validated in-container with pyyaml). No job logic changed beyond the build lines; every check on this PR runs the new configuration end-to-end.
