### PR TITLE
fix(cli): let Ctrl+C interrupt probe

### DIFF
--- a/internal/cli/probe.go
+++ b/internal/cli/probe.go
@@ -92,15 +92,15 @@ func runProbe(cmd *cobra.Command, args []string) error {
 
 	switch strings.ToLower(protocol) {
 	case "a2a":
-		return probeA2A(target, token, timeoutSecs, skipTLS, proxy, format, printer)
+		return probeA2A(cmd.Context(), target, token, timeoutSecs, skipTLS, proxy, format, printer)
 	case "mcp":
-		return probeMCP(target, token, timeoutSecs, skipTLS, proxy, format, printer)
+		return probeMCP(cmd.Context(), target, token, timeoutSecs, skipTLS, proxy, format, printer)
 	default:
 		return fmt.Errorf("unknown protocol %q; supported: a2a, mcp", protocol)
 	}
 }
 
-func probeA2A(target, token string, timeoutSecs int, skipTLS bool, proxy string, format report.Format, printer *report.Printer) error { //nolint:cyclop
+func probeA2A(ctx context.Context, target, token string, timeoutSecs int, skipTLS bool, proxy string, format report.Format, printer *report.Printer) error { //nolint:cyclop
 	if timeoutSecs <= 0 {
 		timeoutSecs = 10
 	}
@@ -123,7 +123,6 @@ func probeA2A(target, token string, timeoutSecs int, skipTLS bool, proxy string,
 	}
 
 	printer.ProbeHeader(target, "a2a")
-	ctx := context.Background()
 
 	printer.Verbose("GET " + target + a2a.WellKnownPath)
 	card, cardResult, err := client.FetchAgentCard(ctx)
@@ -226,7 +225,7 @@ func cardToProbeResult(card *a2a.AgentCard, elapsed time.Duration) *report.Probe
 	return r
 }
 
-func probeMCP(target, token string, timeoutSecs int, skipTLS bool, proxy string, format report.Format, printer *report.Printer) error {
+func probeMCP(ctx context.Context, target, token string, timeoutSecs int, skipTLS bool, proxy string, format report.Format, printer *report.Printer) error {
 	if timeoutSecs <= 0 {
 		timeoutSecs = 10
 	}
@@ -249,7 +248,6 @@ func probeMCP(target, token string, timeoutSecs int, skipTLS bool, proxy string,
 	}
 
 	printer.ProbeHeader(target, "mcp")
-	ctx := context.Background()
 
 	printer.Verbose("POST " + target + "/mcp (initialize)")
 	start := time.Now()

--- a/internal/cli/probe_test.go
+++ b/internal/cli/probe_test.go
@@ -1,13 +1,18 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"sort"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/calbebop/batesian/internal/protocol/a2a"
+	"github.com/calbebop/batesian/internal/report"
 )
 
 // TestCardToProbeResult_ExtendedCardAndProtocol covers the two card fields whose
@@ -181,5 +186,68 @@ func TestCardToProbeResult_SchemeOrderIsDeterministic(t *testing.T) {
 	}
 	if !sort.StringsAreSorted(first) {
 		t.Errorf("schemes should be in a stable, predictable order, got %v", first)
+	}
+}
+
+// Probe ran on context.Background() while main installs signal.NotifyContext,
+// which removes the default SIGINT kill. A stalled target therefore made probe
+// unkillable: the first and second Ctrl+C did nothing and the process hung
+// until the request timeout elapsed. The command's context must reach the
+// wire, and both protocol clients bind it via NewRequestWithContext.
+func TestProbeA2A_ContextCancellationInterruptsStalledFetch(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release // the target accepted the connection and never answers
+	}))
+	// Defers run LIFO: close(release) is registered last, so it runs before
+	// Server.Close, or Close waits on the stalled handler forever.
+	defer srv.Close()
+	defer close(release)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := probeA2A(ctx, srv.URL, "", 30, false, "", report.FormatTable, report.New(io.Discard, false))
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from a stalled target, got nil")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("probe returned after %s; cancellation must interrupt the fetch, not wait out the 30s request timeout", elapsed)
+	}
+}
+
+// Same contract, MCP side: the initialize handshake is the first wire request,
+// so cancellation must unblock it.
+func TestProbeMCP_ContextCancellationInterruptsInitialize(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release // every candidate endpoint stalls
+	}))
+	// Defers run LIFO: close(release) is registered last, so it runs before
+	// Server.Close, or Close waits on the stalled handler forever.
+	defer srv.Close()
+	defer close(release)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := probeMCP(ctx, srv.URL, "", 30, false, "", report.FormatTable, report.New(io.Discard, false))
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from a stalled target, got nil")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("probe returned after %s; cancellation must interrupt initialize, not wait out the 30s request timeout", elapsed)
 	}
 }


### PR DESCRIPTION
`main` installs `signal.NotifyContext`, which removes the default SIGINT kill, and probe ran on `context.Background()`, so nothing observed the cancelled context. Against a stalled target the first and second Ctrl+C did nothing and the process hung until the request timeout elapsed. Commit 9da9c57 ("listener lifecycle safety and interrupt propagation") fixed the scan and OOB paths; probe kept its own `context.Background()` in both `probeA2A` and `probeMCP`.

`runProbe` now passes `cmd.Context()` into both probe paths. Both protocol clients already bind requests via `NewRequestWithContext`, so cancellation reaches the wire; no transport change is needed.

| Where probe runs | Was | Now |
|---|---|---|
| stalled target, Ctrl+C once | nothing; second Ctrl+C also nothing, until the request timeout | request aborts, probe returns with the transport error |
| healthy target | unchanged | unchanged |

## Verification

- `TestProbeA2A_ContextCancellationInterruptsStalledFetch` and `TestProbeMCP_ContextCancellationInterruptsInitialize` point each probe at a server that accepts the connection and never answers, cancel the context at 150ms, and require the probe to return well before the 30s request timeout. Both pass in 0.15s.
- With the old behaviour restored (`ctx = context.Background()` overriding the parameter), the A2A test returns at 30.0s and fails, so the check is not vacuous.
- Full suite green across 18 packages, `go vet` and `gofmt` clean.

## Scope

`probe` still reads no config file and no `BATESIAN_TOKEN`, so recon runs unauthenticated where scan would authenticate; that parity gap is tracked separately. The stalled-target test needs the stalled handler released before `httptest.Server.Close`, whose LIFO defer ordering is annotated in the test because it is the wrong-way-round trap this change itself hit while being written.
