### PR TITLE
fix(mcp): stop reading a 429 as an audience refusal in mcp-oauth-audience-002

### DIFF
--- a/internal/attack/mcp/oauth_audience.go
+++ b/internal/attack/mcp/oauth_audience.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -134,6 +135,19 @@ func (e *OAuthAudienceExecutor) Execute(ctx context.Context, target string, opts
 	finding := coalesceOutcomes(e.rule, endpoint, expected, outcomes)
 	if finding != nil {
 		return []attack.Finding{*finding}, nil
+	}
+
+	// Nothing was accepted. Before calling that a clean result, check that the
+	// probes were actually judged. A reply carrying no verdict used to read as
+	// a rejection, so a rate-limited scan reported audience matching sound;
+	// classifyResponse now grades those inconclusive, and "every probe
+	// inconclusive" is a scan that never happened, not a server that enforced
+	// its gate. This runs before the premise check below: that one explains
+	// refusals, and a rate limiter refused nothing.
+	if everyProbeInconclusive(outcomes) {
+		return nil, fmt.Errorf("%w: every audience probe at %s came back without a verdict "+
+			"(HTTP %s), so whether the server enforces audience matching could not be judged",
+			attack.ErrInconclusive, endpoint, outcomeStatuses(outcomes))
 	}
 
 	// Nothing was accepted. That is only a clean result if the probes were built
@@ -494,6 +508,14 @@ func runProbesAgainstEndpoint(ctx context.Context, client *attack.HTTPClient, an
 // was accepted, so it produces no finding. (Previously this was treated as a
 // downgraded "ambiguous" acceptance, which false-positived non-MCP targets whose
 // /mcp request fell through to a 200 HTML page.)
+//
+// An explicit JSON-RPC `error` envelope counts as a rejection at any HTTP
+// status, the same rule classifyAccess applies: the JSON-RPC layer said no.
+// Every other reply outside 200/401/403 is inconclusive, a 429 above all.
+// Reading the remaining 4xx as a rejection made a rate-limited negative control
+// look like "the audience value was the decisive factor", which upgraded an
+// accepted trap to a confirmed finding, and made a rate-limited scan report
+// audience matching sound.
 func classifyResponse(resp *attack.Response) audVerdict {
 	switch {
 	case resp.StatusCode == 200:
@@ -515,9 +537,13 @@ func classifyResponse(resp *attack.Response) audVerdict {
 		// worked, which is how this rule reported a whole target secure on the
 		// strength of paths that did not exist.
 		return verdictInconclusive
-	case resp.StatusCode >= 400 && resp.StatusCode < 500:
+	case isJSONRPCError(resp.BodyString()):
+		// An explicit JSON-RPC refusal counts whatever HTTP status carries it.
 		return verdictRejected
 	default:
+		// A 429 from a rate limiter, a bare 400, an HTML 500: the server did not
+		// judge the token. classifyAccess leaves these undetermined, and so does
+		// this rule now.
 		return verdictInconclusive
 	}
 }
@@ -634,6 +660,36 @@ func coalesceOutcomes(rc attack.RuleContext, endpoint, expected string, outcomes
 		Remediation: rc.Remediation,
 		TargetURL:   endpoint,
 	}
+}
+
+// everyProbeInconclusive reports whether no probe produced a verdict: nothing
+// was accepted, and nothing was clearly refused either. A clean result claims
+// the audience check is sound, which needs at least one probe the server
+// actually judged; a scan where every probe was rate-limited or otherwise
+// unanswered judged nothing, and is not tested instead.
+func everyProbeInconclusive(outcomes []probeOutcome) bool {
+	for _, o := range outcomes {
+		if o.verdict != verdictInconclusive {
+			return false
+		}
+	}
+	return len(outcomes) > 0
+}
+
+// outcomeStatuses renders the distinct HTTP statuses the probes received, for
+// the not-tested reason. Zero is a transport failure, which said nothing about
+// the endpoint and is left out.
+func outcomeStatuses(outcomes []probeOutcome) string {
+	seen := map[int]bool{}
+	statuses := []string{}
+	for _, o := range outcomes {
+		if o.status == 0 || seen[o.status] {
+			continue
+		}
+		seen[o.status] = true
+		statuses = append(statuses, strconv.Itoa(o.status))
+	}
+	return strings.Join(statuses, ", ")
 }
 
 // formatEvidence renders the per-probe evidence block. The operator-supplied

--- a/internal/attack/mcp/oauth_audience_test.go
+++ b/internal/attack/mcp/oauth_audience_test.go
@@ -298,12 +298,14 @@ func TestOAuthAudience_AutoDiscovery_FromResourceMetadata(t *testing.T) {
 }
 
 func TestOAuthAudience_Ambiguous200(t *testing.T) {
-	// Server returns 200 with no JSON-RPC envelope to every probe (e.g. a
+	// Server returns 200 with no JSON-RPC envelope to any probe (e.g. a
 	// non-MCP endpoint or a generic 2xx ack). That is not evidence that any
-	// forged token was accepted, so the rule must produce no finding rather
-	// than a downgraded indicator. (Previously a 200 non-result was treated as
-	// "ambiguous acceptance" and emitted a RiskIndicator, which false-positived
-	// non-MCP targets whose /mcp fell through to a 200 page.)
+	// forged token was accepted, and it is not a rejection either: no probe was
+	// ever judged. The rule must report not tested rather than either a
+	// downgraded indicator or a clean pass. (A 200 non-result was first treated
+	// as "ambiguous acceptance", which false-positived non-MCP targets whose
+	// /mcp fell through to a 200 page; it then read as clean, which claimed the
+	// audience handling is sound about a JSON-RPC layer that engaged nothing.)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
@@ -315,11 +317,11 @@ func TestOAuthAudience_Ambiguous200(t *testing.T) {
 
 	exec := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC())
 	findings, err := exec.Execute(context.Background(), srv.URL, optsWithAudience(testExpectedAud))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
 	if len(findings) != 0 {
 		t.Fatalf("expected 0 findings for a 200 non-result target, got %d: %+v", len(findings), findings)
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Errorf("no probe was judged; want ErrInconclusive, got %v", err)
 	}
 }
 
@@ -361,6 +363,92 @@ func TestOAuthAudience_TrapAcceptedControlNonResult(t *testing.T) {
 	}
 	if findings[0].Confidence != attack.RiskIndicator {
 		t.Errorf("expected RiskIndicator (control not clearly rejected), got %q", findings[0].Confidence)
+	}
+}
+
+// A 429 is not a rejection. The negative control is what upgrades an accepted
+// trap to a confirmed finding: "the control was REJECTED, so the audience value
+// was the decisive factor". A rate limiter catching the control (plausible on
+// its own: the probes are a burst) made that argument out of a reply that said
+// nothing about the token, and every trap acceptance read as confirmed.
+func TestOAuthAudience_RateLimitedControlDowngradesToIndicator(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+			// Gate initialize itself, so the probes' initialize verdicts stand.
+			challenge401(w)
+			return
+		}
+		aud := decodeJWTAud(t, r.Header.Get("Authorization"))
+		if s, ok := aud.(string); ok && strings.HasPrefix(s, "https://batesian-control") {
+			// The rate limiter caught the control probe.
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		// Every trap probe is accepted with a clean result envelope.
+		initializeOK(w)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC())
+	findings, err := exec.Execute(context.Background(), srv.URL, optsWithAudience(testExpectedAud))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected the accepted traps to survive a rate-limited control, got %d findings: %+v", len(findings), findings)
+	}
+	if findings[0].Confidence != attack.RiskIndicator {
+		t.Errorf("a control that was rate-limited, not rejected, cannot isolate the audience value as decisive; want RiskIndicator, got %q", findings[0].Confidence)
+	}
+}
+
+// A 429 on every probe is a scan that never happened: no token was judged.
+// Reading 429 as a rejection made this a clean result, claiming the audience
+// check is sound about a server that refused nothing and accepted nothing.
+func TestOAuthAudience_RateLimitedEverythingIsNotTested(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC())
+	findings, err := exec.Execute(context.Background(), srv.URL, optsWithAudience(testExpectedAud))
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+	if !errors.Is(err, attack.ErrInconclusive) {
+		t.Errorf("rate-limited probes judged nothing; want ErrInconclusive, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "429") {
+		t.Errorf("the reason should name the statuses that came back, got: %v", err)
+	}
+}
+
+// An explicit JSON-RPC refusal counts as a rejection at any HTTP status, the
+// same rule classifyAccess applies: a 400 carrying an error envelope is the
+// JSON-RPC layer saying no, not a verdict the scanner could not read. Every
+// probe refused is a tested surface, so the result is clean.
+func TestOAuthAudience_ExplicitJSONRPCRefusalIsARejection(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"error":   map[string]interface{}{"code": -32602, "message": "invalid request"},
+		})
+	}))
+	defer srv.Close()
+
+	exec := mcpattack.NewOAuthAudienceExecutor(oauthAudienceRC())
+	findings, err := exec.Execute(context.Background(), srv.URL, optsWithAudience(testExpectedAud))
+	if err != nil {
+		t.Fatalf("an explicit refusal is a tested surface; want clean, got %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected zero findings, got %d", len(findings))
 	}
 }
 


### PR DESCRIPTION
`classifyResponse` folded every 4xx other than 401/403/404/405 into `verdictRejected`. A 429 is not a rejection: the server did not judge the token. Two findings came out of that fold, in opposite directions.

The negative control is what upgrades an accepted trap to **ConfirmedExploit**: "the control was rejected, so the audience value was the decisive factor". A rate limiter catching the control (plausible on its own: the probes are a burst) made that argument out of a reply that said nothing, and every trap acceptance read as confirmed.

And in the other direction, every probe rate-limited read as "all probes rejected", so the rule reported audience matching **sound** about a server that judged nothing.

| Server behaviour | Was | Now |
|---|---|---|
| control 429, traps accepted | **critical confirmed** matching bug | finding downgraded to RiskIndicator; the control that came back inconclusive takes the path `coalesceOutcomes` already defines for that |
| every probe 429 | **clean**, audience matching sound | not tested, naming the HTTP statuses seen |
| 400 carrying a JSON-RPC error envelope | rejected (folded) | rejected, deliberately: the JSON-RPC layer said no, the same rule `classifyAccess` applies |
| 200 with no JSON-RPC envelope on every probe | clean | not tested |

`classifyResponse` now mirrors `classifyAccess`: 401/403 are rejections, an explicit JSON-RPC error envelope is a rejection at any HTTP status, and everything else is inconclusive. `Execute` also gained the check its sibling rules got in #146: when every probe came back without a verdict, the rule reports `ErrInconclusive` instead of clean. The premise check cannot absorb that case, because it explains refusals, and a rate limiter refused nothing.

`TestOAuthAudience_Ambiguous200` moves from clean to not tested for the same reason: a 200 page with no JSON-RPC envelope judged no probe either. No other existing expectation changed.

## Verification

- Rate-limited control + accepted traps: 1 finding, RiskIndicator (was ConfirmedExploit).
- 429 on every probe: `ErrInconclusive` naming HTTP 429 (was clean).
- 400 with an error envelope on every probe: clean, pinning the explicit-refusal rule at any status.
- The 401/403/404/405, blanket-acceptance, ungated-initialize and auto-discovery tests are unchanged and green. Full suite green across 18 packages, `go vet` and `gofmt` clean.

## Scope

The verdict taxonomy here is local to this rule; `token_replay` judges through `classifyAccess` and already leaves 429 undetermined. The A2A package's `classifyProbe` (`card_security_unenforced.go`) has divergent semantics from its MCP sibling, a copy-paste drift worth its own pass rather than bundling here.
