### PR TITLE
fix(oob): stop reporting Stop's own listener double close as a failure

### DIFF
--- a/internal/oob/listener.go
+++ b/internal/oob/listener.go
@@ -18,6 +18,7 @@ package oob
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -156,6 +157,15 @@ func (l *Listener) Stop(ctx context.Context) error {
 		_ = l.ln.Close()
 	}
 	err := l.server.Shutdown(ctx)
+	// When the serve goroutine registered the listener before this call ran,
+	// Shutdown closes it a second time and reports the fd already closed by
+	// the line above. That is this function's own two closes of one listener,
+	// not a shutdown failure: only this call ever closes the fd, so ErrClosed
+	// here can mean nothing else. The lifecycle test asserts on Stop's error,
+	// which is how this surfaced as a CI flake rather than a silent one.
+	if errors.Is(err, net.ErrClosed) {
+		err = nil
+	}
 	l.server = nil
 	l.ln = nil
 	l.addr = ""

--- a/internal/oob/listener_test.go
+++ b/internal/oob/listener_test.go
@@ -97,3 +97,23 @@ func TestListener_StopResetsLifecycle(t *testing.T) {
 		t.Errorf("second stop: %v", err)
 	}
 }
+
+// TestListener_StopRepeatNeverReportsOwnDoubleClose drives the interleaving
+// the single start/stop above only samples once: whether the serve goroutine
+// has registered the listener before Stop runs decides which of Stop's two
+// closes of the same fd observes it already shut, and the loser used to
+// surface as Stop's return value. A CI run caught that as a 1-in-N flake
+// ("close tcp: use of closed network connection"); the loop makes the
+// assertion fire on every run and fails on revert.
+func TestListener_StopRepeatNeverReportsOwnDoubleClose(t *testing.T) {
+	ctx := context.Background()
+	for i := 0; i < 25; i++ {
+		l := New()
+		if _, err := l.Start(); err != nil {
+			t.Fatalf("start %d: %v", i, err)
+		}
+		if err := l.Stop(ctx); err != nil {
+			t.Fatalf("stop %d: %v", i, err)
+		}
+	}
+}


### PR DESCRIPTION
`Stop` closes the listener manually, then calls `Shutdown`. When the serve goroutine has registered the listener with the server before `Stop` runs, `Shutdown` closes the same fd a second time and returns the resulting `close tcp: use of closed network connection` as its error.

The three executors that use the listener discard `Stop`'s error, so the only place this surfaced was `TestListener_StopResetsLifecycle` asserting on it. There it failed as a roughly 1-in-20 local flake, and then took down the Build & Test job on an unrelated pull request (#250), which is how it reached CI.

| Who runs first | Old behaviour | Now |
|---|---|---|
| serve goroutine registers, then `Stop` | `Shutdown` observes the fd already closed by the manual close and returns that error | cleared: it is `Stop`'s own double close |
| `Stop` before the serve goroutine registers | `Shutdown` closes nothing, clean | unchanged |

The double close itself is deliberate: the manual close makes the port deterministically free even when the serve goroutine has not reached Accept yet (without it, a restart could race an open port), and `Shutdown` is what waits for in-flight handlers. Only `Stop` itself ever closes this fd, so `ErrClosed` returned by `Shutdown` can mean nothing but the second of its own two closes. `Stop` now clears exactly that error via `errors.Is(err, net.ErrClosed)` and returns anything else.

## Verification

- `TestListener_StopRepeatNeverReportsOwnDoubleClose` drives the interleaving 25 times per run, converting the sampling the old test did into an every-run assertion. With the fix stashed and the new test kept, the loop fails at iteration 0, so the check is not vacuous.
- `internal/oob` green at `-count=50` (previously failed within 20 on the same machine).
- Full suite green across 18 packages, `go vet` and `gofmt` clean.

This unblocks the dependabot PRs whose Build & Test job tripped the flake; after this merges they want a rebase (`@dependabot rebase`) so their checks re-run against it.
