### PR TITLE
fix(mcp): stop reporting mcp-oauth-dcr-001 clean on an unjudged status

### DIFF
--- a/internal/attack/mcp/oauth_dcr.go
+++ b/internal/attack/mcp/oauth_dcr.go
@@ -91,7 +91,22 @@ func (e *OAuthDCRExecutor) Execute(ctx context.Context, target string, opts atta
 	// privileged scope. A rejected registration (auth required / scope policy)
 	// or a granted scope reduced to read-only is correct behaviour: no finding.
 	if escalatedResp.StatusCode != 200 && escalatedResp.StatusCode != 201 {
-		return nil, nil
+		// RFC 7591 section 3.2.2 answers an invalid registration with 400, an
+		// authorization server requiring a registration token answers 401, and
+		// 403 is the policy-denied variant. Those are verdicts: the server
+		// judged the request and declined it, which is the secure answer to
+		// this rule's question. Any other status - a 429 from a rate limiter,
+		// a gateway 502 - judged nothing, and a clean result there asserted the
+		// server's granted-scope policy is sound about a reply that said
+		// nothing.
+		switch escalatedResp.StatusCode {
+		case 400, 401, 403:
+			return nil, nil
+		}
+		return nil, fmt.Errorf("%w: the registration request to %s was answered with HTTP %d, which is "+
+			"neither an acceptance nor a registration refusal, so the granted-scope policy for anonymous "+
+			"registrants could not be judged",
+			attack.ErrInconclusive, registrationEndpoint, escalatedResp.StatusCode)
 	}
 	grantedScope := escalatedResp.JSONField("scope")
 	granted := privilegedScopesIn(grantedScope)

--- a/internal/attack/mcp/oauth_dcr_test.go
+++ b/internal/attack/mcp/oauth_dcr_test.go
@@ -220,6 +220,44 @@ func TestOAuthDCR_NoOAuthServer(t *testing.T) {
 	}
 }
 
+// A registration answered with a status that is neither an acceptance nor one
+// of the RFC 7591 refusal statuses (400/401/403) judged nothing: a 429 from a
+// rate limiter or a gateway 502 says nothing about the granted-scope policy,
+// and a clean result there asserted that policy is sound about a reply that
+// said nothing. The refusal statuses stay clean and are pinned above by the
+// secure (400) and auth-gated (401) servers.
+func TestOAuthDCR_UnjudgedRegistrationStatusIsNotTested(t *testing.T) {
+	for _, status := range []int{http.StatusTooManyRequests, http.StatusBadGateway, http.StatusInternalServerError} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			var srv *httptest.Server
+			srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				base := "http://" + srv.Listener.Addr().String()
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/.well-known/oauth-authorization-server":
+					json.NewEncoder(w).Encode(map[string]interface{}{
+						"issuer":                base,
+						"registration_endpoint": base + "/register",
+					})
+				case "/register":
+					w.WriteHeader(status)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer srv.Close()
+
+			findings, err := mcpattack.NewOAuthDCRExecutor(oauthRC()).Execute(context.Background(), srv.URL, testOpts())
+			if len(findings) != 0 {
+				t.Fatalf("expected no findings, got %d", len(findings))
+			}
+			if !errors.Is(err, attack.ErrInconclusive) {
+				t.Errorf("HTTP %d judged no registration; want ErrInconclusive, got %v", status, err)
+			}
+		})
+	}
+}
+
 // Nothing answered, so the rule was never exercised.
 func TestOAuthDCR_NothingReachableIsNotTested(t *testing.T) {
 	ts := httptest.NewServer(http.NotFoundHandler())


### PR DESCRIPTION
A registration answered with anything other than 200/201 read as a refusal, and `mcp-oauth-dcr-001` reported clean. A 400/401/403 **is** a refusal, but a 429 from a rate limiter or a gateway 502 judged nothing, and a clean result there asserted the server's granted-scope policy is sound about a reply that said nothing.

The refusal statuses are now explicit: RFC 7591 section 3.2.2 answers an invalid registration with 400, an authorization server requiring a registration token answers 401, and 403 is the policy-denied variant. Those stay clean, which is what the rule's own contract already calls the secure answer. Every other status reports `ErrInconclusive` naming the endpoint and the status.

| Registration answered with | Was | Now |
|---|---|---|
| 200 / 201 | scope check proceeds | unchanged |
| 400 / 401 / 403 | clean | clean, now as an explicit refusal verdict |
| 429, 405, 5xx | **clean** | not tested, naming endpoint and status |

The sibling metadata-SSRF rule reports not-tested for every non-2xx, because its premise (stored metadata URLs to fetch) dies with any refusal. This rule's premise does not: a refused registration is exactly its secure answer. So the two rules legitimately differ here, and the split is refusal versus no-verdict rather than a wholesale copy of the sibling.

## Verification

- New subtyped test drives 429, 502 and 500 registration replies: no findings, `ErrInconclusive` each time.
- The 400 (scope-restricting) and 401 (auth-gated) servers stay clean; the vulnerable and auto-discovery tests are unchanged and green.
- Full suite green across 18 packages, `go vet` and `gofmt` clean.

## Scope

The transport-failure path (`registration request failed`) still returns a plain error, which the engine surfaces as errored rather than not-tested. That is honest and it is the same shape the metadata-SSRF sibling uses, so it is left alone here. The discovery phase skipping PRM-first OAuth metadata (#10 on the review list) is a separate change and covers this rule when it lands.
