### PR TITLE
fix(cli): apply the config file's output field

### DIFF
--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -109,9 +109,9 @@ func runScan(cmd *cobra.Command, args []string) error {
 	if target == "" {
 		target = cfg.Target
 	}
-	if outputFmt == "" {
-		outputFmt = cfg.Output
-	}
+	// The flag carries a default, so this is the same sentinel problem as
+	// --proxy: an empty value cannot say "not passed".
+	outputFmt = effectiveOutput(cmd.Flags().Changed("output"), outputFmt, cfg.Output)
 	if protocol == "" {
 		protocol = cfg.Protocol
 	}
@@ -446,6 +446,21 @@ func firstNonEmpty(vals ...string) string {
 // Otherwise a positive config value is used; otherwise the flag value (default).
 func effectiveTimeout(flagChanged bool, flagVal, cfgVal int) int {
 	if !flagChanged && cfgVal > 0 {
+		return cfgVal
+	}
+	return flagVal
+}
+
+// effectiveOutput resolves --output from the flag and the config file. The flag
+// carries a default ("table"), so its value can never distinguish "not passed"
+// from "explicitly table" and the config file's documented, validated output
+// field could never apply; the flag therefore wins only when it was actually
+// passed, the same treatment --proxy got for the same sentinel problem.
+func effectiveOutput(flagChanged bool, flagVal, cfgVal string) string {
+	if flagChanged {
+		return flagVal
+	}
+	if cfgVal != "" {
 		return cfgVal
 	}
 	return flagVal

--- a/internal/cli/scan_test.go
+++ b/internal/cli/scan_test.go
@@ -1,6 +1,13 @@
 package cli
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -170,5 +177,82 @@ func TestEffectiveSkipTLS(t *testing.T) {
 				t.Errorf("effectiveSkipTLS(%v, %v, %v) = %v, want %v", tc.flagChanged, tc.flagVal, tc.cfgVal, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestEffectiveOutput(t *testing.T) {
+	tests := []struct {
+		name        string
+		flagChanged bool
+		flagVal     string
+		cfgVal      string
+		want        string
+	}{
+		// The bug this guards: the flag carries a default, so the old
+		// empty-string sentinel never fired and the config value could never
+		// apply. "flag wins" therefore means "flag was actually passed".
+		{"explicit flag wins over config", true, "json", "sarif", "json"},
+		{"explicit flag equal to default wins over config", true, "table", "sarif", "table"},
+		{"config used when flag not passed", false, "table", "sarif", "sarif"},
+		{"flag default when neither set", false, "table", "", "table"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := effectiveOutput(tc.flagChanged, tc.flagVal, tc.cfgVal); got != tc.want {
+				t.Errorf("effectiveOutput(%v, %q, %q) = %q, want %q", tc.flagChanged, tc.flagVal, tc.cfgVal, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestScan_ConfigOutputFieldApplies pins the WIRING, not just the helper: the
+// config file's output field is validated, documented in the generated
+// example, and was silently ignored because the --output default masked the
+// empty-string sentinel. Driven through the real command against a target
+// that answers nothing, so the run is fast and sends no attack traffic: a
+// 404-everything server leaves every rule not-tested and the payload on
+// stdout must be the JSON envelope the config asked for.
+func TestScan_ConfigOutputFieldApplies(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "batesian.yaml")
+	if err := os.WriteFile(cfgPath, []byte("output: json\n"), 0o644); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+
+	// The machine-readable payload goes to os.Stdout; banner and status go to
+	// stderr for json output, so stdout must carry the envelope alone. The
+	// reader runs concurrently: the payload exceeds a pipe's buffer, and a
+	// reader that starts only after Execute returns deadlocks the writer.
+	stdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	var buf bytes.Buffer
+	readerDone := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(readerDone)
+	}()
+
+	os.Stdout = w
+	rootCmd.SetArgs([]string{"scan", "--target", srv.URL, "--config", cfgPath})
+	cmdErr := rootCmd.Execute()
+	os.Stdout = stdout
+	_ = w.Close()
+	defer func() { rootCmd.SetArgs(nil) }()
+	<-readerDone
+	if cmdErr != nil {
+		t.Fatalf("scan: %v", cmdErr)
+	}
+
+	var doc map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("config output: json did not produce a JSON payload on stdout: %v; got %.200s", err, buf.String())
+	}
+	if _, ok := doc["findings"]; !ok {
+		t.Errorf("payload missing the findings key: %.200s", buf.String())
 	}
 }


### PR DESCRIPTION
The `output:` field in `batesian.yaml` is validated by the config loader and documented in the example `batesian init` writes, and it never applied: `runScan` read the `--output` flag (default `"table"`) and fell back to the config only when the value was empty, which it never is. An operator who put `output: sarif` in the config got the table anyway.

| Configuration | Was | Now |
|---|---|---|
| `output: sarif` in config, no flag | table, silently | sarif |
| `--output json` with `output: sarif` in config | json | json (flag still wins) |
| `--output table` with `output: sarif` in config | table (indistinguishable from the default) | table (explicitly) |
| neither | table | table |

The fix is `effectiveOutput(flagChanged, flagVal, cfgVal)`, mirroring the helpers `--timeout`, `--skip-tls` and `--proxy` already use for the same default-masks-the-sentinel problem: the flag wins only when `cmd.Flags().Changed("output")`.

## Verification

- `TestEffectiveOutput` covers the resolution table, including the case where an explicit `--output table` must beat a config `sarif`.
- The wiring is pinned by `TestScan_ConfigOutputFieldApplies`, which runs the real command against a 404-everything target with `output: json` in the config and requires the JSON envelope on stdout. With the call site reverted to the old sentinel it fails, so the check is not vacuous.
- One test-harness lesson worth recording: the payload exceeds a pipe buffer, so a reader that starts only after `Execute` returns deadlocks the writer on Windows (the scan finished; the JSON write blocked). The test drains stdout concurrently.
- Full suite green across 18 packages, `go vet` and `gofmt` clean.

## Scope

`probe` and `rules` accept `--output` but read no config at all, so they have no dead field, just a parity gap (no `--config`, no `BATESIAN_TOKEN` for probe) tracked separately. The rules subcommand also ignores the config's `output:` value today; now that scan honours it, that divergence is worth its own pass rather than bundling here.
