### PR TITLE
fix(mcp): stop suppressing mcp-task-idor-001 on a polite creation refusal

### DIFF
--- a/internal/attack/mcp/task_idor.go
+++ b/internal/attack/mcp/task_idor.go
@@ -599,6 +599,12 @@ func synthesizeArgs(schema map[string]interface{}, randID string) map[string]int
 // credential is required here", from a probe that produced no verdict at all. Both
 // used to return an empty id, so a transport failure or a 429 on the anonymous control
 // was written into a finding's evidence as "anonymous task creation: refused".
+//
+// A refusal can arrive as a JSON-RPC error envelope at HTTP 200, the spec'd
+// refusal shape, and that is a real answer rather than a missing verdict. It
+// used to fall into the empty-taskId branch below, so a server that refused
+// creation politely suppressed the rule with "the anonymous control returned no
+// verdict"; getTask in this file already read the identical shape as a refusal.
 func (e *TaskIDORExecutor) createTask(ctx context.Context, client *attack.HTTPClient, s mcpSession, p taskPrincipal, tool safeTool) (string, taskPremise) {
 	resp, err := client.POST(ctx, s.Endpoint, e.headers(s, p), map[string]interface{}{
 		"jsonrpc": "2.0",
@@ -623,9 +629,15 @@ func (e *TaskIDORExecutor) createTask(ctx context.Context, client *attack.HTTPCl
 				TaskID string `json:"taskId"`
 			} `json:"task"`
 		} `json:"result"`
+		Error map[string]interface{} `json:"error"`
 	}
 	if err := json.Unmarshal(resp.Body, &body); err != nil {
 		return "", premiseUndetermined
+	}
+	if body.Error != nil {
+		// A JSON-RPC error at HTTP 200 is the spec'd refusal shape, so it is a
+		// real answer: the control reads it as "a credential is required here".
+		return "", premiseAbsent
 	}
 	if body.Result.Task.TaskID == "" {
 		// Answered, but with no task handle, on a server that advertised

--- a/internal/attack/mcp/task_idor_test.go
+++ b/internal/attack/mcp/task_idor_test.go
@@ -28,6 +28,10 @@ import (
 //   - "create-open":   task creation needs no credentials but reads do, and reads
 //     are not scoped. Authentication really is enforced on the surface this rule
 //     tests, so the boundary B crosses is real => both findings.
+//   - "anon-create-envelope": anonymous creation is refused with a JSON-RPC
+//     error envelope at HTTP 200, the spec'd refusal shape, while reads are
+//     unscoped. The refusal is a verdict, so the rule proceeds; it used to read
+//     as no verdict and suppress the rule.
 //   - "no-tasks-cap":  the tasks capability is absent => skip.
 //   - "unsafe-tool":   the only task-capable tool carries no safety annotations,
 //     so the rule refuses to invoke it => skip.
@@ -121,6 +125,12 @@ func taskIDORServer(mode string) *httptest.Server {
 			}
 			// Only no-auth and create-open let an anonymous caller create a task.
 			if mode != "no-auth" && mode != "create-open" && !authed {
+				if mode == "anon-create-envelope" {
+					// The spec'd refusal shape: a JSON-RPC error envelope at
+					// HTTP 200. That is a real answer, not a missing verdict.
+					rpcErr(-32001, "Unauthorized")
+					return
+				}
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			}
@@ -240,6 +250,28 @@ func TestTaskIDOR_HiddenAnonInitializeIsNotTested(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "returned no verdict") {
 		t.Errorf("reason should name the unanswered control: %v", err)
+	}
+}
+
+// TestTaskIDOR_AnonCreationRefusedAt200StillTestsScoping: the anonymous control
+// had task creation refused with a JSON-RPC error envelope at HTTP 200, which
+// is the spec'd refusal shape and a real answer. createTask used to read it as
+// no verdict, so the discriminator suppressed the whole rule with "the
+// anonymous control returned no verdict" on exactly the servers that refuse
+// politely; getTask in the same file already read the identical shape as a
+// refusal. The refusal is also what the findings' evidence records.
+func TestTaskIDOR_AnonCreationRefusedAt200StillTestsScoping(t *testing.T) {
+	srv := taskIDORServer("anon-create-envelope")
+	defer srv.Close()
+
+	findings := runTaskIDOR(t, srv)
+	if len(findings) != 3 {
+		t.Fatalf("expected 3 findings (tasks/get + tasks/result + tasks/list), got %d: %+v", len(findings), findings)
+	}
+	for _, f := range findings {
+		if !strings.Contains(f.Evidence, "anonymous task creation: refused") {
+			t.Errorf("evidence should record the observed anonymous refusal: %s", f.Evidence)
+		}
 	}
 }
 


### PR DESCRIPTION
`createTask` unmarshalled only `result.task.taskId`. A JSON-RPC error envelope at HTTP 200, which is the spec'd refusal shape for a task-augmented `tools/call`, has no `result`, so it landed in the empty-taskId branch as `premiseUndetermined`, and the anonymous discriminator reported "the anonymous control returned no verdict" and suppressed the whole rule.

That suppressed the rule on exactly the servers the discriminator exists to separate: a server that refuses anonymous creation politely **has** an authorization context, and the cross-principal read is precisely what should be tested next. `getTask` in the same file already reads the identical shape as a refusal ("A JSON-RPC error at HTTP 200 is the spec'd refusal shape, so it is a real answer"), and the entropy rule's task minting does the same; `createTask` was the one remaining reader of that shape that did not.

| Anonymous task creation answered with | Was | Now |
|---|---|---|
| HTTP 401 | refused, rule proceeds | unchanged |
| JSON-RPC error envelope at HTTP 200 | **not tested**, "returned no verdict" | refused, rule proceeds |
| 2xx with no taskId | not tested (deviation) | unchanged |
| transport failure / 429 | not tested | unchanged |

`createTask` now maps `body.Error` to `premiseAbsent`, the same premise a 401 produces, so the control reads it as "a credential is required here" and the rule proceeds with the evidence line "anonymous task creation: refused", which is now a refusal the rule actually observed.

The live fixture refuses anonymous creation with HTTP 401 (`mcp_task_idor_server.py` line 91), so no bundled gate changes; the 200-envelope shape was the path no test drove.

## Verification

- New mode `anon-create-envelope` in the task-idor harness: anonymous creation refused with a 200 error envelope, reads unscoped. Before the fix the rule reported `ErrInconclusive` ("returned no verdict"); now it produces all three findings, each citing the observed refusal.
- All other task-idor modes unchanged and green. Full suite green across 17 packages, `go vet` and `gofmt` clean.

## Scope

The same three-outcome discipline is applied to `getTask` already and to the entropy rule's minting loop; `getResult` deliberately returns a boolean and is not verdict-bearing. The A-side creation refusal (principal A scope-gated) lands in the same "could not create a task" not-tested message as before, which stays honest, but it could name the refusal reason; left as-is to keep this change one behaviour.
