### PR TITLE
fix(mcp): stop reading an error envelope as a completed initialize

### DIFF
--- a/internal/attack/mcp/init_downgrade.go
+++ b/internal/attack/mcp/init_downgrade.go
@@ -316,12 +316,11 @@ func (e *InitDowngradeExecutor) handshake(ctx context.Context, client *attack.HT
 	if err != nil || !initResp.IsSuccess() {
 		return false, mcpSession{}
 	}
-	body := initResp.BodyString()
-	// Explicit version rejection (error without a negotiated version).
-	if strings.Contains(body, `"error"`) && !strings.Contains(body, `"protocolVersion"`) {
-		return false, mcpSession{}
-	}
-	if !initResp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
+	// A version rejection, or any other error envelope, means the handshake did
+	// not complete, which is initOK=false either way per the contract above.
+	// initializeSucceeded reads result.protocolVersion, so an error whose message
+	// quotes the field names no longer passes the way a substring gate let it.
+	if !initializeSucceeded(initResp.Body) {
 		return false, mcpSession{}
 	}
 	session := mcpSession{

--- a/internal/attack/mcp/jsonrpc_batch_bypass.go
+++ b/internal/attack/mcp/jsonrpc_batch_bypass.go
@@ -194,9 +194,12 @@ func isAuthRejection(resp *attack.Response) bool {
 	return authFlavoredError(obj.Error.Code, obj.Error.Message)
 }
 
-// isMCPInitialize reports whether a response is a successful MCP initialize result.
+// isMCPInitialize reports whether a response is a completed MCP initialize
+// result. The JSON-level oracle, not a substring over the raw body: an error
+// envelope whose message quotes the field names is not a handshake, and this
+// rule derives which methods to probe from ServerSupports parsing that body.
 func isMCPInitialize(resp *attack.Response) bool {
-	return resp.IsSuccess() && resp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`)
+	return resp.IsSuccess() && initializeSucceeded(resp.Body)
 }
 
 // batchHasResult reports whether body is a JSON-RPC batch response (a JSON array)

--- a/internal/attack/mcp/reachability_test.go
+++ b/internal/attack/mcp/reachability_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/calbebop/batesian/internal/attack"
@@ -77,6 +78,103 @@ func TestAnswersMCPInitialize(t *testing.T) {
 				t.Errorf("answersMCPInitialize(%s) = %v, want %v", tc.body, got, tc.want)
 			}
 		})
+	}
+}
+
+// initializeSucceeded is the oracle every session-building call site gates the
+// handshake on. It replaced a substring check over the raw body, which accepted
+// any 2xx error envelope whose message quotes a field name, so the rules then
+// built a session from an error body. The quoting case is the regression that
+// motivates the JSON-level read; unlike answersMCPInitialize, no error counts,
+// because the question is whether the handshake completed, not whether an MCP
+// endpoint answered.
+func TestInitializeSucceeded(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "completed handshake",
+			body: `{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"tools":{}},"serverInfo":{"name":"s"}}}`,
+			want: true,
+		},
+		{
+			// The defect this oracle replaced: the error message quotes the field
+			// names the substring gate matched on.
+			name: "error envelope quoting the field names is not a handshake",
+			body: `{"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"unsupported \"protocolVersion\" value, expected \"serverInfo\" and \"capabilities\""}}`,
+			want: false,
+		},
+		{
+			// answersMCPInitialize deliberately counts this; the handshake oracle
+			// must not, or a version rejection would open a session.
+			name: "version rejection is not a completed handshake",
+			body: `{"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"Unsupported protocol version"}}`,
+			want: false,
+		},
+		{
+			name: "result without a protocolVersion is not a handshake",
+			body: `{"jsonrpc":"2.0","id":1,"result":{"serverInfo":{"name":"s"}}}`,
+			want: false,
+		},
+		{
+			name: "batch response is not a handshake",
+			body: `[{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25"}}]`,
+			want: false,
+		},
+		{
+			name: "non-JSON body is not a handshake",
+			body: `<html>not json</html>`,
+			want: false,
+		},
+		{
+			name: "empty body is not a handshake",
+			body: ``,
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := initializeSucceeded([]byte(tc.body)); got != tc.want {
+				t.Errorf("initializeSucceeded(%s) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+// This pins the WIRING through initializeMCP, not just the oracle. A unit test
+// on initializeSucceeded alone stays green when a call site is reverted to the
+// substring gate, so it does not protect the behaviour that matters.
+//
+// initializeMCP is the shared handshake walk. Pointed at a server that answers
+// every candidate with a 2xx error envelope quoting the field names, the old
+// gate opened a session whose RawInit was that error body and cached the
+// endpoint for the whole scan. Now the walk must fail with the reason
+// classifyInitFailure derives from the envelope, and no session may come back.
+func TestInitializeMCP_ErrorEnvelopeIsNotASession(t *testing.T) {
+	const envelope = `{"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"unsupported \"protocolVersion\" value, expected \"serverInfo\" and \"capabilities\""}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(envelope))
+	}))
+	defer srv.Close()
+
+	client := attack.NewUnauthHTTPClient(attack.Options{TimeoutSeconds: 5}, attack.NewVars(srv.URL, ""))
+	session, err := initializeMCP(context.Background(), client, srv.URL)
+	if err == nil {
+		t.Fatal("initializeMCP must not report success against an error-envelope server")
+	}
+	if session.Endpoint != "" {
+		t.Fatalf("an error envelope must not produce a session; got endpoint %q", session.Endpoint)
+	}
+	var refusal handshakeRefusal
+	if !errors.As(err, &refusal) {
+		t.Fatalf("expected a handshakeRefusal naming the refusal, got %v", err)
+	}
+	if !strings.Contains(refusal.reason, `-32602`) {
+		t.Errorf("the refusal should quote the server's own JSON-RPC code, got %q", refusal.reason)
 	}
 }
 

--- a/internal/attack/mcp/resources_unauth.go
+++ b/internal/attack/mcp/resources_unauth.go
@@ -292,7 +292,7 @@ func initializeMCP(ctx context.Context, client *attack.HTTPClient, baseURL strin
 		if err != nil {
 			continue // transport failure: nothing answered, so nothing to explain
 		}
-		if !initResp.IsSuccess() || !initResp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
+		if !initResp.IsSuccess() || !initializeSucceeded(initResp.Body) {
 			if hadCached && ep == cachedEp {
 				// The remembered endpoint has gone stale: forget it and let
 				// this walk continue over every candidate as before.

--- a/internal/attack/mcp/scope_confusion.go
+++ b/internal/attack/mcp/scope_confusion.go
@@ -185,7 +185,7 @@ func scopeHandshake(ctx context.Context, client *attack.HTTPClient, baseURL stri
 		if err != nil {
 			continue
 		}
-		if !resp.IsSuccess() || !resp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
+		if !resp.IsSuccess() || !initializeSucceeded(resp.Body) {
 			observed.observe(classifyInitFailure(ep, p.token != "", resp))
 			continue
 		}

--- a/internal/attack/mcp/session.go
+++ b/internal/attack/mcp/session.go
@@ -175,6 +175,31 @@ func legacyHandshakeBody() map[string]interface{} {
 	}
 }
 
+// initializeSucceeded reports whether body is a completed MCP initialize: a
+// result envelope naming the negotiated revision. It is the handshake-grade
+// counterpart of answersMCPInitialize, which answers the reachability question
+// and deliberately counts version rejections and auth refusals, because for
+// that question an error still proves an MCP endpoint is listening.
+//
+// The distinction is load-bearing. A 2xx JSON-RPC error envelope whose message
+// quotes a field name (an SDK writing `unsupported "protocolVersion" value`)
+// serializes with the quotes intact, so a substring gate over the raw body
+// accepts it, and a rule built on that gate then treated the error as the
+// session's initialize result: RawInit became the error body, ServerSupports
+// derived capabilities from it, and notifications/initialized was sent against
+// a session the server never established. This oracle reads
+// result.protocolVersion, so an error envelope does not count whatever it
+// quotes. Callers pair it with IsSuccess so a non-2xx carrying a result body
+// does not count either.
+func initializeSucceeded(initBody []byte) bool {
+	var body struct {
+		Result struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		} `json:"result"`
+	}
+	return json.Unmarshal(initBody, &body) == nil && body.Result.ProtocolVersion != ""
+}
+
 // negotiatedVersion reads the protocolVersion the server chose from its
 // initialize result body, falling back to latestStable if the server did not
 // echo one. The negotiated value is sent in the Mcp-Protocol-Version header on

--- a/internal/attack/mcp/session_fixation.go
+++ b/internal/attack/mcp/session_fixation.go
@@ -170,10 +170,7 @@ func (e *SessionFixationExecutor) initWithSession(ctx context.Context, client *a
 			"clientInfo":      map[string]interface{}{"name": "batesian", "version": "1.0"},
 		},
 	})
-	if err != nil || !resp.IsSuccess() {
-		return "", false
-	}
-	if !resp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
+	if err != nil || !resp.IsSuccess() || !initializeSucceeded(resp.Body) {
 		return "", false
 	}
 	return resp.Headers.Get("Mcp-Session-Id"), true

--- a/internal/attack/mcp/shadow_surface.go
+++ b/internal/attack/mcp/shadow_surface.go
@@ -103,7 +103,7 @@ func (e *ShadowSurfaceExecutor) probePort(ctx context.Context, client *attack.HT
 	mcpPath := ""
 	for _, path := range shadowPaths {
 		resp, err := client.POST(ctx, base+path, nil, legacyHandshakeBody())
-		if err != nil || !resp.IsSuccess() || !resp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
+		if err != nil || !resp.IsSuccess() || !initializeSucceeded(resp.Body) {
 			continue
 		}
 		mcpPath = path
@@ -141,8 +141,7 @@ func (e *ShadowSurfaceExecutor) probePort(ctx context.Context, client *attack.HT
 	// one header different. Accepting it is the browser-reachability half of
 	// the rebinding chain.
 	rebindResp, rebindErr := client.POST(ctx, endpoint, map[string]string{"Origin": foreignOrigin}, legacyHandshakeBody())
-	originOpen := rebindErr == nil && rebindResp.IsSuccess() &&
-		rebindResp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`)
+	originOpen := rebindErr == nil && rebindResp.IsSuccess() && initializeSucceeded(rebindResp.Body)
 
 	sev, title := "medium", fmt.Sprintf("MCP surface answers without authentication on %s:%d%s", host, port, mcpPath)
 	if originOpen {

--- a/internal/attack/mcp/sse_resume_replay.go
+++ b/internal/attack/mcp/sse_resume_replay.go
@@ -143,7 +143,7 @@ func (e *SSEResumeReplayExecutor) initialize(ctx context.Context, client *attack
 	if err != nil {
 		return "", false, nil
 	}
-	if !resp.IsSuccess() || !resp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
+	if !resp.IsSuccess() || !initializeSucceeded(resp.Body) {
 		return "", false, resp
 	}
 	sid := resp.Headers.Get("Mcp-Session-Id")

--- a/internal/attack/mcp/task_idor.go
+++ b/internal/attack/mcp/task_idor.go
@@ -383,7 +383,7 @@ func (e *TaskIDORExecutor) initSession(ctx context.Context, client *attack.HTTPC
 		if err != nil {
 			continue // transport failure: nothing answered, so nothing to explain
 		}
-		if !resp.IsSuccess() || !resp.ContainsAny(`"protocolVersion"`, `"serverInfo"`, `"capabilities"`) {
+		if !resp.IsSuccess() || !initializeSucceeded(resp.Body) {
 			// This rule presents a token explicitly, so the client's ambient
 			// credential is not what decides whether the request carried one.
 			observed.observe(classifyInitFailure(ep, p.token != "", resp))


### PR DESCRIPTION
Seven call sites gated the initialize handshake on `IsSuccess()` plus `ContainsAny` over the raw body. A JSON-RPC error envelope at HTTP 200 whose message quotes a field name passes that gate: `unsupported "protocolVersion" value` serializes with the quotes intact. Against such a reply the rules built an `mcpSession` whose `RawInit` was the error body, derived capabilities from it, sent `notifications/initialized` against a session the server never established, and in the batch rule picked which methods to probe by parsing that body.

`answersMCPInitialize` (added for reachability in #162) already reads the envelope at the JSON level, but it answers a different question, "did an MCP endpoint answer", and deliberately counts version rejections, reserved error codes and auth rejections. The handshake question is different: did this initialize complete. No call site was asking it at the JSON level; the comment above `answersMCPInitialize` records that this side never did.

## Fix

`initializeSucceeded(body)` in `session.go`, next to `negotiatedVersion`: true only when the envelope carries `result.protocolVersion`. Error envelopes do not count, whatever they quote. Call sites pair it with `IsSuccess()` so a non-2xx carrying a result body does not count either.

| Call site | Was | Now |
|---|---|---|
| `initializeMCP` (shared handshake walk), `scopeHandshake`, the task-idor walk, SSE-resume `initialize` | a quoting error envelope became a session, and in `initializeMCP` the dead endpoint was cached for the whole scan | the candidate falls through to `classifyInitFailure`, which already grades error envelopes (`rankRefused`, quoting the server's own JSON-RPC code) |
| `handshake` in init-downgrade | two string checks, the second redundant once the first failed | one call to the oracle; a version rejection still means `initOK=false`, per that function's contract |
| `isMCPInitialize` (batch-bypass, oauth-audience) | same substring gate | JSON-level, so `ServerSupports` never parses an error body |
| `probePort` and its foreign-Origin twin (shadow-surface) | an adjacent port misidentified as MCP, and the twin compared against a different shape than the baseline | both sides JSON-level, so the twin remains an identical-bytes comparison |
| `initWithSession` (session-fixation) | refused read as accepted when the error quoted the fields | refused |

The severity ladder is untouched. A server answering with a version rejection or an auth refusal classifies exactly as before through `classifyInitFailure`; only the "2xx error envelope quoting the field names" shape moves, and it moves from invisible-session to refused-with-explanation.

## Verification

- Unit table on the oracle: a completed result, the quoting error envelope, a version rejection, a result without `protocolVersion`, a batch array, non-JSON, empty.
- End-to-end through `initializeMCP` against a server answering every candidate with the quoting error envelope: no session, and the error is a `handshakeRefusal` naming `-32602`. This pins the wiring, not just the oracle; a unit test alone stays green if a call site reverts.
- Full suite green across 18 packages, `go vet` and `gofmt` clean.

## Scope

The A2A mirror, `answersMCPInitialize` in `a2a/endpoint.go`, greps for `"protocolVersion"` over the raw body too. Different package, lower stakes (an A2A error message would have to quote the field), and it wants its own fixture; left for a separate change.

Two notes from testing on Windows: `internal/oob`'s `TestListener_StopResetsLifecycle` fails on main under `-count=20` on this platform (a double-close race invisible to the Linux CI job). Unrelated to this change, recorded for a follow-up.
